### PR TITLE
[DOCS] EQL: Prepare docs for release

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Delete async EQL search</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 Deletes an <<eql-search-async,async EQL search>> or a
 <<eql-search-store-sync-eql-search,stored synchronous EQL search>>. The API also

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Function reference</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 {es} supports the following EQL functions:
 

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Get async EQL search</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 Returns the current status and available results for an <<eql-search-async,async
 EQL search>> or a <<eql-search-store-sync-eql-search,stored synchronous EQL

--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>EQL</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 {eql-ref}/index.html[Event Query Language (EQL)] is a query language used for
 logs and other event-based data.

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 [discrete]
 [[eql-nested-fields]]

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Pipe reference</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 {es} supports the following EQL pipes:
 

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Requirements</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 EQL is schema-less and works well with most common log formats.
 

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -3,7 +3,7 @@
 [[eql-search]]
 == Run an EQL search
 
-dev::[]
+experimental::[]
 
 To start using EQL in {es}, first ensure your event data meets
 <<eql-requirements,EQL requirements>>. You can then use the <<eql-search-api,EQL

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Syntax reference</titleabbrev>
 ++++
 
-dev::[]
+experimental::[]
 
 [IMPORTANT]
 ====

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -25,9 +25,7 @@ include::search/index.asciidoc[]
 
 include::query-dsl.asciidoc[]
 
-ifdef::permanently-unreleased-branch[]
 include::eql/index.asciidoc[]
-endif::[]
 
 include::sql/index.asciidoc[]
 

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -168,15 +168,11 @@ include::search/suggesters.asciidoc[]
 
 include::search/multi-search.asciidoc[]
 
-ifdef::permanently-unreleased-branch[]
-
 include::eql/eql-search-api.asciidoc[]
 
 include::eql/get-async-eql-search-api.asciidoc[]
 
 include::eql/delete-async-eql-search-api.asciidoc[]
-
-endif::[]
 
 include::search/count.asciidoc[]
 


### PR DESCRIPTION
Changes:

* Swaps the `dev` admonitions for `experimental` admonitions
* Removes `ifdef` statements preventing the docs from appearing in
  released branches