### PR TITLE
Remove misc dependency related deprecation warnings

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -37,8 +37,8 @@ dependencies {
   api "org.openjdk.jmh:jmh-core:$versions.jmh"
   annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$versions.jmh"
   // Dependencies of JMH
-  runtime 'net.sf.jopt-simple:jopt-simple:4.6'
-  runtime 'org.apache.commons:commons-math3:3.2'
+  runtimeOnly 'net.sf.jopt-simple:jopt-simple:4.6'
+  runtimeOnly 'org.apache.commons:commons-math3:3.2'
 }
 
 // enable the JMH's BenchmarkProcessor to generate the final benchmark classes

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -280,14 +280,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 compilerArgs.add(targetCompatibilityVersion.getMajorVersion());
             });
         });
-
-        project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", plugin -> {
-            // Ensure that when we are compiling against the "original" JAR that we also include any "shadow" dependencies on the compile
-            // classpath
-            Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
-            Configuration apiConfig = project.getConfigurations().getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME);
-            shadowConfig.getDependencies().all(dependency -> apiConfig.getDependencies().add(dependency));
-        });
     }
 
     /**

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -83,8 +83,8 @@ sourceSets {
 }
 
 dependencies {
-  docCompile project(':server')
-  docCompile project(':modules:lang-painless')
+  docImplementation project(':server')
+  docImplementation project(':modules:lang-painless')
 }
 
 testClusters {

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -70,7 +70,7 @@ dependencies {
   // Set the keytab files in the classpath so that we can access them from test code without the security manager
   // freaking out.
   if (isEclipse == false) {
-    testRuntime files(project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab").parent)
+    testRuntimeOnly files(project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab").parent)
   }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -45,11 +45,11 @@ if (!isEclipse) {
   }
 
   configurations {
-    java12Compile.extendsFrom(compile)
+    java12Api.extendsFrom(api)
   }
 
   dependencies {
-    java12Compile sourceSets.main.output
+    java12Api sourceSets.main.output
   }
 
   compileJava12Java {
@@ -128,7 +128,7 @@ dependencies {
   api "co.elastic.logging:ecs-logging-core:${versions.ecsLogging}"
 
   if (!isEclipse) {
-    java12Compile sourceSets.main.output
+    java12Api sourceSets.main.output
   }
 
   testImplementation(project(":test:framework")) {

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   }
   api project(':libs:elasticsearch-core')
   api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
-  runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  runtimeOnly "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   testImplementation project(":test:framework")
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -44,7 +44,7 @@ subprojects {
         }
         testImplementation project(":test:framework")
 
-        testRuntime project(path: xpackModule('sql:jdbc'))
+        testRuntimeOnly project(path: xpackModule('sql:jdbc'))
     }
 
     if (project.name != 'security') {

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   api "org.jline:jline-reader:${jlineVersion}"
   api "org.jline:jline-style:${jlineVersion}"
 
-  testRuntime "org.elasticsearch:jna:${versions.jna}"
+  testRuntimeOnly "org.elasticsearch:jna:${versions.jna}"
 }
 
 /* disable unit tests because these are all integration tests used
@@ -55,7 +55,7 @@ subprojects {
     configurations.testRuntimeClasspath {
       resolutionStrategy.force "org.slf4j:slf4j-api:1.7.25"
     }
-    configurations.testRuntime {
+    configurations.testRuntimeOnly {
       // This is also required to make resolveAllDependencies work
       resolutionStrategy.force "org.slf4j:slf4j-api:1.7.25"
     }
@@ -70,35 +70,35 @@ subprojects {
     testImplementation project(":test:framework")
 
     // JDBC testing dependencies
-    testRuntime "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"
-    testRuntime "com.h2database:h2:${h2Version}"
+    testRuntimeOnly "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"
+    testRuntimeOnly "com.h2database:h2:${h2Version}"
 
     // H2GIS testing dependencies
-    testRuntime("org.orbisgis:h2gis:${h2gisVersion}") {
+    testRuntimeOnly("org.orbisgis:h2gis:${h2gisVersion}") {
       exclude group: "org.locationtech.jts"
       exclude group: "com.fasterxml.jackson.core"
     }
 
-    testRuntime project(path: xpackModule('sql:jdbc'))
-    testRuntime xpackProject('plugin:sql:sql-client')
+    testRuntimeOnly project(path: xpackModule('sql:jdbc'))
+    testRuntimeOnly xpackProject('plugin:sql:sql-client')
 
     // CLI testing dependencies
-    testRuntime project(path: xpackModule('sql:sql-cli'))
-    testRuntime(xpackProject('plugin:sql:sql-action')) {
+    testRuntimeOnly project(path: xpackModule('sql:sql-cli'))
+    testRuntimeOnly(xpackProject('plugin:sql:sql-action')) {
       transitive = false
     }
 
-    testRuntime("org.jline:jline-terminal-jna:${jlineVersion}") {
+    testRuntimeOnly("org.jline:jline-terminal-jna:${jlineVersion}") {
       exclude group: "net.java.dev.jna"
     }
-    testRuntime "org.jline:jline-terminal:${jlineVersion}"
-    testRuntime "org.jline:jline-reader:${jlineVersion}"
-    testRuntime "org.jline:jline-style:${jlineVersion}"
+    testRuntimeOnly "org.jline:jline-terminal:${jlineVersion}"
+    testRuntimeOnly "org.jline:jline-reader:${jlineVersion}"
+    testRuntimeOnly "org.jline:jline-style:${jlineVersion}"
 
-    testRuntime "org.elasticsearch:jna:${versions.jna}"
+    testRuntimeOnly "org.elasticsearch:jna:${versions.jna}"
 
     // spatial dependency
-    testRuntime project(path: xpackModule('spatial'))
+    testRuntimeOnly project(path: xpackModule('spatial'))
   }
 
   if (project.name != 'security') {

--- a/x-pack/plugin/sql/sql-action/build.gradle
+++ b/x-pack/plugin/sql/sql-action/build.gradle
@@ -21,9 +21,9 @@ dependencies {
   api xpackProject('plugin:sql:sql-proto')
   api "org.apache.lucene:lucene-core:${versions.lucene}"
   api "joda-time:joda-time:${versions.joda}"
-  runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  runtime "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-  runtime "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+  runtimeOnly "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  runtimeOnly "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+  runtimeOnly "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
   testImplementation project(":test:framework")
 }

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   api xpackProject('plugin:sql:sql-action')
   api project(":libs:elasticsearch-cli")
   api project(':libs:elasticsearch-x-content')
-  runtime "org.elasticsearch:jna:${versions.jna}"
+  runtimeOnly "org.elasticsearch:jna:${versions.jna}"
   testImplementation project(":test:framework")
 }
 

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   api( project(':libs:elasticsearch-x-content')) {
     transitive = false
   }
-  runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  runtimeOnly "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
 
   testImplementation project(":test:framework")
 }

--- a/x-pack/plugin/stack/qa/rest/build.gradle
+++ b/x-pack/plugin/stack/qa/rest/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation project(path: xpackModule('stack'), configuration: 'runtime')
+  testImplementation project(xpackModule('stack'))
 }
 
 restResources {


### PR DESCRIPTION
Removes dependency related deprecation warnings.
This should give us a deprecation free precommit build now

- replace x-runtime configuration usage by runtimeOnly usage
- replace x-compile configuration usage by x-implementation or x-api usage
- remove explicit runtime config reference in project dependency declaration to use gradles default variant aware dependency handling

Related to #57920