### PR TITLE
[DOCS] Add data streams to flush API docs

### DIFF
--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Flush</titleabbrev>
 ++++
 
-Flushes one or more indices.
+Flushes one or more data streams or indices.
 
 [source,console]
 --------------------------------------------------
@@ -16,9 +16,9 @@ POST /twitter/_flush
 [[flush-api-request]]
 ==== {api-request-title}
 
-`POST /<index>/_flush`
+`POST /<target>/_flush`
 
-`GET /<index>/_flush`
+`GET /<target>/_flush`
 
 `POST /_flush`
 
@@ -28,7 +28,7 @@ POST /twitter/_flush
 [[flush-api-desc]]
 ==== {api-description-title}
 
-Flushing an index is the process of making sure that any data that is currently
+Flushing a data stream or index is the process of making sure that any data that is currently
 only stored in the <<index-modules-translog,transaction log>> is also
 permanently stored in the Lucene index. When restarting, {es} replays any
 unflushed operations from the transaction log into the Lucene index to bring it
@@ -52,11 +52,13 @@ flush API was called.
 [[flush-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases to flush.
+Wildcard expressions (`*`) are supported.
 +
-To flush all indices,
-omit this parameter
-or use a value of `_all` or `*`.
+To flush all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[flush-api-query-params]]
@@ -111,7 +113,7 @@ Defaults to `true`.
 
 
 [[flush-api-specific-ex]]
-===== Flush a specific index
+===== Flush a specific data stream or index
 
 [source,console]
 ----
@@ -121,7 +123,7 @@ POST /kimchy/_flush
 
 
 [[flush-multi-index]]
-===== Flush several indices
+===== Flush several data streams and indices
 
 [source,console]
 ----
@@ -131,7 +133,7 @@ POST /kimchy,elasticsearch/_flush
 
 
 [[flush-api-all-ex]]
-===== Flush all indices
+===== Flush all data streams and indices in a cluster
 
 [source,console]
 ----


### PR DESCRIPTION
Makes existing flush API docs aware of data streams.
Relates to #55726.