### PR TITLE
Fix MinimumMasterNodesIT Test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -295,6 +295,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         final String master = internalCluster().getMasterName();
         Set<String> otherNodes = new HashSet<>(Arrays.asList(internalCluster().getNodeNames()));
+        otherNodes.remove(master);
         NetworkDisruption partition = isolateMasterDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(partition);
 


### PR DESCRIPTION
Tiny oversight in dee9e048bdcc5ba59f20d2554e989015463df05a caused
the `otherNodes` collection to incorrectly contain `master` here.

