### PR TITLE
Fix external javadoc reference to server project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,8 @@ allprojects {
         } else {
           // Link to non-shadowed dependant projects
           project.javadoc.dependsOn "${upstreamProject.path}:javadoc"
-          String artifactPath = dep.group.replaceAll('\\.', '/') + '/' + dep.name.replaceAll('\\.', '/') + '/' + dep.version
+          String externalLinkName = dep.name == upstreamProject.archivesBaseName ? dep.name : upstreamProject.archivesBaseName
+          String artifactPath = dep.group.replaceAll('\\.', '/') + '/' + externalLinkName.replaceAll('\\.', '/') + '/' + dep.version
           project.javadoc.options.linksOffline artifactsHost + "/javadoc/" + artifactPath, "${upstreamProject.buildDir}/docs/javadoc/"
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ allprojects {
         } else {
           // Link to non-shadowed dependant projects
           project.javadoc.dependsOn "${upstreamProject.path}:javadoc"
-          String externalLinkName = dep.name == upstreamProject.archivesBaseName ? dep.name : upstreamProject.archivesBaseName
+          String externalLinkName = upstreamProject.archivesBaseName
           String artifactPath = dep.group.replaceAll('\\.', '/') + '/' + externalLinkName.replaceAll('\\.', '/') + '/' + dep.version
           project.javadoc.options.linksOffline artifactsHost + "/javadoc/" + artifactPath, "${upstreamProject.buildDir}/docs/javadoc/"
         }


### PR DESCRIPTION
This fixes https://github.com/elastic/infra/issues/20103
The problem here is that we rename all artifacts in the :server project to elasticsearch. 
The ideal fix would be to rename the gradle project thereto elasticsearch. 
I'm open to that but it seems quite invasive. Would love to hear other opinions on that. 

The applied alternative minimal invasive fix provided with this PR just takes
potential renamed projects / artifacts (Currently I only see `:server`) into account
when declaring external links.