### PR TITLE
Fix numerical error in CentroidCalculatorTests#testPolygonAsPoint 

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
@@ -251,14 +251,16 @@ public class CentroidCalculatorTests extends ESTestCase {
         assertThat(calculator.getDimensionalShapeType(), equalTo(LINE));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58245")
     public void testPolygonAsPoint() {
         Point point = GeometryTestUtils.randomPoint(false);
         Polygon polygon = new Polygon(new LinearRing(new double[] { point.getX(), point.getX(), point.getX(), point.getX() },
             new double[] { point.getY(), point.getY(), point.getY(), point.getY() }));
         CentroidCalculator calculator = new CentroidCalculator(polygon);
-        assertThat(calculator.getX(), equalTo(GeoUtils.normalizeLon(point.getX())));
-        assertThat(calculator.getY(), equalTo(GeoUtils.normalizeLat(point.getY())));
+        double normLon = GeoUtils.normalizeLon(point.getX());
+        double normLat = GeoUtils.normalizeLat(point.getY());
+        // make calculation to account for floating-point arithmetic
+        assertThat(calculator.getX(), equalTo((3 * normLon) / 3));
+        assertThat(calculator.getY(), equalTo((3 * normLat) / 3));
         assertThat(calculator.sumWeight(), equalTo(3.0));
         assertThat(calculator.getDimensionalShapeType(), equalTo(POINT));
     }


### PR DESCRIPTION
This PR fix the test CentroidCalculatorTests#testPolygonAsPoint by taking into account the error introduced by floating-point arithmetic.

backport of #59012