### PR TITLE
Parameterize windows packaging test script

### DIFF
--- a/.ci/os.ps1
+++ b/.ci/os.ps1
@@ -1,3 +1,5 @@
+param($GradleTasks='destructiveDistroTest')
+
 If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
 {
     # Relaunch as an elevated process:
@@ -25,7 +27,6 @@ Remove-Item -Recurse -Force \tmp -ErrorAction Ignore
 New-Item -ItemType directory -Path \tmp
 
 $ErrorActionPreference="Continue"
-# TODO: remove the task exclusions once dependencies are set correctly and these don't run for Windows or buldiung the deb on windows is fixed
-& .\gradlew.bat -g "C:\Users\$env:username\.gradle" --parallel --no-daemon --scan --console=plain destructiveDistroTest
+& .\gradlew.bat -g "C:\Users\$env:username\.gradle" --parallel --no-daemon --scan --console=plain $GradleTasks
 
 exit $LastExitCode


### PR DESCRIPTION
Parameterize the script for running Windows packaging tests so that specific Gradle tasks can be passed as a script parameter. This change is backwards compatible with current CI jobs as well since it defaults the parameter value to the existing `destructiveDistroTest` task. Calling the script with a specific task looks like this:

```
./.ci/os.ps1 -GradleTasks someTaskName
```

This change will facilitate the ability to break up the existing monolithic Windows packaging job into multiple parts.