### PR TITLE
[7.x][ML] Perform test inference on java (#58877)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -370,6 +370,11 @@ public class Classification implements DataFrameAnalysis {
             .build();
     }
 
+    @Override
+    public boolean supportsInference() {
+        return true;
+    }
+
     public static String extractJobIdFromStateDoc(String stateDocId) {
         int suffixIndex = stateDocId.lastIndexOf(STATE_DOC_ID_SUFFIX);
         return suffixIndex <= 0 ? null : stateDocId.substring(0, suffixIndex);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -79,6 +79,11 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
     InferenceConfig inferenceConfig(FieldInfo fieldInfo);
 
     /**
+     * @return {@code true} if this analysis trains a model that can be used for inference
+     */
+    boolean supportsInference();
+
+    /**
      * Summarizes information about the fields that is necessary for analysis to generate
      * the parameters needed for the process configuration.
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -257,6 +257,11 @@ public class OutlierDetection implements DataFrameAnalysis {
         return null;
     }
 
+    @Override
+    public boolean supportsInference() {
+        return false;
+    }
+
     public enum Method {
         LOF, LDOF, DISTANCE_KTH_NN, DISTANCE_KNN;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -283,6 +283,11 @@ public class Regression implements DataFrameAnalysis {
             .build();
     }
 
+    @Override
+    public boolean supportsInference() {
+        return true;
+    }
+
     public static String extractJobIdFromStateDoc(String stateDocId) {
         int suffixIndex = stateDocId.lastIndexOf(STATE_DOC_ID_SUFFIX);
         return suffixIndex <= 0 ? null : stateDocId.substring(0, suffixIndex);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -137,18 +139,20 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
     public void writeResult(IngestDocument document, String parentResultField) {
         ExceptionsHelper.requireNonNull(document, "document");
         ExceptionsHelper.requireNonNull(parentResultField, "parentResultField");
-        document.setFieldValue(parentResultField + "." + this.resultsField,
-            predictionFieldType.transformPredictedValue(value(), valueAsString()));
-        if (topClasses.size() > 0) {
-            document.setFieldValue(parentResultField + "." + topNumClassesField,
-                topClasses.stream().map(TopClassEntry::asValueMap).collect(Collectors.toList()));
+        document.setFieldValue(parentResultField, asMap());
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(resultsField, predictionFieldType.transformPredictedValue(value(), valueAsString()));
+        if (topClasses.isEmpty() == false) {
+            map.put(topNumClassesField, topClasses.stream().map(TopClassEntry::asValueMap).collect(Collectors.toList()));
         }
-        if (getFeatureImportance().size() > 0) {
-            document.setFieldValue(parentResultField + "." + FEATURE_IMPORTANCE, getFeatureImportance()
-                .stream()
-                .map(FeatureImportance::toMap)
-                .collect(Collectors.toList()));
+        if (getFeatureImportance().isEmpty() == false) {
+            map.put(FEATURE_IMPORTANCE, getFeatureImportance().stream().map(FeatureImportance::toMap).collect(Collectors.toList()));
         }
+        return map;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
@@ -9,9 +9,13 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.ingest.IngestDocument;
 
+import java.util.Map;
+
 public interface InferenceResults extends NamedWriteable, ToXContentFragment {
 
     void writeResult(IngestDocument document, String parentResultField);
+
+    Map<String, Object> asMap();
 
     Object predictedValue();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ingest.IngestDocument;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 
 public class RawInferenceResults implements InferenceResults {
@@ -57,6 +58,10 @@ public class RawInferenceResults implements InferenceResults {
         throw new UnsupportedOperationException("[raw] does not support writing inference results");
     }
 
+    @Override
+    public Map<String, Object> asMap() {
+        throw new UnsupportedOperationException("[raw] does not support map conversion");
+    }
     @Override
     public Object predictedValue() {
         return null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -15,7 +15,9 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -85,13 +87,17 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
     public void writeResult(IngestDocument document, String parentResultField) {
         ExceptionsHelper.requireNonNull(document, "document");
         ExceptionsHelper.requireNonNull(parentResultField, "parentResultField");
-        document.setFieldValue(parentResultField + "." + this.resultsField, value());
-        if (getFeatureImportance().size() > 0) {
-            document.setFieldValue(parentResultField + ".feature_importance", getFeatureImportance()
-                .stream()
-                .map(FeatureImportance::toMap)
-                .collect(Collectors.toList()));
+        document.setFieldValue(parentResultField, asMap());
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(resultsField, value());
+        if (getFeatureImportance().isEmpty() == false) {
+            map.put(FEATURE_IMPORTANCE, getFeatureImportance().stream().map(FeatureImportance::toMap).collect(Collectors.toList()));
         }
+        return map;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
@@ -13,6 +13,8 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class WarningInferenceResults implements InferenceResults {
@@ -56,7 +58,14 @@ public class WarningInferenceResults implements InferenceResults {
     public void writeResult(IngestDocument document, String parentResultField) {
         ExceptionsHelper.requireNonNull(document, "document");
         ExceptionsHelper.requireNonNull(parentResultField, "resultField");
-        document.setFieldValue(parentResultField + "." + NAME, warning);
+        document.setFieldValue(parentResultField, asMap());
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> asMap = new LinkedHashMap<>();
+        asMap.put(NAME, warning);
+        return asMap;
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
@@ -649,4 +649,9 @@ public class ClassificationEvaluationIT extends MlNativeDataFrameAnalyticsIntegT
             fail("Failed to index data: " + bulkResponse.buildFailureMessage());
         }
     }
+
+    @Override
+    boolean supportsInference() {
+        return true;
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -893,4 +893,9 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
     private String expectedDestIndexAuditMessage() {
         return (analysisUsesExistingDestIndex ? "Using existing" : "Creating") + " destination index [" + destIndex + "]";
     }
+
+    @Override
+    boolean supportsInference() {
+        return true;
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
@@ -123,7 +123,12 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
 
         explainResponse = explainDataFrame(config);
 
-        assertThat(explainResponse.getMemoryEstimation().getExpectedMemoryWithoutDisk(), 
+        assertThat(explainResponse.getMemoryEstimation().getExpectedMemoryWithoutDisk(),
                    lessThanOrEqualTo(allDataUsedForTraining));
+    }
+
+    @Override
+    boolean supportsInference() {
+        return false;
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -219,6 +219,8 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
             progress.stream().allMatch(phaseProgress -> phaseProgress.getProgressPercent() == 100), is(true));
     }
 
+    abstract boolean supportsInference();
+
     private List<PhaseProgress> getProgress(String id) {
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(id);
         assertThat(stats.getId(), equalTo(id));
@@ -227,7 +229,12 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
         assertThat(progress.size(), greaterThanOrEqualTo(4));
         assertThat(progress.get(0).getPhase(), equalTo("reindexing"));
         assertThat(progress.get(1).getPhase(), equalTo("loading_data"));
-        assertThat(progress.get(progress.size() - 1).getPhase(), equalTo("writing_results"));
+        if (supportsInference()) {
+            assertThat(progress.get(progress.size() - 2).getPhase(), equalTo("writing_results"));
+            assertThat(progress.get(progress.size() - 1).getPhase(), equalTo("inference"));
+        } else {
+            assertThat(progress.get(progress.size() - 1).getPhase(), equalTo("writing_results"));
+        }
         return progress;
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
@@ -111,4 +111,9 @@ public class OutlierDetectionWithMissingFieldsIT extends MlNativeDataFrameAnalyt
         assertProgressComplete(id);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
     }
+
+    @Override
+    boolean supportsInference() {
+        return false;
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionEvaluationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionEvaluationIT.java
@@ -155,4 +155,9 @@ public class RegressionEvaluationIT extends MlNativeDataFrameAnalyticsIntegTestC
             fail("Failed to index data: " + bulkResponse.buildFailureMessage());
         }
     }
+
+    @Override
+    boolean supportsInference() {
+        return true;
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -540,4 +540,9 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
     protected String stateDocId() {
         return jobId + "_regression_state#1";
     }
+
+    @Override
+    boolean supportsInference() {
+        return true;
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -745,4 +745,9 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             "Started writing results",
             "Finished analysis");
     }
+
+    @Override
+    boolean supportsInference() {
+        return false;
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -693,8 +693,13 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         this.modelLoadingService.set(modelLoadingService);
 
         // Data frame analytics components
-        AnalyticsProcessManager analyticsProcessManager = new AnalyticsProcessManager(client, threadPool, analyticsProcessFactory,
-            dataFrameAnalyticsAuditor, trainedModelProvider, resultsPersisterService);
+        AnalyticsProcessManager analyticsProcessManager = new AnalyticsProcessManager(client,
+            threadPool,
+            analyticsProcessFactory,
+            dataFrameAnalyticsAuditor,
+            trainedModelProvider,
+            modelLoadingService,
+            resultsPersisterService);
         MemoryUsageEstimationProcessManager memoryEstimationProcessManager =
             new MemoryUsageEstimationProcessManager(
                 threadPool.generic(), threadPool.executor(MachineLearning.JOB_COMMS_THREAD_POOL_NAME), memoryEstimationProcessFactory);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -195,7 +195,7 @@ public class TransportGetDataFrameAnalyticsStatsAction
         logger.debug("[{}] Gathering stats for stopped task", config.getId());
 
         RetrievedStatsHolder retrievedStatsHolder = new RetrievedStatsHolder(
-            ProgressTracker.fromZeroes(config.getAnalysis().getProgressPhases()).report());
+            ProgressTracker.fromZeroes(config.getAnalysis().getProgressPhases(), config.getAnalysis().supportsInference()).report());
 
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.add(buildStoredProgressSearch(config.getId()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -84,7 +84,8 @@ public class DataFrameAnalyticsManager {
                 // At this point we have the config at hand and we can reset the progress tracker
                 // to use the analyses phases. We preserve reindexing progress as if reindexing was
                 // finished it will not be reset.
-                task.getStatsHolder().resetProgressTrackerPreservingReindexingProgress(config.getAnalysis().getProgressPhases());
+                task.getStatsHolder().resetProgressTrackerPreservingReindexingProgress(config.getAnalysis().getProgressPhases(),
+                    config.getAnalysis().supportsInference());
 
                 switch(currentState) {
                     // If we are STARTED, it means the job was started because the start API was called.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -49,6 +49,11 @@ public final class DestinationIndex {
 
     public static final String ID_COPY = "ml__id_copy";
 
+    /**
+     * The field that indicates whether a doc was used for training or not
+     */
+    public static final String IS_TRAINING = "is_training";
+
     // Metadata fields
     static final String CREATION_DATE_MILLIS = "creation_date_in_millis";
     static final String VERSION = "version";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -28,6 +29,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
+import org.elasticsearch.xpack.ml.dataframe.process.crossvalidation.CrossValidationSplitter;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 
@@ -64,12 +66,14 @@ public class DataFrameDataExtractor {
     private boolean isCancelled;
     private boolean hasNext;
     private boolean searchHasShardFailure;
+    private final CachedSupplier<CrossValidationSplitter> crossValidationSplitter;
 
     DataFrameDataExtractor(Client client, DataFrameDataExtractorContext context) {
         this.client = Objects.requireNonNull(client);
         this.context = Objects.requireNonNull(context);
         hasNext = true;
         searchHasShardFailure = false;
+        this.crossValidationSplitter = new CachedSupplier<>(context.crossValidationSplitterFactory::create);
     }
 
     public Map<String, String> getHeaders() {
@@ -93,6 +97,7 @@ public class DataFrameDataExtractor {
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
+
         Optional<List<Row>> hits = scrollId == null ? Optional.ofNullable(initScroll()) : Optional.ofNullable(continueScroll());
         if (!hits.isPresent()) {
             hasNext = false;
@@ -162,7 +167,7 @@ public class DataFrameDataExtractor {
         }
     }
 
-    private List<Row> processSearchResponse(SearchResponse searchResponse) throws IOException {
+    private List<Row> processSearchResponse(SearchResponse searchResponse) {
         scrollId = searchResponse.getScrollId();
         if (searchResponse.getHits().getHits().length == 0) {
             hasNext = false;
@@ -202,7 +207,8 @@ public class DataFrameDataExtractor {
                 }
             }
         }
-        return new Row(extractedValues, hit);
+        boolean isTraining = extractedValues == null ? false : crossValidationSplitter.get().isTraining(extractedValues);
+        return new Row(extractedValues, hit, isTraining);
     }
 
     private List<Row> continueScroll() throws IOException {
@@ -307,14 +313,17 @@ public class DataFrameDataExtractor {
 
     public static class Row {
 
-        private SearchHit hit;
+        private final SearchHit hit;
 
         @Nullable
-        private String[] values;
+        private final String[] values;
 
-        private Row(String[] values, SearchHit hit) {
+        private final boolean isTraining;
+
+        private Row(String[] values, SearchHit hit, boolean isTraining) {
             this.values = values;
             this.hit = hit;
+            this.isTraining = isTraining;
         }
 
         @Nullable
@@ -328,6 +337,10 @@ public class DataFrameDataExtractor {
 
         public boolean shouldSkip() {
             return values == null;
+        }
+
+        public boolean isTraining() {
+            return isTraining;
         }
 
         public int getChecksum() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorContext.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.dataframe.extractor;
 
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.ml.dataframe.process.crossvalidation.CrossValidationSplitterFactory;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 
 import java.util.List;
@@ -22,9 +23,11 @@ public class DataFrameDataExtractorContext {
     final Map<String, String> headers;
     final boolean includeSource;
     final boolean supportsRowsWithMissingValues;
+    final CrossValidationSplitterFactory crossValidationSplitterFactory;
 
     DataFrameDataExtractorContext(String jobId, ExtractedFields extractedFields, List<String> indices, QueryBuilder query, int scrollSize,
-                                  Map<String, String> headers, boolean includeSource, boolean supportsRowsWithMissingValues) {
+                                  Map<String, String> headers, boolean includeSource, boolean supportsRowsWithMissingValues,
+                                  CrossValidationSplitterFactory crossValidationSplitterFactory) {
         this.jobId = Objects.requireNonNull(jobId);
         this.extractedFields = Objects.requireNonNull(extractedFields);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -33,5 +36,6 @@ public class DataFrameDataExtractorContext {
         this.headers = headers;
         this.includeSource = includeSource;
         this.supportsRowsWithMissingValues = supportsRowsWithMissingValues;
+        this.crossValidationSplitterFactory = Objects.requireNonNull(crossValidationSplitterFactory);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -7,9 +7,13 @@ package org.elasticsearch.xpack.ml.dataframe.extractor;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.RequiredField;
+import org.elasticsearch.xpack.ml.dataframe.process.crossvalidation.CrossValidationSplitterFactory;
+import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 
 import java.util.Arrays;
@@ -17,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class DataFrameDataExtractorFactory {
 
@@ -25,19 +30,24 @@ public class DataFrameDataExtractorFactory {
     private final List<String> indices;
     private final QueryBuilder sourceQuery;
     private final ExtractedFields extractedFields;
+    private final List<RequiredField> requiredFields;
     private final Map<String, String> headers;
     private final boolean supportsRowsWithMissingValues;
+    private final CrossValidationSplitterFactory crossValidationSplitterFactory;
 
     private DataFrameDataExtractorFactory(Client client, String analyticsId, List<String> indices, QueryBuilder sourceQuery,
-                                          ExtractedFields extractedFields, Map<String, String> headers,
-                                          boolean supportsRowsWithMissingValues) {
+                                          ExtractedFields extractedFields, List<RequiredField> requiredFields, Map<String, String> headers,
+                                          boolean supportsRowsWithMissingValues,
+                                          CrossValidationSplitterFactory crossValidationSplitterFactory) {
         this.client = Objects.requireNonNull(client);
         this.analyticsId = Objects.requireNonNull(analyticsId);
         this.indices = Objects.requireNonNull(indices);
         this.sourceQuery = Objects.requireNonNull(sourceQuery);
         this.extractedFields = Objects.requireNonNull(extractedFields);
+        this.requiredFields = Objects.requireNonNull(requiredFields);
         this.headers = headers;
         this.supportsRowsWithMissingValues = supportsRowsWithMissingValues;
+        this.crossValidationSplitterFactory = Objects.requireNonNull(crossValidationSplitterFactory);
     }
 
     public DataFrameDataExtractor newExtractor(boolean includeSource) {
@@ -45,13 +55,20 @@ public class DataFrameDataExtractorFactory {
                 analyticsId,
                 extractedFields,
                 indices,
-                QueryBuilders.boolQuery().filter(sourceQuery),
+                buildQuery(),
                 1000,
                 headers,
                 includeSource,
-                supportsRowsWithMissingValues
+                supportsRowsWithMissingValues,
+                crossValidationSplitterFactory
             );
         return new DataFrameDataExtractor(client, context);
+    }
+
+    private QueryBuilder buildQuery() {
+        BoolQueryBuilder query = QueryBuilders.boolQuery().filter(sourceQuery);
+        requiredFields.forEach(requiredField -> query.filter(QueryBuilders.existsQuery(requiredField.getName())));
+        return query;
     }
 
     public ExtractedFields getExtractedFields() {
@@ -71,7 +88,14 @@ public class DataFrameDataExtractorFactory {
     public static DataFrameDataExtractorFactory createForSourceIndices(Client client, String taskId, DataFrameAnalyticsConfig config,
                                                                        ExtractedFields extractedFields) {
         return new DataFrameDataExtractorFactory(client, taskId, Arrays.asList(config.getSource().getIndex()),
-            config.getSource().getParsedQuery(), extractedFields, config.getHeaders(), config.getAnalysis().supportsMissingValues());
+            config.getSource().getParsedQuery(), extractedFields, config.getAnalysis().getRequiredFields(), config.getHeaders(),
+            config.getAnalysis().supportsMissingValues(), createCrossValidationSplitterFactory(client, config, extractedFields));
+    }
+
+    private static CrossValidationSplitterFactory createCrossValidationSplitterFactory(Client client, DataFrameAnalyticsConfig config,
+                                                                                       ExtractedFields extractedFields) {
+        return new CrossValidationSplitterFactory(client, config,
+            extractedFields.getAllFields().stream().map(ExtractedField::getName).collect(Collectors.toList()));
     }
 
     /**
@@ -93,7 +117,8 @@ public class DataFrameDataExtractorFactory {
 
                 DataFrameDataExtractorFactory extractorFactory = new DataFrameDataExtractorFactory(client, config.getId(),
                     Collections.singletonList(config.getDest().getIndex()), config.getSource().getParsedQuery(), extractedFields,
-                    config.getHeaders(), config.getAnalysis().supportsMissingValues());
+                    config.getAnalysis().getRequiredFields(), config.getHeaders(), config.getAnalysis().supportsMissingValues(),
+                    createCrossValidationSplitterFactory(client, config, extractedFields));
                 listener.onResponse(extractorFactory);
             },
             listener::onFailure

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.inference;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
+import org.elasticsearch.xpack.ml.dataframe.stats.DataCountsTracker;
+import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
+import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class InferenceRunner {
+
+    private static final Logger LOGGER = LogManager.getLogger(InferenceRunner.class);
+
+    private static final int MAX_PROGRESS_BEFORE_COMPLETION = 98;
+    private static final int RESULTS_BATCH_SIZE = 1000;
+
+    private final Client client;
+    private final ModelLoadingService modelLoadingService;
+    private final ResultsPersisterService resultsPersisterService;
+    private final TaskId parentTaskId;
+    private final DataFrameAnalyticsConfig config;
+    private final ProgressTracker progressTracker;
+    private final DataCountsTracker dataCountsTracker;
+    private volatile boolean isCancelled;
+
+    public InferenceRunner(Client client, ModelLoadingService modelLoadingService, ResultsPersisterService resultsPersisterService,
+                           TaskId parentTaskId, DataFrameAnalyticsConfig config, ProgressTracker progressTracker,
+                           DataCountsTracker dataCountsTracker) {
+        this.client = Objects.requireNonNull(client);
+        this.modelLoadingService = Objects.requireNonNull(modelLoadingService);
+        this.resultsPersisterService = Objects.requireNonNull(resultsPersisterService);
+        this.parentTaskId = Objects.requireNonNull(parentTaskId);
+        this.config = Objects.requireNonNull(config);
+        this.progressTracker = Objects.requireNonNull(progressTracker);
+        this.dataCountsTracker = Objects.requireNonNull(dataCountsTracker);
+    }
+
+    public void cancel() {
+        isCancelled = true;
+    }
+
+    public void run(String modelId) {
+        if (isCancelled) {
+            return;
+        }
+
+        LOGGER.info("[{}] Started inference on test data against model [{}]", config.getId(), modelId);
+        try {
+            PlainActionFuture<LocalModel> localModelPlainActionFuture = new PlainActionFuture<>();
+            modelLoadingService.getModelForSearch(modelId, localModelPlainActionFuture);
+            LocalModel localModel = localModelPlainActionFuture.actionGet();
+            TestDocsIterator testDocsIterator = new TestDocsIterator(new OriginSettingClient(client, ClientHelper.ML_ORIGIN), config);
+            inferTestDocs(localModel, testDocsIterator);
+        } catch (Exception e) {
+            throw ExceptionsHelper.serverError("[{}] failed running inference on model [{}]", e, config.getId(), modelId);
+        }
+    }
+
+    // Visible for testing
+    void inferTestDocs(LocalModel model, TestDocsIterator testDocsIterator) {
+        long totalDocCount = 0;
+        long processedDocCount = 0;
+        BulkRequest bulkRequest = new BulkRequest();
+
+        while (testDocsIterator.hasNext()) {
+            if (isCancelled) {
+                break;
+            }
+
+            Deque<SearchHit> batch = testDocsIterator.next();
+
+            if (totalDocCount == 0) {
+                totalDocCount = testDocsIterator.getTotalHits();
+            }
+
+            for (SearchHit doc : batch) {
+                dataCountsTracker.incrementTestDocsCount();
+                InferenceResults inferenceResults = model.inferNoStats(new HashMap<>(doc.getSourceAsMap()));
+                bulkRequest.add(createIndexRequest(doc, inferenceResults, config.getDest().getResultsField()));
+
+                processedDocCount++;
+                int progressPercent = Math.min((int) (processedDocCount * 100.0 / totalDocCount), MAX_PROGRESS_BEFORE_COMPLETION);
+                progressTracker.updateInferenceProgress(progressPercent);
+            }
+
+            if (bulkRequest.numberOfActions() == RESULTS_BATCH_SIZE) {
+                executeBulkRequest(bulkRequest);
+                bulkRequest = new BulkRequest();
+            }
+        }
+        if (bulkRequest.numberOfActions() > 0 && isCancelled == false) {
+            executeBulkRequest(bulkRequest);
+        }
+
+        if (isCancelled == false) {
+            progressTracker.updateInferenceProgress(100);
+        }
+    }
+
+    private IndexRequest createIndexRequest(SearchHit hit, InferenceResults results, String resultField) {
+        Map<String, Object> resultsMap = new LinkedHashMap<>(results.asMap());
+        resultsMap.put(DestinationIndex.IS_TRAINING, false);
+
+        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
+        source.put(resultField, resultsMap);
+        IndexRequest indexRequest = new IndexRequest(hit.getIndex());
+        indexRequest.id(hit.getId());
+        indexRequest.source(source);
+        indexRequest.opType(DocWriteRequest.OpType.INDEX);
+        indexRequest.setParentTask(parentTaskId);
+        return indexRequest;
+    }
+
+    private void executeBulkRequest(BulkRequest bulkRequest) {
+        resultsPersisterService.bulkIndexWithHeadersWithRetry(
+            config.getHeaders(),
+            bulkRequest,
+            config.getId(),
+            () -> isCancelled == false,
+            errorMsg -> {});
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.inference;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
+import org.elasticsearch.xpack.ml.utils.persistence.SearchAfterDocumentsIterator;
+
+import java.util.Objects;
+
+public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
+
+    private final DataFrameAnalyticsConfig config;
+    private String lastDocId;
+
+    TestDocsIterator(OriginSettingClient client, DataFrameAnalyticsConfig config) {
+        super(client, config.getDest().getIndex(), true);
+        this.config = Objects.requireNonNull(config);
+    }
+
+    @Override
+    protected QueryBuilder getQuery() {
+        return QueryBuilders.boolQuery().mustNot(
+            QueryBuilders.termQuery(config.getDest().getResultsField() + "." + DestinationIndex.IS_TRAINING, true));
+    }
+
+    @Override
+    protected FieldSortBuilder sortField() {
+        return SortBuilders.fieldSort(DestinationIndex.ID_COPY).order(SortOrder.ASC);
+    }
+
+    @Override
+    protected SearchHit map(SearchHit hit) {
+        return hit;
+    }
+
+    @Override
+    protected Object[] searchAfterFields() {
+        return lastDocId == null ? null : new Object[] {lastDocId};
+    }
+
+    @Override
+    protected void extractSearchAfterFields(SearchHit lastSearchHit) {
+        lastDocId = lastSearchHit.getId();
+    }
+
+    @Override
+    protected SearchResponse executeSearchRequest(SearchRequest searchRequest) {
+        return ClientHelper.executeWithHeaders(config.getHeaders(), ClientHelper.ML_ORIGIN, client(),
+            () -> client().search(searchRequest).actionGet());
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
@@ -31,7 +31,6 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
-
 public class AnalyticsResultProcessor {
 
     private static final Logger LOGGER = LogManager.getLogger(AnalyticsResultProcessor.class);
@@ -57,6 +56,8 @@ public class AnalyticsResultProcessor {
     private final ChunkedTrainedModelPersister chunkedTrainedModelPersister;
     private volatile String failure;
     private volatile boolean isCancelled;
+
+    private volatile String latestModelId;
 
     public AnalyticsResultProcessor(DataFrameAnalyticsConfig analytics, DataFrameRowsJoiner dataFrameRowsJoiner,
                                     StatsHolder statsHolder, TrainedModelProvider trainedModelProvider,
@@ -153,7 +154,7 @@ public class AnalyticsResultProcessor {
         }
         ModelSizeInfo modelSize = result.getModelSizeInfo();
         if (modelSize != null) {
-            chunkedTrainedModelPersister.createAndIndexInferenceModelMetadata(modelSize);
+            latestModelId = chunkedTrainedModelPersister.createAndIndexInferenceModelMetadata(modelSize);
         }
         TrainedModelDefinitionChunk trainedModelDefinitionChunk = result.getTrainedModelDefinitionChunk();
         if (trainedModelDefinitionChunk != null) {
@@ -189,5 +190,10 @@ public class AnalyticsResultProcessor {
     private void processMemoryUsage(MemoryUsage memoryUsage) {
         statsHolder.setMemoryUsage(memoryUsage);
         statsPersister.persistWithRetry(memoryUsage, memoryUsage::documentId);
+    }
+
+    @Nullable
+    public String getLatestModelId() {
+        return latestModelId;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
@@ -95,12 +95,12 @@ public class ChunkedTrainedModelPersister {
         }
     }
 
-    public void createAndIndexInferenceModelMetadata(ModelSizeInfo inferenceModelSize) {
+    public String createAndIndexInferenceModelMetadata(ModelSizeInfo inferenceModelSize) {
         if (readyToStoreNewModel.compareAndSet(true, false) == false) {
             failureHandler.accept(ExceptionsHelper.serverError(
                 "new inference model is attempting to be stored before completion previous model storage"
             ));
-            return;
+            return null;
         }
         TrainedModelConfig trainedModelConfig = createTrainedModelConfig(inferenceModelSize);
         CountDownLatch latch = storeTrainedModelMetadata(trainedModelConfig);
@@ -113,6 +113,7 @@ public class ChunkedTrainedModelPersister {
             this.readyToStoreNewModel.set(true);
             failureHandler.accept(ExceptionsHelper.serverError("interrupted waiting for inference model metadata to be stored"));
         }
+        return trainedModelConfig.getModelId();
     }
 
     private CountDownLatch storeTrainedModelDoc(TrainedModelDefinitionDoc trainedModelDefinitionDoc) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -162,15 +162,19 @@ class DataFrameRowsJoiner implements AutoCloseable {
         @Override
         public DataFrameDataExtractor.Row next() {
             DataFrameDataExtractor.Row row = null;
-            while ((row == null || row.shouldSkip()) && hasNext()) {
+            while (hasNoMatch(row) && hasNext()) {
                 advanceToNextBatchIfNecessary();
                 row = currentDataFrameRows.get(currentDataFrameRowsIndex++);
             }
 
-            if (row == null || row.shouldSkip()) {
+            if (hasNoMatch(row)) {
                 throw ExceptionsHelper.serverError("no more data frame rows could be found while joining results");
             }
             return row;
+        }
+
+        private boolean hasNoMatch(DataFrameDataExtractor.Row row) {
+            return row == null || row.shouldSkip() || row.isTraining() == false;
         }
 
         private void advanceToNextBatchIfNecessary() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/AbstractReservoirCrossValidationSplitter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/AbstractReservoirCrossValidationSplitter.java
@@ -40,11 +40,10 @@ abstract class AbstractReservoirCrossValidationSplitter implements CrossValidati
     }
 
     @Override
-    public void process(String[] row, Runnable incrementTrainingDocs, Runnable incrementTestDocs) {
+    public boolean isTraining(String[] row) {
 
         if (canBeUsedForTraining(row) == false) {
-            incrementTestDocs.run();
-            return;
+            return false;
         }
 
         SampleInfo sample = getSampleInfo(row);
@@ -62,11 +61,10 @@ abstract class AbstractReservoirCrossValidationSplitter implements CrossValidati
         sample.observed++;
         if (isTraining) {
             sample.training++;
-            incrementTrainingDocs.run();
-        } else {
-            row[dependentVariableIndex] = DataFrameDataExtractor.NULL_VALUE;
-            incrementTestDocs.run();
+            return true;
         }
+
+        return false;
     }
 
     private boolean canBeUsedForTraining(String[] row) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/CrossValidationSplitter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/CrossValidationSplitter.java
@@ -10,5 +10,5 @@ package org.elasticsearch.xpack.ml.dataframe.process.crossvalidation;
  */
 public interface CrossValidationSplitter {
 
-    void process(String[] row, Runnable incrementTrainingDocs, Runnable incrementTestDocs);
+    boolean isTraining(String[] row);
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/CrossValidationSplitterFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/crossvalidation/CrossValidationSplitterFactory.java
@@ -47,7 +47,7 @@ public class CrossValidationSplitterFactory {
         if (config.getAnalysis() instanceof Classification) {
             return createStratifiedSplitter((Classification) config.getAnalysis());
         }
-        return (row, incrementTrainingDocs, incrementTestDocs) -> incrementTrainingDocs.run();
+        return row -> true;
     }
 
     private CrossValidationSplitter createSingleClassSplitter(Regression regression) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
@@ -25,16 +25,20 @@ public class ProgressTracker {
     public static final String REINDEXING = "reindexing";
     public static final String LOADING_DATA = "loading_data";
     public static final String WRITING_RESULTS = "writing_results";
+    public static final String INFERENCE = "inference";
 
     private final String[] phasesInOrder;
     private final Map<String, Integer> progressPercentPerPhase;
 
-    public static ProgressTracker fromZeroes(List<String> analysisProgressPhases) {
-        List<PhaseProgress> phases = new ArrayList<>(3 + analysisProgressPhases.size());
+    public static ProgressTracker fromZeroes(List<String> analysisProgressPhases, boolean hasInferencePhase) {
+        List<PhaseProgress> phases = new ArrayList<>(3 + analysisProgressPhases.size() + (hasInferencePhase ? 1 : 0));
         phases.add(new PhaseProgress(REINDEXING, 0));
         phases.add(new PhaseProgress(LOADING_DATA, 0));
         analysisProgressPhases.forEach(analysisPhase -> phases.add(new PhaseProgress(analysisPhase, 0)));
         phases.add(new PhaseProgress(WRITING_RESULTS, 0));
+        if (hasInferencePhase) {
+            phases.add(new PhaseProgress(INFERENCE, 0));
+        }
         return new ProgressTracker(phases);
     }
 
@@ -75,6 +79,14 @@ public class ProgressTracker {
 
     public int getWritingResultsProgressPercent() {
         return progressPercentPerPhase.get(WRITING_RESULTS);
+    }
+
+    public void updateInferenceProgress(int progressPercent) {
+        updatePhase(INFERENCE, progressPercent);
+    }
+
+    public int getInferenceProgressPercent() {
+        return progressPercentPerPhase.getOrDefault(INFERENCE, 0);
     }
 
     public void updatePhase(PhaseProgress phase) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
@@ -30,9 +30,9 @@ public class StatsHolder {
         dataCountsTracker = new DataCountsTracker();
     }
 
-    public void resetProgressTrackerPreservingReindexingProgress(List<String> analysisPhases) {
+    public void resetProgressTrackerPreservingReindexingProgress(List<String> analysisPhases, boolean hasInferencePhase) {
         int reindexingProgressPercent = progressTracker.getReindexingProgressPercent();
-        progressTracker = ProgressTracker.fromZeroes(analysisPhases);
+        progressTracker = ProgressTracker.fromZeroes(analysisPhases, hasInferencePhase);
         progressTracker.updateReindexingProgress(reindexingProgressPercent);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -80,6 +80,20 @@ public class LocalModel {
         }
     }
 
+    /**
+     * Infers without updating the stats.
+     * This is mainly for usage by data frame analytics jobs
+     * when they do inference against test data.
+     */
+    public InferenceResults inferNoStats(Map<String, Object> fields) {
+        LocalModel.mapFieldsIfNecessary(fields, defaultFieldMap);
+        Map<String, Object> flattenedFields = MapHelper.dotCollapse(fields, fieldNames);
+        if (flattenedFields.isEmpty()) {
+            new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId));
+        }
+        return trainedModelDefinition.infer(flattenedFields, inferenceConfig);
+    }
+
     public void infer(Map<String, Object> fields, InferenceConfigUpdate update, ActionListener<InferenceResults> listener) {
         if (update.isSupported(this.inferenceConfig) == false) {
             listener.onFailure(ExceptionsHelper.badRequestException(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.utils.persistence;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
@@ -20,6 +21,7 @@ import java.util.Deque;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * An iterator useful to fetch a large number of documents of type T
@@ -44,12 +46,27 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
 
     private final OriginSettingClient client;
     private final String index;
+    private final boolean trackTotalHits;
+    private final AtomicLong totalHits = new AtomicLong();
     private final AtomicBoolean lastSearchReturnedResults;
     private int batchSize = BATCH_SIZE;
 
     protected SearchAfterDocumentsIterator(OriginSettingClient client, String index) {
+        this(client, index, false);
+    }
+
+    /**
+     * Constructs an iterator that searches docs using search after
+     *
+     * @param client the client
+     * @param index the index
+     * @param trackTotalHits whether to track total hits. Note this is only done in the first search
+     *                       and the result will only be accurate if the index is not changed between searches.
+     */
+    protected SearchAfterDocumentsIterator(OriginSettingClient client, String index, boolean trackTotalHits) {
         this.client = Objects.requireNonNull(client);
         this.index = Objects.requireNonNull(index);
+        this.trackTotalHits = trackTotalHits;
         this.lastSearchReturnedResults = new AtomicBoolean(true);
     }
 
@@ -88,6 +105,9 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
         }
 
         SearchResponse searchResponse = doSearch(searchAfterFields());
+        if (trackTotalHits && totalHits.get() == 0) {
+            totalHits.set(searchResponse.getHits().getTotalHits().value);
+        }
         return mapHits(searchResponse);
     }
 
@@ -100,11 +120,19 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
             .fetchSource(shouldFetchSource())
             .sort(sortField()));
 
+        if (trackTotalHits && totalHits.get() == 0L) {
+            sourceBuilder.trackTotalHits(true);
+        }
+
         if (searchAfterValues != null) {
             sourceBuilder.searchAfter(searchAfterValues);
         }
 
         searchRequest.source(sourceBuilder);
+        return executeSearchRequest(searchRequest);
+    }
+
+    protected SearchResponse executeSearchRequest(SearchRequest searchRequest) {
         return client.search(searchRequest).actionGet();
     }
 
@@ -176,5 +204,16 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
     // for testing
     void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
+    }
+
+    protected Client client() {
+        return client;
+    }
+
+    public long getTotalHits() {
+        if (trackTotalHits == false) {
+            throw new IllegalStateException("cannot return total hits because tracking was not enabled");
+        }
+        return totalHits.get();
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Classification;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetectionTests;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
+import org.elasticsearch.xpack.ml.dataframe.process.crossvalidation.CrossValidationSplitterFactory;
 import org.elasticsearch.xpack.ml.extractor.DocValueField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
@@ -66,6 +67,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
     private QueryBuilder query;
     private int scrollSize;
     private Map<String, String> headers;
+    private CrossValidationSplitterFactory crossValidationSplitterFactory;
     private ArgumentCaptor<ClearScrollRequest> capturedClearScrollRequests;
     private ActionFuture<ClearScrollResponse> clearScrollFuture;
 
@@ -84,6 +86,9 @@ public class DataFrameDataExtractorTests extends ESTestCase {
             new DocValueField("field_2", Collections.singleton("keyword"))), Collections.emptyMap());
         scrollSize = 1000;
         headers = Collections.emptyMap();
+
+        crossValidationSplitterFactory = mock(CrossValidationSplitterFactory.class);
+        when(crossValidationSplitterFactory.create()).thenReturn(row -> true);
 
         clearScrollFuture = mock(ActionFuture.class);
         capturedClearScrollRequests = ArgumentCaptor.forClass(ClearScrollRequest.class);
@@ -461,8 +466,8 @@ public class DataFrameDataExtractorTests extends ESTestCase {
     }
 
     private TestExtractor createExtractor(boolean includeSource, boolean supportsRowsWithMissingValues) {
-        DataFrameDataExtractorContext context = new DataFrameDataExtractorContext(
-            JOB_ID, extractedFields, indices, query, scrollSize, headers, includeSource, supportsRowsWithMissingValues);
+        DataFrameDataExtractorContext context = new DataFrameDataExtractorContext(JOB_ID, extractedFields, indices, query, scrollSize,
+            headers, includeSource, supportsRowsWithMissingValues, crossValidationSplitterFactory);
         return new TestExtractor(client, context);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.inference;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.RegressionTests;
+import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.ml.dataframe.stats.DataCountsTracker;
+import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
+import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InferenceRunnerTests extends ESTestCase {
+
+    private Client client;
+    private ResultsPersisterService resultsPersisterService;
+    private ModelLoadingService modelLoadingService;
+    private DataFrameAnalyticsConfig config;
+    private ProgressTracker progressTracker;
+    private TaskId parentTaskId;
+
+    @Before
+    public void setupTests() {
+        client = mock(Client.class);
+        resultsPersisterService = mock(ResultsPersisterService.class);
+        config = new DataFrameAnalyticsConfig.Builder()
+            .setId("test")
+            .setAnalysis(RegressionTests.createRandom())
+            .setSource(new DataFrameAnalyticsSource(new String[] {"source_index"}, null, null))
+            .setDest(new DataFrameAnalyticsDest("dest_index", "test_results_field"))
+            .build();
+        progressTracker = ProgressTracker.fromZeroes(config.getAnalysis().getProgressPhases(), config.getAnalysis().supportsInference());
+        parentTaskId = new TaskId(randomAlphaOfLength(10), randomLong());
+        modelLoadingService = mock(ModelLoadingService.class);
+    }
+
+    public void testInferTestDocs() {
+        Map<String, Object> doc1 = new HashMap<>();
+        doc1.put("key", 1);
+        Map<String, Object> doc2 = new HashMap<>();
+        doc2.put("key", 2);
+        TestDocsIterator testDocsIterator = mock(TestDocsIterator.class);
+        when(testDocsIterator.hasNext()).thenReturn(true, false);
+        when(testDocsIterator.next()).thenReturn(buildSearchHits(Arrays.asList(doc1, doc2)));
+        when(testDocsIterator.getTotalHits()).thenReturn(2L);
+        InferenceConfig config = ClassificationConfig.EMPTY_PARAMS;
+
+        LocalModel localModel = localModelInferences(new ClassificationInferenceResults(1.0,
+        "foo",
+            Collections.emptyList(),
+            config),
+            new ClassificationInferenceResults(0.0,
+                "bar",
+                Collections.emptyList(),
+                config));
+
+        InferenceRunner inferenceRunner = createInferenceRunner();
+
+        inferenceRunner.inferTestDocs(localModel, testDocsIterator);
+
+        ArgumentCaptor<BulkRequest> argumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+
+        verify(resultsPersisterService).bulkIndexWithHeadersWithRetry(any(), argumentCaptor.capture(), any(), any(), any());
+        assertThat(progressTracker.getInferenceProgressPercent(), equalTo(100));
+
+        BulkRequest bulkRequest = argumentCaptor.getAllValues().get(0);
+        List<DocWriteRequest<?>> indexRequests = bulkRequest.requests();
+        Map<String, Object> doc1Source = ((IndexRequest)indexRequests.get(0)).sourceAsMap();
+        Map<String, Object> doc2Source = ((IndexRequest)indexRequests.get(1)).sourceAsMap();
+
+        Map<String, Object> expectedResultsField1 = new HashMap<>();
+        expectedResultsField1.put("predicted_value", "foo");
+        expectedResultsField1.put("is_training", false);
+
+        Map<String, Object> expectedResultsField2 = new HashMap<>();
+        expectedResultsField2.put("predicted_value", "bar");
+        expectedResultsField2.put("is_training", false);
+
+        assertThat(doc1Source.get("test_results_field"), equalTo(expectedResultsField1));
+        assertThat(doc2Source.get("test_results_field"), equalTo(expectedResultsField2));
+    }
+
+    public void testInferTestDocs_GivenCancelWasCalled() {
+
+        LocalModel localModel = mock(LocalModel.class);
+
+        TestDocsIterator infiniteDocsIterator = mock(TestDocsIterator.class);
+        when(infiniteDocsIterator.hasNext()).thenReturn(true);
+
+        InferenceRunner inferenceRunner = createInferenceRunner();
+        inferenceRunner.cancel();
+
+        inferenceRunner.inferTestDocs(localModel, infiniteDocsIterator);
+
+        Mockito.verifyNoMoreInteractions(localModel, resultsPersisterService);
+        assertThat(progressTracker.getInferenceProgressPercent(), equalTo(0));
+    }
+
+    private static Deque<SearchHit> buildSearchHits(List<Map<String, Object>> vals) {
+        return vals.stream()
+            .map(InferenceRunnerTests::fromMap)
+            .map(reference -> SearchHit.createFromMap(Collections.singletonMap("_source", reference)))
+            .collect(Collectors.toCollection(ArrayDeque::new));
+    }
+
+    private static BytesReference fromMap(Map<String, Object> map) {
+        try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(map)) {
+            return BytesReference.bytes(xContentBuilder);
+        } catch (IOException ex) {
+            throw new ElasticsearchException(ex);
+        }
+    }
+
+    private LocalModel localModelInferences(InferenceResults first, InferenceResults... rest) {
+        LocalModel localModel = mock(LocalModel.class);
+        when(localModel.inferNoStats(any())).thenReturn(first, rest);
+        return localModel;
+    }
+
+    private InferenceRunner createInferenceRunner() {
+        return new InferenceRunner(client, modelLoadingService,  resultsPersisterService, parentTaskId, config, progressTracker,
+            new DataCountsTracker());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.ml.dataframe.process.results.AnalyticsResult;
 import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
 import org.elasticsearch.xpack.ml.dataframe.stats.StatsHolder;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
@@ -64,6 +65,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
     private Client client;
     private DataFrameAnalyticsAuditor auditor;
     private TrainedModelProvider trainedModelProvider;
+    private ModelLoadingService modelLoadingService;
     private ExecutorService executorServiceForJob;
     private ExecutorService executorServiceForProcess;
     private AnalyticsProcess<AnalyticsResult> process;
@@ -96,7 +98,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         task = mock(DataFrameAnalyticsTask.class);
         when(task.getAllocationId()).thenReturn(TASK_ALLOCATION_ID);
         when(task.getStatsHolder()).thenReturn(new StatsHolder(
-            ProgressTracker.fromZeroes(Collections.singletonList("analyzing")).report()));
+            ProgressTracker.fromZeroes(Collections.singletonList("analyzing"), false).report()));
         when(task.getParentTaskId()).thenReturn(new TaskId(""));
         dataFrameAnalyticsConfig = DataFrameAnalyticsConfigTests.createRandomBuilder(CONFIG_ID,
             false,
@@ -109,9 +111,9 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         when(dataExtractorFactory.getExtractedFields()).thenReturn(mock(ExtractedFields.class));
 
         resultsPersisterService = mock(ResultsPersisterService.class);
-
+        modelLoadingService = mock(ModelLoadingService.class);
         processManager = new AnalyticsProcessManager(client, executorServiceForJob, executorServiceForProcess, processFactory, auditor,
-            trainedModelProvider, resultsPersisterService);
+            trainedModelProvider, modelLoadingService, resultsPersisterService);
     }
 
     public void testRunJob_TaskIsStopping() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
@@ -47,7 +47,7 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
 
     private AnalyticsProcess<AnalyticsResult> process;
     private DataFrameRowsJoiner dataFrameRowsJoiner;
-    private StatsHolder statsHolder = new StatsHolder(ProgressTracker.fromZeroes(Collections.singletonList("analyzing")).report());
+    private StatsHolder statsHolder = new StatsHolder(ProgressTracker.fromZeroes(Collections.singletonList("analyzing"), false).report());
     private TrainedModelProvider trainedModelProvider;
     private DataFrameAnalyticsAuditor auditor;
     private StatsPersister statsPersister;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
@@ -37,7 +37,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testFromZeroes() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Arrays.asList("a", "b", "c"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Arrays.asList("a", "b", "c"), false);
 
         List<PhaseProgress> phases = progressTracker.report();
 
@@ -47,8 +47,28 @@ public class ProgressTrackerTests extends ESTestCase {
         assertThat(phases.stream().map(PhaseProgress::getProgressPercent).allMatch(p -> p == 0), is(true));
     }
 
+    public void testFromZeroes_GivenAnalysisWithoutInference() {
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Arrays.asList("a", "b"), false);
+
+        List<PhaseProgress> phaseProgresses = progressTracker.report();
+
+        assertThat(phaseProgresses.size(), equalTo(5));
+        assertThat(phaseProgresses.stream().map(PhaseProgress::getPhase).collect(Collectors.toList()),
+            contains("reindexing", "loading_data", "a", "b", "writing_results"));
+    }
+
+    public void testFromZeroes_GivenAnalysisWithInference() {
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Arrays.asList("a", "b"), true);
+
+        List<PhaseProgress> phaseProgresses = progressTracker.report();
+
+        assertThat(phaseProgresses.size(), equalTo(6));
+        assertThat(phaseProgresses.stream().map(PhaseProgress::getPhase).collect(Collectors.toList()),
+            contains("reindexing", "loading_data", "a", "b", "writing_results", "inference"));
+    }
+
     public void testUpdates() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updateReindexingProgress(1);
         progressTracker.updateLoadingDataProgress(2);
@@ -70,7 +90,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testUpdatePhase_GivenUnknownPhase() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updatePhase(new PhaseProgress("unknown", 42));
         List<PhaseProgress> phases = progressTracker.report();
@@ -81,7 +101,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testUpdateReindexingProgress_GivenLowerValueThanCurrentProgress() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updateReindexingProgress(10);
 
@@ -93,7 +113,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testUpdateLoadingDataProgress_GivenLowerValueThanCurrentProgress() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updateLoadingDataProgress(20);
 
@@ -105,7 +125,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testUpdateWritingResultsProgress_GivenLowerValueThanCurrentProgress() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updateWritingResultsProgress(30);
 
@@ -117,7 +137,7 @@ public class ProgressTrackerTests extends ESTestCase {
     }
 
     public void testUpdatePhase_GivenLowerValueThanCurrentProgress() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"), false);
 
         progressTracker.updatePhase(new PhaseProgress("foo", 40));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
@@ -31,7 +31,7 @@ public class StatsHolderTests extends ESTestCase {
         );
         StatsHolder statsHolder = new StatsHolder(phases);
 
-        statsHolder.resetProgressTrackerPreservingReindexingProgress(Arrays.asList("a", "b"));
+        statsHolder.resetProgressTrackerPreservingReindexingProgress(Arrays.asList("a", "b"), false);
 
         List<PhaseProgress> phaseProgresses = statsHolder.getProgressTracker().report();
 
@@ -57,7 +57,7 @@ public class StatsHolderTests extends ESTestCase {
         );
         StatsHolder statsHolder = new StatsHolder(phases);
 
-        statsHolder.resetProgressTrackerPreservingReindexingProgress(Arrays.asList("c", "d"));
+        statsHolder.resetProgressTrackerPreservingReindexingProgress(Arrays.asList("c", "d"), false);
 
         List<PhaseProgress> phaseProgresses = statsHolder.getProgressTracker().report();
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_cat_apis.yml
@@ -81,6 +81,6 @@ setup:
   - match:
       $body: |
         /^  id                           \s+ t                 \s+ s       \s+ p                                                         \s+ source_index \s+ dest_index    \n
-           (dfa\-classification\-job     \s+ classification    \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0 \s+ index-source \s+ index-dest-c  \n)+
+           (dfa\-classification\-job     \s+ classification    \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0,inference:0 \s+ index-source \s+ index-dest-c  \n)+
            (dfa\-outlier\-detection\-job \s+ outlier_detection \s+ stopped \s+ reindexing:0,loading_data:0,computing_outliers:0,writing_results:0 \s+ index-source \s+ index-dest-od \n)+
-           (dfa\-regression\-job         \s+ regression        \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0 \s+ index-source \s+ index-dest-r  \n)+  $/
+           (dfa\-regression\-job         \s+ regression        \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0,inference:0 \s+ index-source \s+ index-dest-r  \n)+  $/


### PR DESCRIPTION
Since we are able to load the inference model
and perform inference in java, we no longer need
to rely on the analytics process to be performing
test inference on the docs that were not used for
training. The benefit is that we do not need to
send test docs and fit them in memory of the c++
process.

Backport of #58877

Co-authored-by: Dimitris Athanasiou <dimitris@elastic.co>
