### PR TITLE
Correct settings prefix for the crypto thread pool 

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1014,7 +1014,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                     "xpack.security.authc.token.thread_pool", false),
                 new FixedExecutorBuilder(settings, SECURITY_CRYPTO_THREAD_POOL_NAME,
                     (allocatedProcessors + 1) / 2, 1000,
-                    "xpack.security.authc.api_key.thread_pool", false)
+                    "xpack.security.crypto.thread_pool", false)
             );
         }
         return Collections.emptyList();


### PR DESCRIPTION
A small follow up for #58090 to correct the settings prefix