### PR TITLE
7.8 - Create plugin for yamlTest task (#56841) 

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -301,22 +301,21 @@ restResources {
 }
 ---------------------------------------------------------------------------
 
-YAML tests that include x-pack specific APIs need to explicitly declare
+YAML REST tests that include x-pack specific APIs need to explicitly declare
 which APIs are required through a similar `includeXpack` configuration.
 
 The REST tests are run automatically when executing the "./gradlew check" command. To run only the
-REST tests use the following command:
+YAML REST tests use the following command (modules and plugins may also include YAML REST tests):
 
 ---------------------------------------------------------------------------
-./gradlew :distribution:archives:integ-test-zip:integTestRunner \
- --tests "org.elasticsearch.test.rest.IntegTestZipClientYamlTestSuiteIT"
+./gradlew :rest-api-spec:yamlRestTest
 ---------------------------------------------------------------------------
 
 A specific test case can be run with the following command:
 
 ---------------------------------------------------------------------------
-./gradlew ':distribution:archives:integ-test-zip:integTestRunner' \
-  --tests "org.elasticsearch.test.rest.IntegTestZipClientYamlTestSuiteIT" \
+./gradlew ':rest-api-spec:yamlRestTestRunner' \
+  --tests "org.elasticsearch.test.rest.ClientYamlTestSuiteIT" \
   -Dtests.method="test {p0=cat.segments/10_basic/Help}"
 ---------------------------------------------------------------------------
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -24,7 +24,6 @@ import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.test.rest.RestResourcesPlugin
 import org.elasticsearch.gradle.test.RestIntegTestTask
 import org.elasticsearch.gradle.testclusters.RunTask
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
@@ -56,7 +55,6 @@ class PluginBuildPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.pluginManager.apply(BuildPlugin)
         project.pluginManager.apply(TestClustersPlugin)
-        project.pluginManager.apply(RestResourcesPlugin)
 
         PluginPropertiesExtension extension = project.extensions.create(PLUGIN_EXTENSION_NAME, PluginPropertiesExtension, project)
         configureDependencies(project)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
@@ -27,7 +27,6 @@ import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 import org.elasticsearch.gradle.precommit.PrecommitTasks
-import org.elasticsearch.gradle.test.rest.RestResourcesPlugin
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
@@ -73,8 +72,6 @@ class StandaloneRestTestPlugin implements Plugin<Project> {
         // only setup tests to build
         SourceSetContainer sourceSets = project.extensions.getByType(SourceSetContainer)
         SourceSet testSourceSet = sourceSets.create('test')
-        // need to apply plugin after test source sets are created
-        project.pluginManager.apply(RestResourcesPlugin)
 
         project.tasks.withType(Test).configureEach { Test test ->
             test.testClassesDirs = testSourceSet.output.classesDirs

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestIntegTestTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestIntegTestTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.tasks.Internal;
 
 public class RestIntegTestTask extends DefaultTask {
 
@@ -36,6 +37,9 @@ public class RestIntegTestTask extends DefaultTask {
     private static final String TESTS_CLUSTER = "tests.cluster";
     private static final String TESTS_CLUSTER_NAME = "tests.clustername";
 
+    // TODO: refactor this so that work is not done in constructor and find usages and register them, not create them
+    // See: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
+    // See: https://github.com/elastic/elasticsearch/issues/47804
     public RestIntegTestTask() {
         Project project = getProject();
         String name = getName();
@@ -100,5 +104,10 @@ public class RestIntegTestTask extends DefaultTask {
 
     public void runner(Action<? super RestTestRunnerTask> configure) {
         configure.execute(runner);
+    }
+
+    @Internal
+    public RestTestRunnerTask getRunner() {
+        return runner;
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.test.rest;
+
+import org.elasticsearch.gradle.ElasticsearchJavaPlugin;
+import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.info.BuildParams;
+import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
+import org.elasticsearch.gradle.test.RestIntegTestTask;
+import org.elasticsearch.gradle.testclusters.RestTestRunnerTask;
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.bundling.Zip;
+
+/**
+ * Apply this plugin to run the YAML based REST tests.
+ */
+public class YamlRestTestPlugin implements Plugin<Project> {
+
+    public static final String SOURCE_SET_NAME = "yamlRestTest";
+
+    @Override
+    public void apply(Project project) {
+
+        // yaml Rest tests require a Java test runner
+        project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
+        // to spin up the external cluster
+        project.getPluginManager().apply(TestClustersPlugin.class);
+        // to copy around the yaml tests and json spec
+        project.getPluginManager().apply(RestResourcesPlugin.class);
+
+        // note - source sets are not created via org.elasticsearch.gradle.util.GradleUtils.addTestSourceSet since unlike normal tests
+        // we only want the yamlRestTestSourceSet on the classpath by default. The yaml tests should be pure black box testing over HTTP and
+        // such it should not need the main class on the class path. Also, there are some special setup steps unique to YAML REST tests.
+
+        // create source set
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
+
+        // create task - note can not use .register due to the work in RestIntegTestTask's constructor :(
+        // see: https://github.com/elastic/elasticsearch/issues/47804
+        RestIntegTestTask yamlRestTestTask = project.getTasks().create(SOURCE_SET_NAME, RestIntegTestTask.class);
+        yamlRestTestTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+        yamlRestTestTask.setDescription("Runs the YAML based REST tests against an external cluster");
+
+        // setup task dependency
+        if (BuildParams.isInternal()) {
+            project.getDependencies().add(yamlTestSourceSet.getImplementationConfigurationName(), project.project(":test:framework"));
+        } else {
+            project.getDependencies()
+                .add(
+                    yamlTestSourceSet.getImplementationConfigurationName(),
+                    "org.elasticsearch.test:framework:" + VersionProperties.getElasticsearch()
+                );
+        }
+
+        // setup the copy for the rest resources
+        project.getTasks().withType(CopyRestApiTask.class, copyRestApiTask -> {
+            copyRestApiTask.sourceSetName = SOURCE_SET_NAME;
+            project.getTasks().named(yamlTestSourceSet.getProcessResourcesTaskName()).configure(t -> t.dependsOn(copyRestApiTask));
+        });
+        project.getTasks().withType(CopyRestTestsTask.class, copyRestTestTask -> { copyRestTestTask.sourceSetName = SOURCE_SET_NAME; });
+
+        // make the new test run after unit tests
+        yamlRestTestTask.mustRunAfter(project.getTasks().named("test"));
+
+        // setup the runner
+        RestTestRunnerTask runner = yamlRestTestTask.getRunner();
+        runner.setTestClassesDirs(yamlTestSourceSet.getOutput().getClassesDirs());
+        runner.setClasspath(yamlTestSourceSet.getRuntimeClasspath());
+
+        // if this a module or plugin, it may have an associated zip file with it's contents, add that to the test cluster
+        project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
+            Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
+            yamlRestTestTask.dependsOn(bundle);
+            if (project.getPath().startsWith(":modules:")) {
+                runner.getClusters().forEach(c -> c.module(bundle.getArchiveFile()));
+            } else {
+                runner.getClusters().forEach(c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile())));
+            }
+        });
+
+        // es-plugins may declare dependencies on additional modules, add those to the test cluster too.
+        project.afterEvaluate(p -> {
+            PluginPropertiesExtension pluginPropertiesExtension = project.getExtensions().findByType(PluginPropertiesExtension.class);
+            if (pluginPropertiesExtension != null) { // not all projects are defined as plugins
+                pluginPropertiesExtension.getExtendedPlugins().forEach(pluginName -> {
+                    Project extensionProject = project.getProject().findProject(":modules:" + pluginName);
+                    if (extensionProject != null) { // extension plugin may be defined, but not required to be a module
+                        Zip extensionBundle = (Zip) extensionProject.getTasks().getByName("bundlePlugin");
+                        yamlRestTestTask.dependsOn(extensionBundle);
+                        runner.getClusters().forEach(c -> c.module(extensionBundle.getArchiveFile()));
+                    }
+                });
+            }
+        });
+
+        // setup IDE
+        GradleUtils.setupIdeForTestSourceSet(project, yamlTestSourceSet);
+
+        // wire this task into check
+        project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(yamlRestTestTask));
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -163,6 +163,15 @@ public abstract class GradleUtils {
 
         extendSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME, sourceSetName);
 
+        setupIdeForTestSourceSet(project, testSourceSet);
+
+        // add to the check task
+        project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(testTask));
+
+        return testTask;
+    }
+
+    public static void setupIdeForTestSourceSet(Project project, SourceSet testSourceSet) {
         // setup IDEs
         String runtimeClasspathName = testSourceSet.getRuntimeClasspathConfigurationName();
         Configuration runtimeClasspathConfiguration = project.getConfigurations().getByName(runtimeClasspathName);
@@ -178,14 +187,9 @@ public abstract class GradleUtils {
                 eclipseSourceSets.add(old);
             }
             eclipseSourceSets.add(testSourceSet);
-            eclipse.getClasspath().setSourceSets(sourceSets);
+            eclipse.getClasspath().setSourceSets(project.getExtensions().getByType(SourceSetContainer.class));
             eclipse.getClasspath().getPlusConfigurations().add(runtimeClasspathConfiguration);
         });
-
-        // add to the check task
-        project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(testTask));
-
-        return testTask;
     }
 
     /**

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.yaml-rest-test.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.yaml-rest-test.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+implementation-class=org.elasticsearch.gradle.test.rest.YamlRestTestPlugin

--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -332,12 +332,6 @@ configure(subprojects.findAll { it.name == 'integ-test-zip' }) {
 
   group = "org.elasticsearch.distribution.integ-test-zip"
 
-  restResources {
-    restTests {
-      includeCore '*'
-    }
-  }
-
   integTest {
     dependsOn assemble
     runner {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -9,6 +9,7 @@ import org.elasticsearch.gradle.testfixtures.TestFixturesPlugin
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 apply plugin: 'elasticsearch.distribution-download'
+apply plugin: 'elasticsearch.rest-resources'
 
 testFixtures.useFixture()
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -22,6 +22,7 @@ import static org.elasticsearch.gradle.testclusters.TestDistribution.DEFAULT
  */
 
 apply plugin: 'elasticsearch.docs-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 /* List of files that have snippets that will not work until platinum tests can occur ... */
 buildRestTests.expectedUnconvertedCandidates = [

--- a/modules/aggs-matrix-stats/build.gradle
+++ b/modules/aggs-matrix-stats/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Adds aggregations whose input are a list of numeric fields and output includes a matrix.'

--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Adds "built in" analyzers to Elasticsearch.'

--- a/modules/geo/build.gradle
+++ b/modules/geo/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Placeholder plugin for geospatial features in ES. only registers geo_shape field mapper for now'

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Module for ingest processors that do not require additional security permissions or have large dependencies and resources'

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -19,6 +19,8 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+apply plugin: 'elasticsearch.rest-resources'
+
 esplugin {
   description 'Ingest processor that uses looksup geo data based on ip adresses using the Maxmind geo database'
   classname 'org.elasticsearch.ingest.geoip.IngestGeoIpPlugin'

--- a/modules/ingest-user-agent/build.gradle
+++ b/modules/ingest-user-agent/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Ingest processor that extracts information from a user agent'

--- a/modules/lang-expression/build.gradle
+++ b/modules/lang-expression/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Lucene expressions integration for Elasticsearch'

--- a/modules/lang-mustache/build.gradle
+++ b/modules/lang-mustache/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Mustache scripting integration for Elasticsearch'

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -18,6 +18,7 @@
  */
 
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask;
+apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.validate-rest-spec'
 
 esplugin {

--- a/modules/mapper-extras/build.gradle
+++ b/modules/mapper-extras/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Adds advanced field mappers'
@@ -25,6 +26,6 @@ esplugin {
 
 restResources {
   restApi {
-    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get' 
+    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'search', 'get'
   }
 }

--- a/modules/parent-join/build.gradle
+++ b/modules/parent-join/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'This module adds the support parent-child queries and aggregations'
@@ -25,6 +26,6 @@ esplugin {
 
 restResources {
   restApi {
-    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'search' 
+    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'search'
   }
 }

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Percolator module adds capability to index queries and query these queries by specifying documents'

--- a/modules/rank-eval/build.gradle
+++ b/modules/rank-eval/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Rank Eval module adds APIs to evaluate ranking quality.'

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -24,6 +24,7 @@ import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Reindex module adds APIs to reindex from one index to another or update documents in place.'

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -21,6 +21,8 @@ import org.elasticsearch.gradle.PropertyNormalization
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.test.AntFixture
 
+apply plugin: 'elasticsearch.rest-resources'
+
 esplugin {
   description 'Module for URL repository'
   classname 'org.elasticsearch.plugin.repository.url.URLRepositoryPlugin'
@@ -28,7 +30,7 @@ esplugin {
 
 restResources {
   restApi {
-    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'bulk', 'count', 'snapshot' 
+    includeCore '_common', 'cluster', 'nodes', 'indices', 'index', 'bulk', 'count', 'snapshot'
   }
 }
 

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -21,6 +21,8 @@
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
+apply plugin: 'elasticsearch.rest-resources'
+
 /*
  TODOs:
    * fix permissions such that only netty4 can open sockets etc?

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -18,6 +18,7 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding ICU-related analysis components.'

--- a/plugins/analysis-kuromoji/build.gradle
+++ b/plugins/analysis-kuromoji/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.'

--- a/plugins/analysis-nori/build.gradle
+++ b/plugins/analysis-nori/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Korean (nori) Analysis plugin integrates Lucene nori analysis module into elasticsearch.'

--- a/plugins/analysis-phonetic/build.gradle
+++ b/plugins/analysis-phonetic/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.'

--- a/plugins/analysis-smartcn/build.gradle
+++ b/plugins/analysis-smartcn/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.'

--- a/plugins/analysis-stempel/build.gradle
+++ b/plugins/analysis-stempel/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.'

--- a/plugins/analysis-ukrainian/build.gradle
+++ b/plugins/analysis-ukrainian/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Ukrainian Analysis plugin integrates the Lucene UkrainianMorfologikAnalyzer into elasticsearch.'

--- a/plugins/discovery-azure-classic/build.gradle
+++ b/plugins/discovery-azure-classic/build.gradle
@@ -19,6 +19,7 @@ import org.elasticsearch.gradle.info.BuildParams
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Azure Classic Discovery plugin allows to use Azure Classic API for the unicast discovery mechanism'

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -18,6 +18,7 @@ import org.elasticsearch.gradle.info.BuildParams
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The EC2 discovery plugin allows to use AWS API for the unicast discovery mechanism.'

--- a/plugins/discovery-ec2/qa/amazon-ec2/build.gradle
+++ b/plugins/discovery-ec2/qa/amazon-ec2/build.gradle
@@ -27,6 +27,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':plugins:discovery-ec2')

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'elasticsearch.rest-resources'
+
 esplugin {
   description 'The Google Compute Engine (GCE) Discovery plugin allows to use GCE API for the unicast discovery mechanism.'
   classname 'org.elasticsearch.plugin.discovery.gce.GceDiscoveryPlugin'

--- a/plugins/discovery-gce/qa/gce/build.gradle
+++ b/plugins/discovery-gce/qa/gce/build.gradle
@@ -26,6 +26,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 final int gceNumberOfNodes = 3
 

--- a/plugins/examples/custom-settings/build.gradle
+++ b/plugins/examples/custom-settings/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'custom-settings'

--- a/plugins/examples/custom-significance-heuristic/build.gradle
+++ b/plugins/examples/custom-significance-heuristic/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'custom-significance-heuristic'

--- a/plugins/examples/custom-suggester/build.gradle
+++ b/plugins/examples/custom-suggester/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'custom-suggester'

--- a/plugins/examples/painless-whitelist/build.gradle
+++ b/plugins/examples/painless-whitelist/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'painless-whitelist'

--- a/plugins/examples/rescore/build.gradle
+++ b/plugins/examples/rescore/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'example-rescore'

--- a/plugins/examples/rest-handler/build.gradle
+++ b/plugins/examples/rest-handler/build.gradle
@@ -20,6 +20,7 @@ import org.elasticsearch.gradle.info.BuildParams
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'rest-handler'

--- a/plugins/examples/script-expert-scoring/build.gradle
+++ b/plugins/examples/script-expert-scoring/build.gradle
@@ -18,6 +18,7 @@
  */
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'script-expert-scoring'

--- a/plugins/examples/security-authorization-engine/build.gradle
+++ b/plugins/examples/security-authorization-engine/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'security-authorization-engine'

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -18,6 +18,7 @@ import org.elasticsearch.gradle.info.BuildParams
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Ingest processor that uses Apache Tika to extract contents'

--- a/plugins/mapper-annotated-text/build.gradle
+++ b/plugins/mapper-annotated-text/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Mapper Annotated_text plugin adds support for text fields with markup used to inject annotation tokens into the index.'

--- a/plugins/mapper-murmur3/build.gradle
+++ b/plugins/mapper-murmur3/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Mapper Murmur3 plugin allows to compute hashes of a field\'s values at index-time and to store them in the index.'

--- a/plugins/mapper-size/build.gradle
+++ b/plugins/mapper-size/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Mapper Size plugin allows document to record their uncompressed size at index time.'

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -22,6 +22,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Azure Repository plugin adds support for Azure storage repositories.'

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -28,6 +28,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The GCS repository plugin adds Google Cloud Storage support for repositories.'

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -28,6 +28,7 @@ import java.nio.file.Paths
 import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.test.fixtures'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The HDFS repository plugin adds support for Hadoop Distributed File-System (HDFS) repositories.'

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -22,6 +22,8 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
+
 esplugin {
   description 'The S3 repository plugin adds S3 repositories'
   classname 'org.elasticsearch.repositories.s3.S3RepositoryPlugin'

--- a/plugins/store-smb/build.gradle
+++ b/plugins/store-smb/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'The Store SMB plugin adds support for SMB stores.'

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -25,6 +25,7 @@ import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
+apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restTests {

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -21,6 +21,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(":client:rest-high-level")

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -24,6 +24,7 @@ import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
+apply plugin: 'elasticsearch.rest-resources'
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   /*

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -20,6 +20,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':modules:ingest-common')

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -20,6 +20,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':modules:ingest-common')

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -20,6 +20,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restTests {

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -23,6 +23,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 int pluginsCount = 0
 

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,10 +1,13 @@
-apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.validate-rest-spec'
+apply plugin: 'elasticsearch.yaml-rest-test'
 
-test.enabled = false
-jarHell.enabled = false
+restResources {
+  restTests {
+    includeCore '*'
+  }
+}
 
 artifacts {
   restSpecs(new File(projectDir, "src/main/resources/rest-api-spec/api"))

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.validate-rest-spec'
@@ -13,3 +14,6 @@ artifacts {
   restSpecs(new File(projectDir, "src/main/resources/rest-api-spec/api"))
   restTests(new File(projectDir, "src/main/resources/rest-api-spec/test"))
 }
+
+test.enabled = false
+jarHell.enabled = false

--- a/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
@@ -25,8 +25,8 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
 /** Rest integration test. Runs against a cluster started by {@code gradle integTest} */
-public class IntegTestZipClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
-    public IntegTestZipClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
+public class ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+    public ClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
 

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.docs-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 /* List of files that have snippets that probably should be converted to
  * `// CONSOLE` and `// TESTRESPONSE` but have yet to be converted. Try and

--- a/x-pack/plugin/async-search/qa/rest/build.gradle
+++ b/x-pack/plugin/async-search/qa/rest/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   description 'Deprecated query plugin'

--- a/x-pack/plugin/autoscaling/qa/rest/build.gradle
+++ b/x-pack/plugin/autoscaling/qa/rest/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.validate-rest-spec'
 
 archivesBaseName = 'x-pack'
@@ -61,6 +62,12 @@ subprojects {
 configurations {
   testArtifacts.extendsFrom testRuntime
   testArtifacts.extendsFrom testImplementation
+}
+
+restResources {
+  restApi {
+    includeCore '*'
+  }
 }
 
 artifacts {

--- a/x-pack/plugin/ccr/qa/rest/build.gradle
+++ b/x-pack/plugin/ccr/qa/rest/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restApi {

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restApi {

--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restApi {

--- a/x-pack/plugin/graph/qa/with-security/build.gradle
+++ b/x-pack/plugin/graph/qa/with-security/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(":x-pack:plugin:core")

--- a/x-pack/plugin/ilm/qa/rest/build.gradle
+++ b/x-pack/plugin/ilm/qa/rest/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')

--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -21,6 +21,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 final Project fixture = project(':test:fixtures:azure-fixture')
 final Project repositoryPlugin = project(':plugins:repository-azure')

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -27,6 +27,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 final Project fixture = project(':test:fixtures:gcs-fixture')
 final Project repositoryPlugin = project(':plugins:repository-gcs')

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -4,6 +4,7 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
+apply plugin: 'elasticsearch.rest-resources'
 
 final Project fixture = project(':test:fixtures:minio-fixture')
 final Project repositoryPlugin = project(':plugins:repository-s3')

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 final Project fixture = project(':test:fixtures:s3-fixture')
 final Project repositoryPlugin = project(':plugins:repository-s3')

--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -1,6 +1,7 @@
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.rest-resources'
 
 esplugin {
   name 'spatial'

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/plugin/watcher/qa/with-security/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-security/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/qa/multi-cluster-tests-with-security/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -5,6 +5,7 @@ import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -5,6 +5,7 @@ import org.elasticsearch.gradle.http.WaitForHttpResource
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:plugin:core')

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -3,6 +3,7 @@ import org.elasticsearch.gradle.MavenFilteringHack
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/smoke-test-security-with-mustache/build.gradle
+++ b/x-pack/qa/smoke-test-security-with-mustache/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:qa')

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:plugin:core')

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:plugin:core')

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   testImplementation project(':x-pack:plugin:core')


### PR DESCRIPTION
This commit creates a new Gradle plugin to provide a separate task name
and source set for running YAML based REST tests. The only project
converted to use the new plugin in this PR is distribution/archives/integ-test-zip.
For which the testing has been moved to :rest-api-spec since it makes the most
sense and it avoids a small but awkward change to the distribution plugin.

The remaining cases in modules, plugins, and x-pack will be handled in followups.

This plugin is distinctly different from the plugin introduced in #55896 since
the YAML REST tests are intended to be black box tests over HTTP. As such they
should not (by default) have access to the classpath for that which they are testing.

The YAML based REST tests will be moved to separate source sets (yamlRestTest).
The which source is the target for the test resources is dependent on if this
new plugin is applied. If it is not applied, it will default to the test source
set.

Further, this introduces a breaking change for plugin developers that
use the YAML testing framework. They will now need to either use the new source set
and matching task, or configure the rest resources to use the old "test" source set that
matches the old integTest task. (The former should be preferred).

As part of this change (which is also breaking for plugin developers) the
rest resources plugin has been removed from the build plugin and now requires
either explicit application or application via the new YAML REST test plugin.

Plugin developers should be able to fix the breaking changes to the YAML tests
by adding apply plugin: 'elasticsearch.yaml-rest-test' and moving the YAML tests
under a yamlRestTest folder (instead of test)
