### PR TITLE
Increase timeout in MlDistributedFailureIT

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -543,8 +543,6 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
     }
 
     private void ensureStableClusterOnAllNodes(int nodeCount) {
-        for (String nodeName : internalCluster().getNodeNames()) {
-            ensureStableCluster(nodeCount, nodeName);
-        }
+        ensureStableCluster(nodeCount, TimeValue.timeValueSeconds(60));
     }
 }


### PR DESCRIPTION
Closes #58532

Doubles the timeout on the `ensureStableClusterOnAllNodes` method to 60s. That method was calling `ensureStableCluster` on each node in the cluster which is clearly unnecessary as the response is the same from every node.
