### PR TITLE
[ML] Ensure config index mappings are up-to-date before updating configs

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDataFrameAnalyticsAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -23,8 +24,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 
@@ -39,10 +42,11 @@ public class TransportUpdateDataFrameAnalyticsAction
     private final XPackLicenseState licenseState;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final SecurityContext securityContext;
+    private final Client client;
 
     @Inject
     public TransportUpdateDataFrameAnalyticsAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
-                                                   XPackLicenseState licenseState, ThreadPool threadPool,
+                                                   XPackLicenseState licenseState, ThreadPool threadPool, Client client,
                                                    ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
                                                    DataFrameAnalyticsConfigProvider configProvider) {
         super(UpdateDataFrameAnalyticsAction.NAME, transportService, clusterService, threadPool, actionFilters,
@@ -52,6 +56,7 @@ public class TransportUpdateDataFrameAnalyticsAction
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
+        this.client = client;
     }
 
     @Override
@@ -73,17 +78,23 @@ public class TransportUpdateDataFrameAnalyticsAction
     protected void masterOperation(Task task, UpdateDataFrameAnalyticsAction.Request request, ClusterState state,
                                    ActionListener<PutDataFrameAnalyticsAction.Response> listener) {
 
-        useSecondaryAuthIfAvailable(securityContext, () -> {
-            Map<String, String> headers = threadPool.getThreadContext().getHeaders();
-            configProvider.update(
-                request.getUpdate(),
-                headers,
-                state,
-                ActionListener.wrap(
-                    updatedConfig -> listener.onResponse(new PutDataFrameAnalyticsAction.Response(updatedConfig)),
-                    listener::onFailure));
-        });
+        Runnable doUpdate = () ->
+            useSecondaryAuthIfAvailable(securityContext, () -> {
+                Map<String, String> headers = threadPool.getThreadContext().getHeaders();
+                configProvider.update(
+                    request.getUpdate(),
+                    headers,
+                    state,
+                    ActionListener.wrap(
+                        updatedConfig -> listener.onResponse(new PutDataFrameAnalyticsAction.Response(updatedConfig)),
+                        listener::onFailure));
+            });
 
+        // Obviously if we're updating a job it's impossible that the config index has no mappings at
+        // all, but if we rewrite the job config we may add new fields that require the latest mappings
+        ElasticsearchMappings.addDocMappingIfMissing(
+            MlConfigIndex.indexName(), MlConfigIndex::mapping, client, state,
+            ActionListener.wrap(bool -> doUpdate.run(), listener::onFailure));
     }
 
     @Override


### PR DESCRIPTION
We already had code to ensure the config index mappings were
up-to-date before creating a new config.  However, it's also
possible that an update to a config could add the latest
settings that require the latest mappings to index correctly.

This change checks that the latest config index mappings are
in place in the 3 update actions in the same way as the checks
are done in the 3 put actions.