### PR TITLE
Remove deprecated AbstractArchiveTask Gradle API usages (7.8 backport)

### DIFF
--- a/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 ["0.0.1", "0.0.2"].forEach { v ->
   ["elasticsearch", "other"].forEach { p ->
     tasks.register("dummy-${p}-${v}", Jar) {
-      destinationDir = file("${buildDir}/testrepo/org/${p}/gradle/dummy-io/${v}/")
+      destinationDirectory = file("${buildDir}/testrepo/org/${p}/gradle/dummy-io/${v}/")
       archiveFileName = "dummy-io-${v}.jar"
       from sourceSets.main.output
       include "**/TestingIO.class"

--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -147,7 +147,7 @@ tasks.register('buildOssNoJdkWindowsZip', Zip) {
 }
 
 Closure commonTarConfig = {
-  extension = 'tar.gz'
+  archiveExtension = 'tar.gz'
   compression = Compression.GZIP
   dirMode 0755
   fileMode 0644

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -124,10 +124,10 @@ Closure commonPackageConfig(String type, boolean oss, boolean jdk, String archit
     // Follow elasticsearch's file naming convention
     String jdkString = jdk ? "" : "no-jdk-"
     String prefix = "${architecture == 'aarch64' ? 'aarch64-' : ''}${oss ? 'oss-' : ''}${jdk ? '' : 'no-jdk-'}${type}"
-    destinationDir = file("${prefix}/build/distributions")
+    destinationDirectory = file("${prefix}/build/distributions")
 
     // SystemPackagingTask overrides default archive task convention mappings, but doesn't provide a setter so we have to override the convention mapping itself
-    conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDir}/${packageName}-${project.version}-${jdkString}${archString}.${type}")) }
+    conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}-${jdkString}${archString}.${type}")) }
 
     String packagingFiles = "build/packaging/${oss ? 'oss-' : ''}${jdk ? '' : 'no-jdk-'}${type}"
 
@@ -333,7 +333,7 @@ Closure commonDebConfig(boolean oss, boolean jdk, String architecture) {
       customFields['License'] = 'Elastic-License'
     }
 
-    version = project.version.replace('-', '~')
+    archiveVersion = project.version.replace('-', '~')
     packageGroup 'web'
 
     // versions found on oldest supported distro, centos-6

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -68,7 +68,7 @@ task apiJavadoc(type: Javadoc) {
 }
 
 task apiJavadocJar(type: Jar) {
-  classifier = 'apiJavadoc'
+  archiveClassifier = 'apiJavadoc'
   from apiJavadoc
 }
 


### PR DESCRIPTION
backports #58657 to 7.8 branch