### PR TITLE
reduce the number of executions

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -547,6 +547,9 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                             highIdx = relevantNodes - 1;
                             continue;
                         }
+                    } else {
+                        highIdx--;
+                        continue;
                     }
                     if (lowIdx < highIdx - 1) {
                         /* Shrinking the window from MIN to MAX


### PR DESCRIPTION
int lowIdx = 0;
int highIdx = 99;
if (maxNode.numShards(index) == 0)
At this time, lowIdx will increase 98 times, which is invalid.
Because when lowIdx increases, highIdx will not change, and maxNode.numShards(index) is equal to 0.