### PR TITLE
[DOCS] Clean up `Use a data stream` test snippets

### DIFF
--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -51,7 +51,6 @@ PUT /_data_stream/logs_alt
 ----
 // TESTSETUP
 
-////
 [source,console]
 ----
 DELETE /_data_stream/*

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -33,7 +33,32 @@ PUT /_index_template/logs_data_stream
 }
 
 PUT /_data_stream/logs
+
+POST /logs/_rollover/
+
+POST /logs/_rollover/
+
+PUT /logs/_create/bfspvnIBr7VVZlfp2lqX?refresh=wait_for
+{
+  "@timestamp": "2020-12-07T11:06:07.000Z",
+  "user": {
+    "id": "yWIumJd7"
+  },
+  "message": "Login successful"
+}
+
+PUT /_data_stream/logs_alt
 ----
+// TESTSETUP
+
+////
+[source,console]
+----
+DELETE /_data_stream/*
+
+DELETE /_index_template/*
+----
+// TEARDOWN
 ////
 
 [discrete]
@@ -66,7 +91,6 @@ POST /logs/_doc/
   "message": "Login successful"
 }
 ----
-// TEST[continued]
 ====
 
 IMPORTANT: You cannot add new documents to a data stream using the index API's
@@ -89,14 +113,13 @@ the `logs` data stream. Note that only the `create` action is used.
 [source,console]
 ----
 PUT /logs/_bulk?refresh
-{"create":{"_index" : "logs"}}
+{"create":{ }}
 { "@timestamp": "2020-12-08T11:04:05.000Z", "user": { "id": "vlb44hny" }, "message": "Login attempt failed" }
-{"create":{"_index" : "logs"}}
+{"create":{ }}
 { "@timestamp": "2020-12-08T11:06:07.000Z", "user": { "id": "8a4f500d" }, "message": "Login successful" }
-{"create":{"_index" : "logs"}}
+{"create":{ }}
 { "@timestamp": "2020-12-09T11:07:08.000Z", "user": { "id": "l7gk7f82" }, "message": "Logout successful" }
 ----
-// TEST[continued]
 ====
 --
 
@@ -144,7 +167,6 @@ GET /logs/_search
   }
 }
 ----
-// TEST[continued]
 ====
 
 You can use a comma-separated list or wildcard (`*`) expression to search
@@ -153,14 +175,6 @@ multiple data streams, indices, and index aliases in the same request.
 .*Example*
 [%collapsible]
 ====
-////
-[source,console]
-----
-PUT /_data_stream/logs_alt
-----
-// TEST[continued]
-////
-
 The following request searches the `logs` and `logs_alt` data streams, which are
 specified as a comma-separated list in the request path.
 
@@ -175,8 +189,6 @@ GET /logs,logs_alt/_search
   }
 }
 ----
-// TEST[continued]
-
 The following request uses the `logs*` wildcard expression to search any data
 stream, index, or index alias beginning with `logs`.
 
@@ -191,7 +203,6 @@ GET /logs*/_search
   }
 }
 ----
-// TEST[continued]
 
 The following search request omits a target in the request path. The request
 searches all data streams and indices in the cluster.
@@ -207,7 +218,6 @@ GET /_search
   }
 }
 ----
-// TEST[continued]
 ====
 
 [discrete]
@@ -238,7 +248,6 @@ rollover request for the `logs` data stream.
 ----
 POST /logs/_rollover/
 ----
-// TEST[continued]
 ====
 
 [discrete]
@@ -260,18 +269,15 @@ by sending an open request directly to the stream.
 .*Example*
 [%collapsible]
 ====
+The following <<cat-indices,cat indices>> API request retrieves the status for
+the `logs` data stream's backing indices.
+
 ////
 [source,console]
 ----
-POST /logs/_rollover/
-
 POST /.ds-logs-000001,.ds-logs-000002/_close/
 ----
-// TEST[continued]
 ////
-
-The following <<cat-indices,cat indices>> API request retrieves the status for
-the `logs` data stream's backing indices.
 
 [source,console]
 ----
@@ -383,7 +389,6 @@ POST /_aliases
   ]
 }
 ----
-// TEST[continued]
 ////
 
 [source,console]
@@ -440,23 +445,9 @@ requests:
 [%collapsible]
 ====
 The following update by query API request updates documents in the `logs` data
-stream with a `user.id` of `i96BP1mA`. The request uses a
+stream with a `user.id` of `l7gk7f82`. The request uses a
 <<modules-scripting-using,script>> to assign matching documents a new `user.id`
 value of `XgdX0NoX`.
-
-////
-[source,console]
-----
-PUT /logs/_create/2?refresh=wait_for
-{
-  "@timestamp": "2020-12-07T11:06:07.000Z",
-  "user": {
-    "id": "i96BP1mA"
-  }
-}
-----
-// TEST[continued]
-////
 
 [source,console]
 ----
@@ -464,7 +455,7 @@ POST /logs/_update_by_query
 {
   "query": {
     "match": {
-      "user.id": "i96BP1mA"
+      "user.id": "l7gk7f82"
     }
   },
   "script": {
@@ -475,7 +466,6 @@ POST /logs/_update_by_query
   }
 }
 ----
