### PR TITLE
[DOCS] Removing ESS icon for xpack.security.audit.enabled

### DIFF
--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -14,7 +14,7 @@ on each node in the cluster. For more information, see <<enable-audit-logging>>.
 ==== General Auditing Settings
 [[xpack-security-audit-enabled]]
 // tag::xpack-security-audit-enabled-tag[]
-`xpack.security.audit.enabled` {ess-icon}::
+`xpack.security.audit.enabled`::
 Set to `true` to enable auditing on the node. The default value is `false`.
 This puts the auditing events in a dedicated file named `<clustername>_audit.json`
 on each node.


### PR DESCRIPTION
Removing the ESS icon for `xpack.security.audit.enabled`, which is not a supported setting.

Closes #59075  

Backports:
* 7.x #59079 
* 7.8 #59080 