### PR TITLE
[DOCS] Add data streams to force merge API docs

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -55,8 +55,9 @@ until the ongoing force merge is complete.
 
 You can force merge multiple indices with a single request by targeting:
 
-* A data stream that contains multiple backing indices
-* Multiple specific indices
+* One or more data streams that contain multiple backing indices
+* Multiple indices
+* One or more index aliases that point to multiple indices
 * All data streams and indices in a cluster
 
 Multi-index operations are executed one shard at a
@@ -165,8 +166,9 @@ POST /_forcemerge
 [[forcemerge-api-time-based-index-ex]]
 ===== Data streams and time-based indices
 
-Force-merging is useful for a data stream's older backing indices and other time-based indices,
-particularly after a <<indices-rollover-index,rollover>>.
+Force-merging is useful for managing a data stream's older backing indices and
+other time-based indices, particularly after a
+<<indices-rollover-index,rollover>>.
 In these cases,
 each index only receives indexing traffic for a certain period of time.
 Once an index receive no more writes,

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -5,6 +5,8 @@
 ++++
 
 Forces a <<index-modules-merge,merge>> on the shards of one or more indices.
+For data streams, the API forces a merge on the shards of the stream's backing
+indices.
 
 [source,console]
 ----
@@ -16,7 +18,7 @@ POST /twitter/_forcemerge
 [[forcemerge-api-request]]
 ==== {api-request-title}
 
-`POST /<index>/_forcemerge`
+`POST /<target>/_forcemerge`
 
 `POST /_forcemerge`
 
@@ -30,12 +32,12 @@ shard by merging some of them together, and also frees up the space used by
 deleted documents. Merging normally happens automatically, but sometimes it is
 useful to trigger a merge manually.
 
-WARNING: **Force merge should only be called against an index after you have
+WARNING: **Force merge should only be called against a data stream or index after you have
 finished writing to it.** Force merge can cause very large (>5GB) segments to
-be produced, and if you continue to write to such an index then the automatic
+be produced, and if you continue to write to such a data stream or index then the automatic
 merge policy will never consider these segments for future merges until they
 mostly consist of deleted documents. This can cause very large segments to
-remain in the index which can result in increased disk usage and worse search
+remain in the index or the data stream's backing indices. This can result in increased disk usage and worse search
 performance.
 
 
@@ -51,8 +53,13 @@ until the ongoing force merge is complete.
 [[forcemerge-multi-index]]
 ===== Force merging multiple indices
 
-The force merge API can be applied to more than one index with a single call, or
-even on `_all` the indices. Multi index operations are executed one shard at a
+You can force merge multiple indices with a single request by targeting:
+
+* A data stream that contains multiple backing indices
+* Multiple specific indices
+* All data streams and indices in a cluster
+
+Multi-index operations are executed one shard at a
 time per node. Force merge makes the storage for the shard being merged
 temporarily increase, up to double its size in case `max_num_segments` parameter
 is set to `1`, as all segments need to be rewritten into a new one.
@@ -61,11 +68,13 @@ is set to `1`, as all segments need to be rewritten into a new one.
 [[forcemerge-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
 +
-To force merge all indices in the cluster,
-omit this parameter
-or use a value of `_all` or `*`.
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[forcemerge-api-query-params]]
@@ -93,7 +102,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailab
 --
 (Optional, integer)
 The number of segments to merge to.
-To fully merge the index,
+To fully merge indices,
 set it to `1`.
 
 Defaults to checking if a merge needs to execute.
@@ -125,7 +134,7 @@ NOTE: This parameter does *not* override the
 
 
 [[forcemerge-api-specific-ex]]
-===== Force merge a specific index
+===== Force merge a specific data stream or index
 
 [source,console]
 ----
@@ -135,7 +144,7 @@ POST /twitter/_forcemerge
 
 
 [[forcemerge-api-multiple-ex]]
-===== Force merge several indices
+===== Force merge several data streams or indices
 
 [source,console]
 ----
@@ -154,10 +163,10 @@ POST /_forcemerge
 
 
 [[forcemerge-api-time-based-index-ex]]
-===== Time-based indices
+===== Data streams and time-based indices
 
-Force-merging is useful for time-based indices,
-particularly when using <<indices-rollover-index,rollover>>.
+Force-merging is useful for a data stream's older backing indices and other time-based indices,
+particularly after a <<indices-rollover-index,rollover>>.
 In these cases,
 each index only receives indexing traffic for a certain period of time.
 Once an index receive no more writes,
@@ -165,10 +174,10 @@ its shards can be force-merged to a single segment.
 
 [source,console]
 --------------------------------------------------
-POST /logs-000001/_forcemerge?max_num_segments=1
+POST /.ds-logs-000001/_forcemerge?max_num_segments=1
 --------------------------------------------------
 // TEST[setup:twitter]
-// TEST[s/logs-000001/twitter/]
+// TEST[s/.ds-logs-000001/twitter/]
 
 This can be a good idea because single-segment shards can sometimes use simpler
 and more efficient data structures to perform searches.

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -32,12 +32,12 @@ shard by merging some of them together, and also frees up the space used by
 deleted documents. Merging normally happens automatically, but sometimes it is
 useful to trigger a merge manually.
 
-WARNING: **Force merge should only be called against a data stream or index after you have
+WARNING: **Force merge should only be called against an index after you have
 finished writing to it.** Force merge can cause very large (>5GB) segments to
-be produced, and if you continue to write to such a data stream or index then the automatic
+be produced, and if you continue to write to such an index then the automatic
 merge policy will never consider these segments for future merges until they
 mostly consist of deleted documents. This can cause very large segments to
-remain in the index or the data stream's backing indices. This can result in increased disk usage and worse search
+remain in the index which can result in increased disk usage and worse search
 performance.
 
 


### PR DESCRIPTION
Makes the existing force merge API docs aware
of data streams. Relates to #55726