### PR TITLE
Add the possibility to inject a custom RecoveryState factory to IndexStorePlugin implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -156,6 +156,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
             IndexModule.INDEX_STORE_TYPE_SETTING,
             IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
+            IndexModule.INDEX_RECOVERY_TYPE_SETTING,
             IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING,
             FsDirectoryFactory.INDEX_LOCK_FACTOR_SETTING,
             EngineConfig.INDEX_CODEC_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedFunction;
@@ -79,6 +80,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.mapper.MapperRegistry;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -114,6 +116,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final NodeEnvironment nodeEnv;
     private final ShardStoreDeleter shardStoreDeleter;
     private final IndexStorePlugin.DirectoryFactory directoryFactory;
+    private final IndexStorePlugin.RecoveryStateFactory recoveryStateFactory;
     private final CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper;
     private final IndexCache indexCache;
     private final MapperService mapperService;
@@ -174,7 +177,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             BooleanSupplier idFieldDataEnabled,
             BooleanSupplier allowExpensiveQueries,
             IndexNameExpressionResolver expressionResolver,
-            ValuesSourceRegistry valuesSourceRegistry) {
+            ValuesSourceRegistry valuesSourceRegistry,
+            IndexStorePlugin.RecoveryStateFactory recoveryStateFactory) {
         super(indexSettings);
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.indexSettings = indexSettings;
@@ -223,6 +227,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.eventListener = eventListener;
         this.nodeEnv = nodeEnv;
         this.directoryFactory = directoryFactory;
+        this.recoveryStateFactory = recoveryStateFactory;
         this.engineFactory = Objects.requireNonNull(engineFactory);
         // initialize this last -- otherwise if the wrapper requires any other member to be non-null we fail with an NPE
         this.readerWrapper = wrapperFactory.apply(this);
@@ -561,6 +566,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                         "[{}] failed to delete shard content - scheduled a retry", lock.getShardId().id()), e);
             }
         }
+    }
+
+    public RecoveryState createRecoveryState(ShardRouting shardRouting, DiscoveryNode targetNode, DiscoveryNode sourceNode) {
+        return recoveryStateFactory.newRecoveryState(shardRouting, targetNode, sourceNode);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -756,32 +756,11 @@ public class IndicesService extends AbstractLifecycleComponent
             final RetentionLeaseSyncer retentionLeaseSyncer,
             final DiscoveryNode targetNode,
             final DiscoveryNode sourceNode) throws IOException {
-        IndexService indexService = indexService(shardRouting.index());
-        RecoveryState recoveryState = indexService.createRecoveryState(shardRouting, targetNode, sourceNode);
-
-        return createShard(shardRouting,
-            recoveryState,
-            recoveryTargetService,
-            recoveryListener,
-            repositoriesService,
-            onShardFailure,
-            globalCheckpointSyncer,
-            retentionLeaseSyncer);
-    }
-
-    @Override
-    public IndexShard createShard(
-            final ShardRouting shardRouting,
-            final RecoveryState recoveryState,
-            final PeerRecoveryTargetService recoveryTargetService,
-            final PeerRecoveryTargetService.RecoveryListener recoveryListener,
-            final RepositoriesService repositoriesService,
-            final Consumer<IndexShard.ShardFailure> onShardFailure,
-            final Consumer<ShardId> globalCheckpointSyncer,
-            final RetentionLeaseSyncer retentionLeaseSyncer) throws IOException {
         Objects.requireNonNull(retentionLeaseSyncer);
         ensureChangesAllowed();
         IndexService indexService = indexService(shardRouting.index());
+        assert indexService != null;
+        RecoveryState recoveryState = indexService.createRecoveryState(shardRouting, targetNode, sourceNode);
         IndexShard indexShard = indexService.createShard(shardRouting, globalCheckpointSyncer, retentionLeaseSyncer);
         indexShard.addShardFailureCallback(onShardFailure);
         indexShard.startRecovery(recoveryState, recoveryTargetService, recoveryListener, repositoriesService,

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -221,6 +221,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final MetaStateService metaStateService;
     private final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders;
     private final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories;
+    private final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories;
     final AbstractRefCounted indicesRefCount; // pkg-private for testing
     private final CountDownLatch closeLatch = new CountDownLatch(1);
     private volatile boolean idFieldDataEnabled;
@@ -245,7 +246,8 @@ public class IndicesService extends AbstractLifecycleComponent
                           IndexScopedSettings indexScopedSettings, CircuitBreakerService circuitBreakerService, BigArrays bigArrays,
                           ScriptService scriptService, ClusterService clusterService, Client client, MetaStateService metaStateService,
                           Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders,
-                          Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories, ValuesSourceRegistry valuesSourceRegistry) {
+                          Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories, ValuesSourceRegistry valuesSourceRegistry,
+                          Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories) {
         this.settings = settings;
         this.threadPool = threadPool;
         this.pluginsService = pluginsService;
@@ -291,6 +293,7 @@ public class IndicesService extends AbstractLifecycleComponent
         }
 
         this.directoryFactories = directoryFactories;
+        this.recoveryStateFactories = recoveryStateFactories;
         // doClose() is called when shutting down a node, yet there might still be ongoing requests
         // that we need to wait for before closing some resources such as the caches. In order to
         // avoid closing these resources while ongoing requests are still being processed, we use a
@@ -639,7 +642,7 @@ public class IndicesService extends AbstractLifecycleComponent
             indexCreationContext);
 
         final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, getEngineFactory(idxSettings),
