### PR TITLE
Fix race in RecoveryRequestTrackerTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryRequestTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryRequestTrackerTests.java
@@ -59,11 +59,11 @@ public class RecoveryRequestTrackerTests extends ESTestCase {
             final long seqNo = j;
             int iterations = randomIntBetween(2, 5);
             for (int i = 0; i < iterations; ++i) {
+                PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+                Set<PlainActionFuture<Void>> set = seqToResult.computeIfAbsent(seqNo, (k) -> ConcurrentCollections.newConcurrentSet());
+                set.add(future);
                 threadPool.generic().execute(() -> {
-                    PlainActionFuture<Void> future = PlainActionFuture.newFuture();
                     ActionListener<Void> listener = requestTracker.markReceivedAndCreateListener(seqNo, future);
-                    Set<PlainActionFuture<Void>> set = seqToResult.computeIfAbsent(seqNo, (k) -> ConcurrentCollections.newConcurrentSet());
-                    set.add(future);
                     if (listener != null) {
                         boolean added = seqNosReturned.add(seqNo);
                         // Ensure that we only return 1 future per sequence number


### PR DESCRIPTION
Currently in the recovery request tracker tests we place the futures
into the future map on the GENERIC thread. It is possible that the test
has already advanced past the point where we block on these futures
before they are placed in the map. This introduces other potential
failures as we expect all futures have been completed. This commit fixes
the test by places the futures in the map prior to dispatching.