### PR TITLE
[7.x] Data stream support for update by query API

### DIFF
--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/90_data_streams.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/90_data_streams.yml
@@ -1,0 +1,112 @@
+---
+"Update by query from data stream":
+  - skip:
+      features: allowed_warnings
+      version: " - 7.99.99"
+      reason: "change to 7.8.99 after backport"
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [simple-data-stream1]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+          data_stream:
+            timestamp_field: '@timestamp'
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:   simple-data-stream1
+        id:      1
+        op_type: create
+        body:    { "number": 4 }
+
+  # rollover data stream to create new backing index
+  - do:
+      indices.rollover:
+        alias: "simple-data-stream1"
+
+  - match: { old_index: .ds-simple-data-stream1-000001 }
+  - match: { new_index: .ds-simple-data-stream1-000002 }
+  - match: { rolled_over: true }
+  - match: { dry_run: false }
+
+  - do:
+      index:
+        index:   simple-data-stream1
+        id:      2
+        op_type: create
+        body:    { "number": 1 }
+
+  # rollover data stream to create another new backing index
+  - do:
+      indices.rollover:
+        alias: "simple-data-stream1"
+
+  - match: { old_index: .ds-simple-data-stream1-000002 }
+  - match: { new_index: .ds-simple-data-stream1-000003 }
+  - match: { rolled_over: true }
+  - match: { dry_run: false }
+
+  - do:
+      index:
+        index:   simple-data-stream1
+        id:      3
+        op_type: create
+        body:    { "number": 5 }
+
+  - do:
+      indices.refresh:
+        index: simple-data-stream1
+
+  # increment by one any numbers >= 4
+  - do:
+      update_by_query:
+        index: simple-data-stream1
+        body:
+          script:
+            source: "ctx._source.number++"
+            lang: "painless"
+          query:
+            range:
+              number:
+                - gte: 4
+
+  - match: {updated: 2}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {noops: 0}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+
+  - do:
+      indices.refresh:
+        index: simple-data-stream1
+
+  # verify that both numbers originally >= 4 have been incremented by one
+  - do:
+      search:
+        index: simple-data-stream1
+        body: { query: { range: { number: { gte: 5 } } } }
+  - length:   { hits.hits: 2  }
+  - match: { hits.hits.0._index: .ds-simple-data-stream1-000001 }
+  - match: { hits.hits.0._source.number: 5 }
+  - match: { hits.hits.1._index: .ds-simple-data-stream1-000003 }
+  - match: { hits.hits.1._source.number: 6 }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged


### PR DESCRIPTION
The underlying transport actions for update by query already supported data streams so no production code changes were required. The PR adds only a test to verify that update by query works with data streams.

Relates to #53100

Backport of #58590 
