### PR TITLE
[DOCS] Clarify atomic change for alias swap

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -265,8 +265,8 @@ It is an error to index to an alias which points to more than one index.
 It is also possible to swap an index with an alias in one, atomic operation.
 This means there will be no point in time where the alias points to no
 index in the cluster state. However, as indexing and searches involve multiple
-steps it is entirely possible for the in-flight or queued requests to fail
-due to non-existing index transiently.
+steps, it is possible for the in-flight or queued requests to fail
+due to a temporarily non-existent index.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -263,8 +263,10 @@ indices that match this pattern are added/removed.
 It is an error to index to an alias which points to more than one index.
 
 It is also possible to swap an index with an alias in one, atomic operation.
-This means there will be no period of downtime where the alias points to no
-index.
+This means there will be no point in time where the alias points to no
+index in the cluster state. However, as indexing and searches involve multiple
+steps it is entirely possible for the in-flight or queued requests to fail
+due to non-existing index transiently.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Index alias update API documentation describes index removal action as atomic. It is atomic in the sense of cluster state change but doesn't guarantee in-flight or queued tasks won't attempt to access removed index resulting in a failure (reject). This small edit clarifies that.