-                directoryFactories, () -> allowExpensiveQueries, indexNameExpressionResolver);
+                directoryFactories, () -> allowExpensiveQueries, indexNameExpressionResolver, recoveryStateFactories);
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
             indexModule.addIndexOperationListener(operationListener);
         }
@@ -710,7 +713,7 @@ public class IndicesService extends AbstractLifecycleComponent
     public synchronized MapperService createIndexMapperService(IndexMetadata indexMetadata) throws IOException {
         final IndexSettings idxSettings = new IndexSettings(indexMetadata, this.settings, indexScopedSettings);
         final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, getEngineFactory(idxSettings),
-                directoryFactories, () -> allowExpensiveQueries, indexNameExpressionResolver);
+                directoryFactories, () -> allowExpensiveQueries, indexNameExpressionResolver, recoveryStateFactories);
         pluginsService.onIndexModule(indexModule);
         return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry, scriptService);
     }
@@ -740,6 +743,30 @@ public class IndicesService extends AbstractLifecycleComponent
         } finally {
             IOUtils.close(closeables);
         }
+    }
+
+    @Override
+    public IndexShard createShard(
+            final ShardRouting shardRouting,
+            final PeerRecoveryTargetService recoveryTargetService,
+            final PeerRecoveryTargetService.RecoveryListener recoveryListener,
+            final RepositoriesService repositoriesService,
+            final Consumer<IndexShard.ShardFailure> onShardFailure,
+            final Consumer<ShardId> globalCheckpointSyncer,
+            final RetentionLeaseSyncer retentionLeaseSyncer,
+            final DiscoveryNode targetNode,
+            final DiscoveryNode sourceNode) throws IOException {
+        IndexService indexService = indexService(shardRouting.index());
+        RecoveryState recoveryState = indexService.createRecoveryState(shardRouting, targetNode, sourceNode);
+
+        return createShard(shardRouting,
+            recoveryState,
+            recoveryTargetService,
+            recoveryListener,
+            repositoriesService,
+            onShardFailure,
+            globalCheckpointSyncer,
+            retentionLeaseSyncer);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -604,16 +604,16 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         try {
             final long primaryTerm = state.metadata().index(shardRouting.index()).primaryTerm(shardRouting.id());
             logger.debug("{} creating shard with primary term [{}]", shardRouting.shardId(), primaryTerm);
-            RecoveryState recoveryState = new RecoveryState(shardRouting, nodes.getLocalNode(), sourceNode);
             indicesService.createShard(
                     shardRouting,
-                    recoveryState,
                     recoveryTargetService,
                     new RecoveryListener(shardRouting, primaryTerm),
                     repositoriesService,
                     failedShardHandler,
                     this::updateGlobalCheckpointForShard,
-                    retentionLeaseSyncer);
+                    retentionLeaseSyncer,
+                    nodes.getLocalNode(),
+                    sourceNode);
         } catch (Exception e) {
             failAndRemoveShard(shardRouting, true, "failed to create shard", e, state);
         }
