### PR TITLE
[7.x] [DOCS] EQL: Document `size` limit for pipes (#59085)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -160,6 +160,22 @@ Defaults to `event.category`, as defined in the {ecs-ref}/ecs-event.html[Elastic
 Common Schema (ECS)]. If an index does not contain the `event.category` field,
 this value is required.
 
+`fetch_size`::
+(Optional, integer)
+Maximum number of events to search at a time for sequence queries. Defaults to
+`1000`.
++
+This value must be greater than `2` but cannot exceed the value of the
+<<index-max-result-window,`index.max_result_window`>> setting, which defaults to
+`10000`.
++
+Internally, a sequence query fetches and paginates sets of events to search for
+matches. This parameter controls the size of those sets. This parameter does not
+limit the total number of events searched or the number of matching events
+returned.
++
+A greater `fetch_size` value often increases search speed but uses more memory.
+
 `filter`::
 (Optional, <<query-dsl,query DSL object>>)
 Query, written in query DSL, used to filter the events on which the EQL query
@@ -231,7 +247,10 @@ return.
 For <<eql-sequences,sequence queries>>, the maximum number of matching sequences
 to return.
 +
-Defaults to `50`. This value must be greater than `0`.
+Defaults to `10`. This value must be greater than `0`.
++
+NOTE: You cannot use <<eql-pipe-ref,pipes>>, such as `head` or `tail`, to exceed
+this value.
 
 [[eql-search-api-tiebreaker-field]]
 `tiebreaker_field`::

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -17,21 +17,21 @@ dev::[]
 [[eql-pipe-head]]
 === `head`
 
-Returns up to a specified number of events, starting with the earliest matching
-events. Works similarly to the
+Returns up to a specified number of events or sequences, starting with the
+earliest matches. Works similarly to the
 https://en.wikipedia.org/wiki/Head_(Unix)[Unix head command].
 
 [%collapsible]
 ====
 *Example*
 
-The following EQL query returns up to fifty of the earliest powershell
+The following EQL query returns up to three of the earliest powershell
 commands.
 
 [source,eql]
 ----
 process where process.name == "powershell.exe"
-| head 50
+| head 3
 ----
 
 *Syntax*
@@ -44,28 +44,28 @@ head <max>
 
 `<max>`::
 (Required, integer)
-Maximum number of matching events to return.
+Maximum number of matching events or sequences to return.
 ====
 
 [discrete]
 [[eql-pipe-tail]]
 === `tail`
 
-Returns up to a specified number of events, starting with the most recent
-matching events. Works similarly to the
+Returns up to a specified number of events or sequences, starting with the most
+recent matches. Works similarly to the
 https://en.wikipedia.org/wiki/Tail_(Unix)[Unix tail command].
 
 [%collapsible]
 ====
 *Example*
 
-The following EQL query returns up to thirty of the most recent `svchost.exe`
+The following EQL query returns up to five of the most recent `svchost.exe`
 processes.
 
 [source,eql]
 ----
 process where process.name == "svchost.exe"
-| tail 30
+| tail 5
 ----
 
 *Syntax*
@@ -78,5 +78,5 @@ tail <max>
 
 `<max>`::
 (Required, integer)
-Maximum number of matching events to return.
+Maximum number of matching events or sequences to return.
 ====


### PR DESCRIPTION
7.x backport of #59085