### PR TITLE
[DOCS] EQL: Document `size` limit for pipes

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -163,7 +163,11 @@ this value is required.
 `fetch_size`::
 (Optional, integer)
 Maximum number of events to search at a time for sequence queries. Defaults to
-`1000`. This value must be greater than `2`.
+`1000`.
++
+This value must be greater than `2` but cannot exceed the value of the
+<<index-max-result-window,`index.max_result_window`>> setting, which defaults to
+`10000`.
 +
 Internally, a sequence query fetches and paginates sets of events to search for
 matches. This parameter controls the size of those sets. This parameter does not

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -163,14 +163,14 @@ this value is required.
 `fetch_size`::
 (Optional, integer)
 Maximum number of events to search at a time for sequence queries. Defaults to
-`1000`.
+`1000`. This value must be greater than `0`.
 +
 Internally, a sequence query fetches and paginates sets of events to search for
 matches. This parameter controls the size of those sets. This parameter does not
 limit the total number of events searched or the number of matching events
 returned.
 +
-A larger `fetch_size` often increases search speed but uses more memory.
+A greater `fetch_size` value often increases search speed but uses more memory.
 
 `filter`::
 (Optional, <<query-dsl,query DSL object>>)
@@ -244,6 +244,9 @@ For <<eql-sequences,sequence queries>>, the maximum number of matching sequences
 to return.
 +
 Defaults to `10`. This value must be greater than `0`.
++
+NOTE: You cannot use <<eql-pipe-ref,pipes>>, such as `head` or `tail`, to exceed
+this value.
 
 [[eql-search-api-tiebreaker-field]]
 `tiebreaker_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -163,7 +163,7 @@ this value is required.
 `fetch_size`::
 (Optional, integer)
 Maximum number of events to search at a time for sequence queries. Defaults to
-`1000`. This value must be greater than `0`.
+`1000`. This value must be greater than `2`.
 +
 Internally, a sequence query fetches and paginates sets of events to search for
 matches. This parameter controls the size of those sets. This parameter does not

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -231,7 +231,7 @@ return.
 For <<eql-sequences,sequence queries>>, the maximum number of matching sequences
 to return.
 +
-Defaults to `50`. This value must be greater than `0`.
+Defaults to `10`. This value must be greater than `0`.
 
 [[eql-search-api-tiebreaker-field]]
 `tiebreaker_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -160,6 +160,18 @@ Defaults to `event.category`, as defined in the {ecs-ref}/ecs-event.html[Elastic
 Common Schema (ECS)]. If an index does not contain the `event.category` field,
 this value is required.
 
+`fetch_size`::
+(Optional, integer)
+Maximum number of events to search at a time for sequence queries. Defaults to
+`1000`.
++
+Internally, a sequence query fetches and paginates sets of events to search for
+matches. This parameter controls the size of those sets. This parameter does not
+limit the total number of events searched or the number of matching events
+returned.
++
+A larger `fetch_size` often increases search speed but uses more memory.
+
 `filter`::
 (Optional, <<query-dsl,query DSL object>>)
 Query, written in query DSL, used to filter the events on which the EQL query

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -45,9 +45,6 @@ head <max>
 `<max>`::
 (Required, integer)
 Maximum number of matching events to return.
-+
-NOTE: You cannot use this parameter to exceed the <<eql-search-api,EQL search
-API>>'s `size` argument, which defaults to `10`.
 ====
 
 [discrete]
@@ -82,7 +79,4 @@ tail <max>
 `<max>`::
 (Required, integer)
 Maximum number of matching events to return.
-+
-NOTE: You cannot use this parameter to exceed the <<eql-search-api,EQL search
-API>>'s `size` argument, which defaults to `10`.
 ====

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -25,13 +25,13 @@ https://en.wikipedia.org/wiki/Head_(Unix)[Unix head command].
 ====
 *Example*
 
-The following EQL query returns up to fifty of the earliest powershell
+The following EQL query returns up to three of the earliest powershell
 commands.
 
 [source,eql]
 ----
 process where process.name == "powershell.exe"
-| head 50
+| head 3
 ----
 
 *Syntax*
@@ -45,6 +45,9 @@ head <max>
 `<max>`::
 (Required, integer)
 Maximum number of matching events to return.
++
+NOTE: You cannot use this parameter to exceed the <<eql-search-api,EQL search
+API>>'s `size` argument, which defaults to `10`.
 ====
 
 [discrete]
@@ -59,13 +62,13 @@ https://en.wikipedia.org/wiki/Tail_(Unix)[Unix tail command].
 ====
 *Example*
 
-The following EQL query returns up to thirty of the most recent `svchost.exe`
+The following EQL query returns up to five of the most recent `svchost.exe`
 processes.
 
 [source,eql]
 ----
 process where process.name == "svchost.exe"
-| tail 30
+| tail 5
 ----
 
 *Syntax*
@@ -79,4 +82,7 @@ tail <max>
 `<max>`::
 (Required, integer)
 Maximum number of matching events to return.
++
+NOTE: You cannot use this parameter to exceed the <<eql-search-api,EQL search
+API>>'s `size` argument, which defaults to `10`.
 ====

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -17,8 +17,8 @@ dev::[]
 [[eql-pipe-head]]
 === `head`
 
-Returns up to a specified number of events, starting with the earliest matching
-events. Works similarly to the
+Returns up to a specified number of events or sequences, starting with the
+earliest matches. Works similarly to the
 https://en.wikipedia.org/wiki/Head_(Unix)[Unix head command].
 
 [%collapsible]
@@ -44,15 +44,15 @@ head <max>
 
 `<max>`::
 (Required, integer)
-Maximum number of matching events to return.
+Maximum number of matching events or sequences to return.
 ====
 
 [discrete]
 [[eql-pipe-tail]]
 === `tail`
 
-Returns up to a specified number of events, starting with the most recent
-matching events. Works similarly to the
+Returns up to a specified number of events or sequences, starting with the most
+recent matches. Works similarly to the
 https://en.wikipedia.org/wiki/Tail_(Unix)[Unix tail command].
 
 [%collapsible]
@@ -78,5 +78,5 @@ tail <max>
 
 `<max>`::
 (Required, integer)
-Maximum number of matching events to return.
+Maximum number of matching events or sequences to return.
 ====


### PR DESCRIPTION
Changes:
* Documents the `size` default as `10`.
* Updates `size` param def to note its relation to pipes.
* Updates the `head` and `tail` pipe docs to modify sequences.
* Documents the `fetch_size` parameter.

Relates to #59014 and #59063