### PR TITLE
[DOCS] Clarifies number of file and native realms

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -37,6 +37,8 @@ xpack:
           file1:
             order: 0
 ------------------------------------------------------------
+
+NOTE: You can configure only one file realm on {es} nodes.
 --
 
 . Restart {es}.

--- a/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
@@ -13,6 +13,8 @@ cache options.
 explicitly set the `order` attribute for the realm. 
 +
 --
+NOTE: You can configure only one native realm on {es} nodes.
+
 See <<ref-native-settings>> for all of the options you can set for the `native` realm.
 For example, the following snippet shows a `native` realm configuration that
 sets the `order` to zero so the realm is checked first:


### PR DESCRIPTION
The [Kerberos realm documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/kerberos-realm.html#kerberos-realm-create) contains the following note: 
You can configure only one Kerberos realm on Elasticsearch nodes.

This PR adds similar information to the matching step in the native realm and file realm documentation.

Related: https://github.com/elastic/elasticsearch/pull/58369

### Preview

https://elasticsearch_58949.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/file-realm.html
https://elasticsearch_58949.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/native-realm.html