### PR TITLE
Upgrade Gradle docker-compose plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   api "org.elasticsearch:jna:5.5.0"
   api 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
   api 'de.thetaphi:forbiddenapis:3.0'
-  api 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
+  api 'com.avast.gradle:gradle-docker-compose-plugin:0.12.1'
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'
   compileOnly "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"


### PR DESCRIPTION
We are on a quite old version of the docker-compose Gradle plugin from nearly two years ago. Newer releases include compatibility and deprecation fixes for later Gradle versions and also addresses a [recent issue](58795) with service port information missing at execution time.

Closes #58795