### PR TITLE
Count coordinating and primary bytes as write bytes

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
@@ -71,8 +71,7 @@ public class WriteMemoryLimitsIT extends ESIntegTestCase {
     protected int numberOfShards() {
         return 1;
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58983")
+    
     public void testWriteBytesAreIncremented() throws Exception {
         assertAcked(prepareCreate(INDEX_NAME, Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
@@ -71,7 +71,7 @@ public class WriteMemoryLimitsIT extends ESIntegTestCase {
     protected int numberOfShards() {
         return 1;
     }
-    
+
     public void testWriteBytesAreIncremented() throws Exception {
         assertAcked(prepareCreate(INDEX_NAME, Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/WriteMemoryLimitsIT.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.greaterThan;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 1)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2, numClientNodes = 1, transportClientRatio = 0.0D)
 public class WriteMemoryLimitsIT extends ESIntegTestCase {
 
     public static final String INDEX_NAME = "test";

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -166,7 +166,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
     @Override
     protected void doExecute(Task task, BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
         long indexingBytes = bulkRequest.ramBytesUsed();
-        final Releasable releasable = writeMemoryLimits.markCoordinatingOperationStarted(indexingBytes);
+        final Releasable releasable = writeMemoryLimits.markWriteOperationStarted(indexingBytes);
         final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
         try {
             doInternalExecute(task, bulkRequest, releasingListener);

--- a/server/src/main/java/org/elasticsearch/action/bulk/WriteMemoryLimits.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/WriteMemoryLimits.java
@@ -25,34 +25,24 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class WriteMemoryLimits {
 
-    private final AtomicLong coordinatingBytes = new AtomicLong(0);
-    private final AtomicLong primaryBytes = new AtomicLong(0);
-    private final AtomicLong replicaBytes = new AtomicLong(0);
+    private final AtomicLong writeBytes = new AtomicLong(0);
+    private final AtomicLong replicaWriteBytes = new AtomicLong(0);
 
-    public Releasable markCoordinatingOperationStarted(long bytes) {
-        coordinatingBytes.addAndGet(bytes);
-        return () -> coordinatingBytes.getAndAdd(-bytes);
+    public Releasable markWriteOperationStarted(long bytes) {
+        writeBytes.addAndGet(bytes);
+        return () -> writeBytes.getAndAdd(-bytes);
     }
 
-    public long getCoordinatingBytes() {
-        return coordinatingBytes.get();
+    public long getWriteBytes() {
+        return writeBytes.get();
     }
 
-    public Releasable markPrimaryOperationStarted(long bytes) {
-        primaryBytes.addAndGet(bytes);
-        return () -> primaryBytes.getAndAdd(-bytes);
+    public Releasable markReplicaWriteStarted(long bytes) {
+        replicaWriteBytes.getAndAdd(bytes);
+        return () -> replicaWriteBytes.getAndAdd(-bytes);
     }
 
-    public long getPrimaryBytes() {
-        return primaryBytes.get();
-    }
-
-    public Releasable markReplicaOperationStarted(long bytes) {
-        replicaBytes.getAndAdd(bytes);
-        return () -> replicaBytes.getAndAdd(-bytes);
-    }
-
-    public long getReplicaBytes() {
-        return replicaBytes.get();
+    public long getReplicaWriteBytes() {
+        return replicaWriteBytes.get();
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -65,6 +65,11 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
+    protected void doExecute(Task parentTask, ResyncReplicationRequest request, ActionListener<ResyncReplicationResponse> listener) {
+        assert false : "use TransportResyncReplicationAction#sync";
+    }
+
+    @Override
     protected ResyncReplicationResponse newResponseInstance(StreamInput in) throws IOException {
         return new ResyncReplicationResponse(in);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1349,19 +1349,14 @@ public final class InternalTestCluster extends TestCluster {
         assertBusy(() -> {
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 WriteMemoryLimits writeMemoryLimits = getInstance(WriteMemoryLimits.class, nodeAndClient.name);
-                final long coordinatingBytes = writeMemoryLimits.getCoordinatingBytes();
-                if (coordinatingBytes > 0) {
-                    throw new AssertionError("pending coordinating write bytes [" + coordinatingBytes + "] bytes on node ["
+                final long writeBytes = writeMemoryLimits.getWriteBytes();
+                if (writeBytes > 0) {
+                    throw new AssertionError("pending write bytes [" + writeBytes + "] bytes on node ["
                         + nodeAndClient.name + "].");
                 }
-                final long primaryBytes = writeMemoryLimits.getPrimaryBytes();
-                if (primaryBytes > 0) {
-                    throw new AssertionError("pending primary write bytes [" + coordinatingBytes + "] bytes on node ["
-                        + nodeAndClient.name + "].");
-                }
-                final long replicaBytes = writeMemoryLimits.getReplicaBytes();
-                if (replicaBytes > 0) {
-                    throw new AssertionError("pending replica write bytes [" + coordinatingBytes + "] bytes on node ["
+                final long replicaWriteBytes = writeMemoryLimits.getReplicaWriteBytes();
+                if (replicaWriteBytes > 0) {
+                    throw new AssertionError("pending replica write bytes [" + writeBytes + "] bytes on node ["
                         + nodeAndClient.name + "].");
                 }
             }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/LocalIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/LocalIndexFollowingIT.java
@@ -98,7 +98,8 @@ public class LocalIndexFollowingIT extends CcrSingleNodeTestCase {
     }
 
     public void testWriteLimitsIncremented() throws Exception {
-        final String leaderIndexSettings = getIndexSettings(1, 0, Collections.emptyMap());
+        final String leaderIndexSettings = getIndexSettings(1, 0,
+            singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
         assertAcked(client().admin().indices().prepareCreate("leader").setSource(leaderIndexSettings, XContentType.JSON));
         ensureGreen("leader");
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/LocalIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/LocalIndexFollowingIT.java
@@ -6,13 +6,16 @@
 
 package org.elasticsearch.xpack.ccr;
 
+import org.elasticsearch.action.bulk.WriteMemoryLimits;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.CcrSingleNodeTestCase;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
@@ -24,6 +27,8 @@ import org.elasticsearch.xpack.core.ccr.action.ResumeFollowAction;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.StreamSupport;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -90,6 +95,64 @@ public class LocalIndexFollowingIT extends CcrSingleNodeTestCase {
             () -> client().execute(PutFollowAction.INSTANCE, putFollowRequest).actionGet());
         assertThat(error.getMessage(), equalTo("leader index [leader-index] does not have soft deletes enabled"));
         assertThat(client().admin().indices().prepareExists("follower-index").get().isExists(), equalTo(false));
+    }
+
+    public void testWriteLimitsIncremented() throws Exception {
+        final String leaderIndexSettings = getIndexSettings(1, 0, Collections.emptyMap());
+        assertAcked(client().admin().indices().prepareCreate("leader").setSource(leaderIndexSettings, XContentType.JSON));
+        ensureGreen("leader");
+
+        // Use a sufficiently small number of docs to ensure that they are well below the number of docs that
+        // can be sent in a single TransportBulkShardOperationsAction
+        final long firstBatchNumDocs = randomIntBetween(10, 20);
+        long sourceSize = 0;
+        for (int i = 0; i < firstBatchNumDocs; i++) {
+            BytesArray source = new BytesArray("{}");
+            sourceSize += source.length();
+            client().prepareIndex("leader", "doc").setSource(source, XContentType.JSON).get();
+        }
+
+        ThreadPool nodeThreadPool = getInstanceFromNode(ThreadPool.class);
+        ThreadPool.Info writeInfo = StreamSupport.stream(nodeThreadPool.info().spliterator(), false)
+            .filter(i -> i.getName().equals(ThreadPool.Names.WRITE)).findAny().get();
+        int numberOfThreads = writeInfo.getMax();
+        CountDownLatch threadBlockedLatch = new CountDownLatch(numberOfThreads);
+        CountDownLatch blocker = new CountDownLatch(1);
+
+        for (int i = 0; i < numberOfThreads; ++i) {
+            nodeThreadPool.executor(ThreadPool.Names.WRITE).execute(() -> {
+                try {
+                    threadBlockedLatch.countDown();
+                    blocker.await();
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+        }
+        threadBlockedLatch.await();
+
+        try {
+            final PutFollowAction.Request followRequest = getPutFollowRequest("leader", "follower");
+            client().execute(PutFollowAction.INSTANCE, followRequest).get();
+
+            WriteMemoryLimits memoryLimits = getInstanceFromNode(WriteMemoryLimits.class);
+            final long finalSourceSize = sourceSize;
+            assertBusy(() -> {
+                // The actual write bytes will be greater due to other request fields. However, this test is
+                // just spot checking that the bytes are incremented at all.
+                assertTrue(memoryLimits.getWriteBytes() > finalSourceSize);
+            });
+            blocker.countDown();
+            assertBusy(() -> {
+                assertThat(client().prepareSearch("follower").get().getHits().getTotalHits().value, equalTo(firstBatchNumDocs));
+            });
+            ensureEmptyWriteBuffers();
+        } finally {
+            if (blocker.getCount() > 0) {
+                blocker.countDown();
+            }
+        }
+
     }
 
     public void testRemoveRemoteConnection() throws Exception {


### PR DESCRIPTION
This is a follow-up to #57573. This commit combines coordinating and
primary bytes under the same "write" bucket. Double accounting is
prevented by only accounting the bytes at either the reroute phase or
the primary phase. TransportBulkAction calls execute directly, so the
operations handler is skipped and the bytes are not double accounted.
