### PR TITLE
[ML] handle broken setup with state alias being an index

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -432,7 +432,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
                     String msg = "Detected a problem with your setup of machine learning, the state index alias ["
                         + AnomalyDetectorsIndex.jobStateIndexWriteAlias()
                         + "] exists as index but must be an alias.";
-                    logger.error("[{}] {}", jobId, msg, e);
+                    logger.error(new ParameterizedMessage("[{}] {}", jobId, msg), e);
                     auditor.error(jobId, msg);
                     setJobState(jobTask, JobState.FAILED, msg, e2 -> closeHandler.accept(e, true));
                 } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -426,7 +427,19 @@ public class AutodetectProcessManager implements ClusterStateListener {
                     e -> closeHandler.accept(e, true)
                 ));
             },
-            e -> closeHandler.accept(e, true));
+            e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof InvalidAliasNameException) {
+                    String msg = "Detected a problem with your setup of machine learning, the state index alias ["
+                        + AnomalyDetectorsIndex.jobStateIndexWriteAlias()
+                        + "] exists as index but must be an alias.";
+                    logger.error("[{}] {}", jobId, msg, e);
+                    auditor.error(jobId, msg);
+                    setJobState(jobTask, JobState.FAILED, msg, e2 -> closeHandler.accept(e, true));
+                } else {
+                    closeHandler.accept(e, true);
+                }
+            }
+        );
 
         // Make sure the state index and alias exist
         ActionListener<Boolean> resultsMappingUpdateHandler = ActionListener.wrap(


### PR DESCRIPTION
.ml-state-write is supposed to be an index alias, however by accident it can become an index. If 
.ml-state-write is a concrete index instead of an alias ML stops working. This change improves error
handling by setting the job to failed and properly log and audit the problem. The user still has to
manually fix the problem. This change should lead to a quicker resolution of the problem.

fixes #58482