### PR TITLE
Fix SLM Tests Leaking Snapshot Operation

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.core.slm.action.ExecuteSnapshotRetentionAction;
 import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import org.elasticsearch.xpack.core.slm.action.PutSnapshotLifecycleAction;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.Arrays;
@@ -80,6 +81,11 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
         internalCluster().startMasterOnlyNodes(2);
         dataNodeNames = internalCluster().startDataOnlyNodes(2);
         ensureGreen();
+    }
+
+    @After
+    public void awaitNoMoreRunningOps() throws Exception {
+        awaitNoMoreRunningOperations(internalCluster().getMasterName());
     }
 
     @Override
@@ -368,7 +374,6 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
                 assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
             });
         }
-        awaitNoMoreRunningOperations(internalCluster().getMasterName());
     }
 
     public void testSLMRetentionAfterRestore() throws Exception {


### PR DESCRIPTION
Fixed an issue #59082 introduced. We have to wait for no more operations
in all tests here not just the one we were waiting in already so that the cleanup
operation from the parent class can run without failure.

Ran into this in a PR and can reproduce at low rate locally as well: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request-2/3390/testReport/junit/org.elasticsearch.xpack.slm/SLMSnapshotBlockingIntegTests/testSLMRetentionAfterRestore/