### PR TITLE
Fix security-cli distribution packaging

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -301,7 +301,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         if (oss == false) {
           into('tools/security-cli') {
             from { project(':x-pack:plugin:security:cli').jar }
-            from { project(':x-pack:plugin:security:cli').configurations.compileClasspath }
+            from { project(':x-pack:plugin:security:cli').configurations.runtimeClasspath }
           }
         }
       }


### PR DESCRIPTION
- This fixes https://github.com/elastic/elasticsearch/issues/59031
- do not use compileclasspath in distribution packaging as it uses by default
plain class files