### PR TITLE
EQL: Introduce sequencing fetch size

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EqlIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EqlIT.java
@@ -103,7 +103,7 @@ public class EqlIT extends ESRestHighLevelClientTestCase {
 
     public void testBasicSearch() throws Exception {
         EqlClient eql = highLevelClient().eql();
-        EqlSearchRequest request = new EqlSearchRequest("index", "process where true");
+        EqlSearchRequest request = new EqlSearchRequest("index", "process where true").size(RECORD_COUNT);
         assertResponse(execute(request, eql::search, eql::searchAsync), RECORD_COUNT);
     }
 
@@ -115,7 +115,7 @@ public class EqlIT extends ESRestHighLevelClientTestCase {
         EqlSearchRequest request = new EqlSearchRequest("index", "foo where pid > 0");
 
         // test with non-default event.category mapping
-        request.eventCategoryField("event_type");
+        request.eventCategoryField("event_type").size(RECORD_COUNT);
 
         EqlSearchResponse response = execute(request, eql::search, eql::searchAsync);
         assertResponse(response, RECORD_COUNT / DIVIDER);

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -144,6 +144,8 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         EqlSearchRequest request = new EqlSearchRequest(testIndexName, query);
         request.isCaseSensitive(isCaseSensitive);
         request.tiebreakerField("event.sequence");
+        // some queries return more than 10 results
+        request.size(50);
         request.fetchSize(2);
         return eqlClient().search(request, RequestOptions.DEFAULT);
     }

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -144,6 +144,7 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         EqlSearchRequest request = new EqlSearchRequest(testIndexName, query);
         request.isCaseSensitive(isCaseSensitive);
         request.tiebreakerField("event.sequence");
+        //request.fetchSize(1);
         return eqlClient().search(request, RequestOptions.DEFAULT);
     }
 

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -144,7 +144,7 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         EqlSearchRequest request = new EqlSearchRequest(testIndexName, query);
         request.isCaseSensitive(isCaseSensitive);
         request.tiebreakerField("event.sequence");
-        //request.fetchSize(1);
+        request.fetchSize(2);
         return eqlClient().search(request, RequestOptions.DEFAULT);
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -155,8 +155,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             validationException = addValidationError("size must be greater than 0", validationException);
         }
 
-        if (fetchSize <= 0) {
-            validationException = addValidationError("fetch size must be greater than 0", validationException);
+        if (fetchSize < 2) {
+            validationException = addValidationError("fetch size must be greater than 1", validationException);
         }
 
         if (keepAlive != null  && keepAlive.getMillis() < MIN_KEEP_ALIVE) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -277,7 +277,9 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         return this;
     }
 
-    public int fetchSize() { return this.fetchSize; }
+    public int fetchSize() {
+        return this.fetchSize;
+    }
 
     public EqlSearchRequest fetchSize(int fetchSize) {
         this.fetchSize = fetchSize;
@@ -373,7 +375,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             return false;
         }
         EqlSearchRequest that = (EqlSearchRequest) o;
-        return size == that.size && 
+        return size == that.size &&
                 fetchSize == that.fetchSize &&
                 Arrays.equals(indices, that.indices) &&
                 Objects.equals(indicesOptions, that.indicesOptions) &&

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestBuilder.java
@@ -45,8 +45,13 @@ public class EqlSearchRequestBuilder extends ActionRequestBuilder<EqlSearchReque
         return this;
     }
 
