### PR TITLE
Fix GeoHash grid aggregation circuit breaker tests (#58218)

### DIFF
--- a/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/40_geohash_grid.yml
+++ b/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/40_geohash_grid.yml
@@ -60,13 +60,13 @@
 
 ---
 "Test geohash_grid aggregation circuit breaker":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/56257"
   - do:
       indices.create:
         index: locations
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               location:


### PR DESCRIPTION
This commit makes sure we create index with only one shard.

backport #58218