### PR TITLE
Drop rewriting in date_histogram (backport of #57836)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -479,30 +479,6 @@ public final class DateFieldMapper extends FieldMapper {
                 }
             }
 
-            return isFieldWithinRange(reader, fromInclusive, toInclusive);
-        }
-
-        /**
-         * Return whether all values of the given {@link IndexReader} are within the range,
-         * outside the range or cross the range. Unlike {@link #isFieldWithinQuery} this
-         * accepts values that are out of the range of the {@link #resolution} of this field.
-         * @param fromInclusive start date, inclusive
-         * @param toInclusive end date, inclusive
-         */
-        public Relation isFieldWithinRange(IndexReader reader, Instant fromInclusive, Instant toInclusive)
-                throws IOException {
-            return isFieldWithinRange(reader,
-                    resolution.convert(resolution.clampToValidRange(fromInclusive)),
-                    resolution.convert(resolution.clampToValidRange(toInclusive)));
-        }
-
-        /**
-         * Return whether all values of the given {@link IndexReader} are within the range,
-         * outside the range or cross the range.
-         * @param fromInclusive start date, inclusive, {@link Resolution#convert(Instant) converted} to the appropriate scale
-         * @param toInclusive end date, inclusive, {@link Resolution#convert(Instant) converted} to the appropriate scale
-         */
-        private Relation isFieldWithinRange(IndexReader reader, long fromInclusive, long toInclusive) throws IOException {
             if (PointValues.size(reader, name()) == 0) {
                 // no points, so nothing matches
                 return Relation.DISJOINT;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
@@ -54,20 +54,26 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
     private final long minDocCount;
     private final ExtendedBounds extendedBounds;
     private final Rounding rounding;
-    private final Rounding shardRounding;
 
-    public DateHistogramAggregatorFactory(String name, ValuesSourceConfig config,
-            BucketOrder order, boolean keyed, long minDocCount,
-            Rounding rounding, Rounding shardRounding, ExtendedBounds extendedBounds, QueryShardContext queryShardContext,
-            AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
-            Map<String, Object> metadata) throws IOException {
+    public DateHistogramAggregatorFactory(
+        String name,
+        ValuesSourceConfig config,
+        BucketOrder order,
+        boolean keyed,
+        long minDocCount,
+        Rounding rounding,
+        ExtendedBounds extendedBounds,
+        QueryShardContext queryShardContext,
+        AggregatorFactory parent,
+        AggregatorFactories.Builder subFactoriesBuilder,
+        Map<String, Object> metadata
+    ) throws IOException {
         super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
         this.order = order;
         this.keyed = keyed;
         this.minDocCount = minDocCount;
         this.extendedBounds = extendedBounds;
         this.rounding = rounding;
-        this.shardRounding = shardRounding;
     }
 
     public long minDocCount() {
@@ -89,7 +95,7 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
         // TODO: Is there a reason not to get the prepared rounding in the supplier itself?
         Rounding.Prepared preparedRounding = config.getValuesSource()
             .roundingPreparer(queryShardContext.getIndexReader())
-            .apply(shardRounding);
+            .apply(rounding);
         return ((DateHistogramAggregationSupplier) aggregatorSupplier).build(
             name,
             factories,

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -75,7 +75,6 @@ public class DateFieldTypeTests extends FieldTypeTestCase<DateFieldType> {
         DateFieldType ft = new DateFieldType("my_date");
         assertEquals(Relation.DISJOINT, ft.isFieldWithinQuery(reader, "2015-10-12", "2016-04-03",
                 randomBoolean(), randomBoolean(), null, null, context));
-        assertEquals(Relation.DISJOINT, ft.isFieldWithinRange(reader, instant("2015-10-12"), instant("2016-04-03")));
     }
 
     public void testIsFieldWithinQueryDateMillis() throws IOException {
@@ -109,49 +108,11 @@ public class DateFieldTypeTests extends FieldTypeTestCase<DateFieldType> {
         doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, alternateFormat);
 
         QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinRange(reader, instant("2015-10-09"), instant("2016-01-02")));
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinRange(reader, instant("2016-01-02"), instant("2016-06-20")));
-        assertEquals(Relation.INTERSECTS, ft.isFieldWithinRange(reader, instant("2016-01-02"), instant("2016-02-12")));
-        assertEquals(Relation.DISJOINT, ft.isFieldWithinRange(reader, instant("2014-01-02"), instant("2015-02-12")));
-        assertEquals(Relation.DISJOINT, ft.isFieldWithinRange(reader, instant("2016-05-11"), instant("2016-08-30")));
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, instant("2015-09-25"), instant("2016-05-29")));
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, instant("2015-10-12"), instant("2016-04-03")));
-        assertEquals(Relation.INTERSECTS,
-                ft.isFieldWithinRange(reader, instant("2015-10-12").plusMillis(1), instant("2016-04-03").minusMillis(1)));
-        assertEquals(Relation.INTERSECTS,
-                ft.isFieldWithinRange(reader, instant("2015-10-12").plusMillis(1), instant("2016-04-03")));
-        assertEquals(Relation.INTERSECTS,
-                ft.isFieldWithinRange(reader, instant("2015-10-12"), instant("2016-04-03").minusMillis(1)));
-        assertEquals(Relation.INTERSECTS,
-                ft.isFieldWithinRange(reader, instant("2015-10-12").plusNanos(1), instant("2016-04-03").minusNanos(1)));
-        assertEquals(ft.resolution() == Resolution.NANOSECONDS ? Relation.INTERSECTS : Relation.WITHIN, // Millis round down here.
-                ft.isFieldWithinRange(reader, instant("2015-10-12").plusNanos(1), instant("2016-04-03")));
-        assertEquals(Relation.INTERSECTS,
-                ft.isFieldWithinRange(reader, instant("2015-10-12"), instant("2016-04-03").minusNanos(1)));
-
-        // Some edge cases
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, Instant.EPOCH, instant("2016-04-03")));
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, Instant.ofEpochMilli(-1000), instant("2016-04-03")));
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, Instant.ofEpochMilli(Long.MIN_VALUE), instant("2016-04-03")));
-        assertEquals(Relation.WITHIN, ft.isFieldWithinRange(reader, instant("2015-10-12"), Instant.ofEpochMilli(Long.MAX_VALUE)));
 
         // Fields with no value indexed.
         DateFieldType ft2 = new DateFieldType("my_date2");
 
         assertEquals(Relation.DISJOINT, ft2.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02", false, false, null, null, context));
-        assertEquals(Relation.DISJOINT, ft2.isFieldWithinRange(reader, instant("2015-10-09"), instant("2016-01-02")));
-
-        // Fire a bunch of random values into isFieldWithinRange to make sure it doesn't crash
-        for (int iter = 0; iter < 1000; iter++) {
-            long min = randomLong();
-            long max = randomLong();
-            if (min > max) {
-                long swap = max;
-                max = min;
-                min = swap;
-            }
-            ft.isFieldWithinRange(reader, Instant.ofEpochMilli(min), Instant.ofEpochMilli(max));
-        }
 
         IOUtils.close(reader, w, dir);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramTests.java
@@ -19,24 +19,9 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.store.Directory;
-import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.DateFormatters;
-import org.elasticsearch.common.time.DateUtils;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.BucketOrder;
 
-import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -129,99 +114,4 @@ public class DateHistogramTests extends BaseAggregationTestCase<DateHistogramAgg
         return orders;
     }
 