-// TEST[continued]
 ====
 
 * A <<docs-delete-by-query,delete by query API>> request
@@ -484,21 +474,7 @@ POST /logs/_update_by_query
 [%collapsible]
 ====
 The following delete by query API request deletes documents in the `logs` data
-stream with a `user.id` of `zVZMamUM`.
-
-////
-[source,console]
-----
-PUT /logs/_create/1?refresh=wait_for
-{
-  "@timestamp": "2020-12-07T11:06:07.000Z",
-  "user": {
-    "id": "zVZMamUM"
-  }
-}
-----
-// TEST[continued]
-////
+stream with a `user.id` of `vlb44hny`.
 
 [source,console]
 ----
@@ -506,12 +482,11 @@ POST /logs/_delete_by_query
 {
   "query": {
     "match": {
-      "user.id": "zVZMamUM"
+      "user.id": "vlb44hny"
     }
   }
 }
 ----
-// TEST[continued]
 ====
 
 [discrete]
@@ -534,21 +509,6 @@ information.
 .*Example*
 [%collapsible]
 ====
-////
-[source,console]
-----
-PUT /logs/_create/bfspvnIBr7VVZlfp2lqX?refresh=wait_for
-{
-  "@timestamp": "2020-12-07T11:06:07.000Z",
-  "user": {
-    "id": "yWIumJd7"
-  },
-  "message": "Login successful"
-}
-----
-// TEST[continued]
-////
-
 The following search request retrieves documents in the `logs` data stream with
 a `user.id` of `yWIumJd7`. By default, this search returns the document ID and
 backing index for any matching documents.
@@ -569,7 +529,6 @@ GET /logs/_search
   }
 }
 ----
-// TEST[continued]
 
 The API returns the following response. The `hits.hits` property contains
 information for any documents matching the search.
@@ -595,7 +554,7 @@ information for any documents matching the search.
       {
         "_index": ".ds-logs-000003",                <1>
         "_id": "bfspvnIBr7VVZlfp2lqX",              <2>
-        "_seq_no": 8,                               <3>
+        "_seq_no": 0,                               <3>
         "_primary_term": 1,                         <4>
         "_score": 0.2876821,
         "_source": {
@@ -637,7 +596,7 @@ contains a new JSON source for the document.
 
 [source,console]
 ----
-PUT /.ds-logs-000003/_doc/bfspvnIBr7VVZlfp2lqX?if_seq_no=8&if_primary_term=1
+PUT /.ds-logs-000003/_doc/bfspvnIBr7VVZlfp2lqX?if_seq_no=0&if_primary_term=1
 {
   "@timestamp": "2020-12-07T11:06:07.000Z",
   "user": {
@@ -646,7 +605,6 @@ PUT /.ds-logs-000003/_doc/bfspvnIBr7VVZlfp2lqX?if_seq_no=8&if_primary_term=1
   "message": "Login successful"
 }
 ----
-// TEST[continued]
 ====
 
 You use the <<docs-delete,delete API>> to delete individual documents. Deletion
@@ -663,7 +621,6 @@ stream. The request targets document ID `bfspvnIBr7VVZlfp2lqX` in the
 ----
 DELETE /.ds-logs-000003/_doc/bfspvnIBr7VVZlfp2lqX
 ----
-// TEST[continued]
 ====
 
 You can use the <<docs-bulk,bulk API>> to delete or update multiple documents in
@@ -676,21 +633,6 @@ arguments.
 .*Example*
 [%collapsible]
 ====
-////
-[source,console]
-----
-PUT /logs/_create/bfspvnIBr7VVZlfp2lqX?refresh=wait_for
-{
-  "@timestamp": "2020-12-07T11:06:07.000Z",
-  "user": {
-    "id": "yWIumJd7"
-  },
-  "message": "Login successful"
-}
-----
-// TEST[continued]
-////
-
 The following bulk API request uses an `index` action to update an existing
 document in the `logs` data stream.
 
@@ -702,20 +644,8 @@ parameters.
 [source,console]
 ----
 PUT /_bulk?refresh
-{ "index": { "_index": ".ds-logs-000003", "_id": "bfspvnIBr7VVZlfp2lqX", "if_seq_no": 8, "if_primary_term": 1 } }
+{ "index": { "_index": ".ds-logs-000003", "_id": "bfspvnIBr7VVZlfp2lqX", "if_seq_no": 0, "if_primary_term": 1 } }
 { "@timestamp": "2020-12-07T11:06:07.000Z", "user": { "id": "8a4f500d" }, "message": "Login successful" }
 ----
-// TEST[continued]
 ====
 
-////
-[source,console]
-----
-DELETE /_data_stream/logs
-
-DELETE /_data_stream/logs_alt
-
-DELETE /_index_template/logs_data_stream
-----
-// TEST[continued]
-////


### PR DESCRIPTION
Simplifies the setup and tear down for the 'Use a data stream' test
snippets.