### PR TITLE
Make Inference processor field_map and inference_config optional

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -3,7 +3,7 @@
 [[inference-processor]]
 === {infer-cap} Processor
 
-Uses a pre-trained {dfanalytics} model to infer against the data that is being 
+Uses a pre-trained {dfanalytics} model to infer against the data that is being
 ingested in the pipeline.
 
 
@@ -14,8 +14,8 @@ ingested in the pipeline.
 | Name               | Required  | Default                        | Description
 | `model_id`         | yes       | -                              | (String) The ID of the model to load and infer against.
 | `target_field`     | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
-| `field_map`        | yes       | -                              | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
-| `inference_config` | yes       | -                              | (Object) Contains the inference type and its options. There are two types: <<inference-processor-regression-opt,`regression`>> and <<inference-processor-classification-opt,`classification`>>.
+| `field_map`        | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
+| `inference_config` | no        | The default settings defined in the model  | (Object) Contains the inference type and its options. There are two types: <<inference-processor-regression-opt,`regression`>> and <<inference-processor-classification-opt,`classification`>>.
 include::common-options.asciidoc[]
 |======
 
@@ -26,7 +26,9 @@ include::common-options.asciidoc[]
   "inference": {
     "model_id": "flight_delay_regression-1571767128603",
     "target_field": "FlightDelayMin_prediction_infer",
-    "field_map": {},
+    "field_map": {
+      "your_field": "my_field"
+    },
     "inference_config": { "regression": {} }
   }
 }
@@ -91,8 +93,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification
 --------------------------------------------------
 // NOTCONSOLE
 
-This configuration specifies a `regression` inference and the results are 
-written to the `my_regression` field contained in the `target_field` results 
+This configuration specifies a `regression` inference and the results are
+written to the `my_regression` field contained in the `target_field` results
 object.
 
 
@@ -110,10 +112,10 @@ object.
 --------------------------------------------------
 // NOTCONSOLE
 
-This configuration specifies a `classification` inference. The number of 
-categories for which the predicted probabilities are reported is 2 
-(`num_top_classes`). The result is written to the `prediction` field and the top 
-classes to the `probabilities` field. Both fields are contained in the 
+This configuration specifies a `classification` inference. The number of
+categories for which the predicted probabilities are reported is 2
+(`num_top_classes`). The result is written to the `prediction` field and the top
+classes to the `probabilities` field. Both fields are contained in the
 `target_field` results object.
 
 
@@ -121,8 +123,8 @@ classes to the `probabilities` field. Both fields are contained in the
 [[inference-processor-feature-importance]]
 ==== {feat-imp-cap} object mapping
 
-Update your index mapping of the {feat-imp} result field as you can see below to 
-get the full benefit of aggregating and searching for 
+Update your index mapping of the {feat-imp} result field as you can see below to
+get the full benefit of aggregating and searching for
 {ml-docs}/ml-feature-importance.html[{feat-imp}].
 
 [source,js]
@@ -146,7 +148,7 @@ The mapping field name for {feat-imp} is compounded as follows:
 
 `<ml.inference.target_field>`.`<inference.tag>`.`feature_importance`
 
-If `inference.tag` is not provided in the processor definition, it is not part 
+If `inference.tag` is not provided in the processor definition, it is not part
 of the field path. The `<ml.inference.target_field>` defaults to `ml.inference`.
 
 For example, you provide a tag `foo` in the definition as you can see below:
@@ -161,7 +163,7 @@ For example, you provide a tag `foo` in the definition as you can see below:
 // NOTCONSOLE
 
 
-The {feat-imp} value is written to the `ml.inference.foo.feature_importance` 
+The {feat-imp} value is written to the `ml.inference.foo.feature_importance`
 field.
 
 You can also specify a target field as follows:
@@ -175,5 +177,5 @@ You can also specify a target field as follows:
 --------------------------------------------------
 // NOTCONSOLE
 
-In this case, {feat-imp} is exposed in the 
+In this case, {feat-imp} is exposed in the
 `my_field.foo.feature_importance` field.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResu
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.LenientlyParsedInferenceConfig;
@@ -123,8 +124,6 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             ClassificationConfigUpdate::fromXContentStrict));
         namedXContent.add(new NamedXContentRegistry.Entry(InferenceConfigUpdate.class, RegressionConfigUpdate.NAME,
             RegressionConfigUpdate::fromXContentStrict));
