### PR TITLE
Adjust versions for yaml test of clearing app privileges cache

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
@@ -134,7 +134,6 @@ public class NativePrivilegeStore {
     public void getPrivileges(Collection<String> applications, Collection<String> names,
                               ActionListener<Collection<ApplicationPrivilegeDescriptor>> listener) {
 
-        // TODO: We should have a way to express true Zero applications
         final Set<String> applicationNamesCacheKey = (isEmpty(applications) || applications.contains("*")) ?
             Set.of("*") : Set.copyOf(applications);
 
@@ -142,7 +141,7 @@ public class NativePrivilegeStore {
         // This serves as a negative lookup, i.e. when a passed-in non-wildcard application does not exist.
         Set<String> concreteApplicationNames = applicationNamesCache == null ? null : applicationNamesCache.get(applicationNamesCacheKey);
 
-        if (concreteApplicationNames != null && concreteApplicationNames.size() == 0) {
+        if (concreteApplicationNames != null && concreteApplicationNames.isEmpty()) {
             logger.debug("returning empty application privileges for [{}] as application names result in empty list",
                 applicationNamesCacheKey);
             listener.onResponse(Collections.emptySet());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
@@ -328,8 +328,8 @@ teardown:
 ---
 "Test clear privileges cache":
   - skip:
-      version: " - 7.99.99"
-      reason:  "backport pending https://github.com/elastic/elasticsearch/pull/55836"
+      version: " - 7.8.99"
+      reason:  "application privileges cache is available since 7.9.0"
 
   - do:
       security.clear_cached_privileges:


### PR DESCRIPTION
The version needs to be adjusted to v7.9.0 after backport #58798