### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>
 * <<release-notes-6.8.8>>

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,3 +1,16 @@
+[[release-notes-6.8.11]]
+== {es} version 6.8.11
+
+coming::[6.8.11]
+
+[float]
+=== Bug fixes
+
+Machine Learning::
+* Better interrupt handling during named pipe connection {ml-pull}1311[#1311]
+* Trap potential cause of SIGFPE {ml-pull}1351[#1351] (issue: {ml-issue}1348[#1348])
+
+
 [[release-notes-6.8.10]]
 == {es} version 6.8.10
 


### PR DESCRIPTION
This PR adds the items from https://github.com/elastic/ml-cpp/blob/6.8/docs/CHANGELOG.asciidoc to the appropriate section in the Elasticsearch release notes.