@@ -922,6 +922,32 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 Consumer<IndexShard.ShardFailure> onShardFailure,
                 Consumer<ShardId> globalCheckpointSyncer,
                 RetentionLeaseSyncer retentionLeaseSyncer) throws IOException;
+
+        /**
+         * Creates a shard for the specified shard routing and starts recovery.
+         *
+         * @param shardRouting           the shard routing
+         * @param recoveryTargetService  recovery service for the target
+         * @param recoveryListener       a callback when recovery changes state (finishes or fails)
+         * @param repositoriesService    service responsible for snapshot/restore
+         * @param onShardFailure         a callback when this shard fails
+         * @param globalCheckpointSyncer a callback when this shard syncs the global checkpoint
+         * @param retentionLeaseSyncer   a callback when this shard syncs retention leases
+         * @param targetNode             the node where this shard will be recovered
+         * @param sourceNode             the source node to recover this shard from (it might be null)
+         * @return a new shard
+         * @throws IOException if an I/O exception occurs when creating the shard
+         */
+        T createShard(
+                ShardRouting shardRouting,
+                PeerRecoveryTargetService recoveryTargetService,
+                PeerRecoveryTargetService.RecoveryListener recoveryListener,
+                RepositoriesService repositoriesService,
+                Consumer<IndexShard.ShardFailure> onShardFailure,
+                Consumer<ShardId> globalCheckpointSyncer,
+                RetentionLeaseSyncer retentionLeaseSyncer,
+                DiscoveryNode targetNode,
+                @Nullable DiscoveryNode sourceNode) throws IOException;
 
         /**
          * Returns shard for the specified id if it exists otherwise returns <code>null</code>.

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -903,30 +903,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
          * Creates a shard for the specified shard routing and starts recovery.
          *
          * @param shardRouting           the shard routing
-         * @param recoveryState          the recovery state
-         * @param recoveryTargetService  recovery service for the target
-         * @param recoveryListener       a callback when recovery changes state (finishes or fails)
-         * @param repositoriesService    service responsible for snapshot/restore
-         * @param onShardFailure         a callback when this shard fails
-         * @param globalCheckpointSyncer a callback when this shard syncs the global checkpoint
-         * @param retentionLeaseSyncer   a callback when this shard syncs retention leases
-         * @return a new shard
-         * @throws IOException if an I/O exception occurs when creating the shard
-         */
-        T createShard(
-                ShardRouting shardRouting,
-                RecoveryState recoveryState,
-                PeerRecoveryTargetService recoveryTargetService,
-                PeerRecoveryTargetService.RecoveryListener recoveryListener,
-                RepositoriesService repositoriesService,
-                Consumer<IndexShard.ShardFailure> onShardFailure,
-                Consumer<ShardId> globalCheckpointSyncer,
-                RetentionLeaseSyncer retentionLeaseSyncer) throws IOException;
-
-        /**
-         * Creates a shard for the specified shard routing and starts recovery.
-         *
-         * @param shardRouting           the shard routing
          * @param recoveryTargetService  recovery service for the target
          * @param recoveryListener       a callback when recovery changes state (finishes or fails)
          * @param repositoriesService    service responsible for snapshot/restore

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -453,6 +453,13 @@ public class Node implements Closeable {
                             .flatMap(m -> m.entrySet().stream())
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+            final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories =
+                pluginsService.filterPlugins(IndexStorePlugin.class)
+                    .stream()
+                    .map(IndexStorePlugin::getRecoveryStateFactories)
+                    .flatMap(m -> m.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
             final Map<String, Collection<SystemIndexDescriptor>> systemIndexDescriptorMap = pluginsService
                 .filterPlugins(SystemIndexPlugin.class)
                 .stream()
@@ -470,7 +477,7 @@ public class Node implements Closeable {
                     clusterModule.getIndexNameExpressionResolver(), indicesModule.getMapperRegistry(), namedWriteableRegistry,
                     threadPool, settingsModule.getIndexScopedSettings(), circuitBreakerService, bigArrays, scriptService,
                     clusterService, client, metaStateService, engineFactoryProviders, indexStoreFactories,
-                    searchModule.getValuesSourceRegistry());
+                    searchModule.getValuesSourceRegistry(), recoveryStateFactories);
 
             final AliasValidator aliasValidator = new AliasValidator();
 

--- a/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -239,29 +239,8 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends ESTestC
                 final RetentionLeaseSyncer retentionLeaseSyncer,
                 final DiscoveryNode targetNode,
                 final DiscoveryNode sourceNode) throws IOException {
-            RecoveryState recoveryState = new RecoveryState(shardRouting, targetNode, sourceNode);
-
-            return createShard(shardRouting,
-                recoveryState,
-                recoveryTargetService,
-                recoveryListener,
-                repositoriesService,
-                onShardFailure,
-                globalCheckpointSyncer,
-                retentionLeaseSyncer);
-        }
-
-        @Override
-        public MockIndexShard createShard(
-                final ShardRouting shardRouting,
-                final RecoveryState recoveryState,
-                final PeerRecoveryTargetService recoveryTargetService,
-                final PeerRecoveryTargetService.RecoveryListener recoveryListener,
-                final RepositoriesService repositoriesService,
-                final Consumer<IndexShard.ShardFailure> onShardFailure,
-                final Consumer<ShardId> globalCheckpointSyncer,
-                final RetentionLeaseSyncer retentionLeaseSyncer) throws IOException {
             failRandomly();
+            RecoveryState recoveryState = new RecoveryState(shardRouting, targetNode, sourceNode);
             MockIndexService indexService = indexService(recoveryState.getShardId().getIndex());
             MockIndexShard indexShard = indexService.createShard(shardRouting);
             indexShard.recoveryState = recoveryState;

--- a/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -22,6 +22,7 @@ package org.elasticsearch.indices.cluster;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -225,6 +226,29 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends ESTestC
         @Nullable
         public MockIndexService indexService(Index index) {
             return indices.get(index.getUUID());
+        }
+
+        @Override
+        public MockIndexShard createShard(
+                final ShardRouting shardRouting,
+                final PeerRecoveryTargetService recoveryTargetService,
+                final PeerRecoveryTargetService.RecoveryListener recoveryListener,
+                final RepositoriesService repositoriesService,
+                final Consumer<IndexShard.ShardFailure> onShardFailure,
+                final Consumer<ShardId> globalCheckpointSyncer,
+                final RetentionLeaseSyncer retentionLeaseSyncer,
+                final DiscoveryNode targetNode,
+                final DiscoveryNode sourceNode) throws IOException {
+            RecoveryState recoveryState = new RecoveryState(shardRouting, targetNode, sourceNode);
+
+            return createShard(shardRouting,
+                recoveryState,
+                recoveryTargetService,
+                recoveryListener,
+                repositoriesService,
+                onShardFailure,
+                globalCheckpointSyncer,
+                retentionLeaseSyncer);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
@@ -20,9 +20,12 @@
 package org.elasticsearch.plugins;
 
 import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.store.FsDirectoryFactory;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.node.MockNode;
 import org.elasticsearch.test.ESTestCase;
 
@@ -69,6 +72,38 @@ public class IndexStorePluginTests extends ESTestCase {
 
     }
 
+    public static class FooCustomRecoveryStore extends Plugin implements IndexStorePlugin {
+        @Override
+        public Map<String, DirectoryFactory> getDirectoryFactories() {
+            return Collections.singletonMap("store-a", new FsDirectoryFactory());
+        }
+
+        @Override
+        public Map<String, RecoveryStateFactory> getRecoveryStateFactories() {
+            return Collections.singletonMap("recovery-type", new RecoveryFactory());
+        }
+    }
+
+    public static class BarCustomRecoveryStore extends Plugin implements IndexStorePlugin {
+        @Override
+        public Map<String, DirectoryFactory> getDirectoryFactories() {
+            return Collections.singletonMap("store-b", new FsDirectoryFactory());
+        }
+
+        @Override
+        public Map<String, RecoveryStateFactory> getRecoveryStateFactories() {
+            return Collections.singletonMap("recovery-type", new RecoveryFactory());
+        }
+    }
+
+    public static class RecoveryFactory implements IndexStorePlugin.RecoveryStateFactory {
+        @Override
+        public RecoveryState newRecoveryState(ShardRouting shardRouting, DiscoveryNode targetNode, DiscoveryNode sourceNode) {
+            return new RecoveryState(shardRouting, targetNode, sourceNode);
+        }
+    }
+
+
     public void testIndexStoreFactoryConflictsWithBuiltInIndexStoreType() {
         final Settings settings = Settings.builder().put("path.home", createTempDir()).build();
         final IllegalStateException e = expectThrows(
@@ -92,4 +127,20 @@ public class IndexStorePluginTests extends ESTestCase {
         }
     }
 
+    public void testDuplicateIndexStoreRecoveryStateFactories() {
+        final Settings settings = Settings.builder().put("path.home", createTempDir()).build();
+        final IllegalStateException e = expectThrows(
+            IllegalStateException.class, () -> new MockNode(settings, Arrays.asList(FooCustomRecoveryStore.class,
+                                                                                    BarCustomRecoveryStore.class)));
+        if (JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0) {
+            assertThat(e, hasToString(matches(
+                "java.lang.IllegalStateException: Duplicate key recovery-type \\(attempted merging values " +
+                    "org.elasticsearch.plugins.IndexStorePluginTests\\$RecoveryFactory@[\\w\\d]+ " +
+                    "and org.elasticsearch.plugins.IndexStorePluginTests\\$RecoveryFactory@[\\w\\d]+\\)")));
+        } else {
+            assertThat(e, hasToString(matches(
+                "java.lang.IllegalStateException: Duplicate key " +
+                    "org.elasticsearch.plugins.IndexStorePluginTests$RecoveryFactory@[\\w\\d]+")));
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
@@ -133,10 +133,7 @@ public class IndexStorePluginTests extends ESTestCase {
             IllegalStateException.class, () -> new MockNode(settings, Arrays.asList(FooCustomRecoveryStore.class,
                                                                                     BarCustomRecoveryStore.class)));
         if (JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0) {
-            assertThat(e, hasToString(matches(
-                "java.lang.IllegalStateException: Duplicate key recovery-type \\(attempted merging values " +
-                    "org.elasticsearch.plugins.IndexStorePluginTests\\$RecoveryFactory@[\\w\\d]+ " +
-                    "and org.elasticsearch.plugins.IndexStorePluginTests\\$RecoveryFactory@[\\w\\d]+\\)")));
+            assertThat(e.getMessage(), containsString("Duplicate key recovery-type"));
         } else {
             assertThat(e, hasToString(matches(
                 "java.lang.IllegalStateException: Duplicate key " +

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1434,7 +1434,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     new MetaStateService(nodeEnv, namedXContentRegistry),
                     Collections.emptyList(),
                     emptyMap(),
-                    null
+                    null,
+                    emptyMap()
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService =

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -76,7 +76,7 @@ public class WatcherPluginTests extends ESTestCase {
         AnalysisRegistry registry = new AnalysisRegistry(TestEnvironment.newEnvironment(settings), emptyMap(), emptyMap(), emptyMap(),
                 emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
         IndexModule indexModule = new IndexModule(indexSettings, registry, new InternalEngineFactory(), Collections.emptyMap(),
-                () -> true, new IndexNameExpressionResolver());
+                () -> true, new IndexNameExpressionResolver(), Collections.emptyMap());
         // this will trip an assertion if the watcher indexing operation listener is null (which it is) but we try to add it
         watcher.onIndexModule(indexModule);
 


### PR DESCRIPTION
Add a custom factory for recovery state into `IndexStorePlugin` that
allows different implementors to provide its own `RecoveryState`
implementation.