### PR TITLE
[DOCS] Deprecates node.ml

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -29,7 +29,7 @@ file.
 ==== General machine learning settings
 
 `node.ml`::
-deprecated:[7.9.0,Use <<modules-node,`node.roles`>> instead.]
+deprecated:[7.9.0,"Use <<modules-node,node.roles>> instead."]
 Set to `true` (default) to identify the node as a _machine learning node_. +
 +
 If set to `false` in `elasticsearch.yml`, the node cannot run jobs. If set to

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -29,6 +29,7 @@ file.
 ==== General machine learning settings
 
 `node.ml`::
+deprecated:[7.9.0,Use <<modules-node,`node.roles`>> instead.]
 Set to `true` (default) to identify the node as a _machine learning node_. +
 +
 If set to `false` in `elasticsearch.yml`, the node cannot run jobs. If set to


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/54998

This PR adds deprecation text to the node.ml description.

### Preview
https://elasticsearch_59024.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html