-    private static Document documentForDate(String field, long millis) {
-        Document doc = new Document();
-        final long value;
-        switch (field) {
-            case DATE_FIELD_NAME:
-                value = millis;
-                break;
-
-            case DATE_NANOS_FIELD_NAME:
-                value = DateUtils.toNanoSeconds(millis);
-                break;
-            default:
-                throw new AssertionError();
-        }
-        doc.add(new LongPoint(field, value));
-        doc.add(new SortedNumericDocValuesField(field, value));
-        return doc;
-    }
-
-    public void testRewriteTimeZone() throws IOException {
-        DateFormatter format = DateFormatter.forPattern("strict_date_optional_time");
-        for (String fieldName : new String[]{DATE_FIELD_NAME, DATE_NANOS_FIELD_NAME}) {
-            try (Directory dir = newDirectory();
-                 IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
-
-                long millis1 = DateFormatters.from(format.parse("2018-03-11T11:55:00")).toInstant().toEpochMilli();
-                w.addDocument(documentForDate(fieldName, millis1));
-                long millis2 = DateFormatters.from(format.parse("2017-10-30T18:13:00")).toInstant().toEpochMilli();
-                w.addDocument(documentForDate(fieldName, millis2));
-
-                try (IndexReader readerThatDoesntCross = DirectoryReader.open(w)) {
-
-                    long millis3 = DateFormatters.from(format.parse("2018-03-25T02:44:00")).toInstant().toEpochMilli();
-                    w.addDocument(documentForDate(fieldName, millis3));
-
-                    try (IndexReader readerThatCrosses = DirectoryReader.open(w)) {
-
-                        QueryShardContext shardContextThatDoesntCross = createShardContext(new IndexSearcher(readerThatDoesntCross));
-                        QueryShardContext shardContextThatCrosses = createShardContext(new IndexSearcher(readerThatCrosses));
-
-                        DateHistogramAggregationBuilder builder = new DateHistogramAggregationBuilder("my_date_histo");
-                        builder.field(fieldName);
-                        builder.calendarInterval(DateHistogramInterval.DAY);
-
-                        // no timeZone => no rewrite
-                        assertNull(builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertNull(builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // fixed timeZone => no rewrite
-                        ZoneId tz = ZoneOffset.ofHours(1);
-                        builder.timeZone(tz);
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // timeZone without DST => always rewrite
-                        tz = ZoneId.of("Australia/Brisbane");
-                        builder.timeZone(tz);
-                        assertSame(ZoneOffset.ofHours(10), builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(ZoneOffset.ofHours(10), builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // another timeZone without DST => always rewrite
-                        tz = ZoneId.of("Asia/Katmandu");
-                        builder.timeZone(tz);
-                        assertSame(ZoneOffset.ofHoursMinutes(5, 45), builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(ZoneOffset.ofHoursMinutes(5, 45), builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // daylight-saving-times => rewrite if doesn't cross
-                        tz = ZoneId.of("Europe/Paris");
-                        builder.timeZone(tz);
-                        assertEquals(ZoneOffset.ofHours(1), builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // Rounded values are no longer all within the same transitions => no rewrite
-                        builder.calendarInterval(DateHistogramInterval.MONTH);
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        builder = new DateHistogramAggregationBuilder("my_date_histo");
-                        builder.field(fieldName);
-                        builder.timeZone(tz);
-
-                        builder.fixedInterval(new DateHistogramInterval(1000L * 60 * 60 * 24 + "ms")); // ~ 1 day
-                        assertEquals(ZoneOffset.ofHours(1), builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatCrosses));
-
-                        // Because the interval is large, rounded values are not
-                        // within the same transitions as the values => no rewrite
-                        builder.fixedInterval(new DateHistogramInterval(1000L * 60 * 60 * 24 * 30 + "ms")); // ~ 1 month
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatDoesntCross));
-                        assertSame(tz, builder.rewriteTimeZone(shardContextThatCrosses));
-                    }
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
The `date_histogram` aggregation had an optimization where it'd rewrite
`time_zones` who's offset from UTC is fixed across the entire index.
This rewrite is no longer needed after #56371 because we can tell that a
time zone is fixed lower down in the aggregation. So this removes it.
