### PR TITLE
[DOCS] Add data streams to cluster APIs docs

### DIFF
--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -9,14 +9,15 @@ Returns the health status of a cluster.
 [[cluster-health-api-request]]
 ==== {api-request-title}
 
-`GET _cluster/health/<index>`
+`GET _cluster/health/<target>`
 
 [[cluster-health-api-desc]]
 ==== {api-description-title}
 
 The cluster health API returns a simple status on the health of the 
-cluster. The API can also be executed against one or more indices to get just 
-the specified indices health.
+cluster. You can also use the API to get the health status of only specified
+data streams and indices. For data streams, the API retrieves the health status
+of the stream's backing indices.
 
 The cluster health status is: `green`, `yellow` or `red`. On the shard level, a 
 `red` status indicates that the specific shard is not allocated in the cluster, 
@@ -39,7 +40,13 @@ GET /_cluster/health?wait_for_status=yellow&timeout=50s
 [[cluster-health-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
++
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [[cluster-health-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -9,7 +9,7 @@ Returns metadata about the state of the cluster.
 [[cluster-state-api-request]]
 ==== {api-request-title}
 
-`GET /_cluster/state/<metrics>/<index>`
+`GET /_cluster/state/<metrics>/<target>`
 
 [[cluster-state-api-desc]]
 ==== {api-description-title}
@@ -86,7 +86,13 @@ you can request only the part of the cluster state that you need:
       Shows the cluster state version.
 --
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
++
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[cluster-state-api-query-params]]
@@ -127,14 +133,14 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 ==== {api-examples-title}
 
 The following example returns only `metadata` and `routing_table` data for the
-`foo` and `bar` indices:
+`foo` and `bar` data streams or indices:
 
 [source,console]
 --------------------------------------------------
 GET /_cluster/state/metadata,routing_table/foo,bar
 --------------------------------------------------
 
-The next example returns everything for the `foo` and `bar` indices:
+The next example returns all available metadata for `foo` and `bar`:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Makes existing docs for the cluster health and cluster state APIs aware
of data streams. Relates to #56683.