### PR TITLE
[7.x] Data stream support for delete-by-query (#58402)

### DIFF
--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/90_data_streams.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/90_data_streams.yml
@@ -1,0 +1,71 @@
+---
+"DBQ from data stream":
+  - skip:
+      features: allowed_warnings
+      version: " - 7.99.99"
+      reason: "change to 7.8.99 after backport"
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [simple-data-stream1]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+          data_stream:
+            timestamp_field: '@timestamp'
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:   simple-data-stream1
+        id:      1
+        op_type: create
+        body:    { "text": "test" }
+
+  - do:
+      indices.refresh:
+        index: simple-data-stream1
+
+  - do:
+      delete_by_query:
+        index: simple-data-stream1
+        body:
+          query:
+            match_all: {}
+
+  - is_false: timed_out
+  - match: {deleted: 1}
+  - is_false: created
+  - is_false: updated
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {noops: 0}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+
+  - do:
+      indices.refresh:
+        index: simple-data-stream1
+
+  - do:
+      count:
+        index: .ds-simple-data-stream1-000001
+
+  - match: {count: 0}
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/96_data_streams.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/96_data_streams.yml
@@ -86,7 +86,7 @@ teardown:
   - match: { hits.hits.0._source.foo: 'bar' }
 
 ---
-"Reindex from data source into an index":
+"Reindex from data stream into an index":
   - skip:
       version: " - 7.99.99"
       reason: "change to 7.8.99 after backport"


### PR DESCRIPTION
The underlying transport actions for delete by query already supported data streams so no production code changes were required. The PR adds only a test to verify that delete by query works with data streams.

Relates to #53100

Backport of #58402 