### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.8.1>>
 * <<release-notes-7.8.0>>
 * <<release-notes-7.7.1>>
 * <<release-notes-7.7.0>>

--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -1,3 +1,16 @@
+[[release-notes-7.8.1]]
+== {es} version 7.8.1
+
+coming::[7.8.1]
+
+[float]
+[[bug-7.8.1]]
+=== Bug fixes
+
+Machine Learning::
+* Better interrupt handling during named pipe connection {ml-pull}1311[#1311]
+* Trap potential cause of SIGFPE {ml-pull}1351[#1351] (issue: {ml-issue}1348[#1348])
+
 [[release-notes-7.8.0]]
 == {es} version 7.8.0
 


### PR DESCRIPTION
This PR adds the items from https://github.com/elastic/ml-cpp/blob/7.8/docs/CHANGELOG.asciidoc to the appropriate section in the Elasticsearch release notes.