### PR TITLE
[7.x] Remove unused function InferenceIndexConstants.mapping() (#59146)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
@@ -5,9 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.persistence;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.xpack.core.template.TemplateUtils;
 
 /**
  * Class containing the index constants so that the index version, name, and prefix are available to a wider audience.
@@ -26,10 +24,4 @@ public final class InferenceIndexConstants {
     public static final ParseField DOC_TYPE = new ParseField("doc_type");
 
     private InferenceIndexConstants() {}
-    private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
-
-    public static String mapping() {
-        return TemplateUtils.loadTemplate("/org/elasticsearch/xpack/core/ml/inference_index_mappings.json",
-            Version.CURRENT.toString(), MAPPINGS_VERSION_VARIABLE);
-    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove unused function InferenceIndexConstants.mapping() (#59146)