### PR TITLE
Fix bug in parent and child aggregators when parent field not defined (backport of #57089)

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
@@ -112,17 +112,25 @@ public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<C
     @Override
     protected ValuesSourceConfig resolveConfig(QueryShardContext queryShardContext) {
         ValuesSourceConfig config;
+
         ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(queryShardContext.getMapperService());
-        ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
-        if (parentIdFieldMapper != null) {
-            parentFilter = parentIdFieldMapper.getParentFilter();
-            childFilter = parentIdFieldMapper.getChildFilter(childType);
-            MappedFieldType fieldType = parentIdFieldMapper.fieldType();
-            config = ValuesSourceConfig.resolveFieldOnly(fieldType, queryShardContext);
-        } else {
+        if (parentJoinFieldMapper == null) {
             // Unmapped field case
             config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), queryShardContext);
+            return config;
         }
+
+        ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
+        if (parentIdFieldMapper == null) {
+            // Unmapped field case
+            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), queryShardContext);
+            return config;
+        }
+
+        parentFilter = parentIdFieldMapper.getParentFilter();
+        childFilter = parentIdFieldMapper.getChildFilter(childType);
+        MappedFieldType fieldType = parentIdFieldMapper.fieldType();
+        config = ValuesSourceConfig.resolveFieldOnly(fieldType, queryShardContext);
         return config;
     }
 

--- a/modules/parent-join/src/test/resources/rest-api-spec/test/40_unconfigred.yml
+++ b/modules/parent-join/src/test/resources/rest-api-spec/test/40_unconfigred.yml
@@ -1,0 +1,24 @@
+---
+"unconfigured":
+  - do:
+      index:
+        index: test
+        refresh: true
+        body:
+          join:
+            name: question
+          body: <p>I have Windows 2003 server and i bought a new Windows 2008 server...,
+          title: Whats the best way to file transfer my site from server to a newer one?,
+          tags: [windows-server-2003, windows-server-2008, file-transfer]
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            to-answers:
+              children:
+                type: answer
+  - match: { hits.total.value: 1 }
+  - match: { aggregations.to-answers.doc_count: 0 }


### PR DESCRIPTION
Adding null check for ParentJoinFieldMapper in ChildrenAggregationBuilder.joinFieldResolveConfig

Closes #42997
