### PR TITLE
Dry up Master Disconnect Disruption Tests (#58953)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
@@ -25,15 +25,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
-import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.transport.MockTransportService;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
@@ -103,13 +98,7 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
         barrier.await();
 
         // interrupt communication between master and other nodes in cluster
-        String master = internalCluster().getMasterName();
-        Set<String> otherNodes = new HashSet<>(Arrays.asList(internalCluster().getNodeNames()));
-        otherNodes.remove(master);
-
-        NetworkDisruption partition = new NetworkDisruption(
-            new TwoPartitions(Collections.singleton(master), otherNodes),
-            new NetworkDisconnect());
+        NetworkDisruption partition = isolateMasterDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(partition);
 
         logger.info("--> disrupting network");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -40,7 +40,6 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.ArrayList;
@@ -296,10 +295,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         final String master = internalCluster().getMasterName();
         Set<String> otherNodes = new HashSet<>(Arrays.asList(internalCluster().getNodeNames()));
-        otherNodes.remove(master);
-        NetworkDisruption partition = new NetworkDisruption(
-                new TwoPartitions(Collections.singleton(master), otherNodes),
-                new NetworkDisruption.NetworkDisconnect());
+        NetworkDisruption partition = isolateMasterDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(partition);
 
         final CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.disruption.NetworkDisruption.IsolateAllNodes;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Collection;
@@ -84,7 +83,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
 
         final NetworkDisruption disruptionScheme
-            = new NetworkDisruption(new IsolateAllNodes(new HashSet<>(nodes)), new NetworkDisconnect());
+            = new NetworkDisruption(new IsolateAllNodes(new HashSet<>(nodes)), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(disruptionScheme);
         disruptionScheme.startDisrupting();
 
@@ -213,7 +212,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         logger.info("Cluster state:\n{}", clusterState.getState());
 
         final NetworkDisruption disruptionScheme
-            = new NetworkDisruption(new IsolateAllNodes(new HashSet<>(nodes)), new NetworkDisconnect());
+            = new NetworkDisruption(new IsolateAllNodes(new HashSet<>(nodes)), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(disruptionScheme);
         disruptionScheme.startDisrupting();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -51,7 +51,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.transport.MockTransportService;
 
@@ -148,7 +147,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         NetworkDisruption partition = new NetworkDisruption(
             new TwoPartitions(Sets.newHashSet(master, replicaNode), Collections.singleton(primaryNode)),
-            new NetworkDisconnect());
+            NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(partition);
         logger.info("--> partitioning node with primary shard from rest of cluster");
         partition.startDisrupting();
@@ -528,7 +527,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         }
         final Set<String> replicasSide1 = Sets.newHashSet(randomSubsetOf(between(1, numberOfReplicas - 1), replicaNodes));
         final Set<String> replicasSide2 = Sets.difference(replicaNodes, replicasSide1);
-        NetworkDisruption partition = new NetworkDisruption(new TwoPartitions(replicasSide1, replicasSide2), new NetworkDisconnect());
+        NetworkDisruption partition = new NetworkDisruption(new TwoPartitions(replicasSide1, replicasSide2), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(partition);
         logger.info("--> isolating some replicas during primary-replica resync");
         partition.startDisrupting();

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -48,8 +48,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.disruption.NetworkDisruption.Bridge;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruptionType;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
@@ -345,8 +343,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
         TwoPartitions partitions = isolateNode(isolatedNode);
         // we cannot use the NetworkUnresponsive disruption type here as it will swallow the "shard failed" request, calling neither
         // onSuccess nor onFailure on the provided listener.
-        NetworkLinkDisruptionType disruptionType = new NetworkDisconnect();
-        NetworkDisruption networkDisruption = new NetworkDisruption(partitions, disruptionType);
+        NetworkDisruption networkDisruption = new NetworkDisruption(partitions, NetworkDisruption.DISCONNECT);
         setDisruptionScheme(networkDisruption);
         networkDisruption.startDisrupting();
 
@@ -443,7 +440,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
 
         final String masterNode1 = internalCluster().getMasterName();
         NetworkDisruption networkDisruption =
-                new NetworkDisruption(new TwoPartitions(masterNode1, dataNode), new NetworkDisruption.NetworkUnresponsive());
+            new NetworkDisruption(new TwoPartitions(masterNode1, dataNode), NetworkDisruption.UNRESPONSIVE);
         internalCluster().setDisruptionScheme(networkDisruption);
         networkDisruption.startDisrupting();
         // We know this will time out due to the partition, we check manually below to not proceed until

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -31,14 +31,12 @@ import org.elasticsearch.discovery.zen.PublishClusterStateAction;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.disruption.SlowClusterStateProcessing;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -129,7 +127,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         final Set<String> nodes = new HashSet<>(internalCluster().startNodes(3));
         ensureStableCluster(3);
         ServiceDisruptionScheme isolateAllNodes =
-                new NetworkDisruption(new NetworkDisruption.IsolateAllNodes(nodes), new NetworkDisconnect());
+                new NetworkDisruption(new NetworkDisruption.IsolateAllNodes(nodes), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(isolateAllNodes);
 
         logger.info("--> forcing a complete election to make sure \"preferred\" master is elected");
@@ -153,11 +151,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         logger.info("--> preferred master is {}", preferredMaster);
         final Set<String> nonPreferredNodes = new HashSet<>(nodes);
         nonPreferredNodes.remove(preferredMasterName);
-        final ServiceDisruptionScheme isolatePreferredMaster =
-                new NetworkDisruption(
-                        new NetworkDisruption.TwoPartitions(
-                                Collections.singleton(preferredMasterName), nonPreferredNodes),
-                        new NetworkDisconnect());
+        final ServiceDisruptionScheme isolatePreferredMaster = isolateMasterDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(isolatePreferredMaster);
         isolatePreferredMaster.startDisrupting();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -37,9 +37,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.LongGCDisruption;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruptionType;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkUnresponsive;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.SingleNodeDisruption;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -91,9 +89,8 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
 
         // Simulate a network issue between the unlucky node and elected master node in both directions.
 
-        NetworkDisruption networkDisconnect = new NetworkDisruption(
-            new NetworkDisruption.TwoPartitions(masterNode, unluckyNode),
-            new NetworkDisruption.NetworkDisconnect());
+        NetworkDisruption networkDisconnect =
+            new NetworkDisruption(new NetworkDisruption.TwoPartitions(masterNode, unluckyNode), NetworkDisruption.DISCONNECT);
         setDisruptionScheme(networkDisconnect);
         networkDisconnect.startDisrupting();
 
@@ -123,14 +120,14 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * Verify that nodes fault detection detects a disconnected node after master reelection
      */
     public void testFollowerCheckerDetectsDisconnectedNodeAfterMasterReelection() throws Exception {
-        testFollowerCheckerAfterMasterReelection(new NetworkDisconnect(), Settings.EMPTY);
+        testFollowerCheckerAfterMasterReelection(NetworkDisruption.DISCONNECT, Settings.EMPTY);
     }
 
     /**
      * Verify that nodes fault detection detects an unresponsive node after master reelection
      */
     public void testFollowerCheckerDetectsUnresponsiveNodeAfterMasterReelection() throws Exception {
-        testFollowerCheckerAfterMasterReelection(new NetworkUnresponsive(), Settings.builder()
+        testFollowerCheckerAfterMasterReelection(NetworkDisruption.UNRESPONSIVE, Settings.builder()
             .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s")
             .put(LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING.getKey(), "4")
             .put(FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING.getKey(), "1s")

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
@@ -50,8 +50,8 @@ public class SnapshotShardsServiceIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testRetryPostingSnapshotStatusMessages() throws Exception {
-        String masterNode = internalCluster().startMasterOnlyNode();
-        String dataNode = internalCluster().startDataOnlyNode();
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
 
         createRepository("test-repo", "mock", Settings.builder()
             .put("location", randomRepoPath()).put("compress", randomBoolean())
@@ -77,8 +77,7 @@ public class SnapshotShardsServiceIT extends AbstractSnapshotIntegTestCase {
             .get().getSnapshots().get(0).snapshotId();
 
         logger.info("--> start disrupting cluster");
-        final NetworkDisruption networkDisruption = new NetworkDisruption(new NetworkDisruption.TwoPartitions(masterNode, dataNode),
-            NetworkDisruption.NetworkDelay.random(random()));
+        final NetworkDisruption networkDisruption = isolateMasterDisruption(NetworkDisruption.NetworkDelay.random(random()));
         internalCluster().setDisruptionScheme(networkDisruption);
         networkDisruption.startDisrupting();
 

--- a/server/src/test/java/org/elasticsearch/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/org/elasticsearch/discovery/AbstractDisruptionTestCase.java
@@ -38,7 +38,6 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.disruption.NetworkDisruption.Bridge;
 import org.elasticsearch.test.disruption.NetworkDisruption.DisruptedLinks;
-import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruptionType;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
@@ -96,7 +95,7 @@ public abstract class AbstractDisruptionTestCase extends ESIntegTestCase {
     @Override
     public void setDisruptionScheme(ServiceDisruptionScheme scheme) {
         if (scheme instanceof NetworkDisruption &&
-                ((NetworkDisruption) scheme).getNetworkLinkDisruptionType() instanceof NetworkDisruption.NetworkUnresponsive) {
+                ((NetworkDisruption) scheme).getNetworkLinkDisruptionType() == NetworkDisruption.UNRESPONSIVE) {
             // the network unresponsive disruption may leave operations in flight
             // this is because this disruption scheme swallows requests by design
             // as such, these operations will never be marked as finished
@@ -202,10 +201,10 @@ public abstract class AbstractDisruptionTestCase extends ESIntegTestCase {
         final NetworkLinkDisruptionType disruptionType;
         switch (randomInt(2)) {
             case 0:
-                disruptionType = new NetworkDisruption.NetworkUnresponsive();
+                disruptionType = NetworkDisruption.UNRESPONSIVE;
                 break;
             case 1:
-                disruptionType = new NetworkDisconnect();
+                disruptionType = NetworkDisruption.DISCONNECT;
                 break;
             case 2:
                 disruptionType = NetworkDisruption.NetworkDelay.random(random());
@@ -226,9 +225,9 @@ public abstract class AbstractDisruptionTestCase extends ESIntegTestCase {
     NetworkDisruption addRandomDisruptionType(TwoPartitions partitions) {
         final NetworkLinkDisruptionType disruptionType;
         if (randomBoolean()) {
-            disruptionType = new NetworkDisruption.NetworkUnresponsive();
+            disruptionType = NetworkDisruption.UNRESPONSIVE;
         } else {
-            disruptionType = new NetworkDisconnect();
+            disruptionType = NetworkDisruption.DISCONNECT;
         }
         NetworkDisruption partition = new NetworkDisruption(partitions, disruptionType);
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -701,6 +701,21 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     /**
+     * Creates a disruption that isolates the current master node from all other nodes in the cluster.
+     *
+     * @param disruptionType type of disruption to create
+     * @return disruption
+     */
+    protected static NetworkDisruption isolateMasterDisruption(NetworkDisruption.NetworkLinkDisruptionType disruptionType) {
+        final String masterNode = internalCluster().getMasterName();
+        return new NetworkDisruption(
+            new NetworkDisruption.TwoPartitions(
+                Collections.singleton(masterNode),
+                Arrays.stream(internalCluster().getNodeNames()).filter(name -> name.equals(masterNode) == false)
+                    .collect(Collectors.toSet())), disruptionType);
+    }
+
+    /**
      * Returns a settings object used in {@link #createIndex(String...)} and {@link #prepareCreate(String)} and friends.
      * This method can be overwritten by subclasses to set defaults for the indices that are created by the test.
      * By default it returns a settings object that sets a random number of shards. Number of shards and replicas

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
@@ -420,7 +420,7 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
     /**
      * Simulates a network disconnect. Sending a request from source to target node throws a {@link ConnectTransportException}.
      */
-    public static class NetworkDisconnect extends NetworkLinkDisruptionType {
+    public static final NetworkLinkDisruptionType DISCONNECT = new NetworkLinkDisruptionType() {
 
         @Override
         public void applyDisruption(MockTransportService sourceTransportService, MockTransportService targetTransportService) {
@@ -431,13 +431,12 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
         public String toString() {
             return "network disconnects";
         }
-    }
+    };
 
     /**
      * Simulates an unresponsive target node by dropping requests sent from source to target node.
      */
-    public static class NetworkUnresponsive extends NetworkLinkDisruptionType {
-
+    public static final NetworkLinkDisruptionType UNRESPONSIVE = new NetworkLinkDisruptionType() {
         @Override
         public void applyDisruption(MockTransportService sourceTransportService, MockTransportService targetTransportService) {
             sourceTransportService.addUnresponsiveRule(targetTransportService);
@@ -447,7 +446,7 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
         public String toString() {
             return "network unresponsive";
         }
-    }
+    };
 
     /**
      * Simulates slow or congested network. Delivery of requests that are sent from source to target node are delayed by a configurable

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
@@ -77,8 +77,7 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
         Set<String> side2 = new HashSet<>(nodes);
         side2.removeAll(side1);
         assertThat(side2.size(), greaterThanOrEqualTo(1));
-        NetworkDisruption networkDisruption = new NetworkDisruption(new TwoPartitions(side1, side2),
-                new NetworkDisruption.NetworkDisconnect());
+        NetworkDisruption networkDisruption = new NetworkDisruption(new TwoPartitions(side1, side2), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(networkDisruption);
         networkDisruption.startDisrupting();
 
@@ -124,8 +123,8 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
             disruptedLinks = NetworkDisruption.Bridge.random(random(), internalCluster().getNodeNames());
         }
 
-        NetworkDisruption networkDisruption = new NetworkDisruption(disruptedLinks, randomFrom(new NetworkDisruption.NetworkUnresponsive(),
-            new NetworkDisruption.NetworkDisconnect(), NetworkDisruption.NetworkDelay.random(random())));
+        NetworkDisruption networkDisruption = new NetworkDisruption(disruptedLinks, randomFrom(NetworkDisruption.UNRESPONSIVE,
+            NetworkDisruption.DISCONNECT, NetworkDisruption.NetworkDelay.random(random())));
         internalCluster().setDisruptionScheme(networkDisruption);
 
         networkDisruption.startDisrupting();
@@ -144,7 +143,7 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
 
         // give a bit of time to send something under disruption.
         assertFalse(latch.await(500, TimeUnit.MILLISECONDS)
-            && networkDisruption.getNetworkLinkDisruptionType() instanceof NetworkDisruption.NetworkDisconnect == false);
+            && networkDisruption.getNetworkLinkDisruptionType() != NetworkDisruption.DISCONNECT);
         networkDisruption.stopDisrupting();
 
         latch.await(30, TimeUnit.SECONDS);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -63,8 +63,8 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         restOfClusterSide.remove(origJobNode);
         String notIsolatedNode = restOfClusterSide.iterator().next();
 
-        NetworkDisruption networkDisruption = new NetworkDisruption(new NetworkDisruption.TwoPartitions(isolatedSide, restOfClusterSide),
-                new NetworkDisruption.NetworkDisconnect());
+        NetworkDisruption networkDisruption =
+            new NetworkDisruption(new NetworkDisruption.TwoPartitions(isolatedSide, restOfClusterSide), NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(networkDisruption);
         networkDisruption.startDisrupting();
         ensureStableCluster(4, notIsolatedNode);


### PR DESCRIPTION
Dry up tests that use a disruption that isolates the master from all other nodes.
Also, turn disruption types that have neither parameters nor state into constants
to make things a little clearer.

backport of #58953 