### PR TITLE
[DOCS] Clarifies transform node settings

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -15,7 +15,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-and (if available) machine learning and transform.
+and (if available) machine learning. All data nodes are also transform nodes.
 // end::modules-node-description-tag[]
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
@@ -401,12 +401,9 @@ node.remote_cluster_client: false <8>
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
-{transform-cap} nodes run {transforms} and handle {transform} API requests.
-
-If you want to use {transforms} in your cluster, you must have `node.transform`
-set to `true` on at least one node. This is the default behavior. If you have
-the {oss-dist}, do not use these settings. For more information, see
-<<transform-settings>>.
+{transform-cap} nodes run {transforms} and handle {transform} API requests. By
+default, data nodes are also transform nodes. If you have the {oss-dist}, do not
+use these settings. For more information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 

--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -15,14 +15,10 @@ To use the {transforms}, you must have the
 [[transform-setup-nodes]]
 ==== {transform-cap} nodes
 
-To use {transforms}, there must be at least one node in your cluster with
-`node.transform` set to `true`. By default, all nodes are {transform} nodes
-unless you explicitly change these settings or set `node.data` to `false`.
-
-If you want to control which nodes run {transforms}, set `node.transform` to
-`false` on some nodes.
-
-For more information, see <<transform-settings>> and <<modules-node>>.
+To use {transforms}, there must be at least one {transform} node in your cluster.
+If you want to control which nodes run {transforms}, explicitly enable or
+disable the `node.transform` setting on some nodes. For more information, see
+<<modules-node>> and <<transform-settings>>.
 
 [discrete]
 [[transform-privileges]]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/59023

This PR clarifies the default behaviour of transform nodes.

### Preview

* https://elasticsearch_59199.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.8/modules-node.html
* https://elasticsearch_59199.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.8/transform-setup.html#transform-setup-nodes