### PR TITLE
Fix implicit duplicate duplicatesStrategy in processResources

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -61,10 +61,6 @@ dependencies {
   testImplementation(project(':x-pack:plugin:eql'))
 }
 
-processTestResources {
-  from(project(':client:rest-high-level').file('src/test/resources'))
-}
-
 tasks.named('forbiddenApisMain').configure {
   // core does not depend on the httpclient for compile so we add the signatures here. We don't add them for test as they are already
   // specified

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -93,6 +93,7 @@ project.ext {
          * Oss and default distribution can have different configuration, therefore we want to allow overriding the default configuration
          * by creating config files in oss or default build-context sub-modules.
          */
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
         from project.projectDir.toPath().resolve("src/docker/config")
         if (oss) {
           from project.projectDir.toPath().resolve("src/docker/config/oss")

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -65,6 +65,10 @@ ext.expansions = [
 
 processResources {
   from(sourceSets.main.resources.srcDirs) {
+    // we need to have duplicate strategy here as
+    // we cannot apply the filter on root level due
+    // to wrong behaviour with binary files.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     exclude '**/public.key'
     inputs.properties(expansions)
     MavenFilteringHack.filter(it, expansions)


### PR DESCRIPTION
This addresses gradle deprecations caused by implicit duplicate copy
strategy in processResources and processTestResources tasks

Related to #57920