### PR TITLE
[DOCS] Clarify subscription requirements

### DIFF
--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get trial status</titleabbrev>
 ++++
 
-This API enables you to check the status of your trial license.
+Enables you to check the status of your trial.
 
 [float]
 ==== Request
@@ -21,7 +21,7 @@ If you want to try all the subscription features, you can start a 30-day trial.
 NOTE: You are allowed to initiate a trial only if your cluster has not
 already activated a trial for the current major product version. For example, if
 you have already activated a trial for v6.0, you cannot start a new trial until
-v7.0. You can, however, contact `info@elastic.co` to request an extended trial.
+v7.0. You can, however, request an extended trial at {extendtrial}.
 
 For more information about features and subscriptions, see
 https://www.elastic.co/subscriptions.

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -16,16 +16,14 @@ This API enables you to check the status of your trial license.
 [float]
 ==== Description
 
-If you want to try the features that are included in a platinum license, you can 
-start a 30-day trial. 
+If you want to try all the subscription features, you can start a 30-day trial. 
 
-NOTE: You are allowed to initiate a trial license only if your cluster has not
-already activated a trial license for the current major product version. For
-example, if you have already activated a trial for v6.0, you cannot start a new
-trial until v7.0. You can, however, contact `info@elastic.co` to request an
-extended trial license.
+NOTE: You are allowed to initiate a trial only if your cluster has not
+already activated a trial for the current major product version. For example, if
+you have already activated a trial for v6.0, you cannot start a new trial until
+v7.0. You can, however, contact `info@elastic.co` to request an extended trial.
 
-For more information about the different types of licenses, see
+For more information about features and subscriptions, see
 https://www.elastic.co/subscriptions.
 
 ==== Authorization

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Start trial</titleabbrev>
 ++++
 
-This API starts a 30-day trial license.
+Starts a 30-day trial.
 
 [float]
 ==== Request
@@ -16,13 +16,13 @@ This API starts a 30-day trial license.
 [float]
 ==== Description
 
-The `start trial` API enables you to upgrade from Basic to a 30-day trial, which
-gives access to all subscription features.
+The `start trial` API enables you to start a 30-day trial, which gives access to
+all subscription features.
 
 NOTE: You are allowed to initiate a trial only if your cluster has not already
 activated a trial for the current major product version. For example, if you
 have already activated a trial for v6.0, you cannot start a new trial until v7.0.
-You can, however, contact `info@elastic.co` to request an extended trial.
+You can, however, request an extended trial at {extendtrial}.
 
 To check the status of your trial, use <<get-trial-status>>. 
 

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -16,19 +16,17 @@ This API starts a 30-day trial license.
 [float]
 ==== Description
 
-The `start trial` API enables you to upgrade from a basic license to a 30-day
-trial license, which gives access to the platinum features.
+The `start trial` API enables you to upgrade from Basic to a 30-day trial, which
+gives access to all subscription features.
 
-NOTE: You are allowed to initiate a trial license only if your cluster has not
-already activated a trial license for the current major product version. For
-example, if you have already activated a trial for v6.0, you cannot start a new
-trial until v7.0. You can, however, contact `info@elastic.co` to request an
-extended trial license.
+NOTE: You are allowed to initiate a trial only if your cluster has not already
+activated a trial for the current major product version. For example, if you
+have already activated a trial for v6.0, you cannot start a new trial until v7.0.
+You can, however, contact `info@elastic.co` to request an extended trial.
 
-To check the status of your trial license, use the following API:
-<<get-trial-status>>. 
+To check the status of your trial, use <<get-trial-status>>. 
 
-For more information about the different types of licenses, see
+For more information about features and subscriptions, see
 https://www.elastic.co/subscriptions.
 
 ==== Authorization
@@ -40,8 +38,8 @@ For more information, see
 [float]
 ==== Examples
 
-The following example starts a 30-day trial license. The acknowledge
-parameter is required as you are initiating a license that will expire.
+The following example starts a 30-day trial. The acknowledge parameter is
+required as you are initiating a license that will expire.
 
 [source,console]
 ------------------------------------------------------------

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -21,7 +21,7 @@ Updates the license for your {es} cluster.
 If {es} {security-features} are enabled, you need `manage` cluster privileges to
 install the license.
 
-If {es} {security-features} are enabled and you are installing a gold or platinum
+If {es} {security-features} are enabled and you are installing a gold or higher
 license, you must enable TLS on the transport networking layer before you
 install the license. See <<configuring-tls>>.
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -36,8 +36,7 @@ POST /_flush
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
-{ml-cap} features require a platinum license or higher. For more information about Elastic
-license levels, see https://www.elastic.co/subscriptions[the subscription page].
+{ml-cap} features require specific {subscriptions}[subscriptions].
 
 You have two options to handle {ml} jobs and {dfeeds} when you shut down a
 cluster:

--- a/x-pack/docs/en/security/authentication/realm-chains.asciidoc
+++ b/x-pack/docs/en/security/authentication/realm-chains.asciidoc
@@ -93,5 +93,6 @@ realms, authentication fails.
 
 See <<configuring-authorization-delegation>> for more details.
 
-NOTE: Delegated authorization requires a
-https://www.elastic.co/subscriptions[Platinum or Trial license].
+NOTE: Delegated authorization requires that you have a
+{subscriptions}[subscription] that includes custom authentication and
+authorization realms.

--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -21,23 +21,24 @@ For {es}, adherence to FIPS 140-2 is ensured by
 [float]
 === Upgrade considerations
 
-If you plan to upgrade your existing Cluster to a version that can be run in
+If you plan to upgrade your existing cluster to a version that can be run in
 a FIPS 140-2 enabled JVM, the suggested approach is to first perform a rolling
 upgrade to the new version in your existing JVM and perform all necessary
 configuration changes in preparation for running in fips mode. You can then
 perform a rolling restart of the nodes, this time starting each node in the FIPS
-140-2 JVM. This will allow {es} to take care of a couple of things automatically for you:
+140-2 JVM. This enables {es} to take care of a couple of things automatically for you:
 
-- <<secure-settings, Secure Settings>> will be upgraded to the latest format version as
+- <<secure-settings,Secure settings>> will be upgraded to the latest format version as
   previous format versions cannot be loaded in a FIPS 140-2 JVM.
 - Self-generated trial licenses will be upgraded to the latest format that
   is compliant with FIPS 140-2.
 
-If you are on a appropriate license level (platinum) you can elect to perform
-a rolling upgrade while at the same time running each upgraded node in a
-FIPS 140-2 JVM. In this case, you would need to also regenerate your
-`elasticsearch.keystore` and migrate all secure settings to it, in addition to the
-necessary configuration changes outlined below, before starting each node.
+If you have a {subscriptions}[subscription] that supports FIPS 140-2 mode, you
+can elect to perform a rolling upgrade while at the same time running each
+upgraded node in a FIPS 140-2 JVM. In this case, you would need to also
+regenerate your `elasticsearch.keystore` and migrate all secure settings to it,
+in addition to the necessary configuration changes outlined below, before
+starting each node.
 
 [float]
 === Configuring {es} for FIPS 140-2


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/pull/70636
Depends on: https://github.com/elastic/docs/pull/1886

This PR fixes the documentation that implies a trial licence maps to a platinum subscription. It also improves some licence-related text to align with the style guide and generally tries to avoid stating which licenses are required for specific features in the docs.

### Preview

https://elasticsearch_58958.docs-preview.app.elstc.co/diff