### PR TITLE
Percolator keyword fields should not store norms

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -400,6 +400,7 @@ public class PercolatorFieldMapper extends FieldMapper {
     private static final FieldType INDEXED_KEYWORD = new FieldType();
     static {
         INDEXED_KEYWORD.setTokenized(false);
+        INDEXED_KEYWORD.setOmitNorms(true);
         INDEXED_KEYWORD.setIndexOptions(IndexOptions.DOCS);
         INDEXED_KEYWORD.freeze();
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -645,7 +645,9 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject().endObject()),
                         XContentType.JSON));
         assertThat(doc.rootDoc().getFields().size(), equalTo(12)); // also includes all other meta fields
-        BytesRef queryBuilderAsBytes = doc.rootDoc().getField("object_field.query_field.query_builder_field").binaryValue();
+        IndexableField queryBuilderField = doc.rootDoc().getField("object_field.query_field.query_builder_field");
+        assertTrue(queryBuilderField.fieldType().omitNorms());
+        BytesRef queryBuilderAsBytes = queryBuilderField.binaryValue();
         assertQueryBuilder(queryBuilderAsBytes, queryBuilder);
 
         doc = mapperService.documentMapper().parse(new SourceToParse("test", "1",

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -647,6 +647,8 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.rootDoc().getFields().size(), equalTo(12)); // also includes all other meta fields
         IndexableField queryBuilderField = doc.rootDoc().getField("object_field.query_field.query_builder_field");
         assertTrue(queryBuilderField.fieldType().omitNorms());
+        IndexableField extractionResultField = doc.rootDoc().getField("object_field.query_field.extraction_result");
+        assertTrue(extractionResultField.fieldType().omitNorms());
         BytesRef queryBuilderAsBytes = queryBuilderField.binaryValue();
         assertQueryBuilder(queryBuilderAsBytes, queryBuilder);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -20,8 +20,8 @@
 package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectArrayList;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
@@ -59,6 +59,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
         static {
             FIELD_TYPE.setIndexOptions(IndexOptions.NONE);
+            FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.freeze();
         }
     }
@@ -188,7 +189,7 @@ public class BinaryFieldMapper extends FieldMapper {
             return;
         }
         if (fieldType.stored()) {
-            context.doc().add(new Field(fieldType().name(), value, fieldType));
+            context.doc().add(new StoredField(fieldType().name(), value));
         }
 
         if (fieldType().hasDocValues()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
@@ -34,6 +34,7 @@ public abstract class CustomDocValuesField implements IndexableField {
     public static final FieldType TYPE = new FieldType();
     static {
       TYPE.setDocValuesType(DocValuesType.BINARY);
+      TYPE.setOmitNorms(true);
       TYPE.freeze();
     }
 


### PR DESCRIPTION
The refactoring in #57666 inadvertently enabled norms on two of the percolator subfields,
leading to an increase in memory usage.  This commit disables norms on these fields again.