### PR TITLE
Fix issue reading template mappings after cluster restart

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/ComposableTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/ComposableTemplateIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.template;
+
+import org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction;
+import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collections;
+
+public class ComposableTemplateIT extends ESIntegTestCase {
+
+    // See: https://github.com/elastic/elasticsearch/issues/58643
+    public void testComponentTemplatesCanBeUpdatedAfterRestart() throws Exception {
+        ComponentTemplate ct = new ComponentTemplate(new Template(null, new CompressedXContent("{\n" +
+            "      \"properties\": {\n" +
+            "        \"foo\": {\n" +
+            "          \"type\": \"text\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }"), null), 3L, Collections.singletonMap("eggplant", "potato"));
+        client().execute(PutComponentTemplateAction.INSTANCE, new PutComponentTemplateAction.Request("my-ct").componentTemplate(ct)).get();
+
+        ComposableIndexTemplate cit = new ComposableIndexTemplate(Collections.singletonList("coleslaw"),
+            new Template(null, new CompressedXContent("{\n" +
+                "      \"dynamic\": false,\n" +
+                "      \"properties\": {\n" +
+                "        \"potato\": {\n" +
+                "          \"type\": \"keyword\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }"), null), Collections.singletonList("my-ct"),
+            4L, 5L, Collections.singletonMap("egg", "bread"));
+        client().execute(PutComposableIndexTemplateAction.INSTANCE,
+            new PutComposableIndexTemplateAction.Request("my-it").indexTemplate(cit)).get();
+
+        internalCluster().fullRestart();
+        ensureGreen();
+
+        ComponentTemplate ct2 = new ComponentTemplate(new Template(null, new CompressedXContent("{\n" +
+            "      \"properties\": {\n" +
+            "        \"foo\": {\n" +
+            "          \"type\": \"text\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }"), null), 3L, Collections.singletonMap("eggplant", "potato"));
+        client().execute(PutComponentTemplateAction.INSTANCE,
+            new PutComponentTemplateAction.Request("my-ct").componentTemplate(ct2)).get();
+
+        ComposableIndexTemplate cit2 = new ComposableIndexTemplate(Collections.singletonList("coleslaw"),
+            new Template(null, new CompressedXContent("{\n" +
+                "      \"dynamic\": false,\n" +
+                "      \"properties\": {\n" +
+                "        \"potato\": {\n" +
+                "          \"type\": \"keyword\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }"), null), Collections.singletonList("my-ct"),
+            4L, 5L, Collections.singletonMap("egg", "bread"));
+        client().execute(PutComposableIndexTemplateAction.INSTANCE,
+            new PutComposableIndexTemplateAction.Request("my-it").indexTemplate(cit2)).get();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -575,10 +575,8 @@ public class MetadataCreateIndexService {
                     // tripping the below assertion, we can safely ignore it
                     continue;
                 }
-                assert templateMapping.size() == 1 : "expected exactly one mapping value, got: " + templateMapping;
                 if (templateMapping.get(MapperService.SINGLE_MAPPING_NAME) instanceof Map == false) {
-                    throw new IllegalStateException("invalid mapping definition, expected a single map underneath [" +
-                        MapperService.SINGLE_MAPPING_NAME + "] but it was: [" + templateMapping + "]");
+                    templateMapping = Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, templateMapping);
                 }
 
                 Map<String, Object> innerTemplateMapping = (Map<String, Object>) templateMapping.get(MapperService.SINGLE_MAPPING_NAME);


### PR DESCRIPTION
Due to the way that our `toXContent` of mappings works, we reduce the type to remove `_doc` from
template mappings when serializing them to disk as part of cluster state. This causes problems
however, as we always expected there to be a `_doc` field in the mappings. This was resolved in
later versions of ES (7.9+) by #58521 which uses a real mapper to handle the mappings. For 7.8.1,
however, we need to ensure that we can still read the state after it has been persisted to disk.

Resolves #58643
Relates to #58883
Relates to #58521
