### PR TITLE
Fix assertion in testCollectNodes test

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -656,6 +656,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                         assertNotNull(ex.get());
                         if (ex.get() instanceof IllegalStateException) {
                             assertThat(ex.get().getMessage(), either(equalTo("no seed node left"))
+                                .or(equalTo("Unable to open any connections to remote cluster [cluster_1]"))
                                 .or(equalTo("Unable to open any connections to remote cluster [cluster_2]")));
                         } else {
                             assertThat(ex.get(),


### PR DESCRIPTION
Currently we assert that the reason we fail collecting nodes in this
test is due to the fact that no seeds are available or no connections
could be established to cluster_2. However, the collection could fail if
we cannot establish connections to cluster_1. This commit adds that as
an acceptable assertion.

Fixes #55292.