### PR TITLE
Document what makes a geo-point malformed

### DIFF
--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -123,6 +123,8 @@ The following parameters are accepted by `geo_point` fields:
 
     If `true`, malformed geo-points are ignored. If `false` (default),
     malformed geo-points throw an exception and reject the whole document.
+    A geo-point is considered malformed if its latitude is outside the range 
+    -90 <= latitude <= 90, or if its longitude is outside the range -180 <= longitude <= 180.
 
 `ignore_z_value`::
 


### PR DESCRIPTION
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
  - Yep!
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
  - Yep!

The docs around malformed-ness for the `geo-point` mapping type didn't mention what a malformed geo-point actually looked like. This PR adds documentation with information retrieved from the [validator class](https://github.com/elastic/elasticsearch/blob/13a8835e5a8615aeb8304b48fd9e543a83361e13/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeographyValidator.java).

