### PR TITLE
Include echo -n example when constructing base64 string

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -125,6 +125,10 @@ by the _credentials_, where _credentials_ are the base64 encoding of `id` and `a
 
 [source,shell]
 --------------------------------------------------
+# Make sure to use the -n option with the echo command
+# Otherwise, the resulting base64 encoding string will be invalid
+echo -n 'VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw' |base64
+
 curl -H "Authorization: ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==" http://localhost:9200/_cluster/health
 --------------------------------------------------
 // NOTCONSOLE

--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -126,7 +126,7 @@ by the _credentials_, where _credentials_ are the base64 encoding of `id` and `a
 [source,shell]
 --------------------------------------------------
 # Make sure to use the -n option with the echo command
-# Otherwise, the resulting base64 encoding string will be invalid
+# Otherwise, the resulting base64 encoded string will be invalid
 echo -n 'VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw' |base64
 
 curl -H "Authorization: ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==" http://localhost:9200/_cluster/health


### PR DESCRIPTION
- Provides an example for "credentials is the base64 encoding of id and api_key joined by a colon"
- We already have multiple users generating invalid base64 encoded strings due to the use of the `echo` command.  This also clarifies the importance of using `-n` with `echo`

It would be nice to backport this doc change to all versions of Elasticsearch that supports API key creation (i.e., 6.7.+)