### PR TITLE
Better error message when an inference model cannot be parsed due to its size

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
@@ -20,6 +20,19 @@ public final class SimpleBoundedInputStream extends InputStream {
     private final long maxBytes;
     private long numBytes;
 
+    public static class StreamSizeExceededException extends IOException {
+        private final long maxBytes;
+
+        public StreamSizeExceededException(String message, long maxBytes) {
+            super(message);
+            this.maxBytes = maxBytes;
+        }
+
+        public long getMaxBytes() {
+            return maxBytes;
+        }
+    }
+
     public SimpleBoundedInputStream(InputStream inputStream, long maxBytes) {
         this.in = ExceptionsHelper.requireNonNull(inputStream, "inputStream");
         if (maxBytes < 0) {
@@ -31,13 +44,14 @@ public final class SimpleBoundedInputStream extends InputStream {
     /**
      * A simple wrapper around the injected input stream that restricts the total number of bytes able to be read.
      * @return The byte read.
-     * @throws IOException on failure or when byte limit is exceeded
+     * @throws StreamSizeExceededException when byte limit is exceeded
+     * @throws IOException on failure
      */
     @Override
     public int read() throws IOException {
         // We have reached the maximum, signal stream completion.
         if (numBytes >= maxBytes) {
-            throw new IOException("input stream exceeded maximum bytes of [" + maxBytes + "]");
+            throw new StreamSizeExceededException("input stream exceeded maximum bytes of [" + maxBytes + "]", maxBytes);
         }
         numBytes++;
         return in.read();


### PR DESCRIPTION
When parsing model definitions there is sensibly a limit on how large the stream size can be. On such an error the actual reason will be at the end of long chain of `XContentParseException`s

`
{'error': {'root_cause': [{'type': 'x_content_parse_exception', 'reason': '[1:107374158] [tree_inference_model_node] failed to parse object'}], 'type': 'x_content_parse_exception', 'reason': '[1:107374158] [inference_model_definition] failed to parse field [trained_model]', 'caused_by': {'type': 'x_content_parse_exception', 'reason': '[1:107374158] [trained_model] failed to parse field [ensemble]', 'caused_by': {'type': 'x_content_parse_exception', 'reason': '[1:107374158] [ensemble_inference_model] failed to parse field [trained_models]', 'caused_by': {'type': 'x_content_parse_exception', 'reason': '[1:107374158] [trained_models] failed to parse field [tree]', 'caused_by': {'type': 'x_content_parse_exception', 'reason': '[1:107374158] [tree_inference_model] failed to parse field [tree_structure]', 'caused_by': {'type': 'x_content_parse_exception', 'reason': '[1:107374158] [tree_inference_model_node] failed to parse object', 'caused_by': {'type': 'i_o_exception', 'reason': 'input stream exceeded maximum bytes of [107374182]'}}}}}}}}
`

Where `'reason': 'input stream exceeded maximum bytes of [107374182]` is the interesting part.

This change brings that reason to the top and provides a more helpful message

`"Cannot parse model definition as the content is larger than the maximum stream size of [X] bytes. Max stream size is 10% of the JVM heap or 1GB whichever is smallest"`