### PR TITLE
Mute FsSearchableSnapshotsIT testClearCache

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -170,6 +170,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58901")
     public void testClearCache() throws Exception {
         @SuppressWarnings("unchecked")
         final Function<Map<?, ?>, Long> sumCachedBytesWritten = stats -> stats.values()


### PR DESCRIPTION
For #58901

I muted the test in the abstract base class which affects all implementations. I couldn't see another way.