### PR TITLE
Fixing typo in node.asciidoc

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -17,6 +17,7 @@ requests to the appropriate node.
 By default, a node is all of the following types: master-eligible, data, ingest,
 and (if available) machine learning and transform.
 // end::modules-node-description-tag[]
+
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.


### PR DESCRIPTION
TIP block was missing due to the lack of line break prior to the "TIP" line

