### PR TITLE
Optimize delay allocation event process performance.

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -291,7 +291,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         assertFalse(firstDelayedRerouteTask.cancelScheduling.get());
         assertThat(firstDelayedRerouteTask.baseTimestampNanos, equalTo(clusterChangeEventTimestampNanos));
         assertThat(firstDelayedRerouteTask.nextDelay.nanos(),
-            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithDelayedShards)));
+            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithDelayedShards).v1()));
         assertThat(firstDelayedRerouteTask.nextDelay.nanos(),
             equalTo(shortDelaySetting.nanos() - (clusterChangeEventTimestampNanos - baseTimestampNanos)));
 
@@ -330,7 +330,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         assertFalse(secondDelayedRerouteTask.cancelScheduling.get());
         assertThat(secondDelayedRerouteTask.baseTimestampNanos, equalTo(clusterChangeEventTimestampNanos));
         assertThat(secondDelayedRerouteTask.nextDelay.nanos(),
-            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithOnlyOneDelayedShard)));
+            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithOnlyOneDelayedShard).v1()));
         assertThat(secondDelayedRerouteTask.nextDelay.nanos(),
             equalTo(longDelaySetting.nanos() - (clusterChangeEventTimestampNanos - baseTimestampNanos)));
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -384,7 +384,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             clusterState = allocation.reroute(clusterState, "time moved");
         }
 
-        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime + delta, clusterState),
+        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime + delta, clusterState).v1(),
             equalTo(expectMinDelaySettingsNanos - delta));
     }
 


### PR DESCRIPTION
During creating indices performance testing, we found `findNextDelayedAllocation` is costly, because it will for-loop all the shards in `RoutingTable` .
We found a duplciate for-loop for logging purpose, so we could calculate the latest delay expiration time and delay shard count together.
The first `RoutingTable` for-loop:
https://github.com/elastic/elasticsearch/blob/961db311f0efb19b6c360243c87479449f855898/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java#L185

The another `RoutingTable` for-loop in the same function: 
https://github.com/elastic/elasticsearch/blob/961db311f0efb19b6c360243c87479449f855898/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java#L208

Here is the related hot threads:
```
32.1% (160.4ms out of 500ms) cpu usage by thread 'elasticsearch[1592969635000032532][clusterApplierService#updateTask][T#1]'
     3/10 snapshots sharing following 27 elements
       java.util.Collections$UnmodifiableCollection$1.<init>(Collections.java:1041)
       java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040)
       java.util.Collections$UnmodifiableCollection$1.<init>(Collections.java:1041)
       java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040)
       org.elasticsearch.cluster.routing.IndexShardRoutingTable.iterator(IndexShardRoutingTable.java:155)
       org.elasticsearch.cluster.routing.IndexShardRoutingTable.shardsWithState(IndexShardRoutingTable.java:657)
       org.elasticsearch.cluster.routing.IndexRoutingTable.shardsWithState(IndexRoutingTable.java:268)
       org.elasticsearch.cluster.routing.RoutingTable.shardsWithState(RoutingTable.java:282)
       org.elasticsearch.cluster.routing.UnassignedInfo.findNextDelayedAllocation(UnassignedInfo.java:421)
       org.elasticsearch.cluster.routing.DelayedAllocationService.scheduleIfNeeded(DelayedAllocationService.java:185)
       org.elasticsearch.cluster.routing.DelayedAllocationService.clusterChanged(DelayedAllocationService.java:164)
       org.elasticsearch.cluster.service.ClusterApplierService.lambda$callClusterStateListeners$6(ClusterApplierService.java:528)
       org.elasticsearch.cluster.service.ClusterApplierService$$Lambda$2279/725736877.accept(Unknown Source)
       java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
       java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:742)
       java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
       org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:524)
       org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:499)
       org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:432)
       org.elasticsearch.cluster.service.ClusterApplierService.access$100(ClusterApplierService.java:73)
       org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:176)
       org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:703)
       org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:252)
       org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:215)
       java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
       java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
       java.lang.Thread.run(Thread.java:748)
```