### PR TITLE
Fix deprecated task input declaration in LazyPropertyMap (7.x backport)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyMap.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyMap.java
@@ -146,11 +146,13 @@ public class LazyPropertyMap<K, V> extends AbstractLazyPropertyCollection implem
             this.normalization = normalization;
         }
 
+        @Input
         public PropertyNormalization getNormalization() {
             return normalization;
         }
 
         @Override
+        @Input
         public String getName() {
             return getKey().toString();
         }


### PR DESCRIPTION
backports #58850 to 7.x branch