### PR TITLE
Default gateway.auto_import_dangling_indices to false

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
@@ -314,11 +315,15 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
     public void testAllMasterEligibleNodesFailedDanglingIndexImport() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
+        Settings settings = Settings.builder()
+            .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+            .build();
+
         logger.info("--> start mixed data and master-eligible node and bootstrap cluster");
-        String masterNode = internalCluster().startNode(); // node ordinal 0
+        String masterNode = internalCluster().startNode(settings); // node ordinal 0
 
         logger.info("--> start data-only node and ensure 2 nodes stable cluster");
-        String dataNode = internalCluster().startDataOnlyNode(); // node ordinal 1
+        String dataNode = internalCluster().startDataOnlyNode(settings); // node ordinal 1
         ensureStableCluster(2);
 
         logger.info("--> index 1 doc and ensure index is green");
@@ -332,11 +337,18 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(true));
 
         logger.info("--> stop data-only node and detach it from the old cluster");
-        Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
+        Settings dataNodeDataPathSettings = Settings.builder()
+            .put(internalCluster().dataPathSettings(dataNode), true)
+            .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+            .build();
         assertBusy(() -> internalCluster().getInstance(GatewayMetaState.class, dataNode).allPendingAsyncStatesWritten());
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(dataNode));
         final Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataNodeDataPathSettings).build());
+            Settings.builder()
+                .put(internalCluster().getDefaultSettings())
+                .put(dataNodeDataPathSettings)
+                .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+                .build());
         detachCluster(environment, false);
 
         logger.info("--> stop master-eligible node, clear its data and start it again - new cluster should form");

--- a/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -63,7 +63,7 @@ public class DanglingIndicesState implements ClusterStateListener {
      */
     public static final Setting<Boolean> AUTO_IMPORT_DANGLING_INDICES_SETTING = Setting.boolSetting(
         "gateway.auto_import_dangling_indices",
-        true,
+        false,
         Setting.Property.NodeScope,
         Setting.Property.Deprecated
     );


### PR DESCRIPTION
Part of #48366. Now that there is a dedicated API for dangling indices,
the auto-import behaviour can default to off.

Docs will be updated in #58751.