### PR TITLE
Scripting: Update node stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -118,7 +118,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
             adaptiveSelectionStats = null;
         }
         if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
-            scriptCacheStats = in.readOptionalWriteable(ScriptCacheStats::new);
+            if (in.getVersion().before(Version.V_7_9_0)) {
+                scriptCacheStats = in.readOptionalWriteable(ScriptCacheStats::new);
+            } else {
+                scriptCacheStats = scriptStats.toScriptCacheStats();
+            }
         } else {
             scriptCacheStats = null;
         }
@@ -271,8 +275,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(ingestStats);
         if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
             out.writeOptionalWriteable(adaptiveSelectionStats);
-        }
-        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
+        } if (out.getVersion().onOrAfter(Version.V_7_8_0) && out.getVersion().before(Version.V_7_9_0)) {
             out.writeOptionalWriteable(scriptCacheStats);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -136,6 +136,10 @@ public class ScriptCache {
         return scriptMetrics.stats();
     }
 
+    public ScriptContextStats stats(String context) {
+        return scriptMetrics.stats(context);
+    }
+
     /**
      * Check whether there have been too many compilations within the last minute, throwing a circuit breaking exception if so.
      * This is a variant of the token bucket algorithm: https://en.wikipedia.org/wiki/Token_bucket

--- a/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCacheStats.java
@@ -32,8 +32,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+// This class is deprecated in favor of ScriptStats and ScriptContextStats.  It is removed in 8.
 public class ScriptCacheStats implements Writeable, ToXContentFragment {
-    private final Map<String,ScriptStats> context;
+    private final Map<String, ScriptStats> context;
     private final ScriptStats general;
 
     public ScriptCacheStats(Map<String, ScriptStats> context) {
@@ -135,7 +136,19 @@ public class ScriptCacheStats implements Writeable, ToXContentFragment {
         if (general != null) {
             return general;
         }
-        return ScriptStats.sum(context.values());
+        long compilations = 0;
+        long cacheEvictions = 0;
+        long compilationLimitTriggered = 0;
+        for (ScriptStats stat: context.values()) {
+            compilations += stat.getCompilations();
+            cacheEvictions += stat.getCacheEvictions();
+            compilationLimitTriggered += stat.getCompilationLimitTriggered();
+        }
+        return new ScriptStats(
+            compilations,
+            cacheEvictions,
+            compilationLimitTriggered
+        );
     }
 
     static final class Fields {

--- a/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ScriptContextStats implements Writeable, ToXContentFragment, Comparable<ScriptContextStats> {
+    private final String context;
+    private final long compilations;
+    private final long cacheEvictions;
+    private final long compilationLimitTriggered;
+
+    public ScriptContextStats(String context, long compilations, long cacheEvictions, long compilationLimitTriggered) {
+        this.context = Objects.requireNonNull(context);
+        this.compilations = compilations;
+        this.cacheEvictions = cacheEvictions;
+        this.compilationLimitTriggered = compilationLimitTriggered;
+    }
+
+    public ScriptContextStats(StreamInput in) throws IOException {
+        context = in.readString();
+        compilations = in.readVLong();
+        cacheEvictions = in.readVLong();
+        compilationLimitTriggered = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(context);
+        out.writeVLong(compilations);
+        out.writeVLong(cacheEvictions);
+        out.writeVLong(compilationLimitTriggered);
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public long getCompilations() {
+        return compilations;
+    }
+
+    public long getCacheEvictions() {
+        return cacheEvictions;
+    }
+
+    public long getCompilationLimitTriggered() {
+        return compilationLimitTriggered;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(Fields.CONTEXT, getContext());
+        builder.field(Fields.COMPILATIONS, getCompilations());
+        builder.field(Fields.CACHE_EVICTIONS, getCacheEvictions());
+        builder.field(Fields.COMPILATION_LIMIT_TRIGGERED, getCompilationLimitTriggered());
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public int compareTo(ScriptContextStats o) {
+        return this.context.compareTo(o.context);
+    }
+
+    static final class Fields {
+        static final String CONTEXT = "context";
+        static final String COMPILATIONS = "compilations";
+        static final String CACHE_EVICTIONS = "cache_evictions";
+        static final String COMPILATION_LIMIT_TRIGGERED = "compilation_limit_triggered";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
@@ -26,10 +26,6 @@ public class ScriptMetrics {
     final CounterMetric cacheEvictionsMetric = new CounterMetric();
     final CounterMetric compilationLimitTriggered = new CounterMetric();
 
-    public ScriptStats stats() {
-        return new ScriptStats(compilationsMetric.count(), cacheEvictionsMetric.count(), compilationLimitTriggered.count());
-    }
-
     public void onCompilation() {
         compilationsMetric.inc();
     }
@@ -40,5 +36,18 @@ public class ScriptMetrics {
 
     public void onCompilationLimit() {
         compilationLimitTriggered.inc();
+    }
+
+    public ScriptStats stats() {
+        return new ScriptStats(compilationsMetric.count(), cacheEvictionsMetric.count(), compilationLimitTriggered.count());
+    }
+
+    public ScriptContextStats stats(String context) {
+        return new ScriptContextStats(
+            context,
+            compilationsMetric.count(),
+            cacheEvictionsMetric.count(),
+            compilationLimitTriggered.count()
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -658,7 +658,12 @@ public class ScriptService implements Closeable, ClusterStateApplier {
             if (general != null) {
                 return general.stats();
             }
-            return ScriptStats.sum(contextCache.values().stream().map(AtomicReference::get).map(ScriptCache::stats)::iterator);
+            List<ScriptContextStats> contextStats = new ArrayList<>(contextCache.size());
+            for (Map.Entry<String, AtomicReference<ScriptCache>> entry : contextCache.entrySet()) {
+                ScriptCache cache = entry.getValue().get();
+                contextStats.add(cache.stats(entry.getKey()));
+            }
+            return new ScriptStats(contextStats);
         }
 
         ScriptCacheStats cacheStats() {

--- a/server/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -120,11 +120,6 @@ public class ScriptStats implements Writeable, ToXContentFragment {
         builder.field(Fields.COMPILATIONS, compilations);
         builder.field(Fields.CACHE_EVICTIONS, cacheEvictions);
         builder.field(Fields.COMPILATION_LIMIT_TRIGGERED, compilationLimitTriggered);
-        builder.startArray(Fields.CONTEXTS);
-        for (ScriptContextStats contextStats: contextStats) {
-            contextStats.toXContent(builder, params);
-        }
-        builder.endArray();
         builder.endObject();
         return builder;
     }


### PR DESCRIPTION
Updated `_nodes/stats`:
 * Remove `script_cache`
 * Update `script` in `_node/stats` to include stats per context:
```
      "script": {
        "compilations": 1,
        "cache_evictions": 0,
        "compilation_limit_triggered": 0,
        "contexts":[
          {
            "context": "aggregation_selector",
            "compilations": 0,
            "cache_evictions": 0,
            "compilation_limit_triggered": 0
          },
```


Refs: #50152
Backport: #59205