-    public EqlSearchRequestBuilder fetchSize(int size) {
-        request.fetchSize(size);
+    public EqlSearchRequestBuilder size(int size) {
+        request.size(size);
+        return this;
+    }
+
+    public EqlSearchRequestBuilder fetchSize(int fetchSize) {
+        request.fetchSize(fetchSize);
         return this;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/RequestDefaults.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/RequestDefaults.java
@@ -14,5 +14,6 @@ public final class RequestDefaults {
     public static final String FIELD_EVENT_CATEGORY = "event.category";
     public static final String FIELD_IMPLICIT_JOIN_KEY = "agent.id";
 
-    public static int FETCH_SIZE = 10;
+    public static int SIZE = 10;
+    public static int FETCH_SIZE = 1000;
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
@@ -44,23 +44,25 @@ public class BoxedQueryRequest implements QueryRequest {
     }
 
     @Override
-    public void next(Ordinal ordinal) {
-        // reset existing constraints
-        timestampRange.gte(null).lte(null);
+    public void nextAfter(Ordinal ordinal) {
         if (tiebreakerRange != null) {
-            tiebreakerRange.gte(null).lte(null);
+            tiebreakerRange.gt(ordinal.tiebreaker());
+            timestampRange.gte(ordinal.timestamp());
+        } else {
+            timestampRange.gt(ordinal.timestamp());
         }
         // and leave only search_after
         searchSource.searchAfter(ordinal.toArray());
     }
 
-    public BoxedQueryRequest between(Ordinal begin, Ordinal end) {
-        timestampRange.gte(begin.timestamp()).lte(end.timestamp());
-
+    /**
+     * Sets the upper boundary for the query. Can be removed (when the query in unbounded) through null.
+     */
+    public BoxedQueryRequest until(Ordinal end) {
+        timestampRange.lte(end != null ? end.timestamp() : null);
         if (tiebreakerRange != null) {
-            tiebreakerRange.gte(begin.tiebreaker()).lte(end.tiebreaker());
+            tiebreakerRange.lte(end != null ? end.tiebreaker() : null);
         }
-
         return this;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
@@ -86,4 +86,9 @@ public class Criterion<Q extends QueryRequest> {
         }
         return new Ordinal(timestamp, tbreaker);
     }
+
+    @Override
+    public String toString() {
+        return "[" + stage + "][" + reverse + "]";
+    }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -73,7 +73,7 @@ public class ExecutionManager {
 
                 BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName, tiebreakerName);
                 Criterion<BoxedQueryRequest> criterion =
-                        new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i> 0 && descending);
+                        new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i > 0 && descending);
                 criteria.add(criterion);
             } else {
                 // until

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -69,6 +69,8 @@ public class ExecutionManager {
             if (query instanceof EsQueryExec) {
                 QueryRequest original = ((EsQueryExec) query).queryRequest(session);
                 
+                // increase the request size based on the fetch size (since size is applied already through limit)
+
                 BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName, tiebreakerName);
                 Criterion<BoxedQueryRequest> criterion =
                         new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i> 0 && descending);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
@@ -143,14 +143,18 @@ public class TumblingWindow implements Executable {
 
         client.query(request, wrap(p -> {
             List<SearchHit> hits = p.values();
-            // no more results in this window so continue in another window
+            // no more results in this window
             if (hits.isEmpty()) {
-                log.info("Advancing window...");
-                advance(listener);
-                return;
+                // if there are no previous matches, the rest of the queries don't matter
+                if (matcher.hasCandidates(criterion.stage()) == false) {
+                    log.info("Advancing window...");
+                    advance(listener);
+                    return;
+                }
+                // otherwise let the other queries run
             }
             // if the limit has been reached, return what's available
-            if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
+            else if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
                 listener.onResponse(payload());
                 return;
             }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
@@ -158,13 +158,16 @@ public class TumblingWindow implements Executable {
                 }
                 // otherwise let the other queries run to allow potential matches with the existing candidates
             }
-            // if the limit has been reached, return what's available
-            else if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
-                listener.onResponse(payload());
-                return;
+            else {
+                // prepare the query for the next search
+                request.nextAfter(criterion.ordinal(hits.get(hits.size() - 1)));
+
+                // if the limit has been reached, return what's available
+                if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
+                    listener.onResponse(payload());
+                    return;
+                }
             }
-            // prepare the query for the next search
-            request.nextAfter(criterion.ordinal(hits.get(hits.size() - 1)));
 
             // keep running the query runs out of the results (essentially returns less than what we want)
             if (hits.size() == windowSize) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/TumblingWindow.java
@@ -41,11 +41,20 @@ public class TumblingWindow implements Executable {
     private final Matcher matcher;
     // shortcut
     private final int maxStages;
+    private final int windowSize;
 
     private long startTime;
 
-    private int baseStage = 0;
-    private Ordinal begin, end;
+    private static class WindowInfo {
+        private final int baseStage;
+        private final Ordinal begin, end;
+
+        WindowInfo(int baseStage, Ordinal begin, Ordinal end) {
+            this.baseStage = baseStage;
+            this.begin = begin;
+            this.end = end;
+        }
+    }
 
     public TumblingWindow(QueryClient client,
                           List<Criterion<BoxedQueryRequest>> criteria,
@@ -56,6 +65,7 @@ public class TumblingWindow implements Executable {
         this.until = until;
         this.criteria = criteria;
         this.maxStages = criteria.size();
+        this.windowSize = criteria.get(0).queryRequest().searchSource().size();
 
         this.matcher = matcher;
     }
@@ -64,23 +74,20 @@ public class TumblingWindow implements Executable {
     public void execute(ActionListener<Payload> listener) {
         log.info("Starting sequence window...");
         startTime = System.currentTimeMillis();
-        advance(listener);
+        advance(0, listener);
     }
 
-
-    private void advance(ActionListener<Payload> listener) {
+    private void advance(int baseStage, ActionListener<Payload> listener) {
         // initialize
-        log.info("Querying base stage");
+        log.info("Querying base stage [{}]" + baseStage);
         Criterion<BoxedQueryRequest> base = criteria.get(baseStage);
+        // remove any potential upper limit (if a criteria has been promoted)
+        base.queryRequest().until(null);
 
-        if (end != null) {
-            // pick up where we left of
-            base.queryRequest().next(end);
-        }
-        client.query(base.queryRequest(), wrap(p -> baseCriterion(p, listener), listener::onFailure));
+        client.query(base.queryRequest(), wrap(p -> baseCriterion(baseStage, p, listener), listener::onFailure));
     }
 
-    private void baseCriterion(Payload p, ActionListener<Payload> listener) {
+    private void baseCriterion(int baseStage, Payload p, ActionListener<Payload> listener) {
         Criterion<BoxedQueryRequest> base = criteria.get(baseStage);
         List<SearchHit> hits = p.values();
 
@@ -95,14 +102,7 @@ public class TumblingWindow implements Executable {
         if (hits.size() < 2) {
             // if there are still candidates, advance the window base
             if (matcher.hasCandidates(baseStage) && baseStage + 1 < maxStages) {
-                // swap window begin/end when changing directions
-                if (base.reverse() != criteria.get(baseStage + 1).reverse()) {
-                    Ordinal temp = begin;
-                    begin = end;
-                    end = temp;
-                }
-                baseStage++;
-                advance(listener);
+                advance(baseStage + 1, listener);
             }
             // there aren't going to be any matches so cancel search
             else {
@@ -112,57 +112,74 @@ public class TumblingWindow implements Executable {
         }
 
         // get borders for the rest of the queries
-        begin = base.ordinal(hits.get(0));
-        end = base.ordinal(hits.get(hits.size() - 1));
+        Ordinal begin = base.ordinal(hits.get(0));
+        Ordinal end = base.ordinal(hits.get(hits.size() - 1));
+
+        // update current query for the next request
+        base.queryRequest().nextAfter(end);
 
         // find until ordinals
         //NB: not currently implemented
 
         // no more queries to run
         if (baseStage + 1 < maxStages) {
-            secondaryCriterion(baseStage + 1, listener);
+            secondaryCriterion(new WindowInfo(baseStage, begin, end), baseStage + 1, listener);
         } else {
-            advance(listener);
+            advance(baseStage, listener);
         }
     }
 
-    private void secondaryCriterion(int index, ActionListener<Payload> listener) {
-        Criterion<BoxedQueryRequest> criterion = criteria.get(index);
+    private void secondaryCriterion(WindowInfo window, int currentStage, ActionListener<Payload> listener) {
+        final Criterion<BoxedQueryRequest> criterion = criteria.get(currentStage);
         log.info("Querying (secondary) stage {}", criterion.stage());
 
         // first box the query
-        BoxedQueryRequest request = criterion.queryRequest();
-        Criterion<BoxedQueryRequest> base = criteria.get(baseStage);
+        final BoxedQueryRequest request = criterion.queryRequest();
+        Criterion<BoxedQueryRequest> base = criteria.get(window.baseStage);
 
         // if the base has a different direction, swap begin/end
+        // set upper limit of secondary query - the start was set on the previous run
         if (criterion.reverse() != base.reverse()) {
-            request.between(end, begin);
+            request.until(window.begin);
         } else {
-            request.between(begin, end);
+            request.until(window.end);
         }
 
         client.query(request, wrap(p -> {
             List<SearchHit> hits = p.values();
-            // no more results in this window
+
+            // no more results for this query
             if (hits.isEmpty()) {
-                // if there are no previous matches, the rest of the queries don't matter
+                // if there are no candidates, advance the window
                 if (matcher.hasCandidates(criterion.stage()) == false) {
                     log.info("Advancing window...");
-                    advance(listener);
+                    advance(window.baseStage, listener);
                     return;
                 }
-                // otherwise let the other queries run
+                // otherwise let the other queries run to allow potential matches with the existing candidates
             }
             // if the limit has been reached, return what's available
             else if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
                 listener.onResponse(payload());
                 return;
             }
+            // prepare the query for the next search
+            request.nextAfter(criterion.ordinal(hits.get(hits.size() - 1)));
 
-            if (index + 1 < maxStages) {
-                secondaryCriterion(index + 1, listener);
-            } else {
-                advance(listener);
+            // keep running the query runs out of the results (essentially returns less than what we want)
+            if (hits.size() == windowSize) {
+                secondaryCriterion(window, currentStage, listener);
+            }
+            // looks like this stage is done, move on
+            else {
+                // to the next query
+                if (currentStage + 1 < maxStages) {
+                    secondaryCriterion(window, currentStage + 1, listener);
+                }
+                // or to the next window
+                else {
+                    advance(window.baseStage, listener);
+                }
             }
 
         }, listener::onFailure));

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicListener.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicListener.java
@@ -34,20 +34,15 @@ public class BasicListener implements ActionListener<SearchResponse> {
             if (CollectionUtils.isEmpty(failures) == false) {
                 listener.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
             } else {
-                handleResponse(response, listener);
+                if (log.isTraceEnabled()) {
+                    logSearchResponse(response, log);
+                }
+                listener.onResponse(new SearchResponsePayload(response));
             }
         } catch (Exception ex) {
             onFailure(ex);
         }
     }
-
-    private void handleResponse(SearchResponse response, ActionListener<Payload> listener) {
-        if (log.isTraceEnabled()) {
-            logSearchResponse(response, log);
-        }
-        listener.onResponse(new SearchResponsePayload(response));
-    }
-
 
     @Override
     public void onFailure(Exception ex) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/QueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/QueryRequest.java
@@ -12,7 +12,7 @@ public interface QueryRequest {
 
     SearchSourceBuilder searchSource();
 
-    default void next(Ordinal ordinal) {
+    default void nextAfter(Ordinal ordinal) {
         searchSource().searchAfter(ordinal.toArray());
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
@@ -28,7 +28,7 @@ public abstract class SourceGenerator {
 
     private SourceGenerator() {}
 
-    public static SearchSourceBuilder sourceBuilder(QueryContainer container, QueryBuilder filter, Integer size) {
+    public static SearchSourceBuilder sourceBuilder(QueryContainer container, QueryBuilder filter) {
         QueryBuilder finalQuery = null;
         // add the source
         if (container.query() != null) {
@@ -59,19 +59,11 @@ public abstract class SourceGenerator {
         sorting(container, source);
         source.fetchSource(FetchSourceContext.FETCH_SOURCE);
 
-        // set fetch size
-        if (size != null) {
-            int sz = size;
-            if (container.limit() != null) {
-                Limit limit = container.limit();
-                // negative limit means DESC order but since the results are ordered ASC
-                // pagination becomes mute (since all the data needs to be returned)
-                sz = limit.limit > 0 ? Math.min(limit.total, size) : limit.total;
-            }
-
-            if (source.size() == -1) {
-                source.size(sz);
-            }
+        // add size and from
+        source.size(container.limit().absLimit());
+        // this should be added only for event queries
+        if (container.limit().offset > 0) {
+            source.from(container.limit().offset);
         }
 
         return source;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
@@ -59,11 +59,13 @@ public abstract class SourceGenerator {
         sorting(container, source);
         source.fetchSource(FetchSourceContext.FETCH_SOURCE);
 
-        // add size and from
-        source.size(container.limit().absLimit());
-        // this should be added only for event queries
-        if (container.limit().offset > 0) {
-            source.from(container.limit().offset);
+        if (container.limit() != null) {
+            // add size and from
+            source.size(container.limit().absLimit());
+            // this should be added only for event queries
+            if (container.limit().offset > 0) {
+                source.from(container.limit().offset);
+            }
         }
 
         return source;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
@@ -102,7 +102,7 @@ public abstract class LogicalPlanBuilder extends ExpressionBuilder {
         plan = new OrderBy(defaultOrderSource, plan, orders);
 
         // add the default limit only if specified
-        Literal defaultSize = new Literal(synthetic("<default-size>"), params.fetchSize(), DataTypes.INTEGER);
+        Literal defaultSize = new Literal(synthetic("<default-size>"), params.size(), DataTypes.INTEGER);
         Source defaultLimitSource = synthetic("<default-limit>");
 
         LogicalPlan previous = plan;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ParserParams.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ParserParams.java
@@ -10,10 +10,10 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.xpack.eql.action.RequestDefaults.FETCH_SIZE;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_EVENT_CATEGORY;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_IMPLICIT_JOIN_KEY;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_TIMESTAMP;
+import static org.elasticsearch.xpack.eql.action.RequestDefaults.SIZE;
 
 public class ParserParams {
 
@@ -22,7 +22,7 @@ public class ParserParams {
     private String fieldTimestamp = FIELD_TIMESTAMP;
     private String fieldTiebreaker = null;
     private String implicitJoinKey = FIELD_IMPLICIT_JOIN_KEY;
-    private int fetchSize = FETCH_SIZE;
+    private int size = SIZE;
     private List<Object> queryParams = emptyList();
 
     public ParserParams(ZoneId zoneId) {
@@ -65,12 +65,12 @@ public class ParserParams {
         return this;
     }
 
-    public int fetchSize() {
-        return fetchSize;
+    public int size() {
+        return size;
     }
 
-    public ParserParams fetchSize(int fetchSize) {
-        this.fetchSize = fetchSize;
+    public ParserParams size(int size) {
+        this.size = size;
         return this;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ParserParams.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ParserParams.java
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.eql.action.RequestDefaults.FETCH_SIZE;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_EVENT_CATEGORY;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_IMPLICIT_JOIN_KEY;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_TIMESTAMP;
@@ -23,6 +24,7 @@ public class ParserParams {
     private String fieldTiebreaker = null;
     private String implicitJoinKey = FIELD_IMPLICIT_JOIN_KEY;
     private int size = SIZE;
+    private int fetchSize = FETCH_SIZE;
     private List<Object> queryParams = emptyList();
 
     public ParserParams(ZoneId zoneId) {
@@ -71,6 +73,15 @@ public class ParserParams {
 
     public ParserParams size(int size) {
         this.size = size;
+        return this;
+    }
+
+    public int fetchSize() {
+        return fetchSize;
+    }
+
+    public ParserParams fetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
         return this;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/EsQueryExec.java
@@ -51,7 +51,9 @@ public class EsQueryExec extends LeafExec {
 
     public QueryRequest queryRequest(EqlSession session) {
         EqlConfiguration cfg = session.configuration();
-        SearchSourceBuilder sourceBuilder = SourceGenerator.sourceBuilder(queryContainer, cfg.filter(), cfg.size());
+        // by default use the configuration size
+        // join/sequence queries will want to override this
+        SearchSourceBuilder sourceBuilder = SourceGenerator.sourceBuilder(queryContainer, cfg.filter());
         return () -> sourceBuilder;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -116,10 +116,11 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
             .fieldTimestamp(request.timestampField())
             .fieldTiebreaker(request.tiebreakerField())
             .implicitJoinKey(request.implicitJoinKeyField())
-                .size(request.size());
+            .size(request.size())
+            .fetchSize(request.fetchSize());
 
-        EqlConfiguration cfg = new EqlConfiguration(request.indices(), zoneId, username, clusterName, filter, timeout, request.size(),
-            request.fetchSize(), includeFrozen, request.isCaseSensitive(), clientId, new TaskId(nodeId, task.getId()), task);
+        EqlConfiguration cfg = new EqlConfiguration(request.indices(), zoneId, username, clusterName, filter, timeout, includeFrozen,
+            request.isCaseSensitive(), clientId, new TaskId(nodeId, task.getId()), task);
         planExecutor.eql(cfg, request.query(), params, wrap(r -> listener.onResponse(createResponse(r, task.getExecutionId())),
             listener::onFailure));
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -24,12 +24,12 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
-import org.elasticsearch.xpack.eql.async.AsyncTaskManagementService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.eql.action.EqlSearchAction;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
 import org.elasticsearch.xpack.eql.action.EqlSearchTask;
+import org.elasticsearch.xpack.eql.async.AsyncTaskManagementService;
 import org.elasticsearch.xpack.eql.execution.PlanExecutor;
 import org.elasticsearch.xpack.eql.parser.ParserParams;
 import org.elasticsearch.xpack.eql.session.EqlConfiguration;
@@ -116,10 +116,10 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
             .fieldTimestamp(request.timestampField())
             .fieldTiebreaker(request.tiebreakerField())
             .implicitJoinKey(request.implicitJoinKeyField())
-            .fetchSize(request.fetchSize());
+                .size(request.size());
 
-        EqlConfiguration cfg = new EqlConfiguration(request.indices(), zoneId, username, clusterName, filter, timeout, request.fetchSize(),
-            includeFrozen, request.isCaseSensitive(), clientId, new TaskId(nodeId, task.getId()), task);
+        EqlConfiguration cfg = new EqlConfiguration(request.indices(), zoneId, username, clusterName, filter, timeout, request.size(),
+            request.fetchSize(), includeFrozen, request.isCaseSensitive(), clientId, new TaskId(nodeId, task.getId()), task);
         planExecutor.eql(cfg, request.query(), params, wrap(r -> listener.onResponse(createResponse(r, task.getExecutionId())),
             listener::onFailure));
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/QueryContainer.java
@@ -168,7 +168,7 @@ public class QueryContainer {
     public String toString() {
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.humanReadable(true).prettyPrint();
-            SourceGenerator.sourceBuilder(this, null, null).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            SourceGenerator.sourceBuilder(this, null).toXContent(builder, ToXContent.EMPTY_PARAMS);
             return Strings.toString(builder);
         } catch (IOException e) {
             throw new EqlIllegalArgumentException("error rendering", e);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
@@ -19,8 +19,6 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     private final String[] indices;
     private final TimeValue requestTimeout;
-    private final int size;
-    private final int fetchSize;
     private final String clientId;
     private final boolean includeFrozenIndices;
     private final TaskId taskId;
@@ -31,15 +29,12 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     private final QueryBuilder filter;
 
     public EqlConfiguration(String[] indices, ZoneId zi, String username, String clusterName, QueryBuilder filter, TimeValue requestTimeout,
-                            int size, int fetchSize, boolean includeFrozen, boolean isCaseSensitive, String clientId, TaskId taskId,
-                            EqlSearchTask task) {
+                            boolean includeFrozen, boolean isCaseSensitive, String clientId, TaskId taskId, EqlSearchTask task) {
         super(zi, username, clusterName);
 
         this.indices = indices;
         this.filter = filter;
         this.requestTimeout = requestTimeout;
-        this.size = size;
-        this.fetchSize = fetchSize;
         this.clientId = clientId;
         this.includeFrozenIndices = includeFrozen;
         this.isCaseSensitive = isCaseSensitive;
@@ -61,14 +56,6 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     public QueryBuilder filter() {
         return filter;
-    }
-
-    public int size() {
-        return size;
-    }
-
-    public int fetchSize() {
-        return fetchSize;
     }
 
     public String clientId() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
@@ -20,6 +20,7 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     private final String[] indices;
     private final TimeValue requestTimeout;
     private final int size;
+    private final int fetchSize;
     private final String clientId;
     private final boolean includeFrozenIndices;
     private final TaskId taskId;
@@ -30,13 +31,15 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     private final QueryBuilder filter;
 
     public EqlConfiguration(String[] indices, ZoneId zi, String username, String clusterName, QueryBuilder filter, TimeValue requestTimeout,
-                         int size, boolean includeFrozen, boolean isCaseSensitive, String clientId, TaskId taskId, EqlSearchTask task) {
+                            int size, int fetchSize, boolean includeFrozen, boolean isCaseSensitive, String clientId, TaskId taskId,
+                            EqlSearchTask task) {
         super(zi, username, clusterName);
 
         this.indices = indices;
         this.filter = filter;
         this.requestTimeout = requestTimeout;
         this.size = size;
+        this.fetchSize = fetchSize;
         this.clientId = clientId;
         this.includeFrozenIndices = includeFrozen;
         this.isCaseSensitive = isCaseSensitive;
@@ -62,6 +65,10 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     public int size() {
         return size;
+    }
+
+    public int fetchSize() {
+        return fetchSize;
     }
 
     public String clientId() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -28,12 +28,12 @@ public final class EqlTestUtils {
     }
 
     public static final EqlConfiguration TEST_CFG_CASE_INSENSITIVE = new EqlConfiguration(new String[] {"none"},
-            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, false, false, "",
-            new TaskId("test", 123), null);
+            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, -1, false, false,
+            "", new TaskId("test", 123), null);
 
     public static final EqlConfiguration TEST_CFG_CASE_SENSITIVE = new EqlConfiguration(new String[] {"none"},
-        org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, false, true, "",
-        new TaskId("test", 123), null);
+            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, -1, false, true,
+            "", new TaskId("test", 123), null);
 
     public static EqlConfiguration randomConfiguration() {
         return internalRandomConfiguration(randomBoolean());
@@ -50,6 +50,7 @@ public final class EqlTestUtils {
             randomAlphaOfLength(16),
             null,
             new TimeValue(randomNonNegativeLong()),
+            randomIntBetween(5, 100),
             randomIntBetween(5, 100),
             randomBoolean(),
             isCaseSensitive,

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
-import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomLong;
 import static org.elasticsearch.test.ESTestCase.randomNonNegativeLong;
 import static org.elasticsearch.test.ESTestCase.randomZone;
@@ -28,11 +27,11 @@ public final class EqlTestUtils {
     }
 
     public static final EqlConfiguration TEST_CFG_CASE_INSENSITIVE = new EqlConfiguration(new String[] {"none"},
-            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, -1, false, false,
+            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), false, false, 
             "", new TaskId("test", 123), null);
 
     public static final EqlConfiguration TEST_CFG_CASE_SENSITIVE = new EqlConfiguration(new String[] {"none"},
-            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), -1, -1, false, true,
+            org.elasticsearch.xpack.ql.util.DateUtils.UTC, "nobody", "cluster", null, TimeValue.timeValueSeconds(30), false, true, 
             "", new TaskId("test", 123), null);
 
     public static EqlConfiguration randomConfiguration() {
@@ -50,8 +49,6 @@ public final class EqlTestUtils {
             randomAlphaOfLength(16),
             null,
             new TimeValue(randomNonNegativeLong()),
-            randomIntBetween(5, 100),
-            randomIntBetween(5, 100),
             randomBoolean(),
             isCaseSensitive,
             randomAlphaOfLength(16),

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlRequestParserTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlRequestParserTests.java
@@ -71,7 +71,8 @@ public class EqlRequestParserTests extends ESTestCase {
         assertEquals("etf", request.eventCategoryField());
         assertEquals("imjf", request.implicitJoinKeyField());
         assertArrayEquals(new Object[]{12345678, "device-20184", "/user/local/foo.exe", "2019-11-26T00:45:43.542"}, request.searchAfter());
-        assertEquals(101, request.fetchSize());
+        assertEquals(101, request.size());
+        assertEquals(1000, request.fetchSize());
         assertEquals("file where user != 'SYSTEM' by file_path", request.query());
         assertEquals(setIsCaseSensitive && isCaseSensitive, request.isCaseSensitive());
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
@@ -81,7 +81,7 @@ public class LogicalPlanTests extends ESTestCase {
         Order order = new Order(Source.EMPTY, timestamp(), OrderDirection.ASC, NullsPosition.FIRST);
         LogicalPlan project = new Project(Source.EMPTY, filter, singletonList(timestamp()));
         LogicalPlan sorted = new OrderBy(Source.EMPTY, project, singletonList(order));
-        LogicalPlan head = new Head(Source.EMPTY, new Literal(Source.EMPTY, RequestDefaults.FETCH_SIZE, DataTypes.INTEGER), sorted);
+        LogicalPlan head = new Head(Source.EMPTY, new Literal(Source.EMPTY, RequestDefaults.SIZE, DataTypes.INTEGER), sorted);
         return head;
     }
     

--- a/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
@@ -534,3 +534,27 @@ process where subtract(43, serial_event_id) == 41
 InternalQlScriptUtils.sub(params.v0,InternalQlScriptUtils.docValue(doc,params.v1)),params.v2))",
 "params":{"v0":43,"v1":"serial_event_id","v2":41}
 ;
+
+eventQueryDefaultLimit
+process where true
+;
+"size":10,
+;
+
+eventQueryWithHead
+process where true | head 5
+;
+"size":5,
+;
+
+eventQueryWithTail
+process where true | tail 5
+;
+"size":5,
+;
+
+eventQueryWithHeadAndTail
+process where true | tail 10 | head 7
+;
+"size":7,
+;


### PR DESCRIPTION
The current internal sequence algorithm relies on fetching multiple results and then paginating through the dataset. Depending on the dataset and memory, setting a larger page size can yield better performance at the expense of memory.
This PR makes this behavior explicit by decoupling the fetch size from size, the maximum number of results desired. 
As such, use in testing a minimum fetch size which exposed a number of bugs:
1. Jumping across data across queries causing valid data to be seen as a gap.
2. Incorrectly resuming searching across pages (again causing data to be discarded).

which have been addressed.