### PR TITLE
[DOCS] Add data streams to rank eval API docs

### DIFF
--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -145,9 +145,10 @@ GET /my_index/_rank_eval
 <1> The search request's ID, used to group result details later.
 <2> The query being evaluated.
 <3> A list of document ratings. Each entry contains the following arguments:
-- `_index`: The document's data stream or index
-- `_id`: The document ID
-- `rating`: The document's relevance with regard to this search request
+- `_index`: The document's index. For data streams, this should be the
+   document's backing index.
+- `_id`: The document ID.
+- `rating`: The document's relevance with regard to this search request.
 
 A document `rating` can be any integer value that expresses the relevance of the 
 document on a user-defined scale. For some of the metrics, just giving a binary 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -1,5 +1,8 @@
 [[search-rank-eval]]
-=== Ranking Evaluation API
+=== Ranking evaluation API
+++++
+<titleabbrev>Ranking evaluation</titleabbrev>
+++++
 
 Allows you to evaluate the quality of ranked search results over a set of 
 typical search queries.
@@ -7,9 +10,9 @@ typical search queries.
 [[search-rank-eval-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_rank_eval`
+`GET /<target>/_rank_eval`
 
-`POST /<index>/_rank_eval`
+`POST /<target>/_rank_eval`
 
 
 [[search-rank-eval-api-desc]]
@@ -42,7 +45,7 @@ In order to get started with search quality evaluation, you need three basic
 things:
 
 . A collection of documents you want to evaluate your query performance against, 
-  usually one or more indices.
+  usually one or more data streams or indices.
 . A collection of typical search requests that users enter into your system.
 . A set of document ratings that represent the documents' relevance with respect
   to a search request.
@@ -61,9 +64,13 @@ generation in your application.
 [[search-rank-eval-api-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
- (Required, string) Comma-separated list or wildcard expression of index names
- used to limit the request.
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard (`*`) expressions are supported.
++
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [[search-rank-eval-api-query-params]]
 ==== {api-query-parms-title}
@@ -135,11 +142,12 @@ GET /my_index/_rank_eval
 -----------------------------
 // NOTCONSOLE
 
-<1> the search request's id, used to group result details later 
-<2> the query that is being evaluated
-<3> a list of document ratings, each entry containing the document's `_index` and 
-`_id` together with the rating of the document's relevance with regard to this 
-search request
+<1> The search request's ID, used to group result details later.
+<2> The query being evaluated.
+<3> A list of document ratings. Each entry contains the following arguments:
+- `_index`: The document's data stream or index
+- `_id`: The document ID
+- `rating`: The document's relevance with regard to this search request
 
 A document `rating` can be any integer value that expresses the relevance of the 
 document on a user-defined scale. For some of the metrics, just giving a binary 


### PR DESCRIPTION
Updates the existing rank evaluation API docs to make them
aware of data streams.

Relates to #58848