### PR TITLE
[DOCS] Clarifies transform node settings

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -15,7 +15,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-and (if available) machine learning.
+and (if available) machine learning. All data nodes are also transform nodes.
 // end::modules-node-description-tag[]
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -259,12 +259,9 @@ xpack.ml.enabled: true <1>
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
-{transform-cap} nodes run {transforms} and handle {transform} API requests.
-
-By default, data nodes are also transform nodes. If you want to use {transforms}
-in clients (including {kib}), coordinating nodes must also have the
-`transform` role. If you have the {oss-dist}, do not use these settings. For
-more information, see <<transform-settings>>.
+{transform-cap} nodes run {transforms} and handle {transform} API requests. By
+default, data nodes are also transform nodes. If you have the {oss-dist}, do not
+use these settings. For more information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -15,7 +15,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-and (if available) machine learning and transform.
+and (if available) machine learning.
 // end::modules-node-description-tag[]
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
@@ -261,10 +261,10 @@ xpack.ml.enabled: true <1>
 
 {transform-cap} nodes run {transforms} and handle {transform} API requests.
 
-If you want to use {transforms} in clients (including {kib}), it must also be
-enabled on all coordinating nodes. You must also have at least one node with the
-`transform` role. This is the default behavior. If you have the {oss-dist}, do
-not use these settings. For more information, see <<transform-settings>>.
+By default, data nodes are also transform nodes. If you want to use {transforms}
+in clients (including {kib}), coordinating nodes must also have the
+`transform` role. If you have the {oss-dist}, do not use these settings. For
+more information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -7,7 +7,8 @@
 <titleabbrev>{transforms-cap} settings</titleabbrev>
 ++++
 
-You do not need to configure any settings to use {transforms}. It is enabled by default.
+You do not need to configure any settings to use {transforms}. It is enabled by
+default.
 
 All of these settings can be added to the `elasticsearch.yml` configuration file.
 The dynamic settings can also be updated across a cluster with the
@@ -21,6 +22,7 @@ file.
 ==== General {transforms} settings
 
 `node.transform`::
+deprecated:[7.9.0,Use <<modules-node,`node.roles`>> instead.]
 Set to `true` to identify the node as a _transform node_. If `node.data`
 is `false` for the node, the default value is `false`. Otherwise, the default
 value is `true`.

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -22,7 +22,7 @@ file.
 ==== General {transforms} settings
 
 `node.transform`::
-deprecated:[7.9.0,Use <<modules-node,`node.roles`>> instead.]
+deprecated:[7.9.0,"Use <<modules-node,node.roles>> instead."]
 Set to `true` to identify the node as a _transform node_. If `node.data`
 is `false` for the node, the default value is `false`. Otherwise, the default
 value is `true`.

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -15,14 +15,11 @@ To use the {transforms}, you must have the
 [[transform-setup-nodes]]
 ==== {transform-cap} nodes
 
-To use {transforms}, there must be at least one node in your cluster with
-`node.transform` set to `true`. By default, all nodes are {transform} nodes
-unless you explicitly change these settings or set `node.data` to `false`.
+To use {transforms}, there must be at least one {transform} node in your cluster.
+If you want to control which nodes run {transforms}, set `node.roles` to
+`transform` on some nodes.
 
-If you want to control which nodes run {transforms}, set `node.transform` to
-`false` on some nodes.
-
-For more information, see <<transform-settings>> and <<modules-node>>.
+For more information, see <<modules-node>> and <<transform-settings>>.
 
 [discrete]
 [[transform-privileges]]

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -16,10 +16,9 @@ To use the {transforms}, you must have the
 ==== {transform-cap} nodes
 
 To use {transforms}, there must be at least one {transform} node in your cluster.
-If you want to control which nodes run {transforms}, set `node.roles` to
-`transform` on some nodes.
-
-For more information, see <<modules-node>> and <<transform-settings>>.
+If you want to control which nodes run {transforms}, add or remove `transform`
+from the `node.roles` setting on some nodes. For more information, see
+<<modules-node>> and <<transform-settings>>.
 
 [discrete]
 [[transform-privileges]]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/54998

This PR adds deprecation text to the node.transform setting and clarifies the default behavior of transform nodes.

### Preview

* https://elasticsearch_59023.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html
* https://elasticsearch_59023.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-settings.html
* https://elasticsearch_59023.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-setup.html#transform-setup-nodes