### PR TITLE
Implement toString for BulkByScrollTask

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -982,6 +983,15 @@ public class BulkByScrollTask extends CancellableTask {
                     }
                 }
                 throw new XContentParseException("Unable to parse StatusFromException. Expected fields not found.");
+            }
+        }
+
+        @Override
+        public String toString() {
+            if (exception != null) {
+                return "BulkByScrollTask{error=" + Strings.toString(this) + "}";
+            } else {
+                return "BulkByScrollTask{status=" + Strings.toString(this) + "}";
             }
         }
 


### PR DESCRIPTION
We should implement "toString" of BulkByScrollTask.StatusOrException to have a meaningful log message when a reindex task completes.