-        namedXContent.add(new NamedXContentRegistry.Entry(InferenceConfigUpdate.class, ResultsFieldUpdate.NAME,
-            ResultsFieldUpdate::fromXContent));
 
         // Inference models
         namedXContent.add(new NamedXContentRegistry.Entry(InferenceModel.class, Ensemble.NAME, EnsembleInferenceModel::fromXContent));
@@ -188,6 +187,10 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             ClassificationConfigUpdate.NAME.getPreferredName(), ClassificationConfigUpdate::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class,
             RegressionConfigUpdate.NAME.getPreferredName(), RegressionConfigUpdate::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class,
+            ResultsFieldUpdate.NAME, ResultsFieldUpdate::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class,
+            EmptyConfigUpdate.NAME, EmptyConfigUpdate::new));
 
         return namedWriteables;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -24,9 +25,9 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.Classificat
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig.RESULTS_FIELD;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig.TOP_CLASSES_RESULTS_FIELD;
 
-public class ClassificationConfigUpdate implements InferenceConfigUpdate {
+public class ClassificationConfigUpdate implements InferenceConfigUpdate, NamedXContentObject {
 
-    public static final ParseField NAME = new ParseField("classification");
+    public static final ParseField NAME = ClassificationConfig.NAME;
 
     public static ClassificationConfigUpdate EMPTY_PARAMS =
         new ClassificationConfigUpdate(null, null, null, null, null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -7,25 +7,14 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
 public class EmptyConfigUpdate implements InferenceConfigUpdate {
 
-    public static final ParseField NAME = new ParseField("empty");
-
-    private static final ObjectParser<EmptyConfigUpdate, Void> PARSER =
-        new ObjectParser<>(NAME.getPreferredName(), EmptyConfigUpdate::new);
-
-    public static EmptyConfigUpdate fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
+    public static final String NAME = "empty";
 
     public static Version minimumSupportedVersion() {
         return Version.V_7_9_0;
@@ -64,24 +53,12 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
 
     @Override
     public String getWriteableName() {
-        return NAME.getPreferredName();
+        return NAME;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
 
-    }
-
-    @Override
-    public String getName() {
-        return NAME.getPreferredName();
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.endObject();
-        return builder;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -24,6 +25,10 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
 
     public static EmptyConfigUpdate fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
+    }
+
+    public static Version minimumSupportedVersion() {
+        return Version.V_7_9_0;
     }
 
     public EmptyConfigUpdate() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class EmptyConfigUpdate implements InferenceConfigUpdate {
+
+    public static final ParseField NAME = new ParseField("empty");
+
+    private static final ObjectParser<EmptyConfigUpdate, Void> PARSER =
+        new ObjectParser<>(NAME.getPreferredName(), EmptyConfigUpdate::new);
+
+    public static EmptyConfigUpdate fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    public EmptyConfigUpdate() {
+    }
+
+    public EmptyConfigUpdate(StreamInput in) {
+    }
+
+    @Override
+    public InferenceConfig apply(InferenceConfig originalConfig) {
+        return originalConfig;
+    }
+
+    @Override
+    public InferenceConfig toConfig() {
+        return RegressionConfig.EMPTY_PARAMS;
+    }
+
+    @Override
+    public boolean isSupported(InferenceConfig config) {
+        return true;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+    }
+
+    @Override
+    public String getName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return EmptyConfigUpdate.class.hashCode();
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdate.java
@@ -38,18 +38,28 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
     }
 
     @Override
+    public String getResultsField() {
+        return null;
+    }
+
+    @Override
     public InferenceConfig apply(InferenceConfig originalConfig) {
         return originalConfig;
     }
 
     @Override
     public InferenceConfig toConfig() {
-        return RegressionConfig.EMPTY_PARAMS;
+        throw new UnsupportedOperationException("the empty config update cannot be rewritten");
     }
 
     @Override
     public boolean isSupported(InferenceConfig config) {
         return true;
+    }
+
+    @Override
+    public InferenceConfigUpdate.Builder<? extends InferenceConfigUpdate.Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder() {
+        return new Builder();
     }
 
     @Override
@@ -82,5 +92,17 @@ public class EmptyConfigUpdate implements InferenceConfigUpdate {
     @Override
     public int hashCode() {
         return EmptyConfigUpdate.class.hashCode();
+    }
+
+    public static class Builder implements InferenceConfigUpdate.Builder<Builder, EmptyConfigUpdate> {
+
+        @Override
+        public Builder setResultsField(String resultsField) {
+            return this;
+        }
+
+        public EmptyConfigUpdate build() {
+            return new EmptyConfigUpdate();
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
@@ -50,7 +50,7 @@ public interface InferenceConfigUpdate extends NamedXContentObject, NamedWriteab
             }
         }
         if (duplicatedFieldNames.isEmpty() == false) {
-            throw ExceptionsHelper.badRequestException("Cannot apply inference config." +
+            throw ExceptionsHelper.badRequestException("Invalid inference config." +
                     " More than one field is configured as {}",
                 duplicatedFieldNames);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
@@ -9,14 +9,13 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 
-public interface InferenceConfigUpdate extends NamedXContentObject, NamedWriteable {
+public interface InferenceConfigUpdate extends NamedWriteable {
     Set<String> RESERVED_ML_FIELD_NAMES = new HashSet<>(Arrays.asList(
         WarningInferenceResults.WARNING.getPreferredName(),
         TrainedModelConfig.MODEL_ID.getPreferredName()));
@@ -35,6 +34,10 @@ public interface InferenceConfigUpdate extends NamedXContentObject, NamedWriteab
     }
 
     Builder<? extends Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder();
+
+    default String getName() {
+        return getWriteableName();
+    }
 
     static void checkFieldUniqueness(String... fieldNames) {
         Set<String> duplicatedFieldNames = new HashSet<>();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -21,9 +22,9 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig.NUM_TOP_FEATURE_IMPORTANCE_VALUES;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig.RESULTS_FIELD;
 
-public class RegressionConfigUpdate implements InferenceConfigUpdate {
+public class RegressionConfigUpdate implements InferenceConfigUpdate, NamedXContentObject {
 
-    public static final ParseField NAME = new ParseField("regression");
+    public static final ParseField NAME = RegressionConfig.NAME;
 
     public static RegressionConfigUpdate EMPTY_PARAMS = new RegressionConfigUpdate(null, null);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdate.java
@@ -6,20 +6,12 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig.RESULTS_FIELD;
 
 /**
  * A config update that sets the results field only.
@@ -27,18 +19,7 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionC
  */
 public class ResultsFieldUpdate implements InferenceConfigUpdate {
 
-    public static final ParseField NAME = new ParseField("field_update");
-
-    private static final ConstructingObjectParser<ResultsFieldUpdate, Void> PARSER =
-        new ConstructingObjectParser<>(NAME.getPreferredName(), args -> new ResultsFieldUpdate((String) args[0]));
-
-    static {
-        PARSER.declareString(constructorArg(), RESULTS_FIELD);
-    }
-
-    public static ResultsFieldUpdate fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
+    public static final String NAME = "field_update";
 
     private final String resultsField;
 
@@ -86,25 +67,12 @@ public class ResultsFieldUpdate implements InferenceConfigUpdate {
 
     @Override
     public String getWriteableName() {
-        return NAME.getPreferredName();
+        return NAME;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(resultsField);
-    }
-
-    @Override
-    public String getName() {
-        return NAME.getPreferredName();
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        builder.startObject();
-        builder.field(RESULTS_FIELD.getPreferredName(), resultsField);
-        builder.endObject();
-        return builder;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
@@ -8,16 +8,18 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Request;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdateTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdateTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ResultsFieldUpdateTests;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
-public class InternalInferModelActionRequestTests extends AbstractBWCWireSerializationTestCase<Request> {
+public class InternalInferModelActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -46,7 +48,9 @@ public class InternalInferModelActionRequestTests extends AbstractBWCWireSeriali
 
     private static InferenceConfigUpdate randomInferenceConfigUpdate() {
         return randomFrom(RegressionConfigUpdateTests.randomRegressionConfigUpdate(),
-            ClassificationConfigUpdateTests.randomClassificationConfigUpdate());
+            ClassificationConfigUpdateTests.randomClassificationConfigUpdate(),
+            ResultsFieldUpdateTests.randomUpdate(),
+            EmptyConfigUpdateTests.testInstance());
     }
 
     private static Map<String, Object> randomMap() {
@@ -66,23 +70,4 @@ public class InternalInferModelActionRequestTests extends AbstractBWCWireSeriali
         entries.addAll(new MlInferenceNamedXContentProvider().getNamedWriteables());
         return new NamedWriteableRegistry(entries);
     }
-
-    @Override
-    protected Request mutateInstanceForVersion(Request instance, Version version) {
-        if (version.before(Version.V_7_8_0)) {
-            InferenceConfigUpdate update = null;
-            if (instance.getUpdate() instanceof ClassificationConfigUpdate) {
-                update = ClassificationConfigUpdate.fromConfig((ClassificationConfig) instance.getUpdate().toConfig());
-            }
-            else if (instance.getUpdate() instanceof RegressionConfigUpdate) {
-                update = RegressionConfigUpdate.fromConfig((RegressionConfig) instance.getUpdate().toConfig());
-            }
-            else {
-                fail("unknown update type " + instance.getUpdate().getName());
-            }
-            return new Request(instance.getModelId(), instance.getObjectsToInfer(), update, instance.isPreviouslyLicensed());
-        }
-        return instance;
-    }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Request;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ResultsFieldUpdateTests;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
@@ -5,9 +5,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Request;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdateTests;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
-public class InternalInferModelActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+public class InternalInferModelActionRequestTests extends AbstractBWCWireSerializationTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -64,5 +65,10 @@ public class InternalInferModelActionRequestTests extends AbstractWireSerializin
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.addAll(new MlInferenceNamedXContentProvider().getNamedWriteables());
         return new NamedWriteableRegistry(entries);
+    }
+
+    @Override
+    protected Request mutateInstanceForVersion(Request instance, Version version) {
+        return instance;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdateTests.java
@@ -80,7 +80,7 @@ public class ClassificationConfigUpdateTests extends AbstractBWCSerializationTes
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
             () -> new ClassificationConfigUpdate(5, "foo", "foo", 1, PredictionFieldType.BOOLEAN));
 
-        assertEquals("Cannot apply inference config. More than one field is configured as [foo]", e.getMessage());
+        assertEquals("Invalid inference config. More than one field is configured as [foo]", e.getMessage());
     }
 
     public void testDuplicateWithResultsField() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class EmptyConfigUpdateTests extends AbstractSerializingTestCase<EmptyConfigUpdate> {
+    @Override
+    protected EmptyConfigUpdate doParseInstance(XContentParser parser) throws IOException {
+        return EmptyConfigUpdate.fromXContent(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<EmptyConfigUpdate> instanceReader() {
+        return EmptyConfigUpdate::new;
+    }
+
+    @Override
+    protected EmptyConfigUpdate createTestInstance() {
+        return new EmptyConfigUpdate();
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
@@ -7,15 +7,12 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
-import java.io.IOException;
+public class EmptyConfigUpdateTests extends AbstractWireSerializingTestCase<EmptyConfigUpdate> {
 
-public class EmptyConfigUpdateTests extends AbstractSerializingTestCase<EmptyConfigUpdate> {
-    @Override
-    protected EmptyConfigUpdate doParseInstance(XContentParser parser) throws IOException {
-        return EmptyConfigUpdate.fromXContent(parser);
+    public static EmptyConfigUpdate testInstance() {
+        return new EmptyConfigUpdate();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/EmptyConfigUpdateTests.java
@@ -27,4 +27,8 @@ public class EmptyConfigUpdateTests extends AbstractSerializingTestCase<EmptyCon
     protected EmptyConfigUpdate createTestInstance() {
         return new EmptyConfigUpdate();
     }
+
+    public void testToConfig() {
+        expectThrows(UnsupportedOperationException.class, () -> new EmptyConfigUpdate().toConfig());
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdateTests.java
@@ -65,7 +65,7 @@ public class RegressionConfigUpdateTests extends AbstractBWCSerializationTestCas
     public void testInvalidResultFieldNotUnique() {
         ElasticsearchStatusException e =
             expectThrows(ElasticsearchStatusException.class, () -> new RegressionConfigUpdate("warning", 0));
-        assertEquals("Cannot apply inference config. More than one field is configured as [warning]", e.getMessage());
+        assertEquals("Invalid inference config. More than one field is configured as [warning]", e.getMessage());
     }
 
     public void testNewBuilder() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ResultsFieldUpdateTests.java
@@ -7,19 +7,15 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
-
-import java.io.IOException;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 
-public class ResultsFieldUpdateTests extends AbstractSerializingTestCase<ResultsFieldUpdate> {
+public class ResultsFieldUpdateTests extends AbstractWireSerializingTestCase<ResultsFieldUpdate> {
 
-    @Override
-    protected ResultsFieldUpdate doParseInstance(XContentParser parser) throws IOException {
-        return ResultsFieldUpdate.fromXContent(parser);
+    public static ResultsFieldUpdate randomUpdate() {
+        return new ResultsFieldUpdate(randomAlphaOfLength(4));
     }
 
     @Override
@@ -29,7 +25,7 @@ public class ResultsFieldUpdateTests extends AbstractSerializingTestCase<Results
 
     @Override
     protected ResultsFieldUpdate createTestInstance() {
-        return new ResultsFieldUpdate(randomAlphaOfLength(4));
+        return randomUpdate();
     }
 
     public void testIsSupported() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -30,6 +30,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
@@ -40,6 +41,7 @@ import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
 import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -289,8 +291,17 @@ public class InferenceProcessor extends AbstractProcessor {
                     LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, FIELD_MAPPINGS, FIELD_MAP);
                 }
             }
-            InferenceConfigUpdate inferenceConfig =
-                inferenceConfigFromMap(ConfigurationUtils.readMap(TYPE, tag, config, INFERENCE_CONFIG));
+            if (fieldMap == null) {
+                fieldMap = Collections.emptyMap();
+            }
+
+            InferenceConfigUpdate inferenceConfig;
+            Map<String, Object> inferenceConfigMap = ConfigurationUtils.readOptionalMap(TYPE, tag, config, INFERENCE_CONFIG);
+            if (inferenceConfigMap == null) {
+                inferenceConfig = new EmptyConfigUpdate();
+            } else {
+                inferenceConfig = inferenceConfigFromMap(inferenceConfigMap);
+            }
 
             return new InferenceProcessor(client,
                 auditor,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -227,6 +227,22 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             equalTo("Configuration [classification] requires minimum node version [7.6.0] (current minimum node version [7.5.0]"));
     }
 
+    public void testCreateProcessorWithEmptyConfigNotSupportedOnOldNode() throws IOException {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
+            clusterService,
+            Settings.EMPTY);
+        processorFactory.accept(builderClusterStateWithModelReferences(Version.V_7_5_0, "model1"));
+
+        Map<String, Object> minimalConfig = new HashMap<>() {{
+            put(InferenceProcessor.MODEL_ID, "my_model");
+            put(InferenceProcessor.TARGET_FIELD, "result");
+        }};
+
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class,
+            () -> processorFactory.create(Collections.emptyMap(), "my_inference_processor", null, minimalConfig));
+        assertThat(ex.getMessage(), equalTo("[inference_config] required property is missing"));
+    }
+
     public void testCreateProcessor() {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -292,7 +292,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
 
         Exception ex = expectThrows(Exception.class, () ->
             processorFactory.create(Collections.emptyMap(), "my_inference_processor", null, regression));
-        assertThat(ex.getMessage(), equalTo("Cannot create processor as configured. " +
+        assertThat(ex.getMessage(), equalTo("Invalid inference config. " +
             "More than one field is configured as [warning]"));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
@@ -67,8 +66,6 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                 ClusterService.USER_DEFINED_METADATA,
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING)));
         clusterService = new ClusterService(settings, clusterSettings, tp);
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
     }
 
     public void testNumInferenceProcessors() throws Exception {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_processor.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_processor.yml
@@ -68,22 +68,6 @@ setup:
               }
             ]
           }
-  - do:
-      catch: /\[inference_config\] required property is missing/
-      ingest.put_pipeline:
-        id: "regression-model-pipeline"
-        body:  >
-          {
-            "processors": [
-              {
-                "inference" : {
-                  "model_id" : "a-perfect-regression-model",
-                  "target_field": "regression_field",
-                  "field_map": {}
-                }
-              }
-            ]
-          }
 ---
 "Test create processor with deprecated fields":
   - skip:
@@ -124,7 +108,6 @@ setup:
               {
                 "inference" : {
                   "model_id" : "a-perfect-regression-model",
-                  "inference_config": {"regression": {}},
                   "target_field": "regression_field",
                   "field_map": {}
                 }
@@ -144,8 +127,7 @@ setup:
                 "inference" : {
                   "model_id" : "a-perfect-regression-model",
                   "inference_config": {"regression": {"results_field": "value"}},
-                  "target_field": "regression_field",
-                  "field_map": {}
+                  "target_field": "regression_field"
                 }
               }
             ]},


### PR DESCRIPTION
Drop the requirement that the inference ingest processor has a `field_map` and `inference_config` defined even if they are empty. 

The model defaults are usually sufficient meaning that often an empty `inference_config` was added just to satisfy a validation step.

Now the following is valid configuration despite the fact the `field_map` and `inference_config` settings are not present. 
```
{
  "inference": {
    "model_id": "flight_delay_regression-1571767128603",
    "target_field": "FlightDelayMin_prediction_infer"
  }
}
```