### PR TITLE
[DOCS] Fix gradlew command in docs README

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -22,8 +22,9 @@ See: https://github.com/elastic/docs
 
 Snippets marked with `[source,console]` are automatically annotated with
 "VIEW IN CONSOLE" and "COPY AS CURL" in the documentation and are automatically
-tested by the command `./gradlew -pdocs check`. To test just the docs from a
-single page, use e.g. `./gradlew -pdocs integTestRunner --tests "\*rollover*"`.
+tested by the command `./gradlew :docs:check`. To test just the docs from a
+single page, use e.g.
+`./gradlew :docs:integTestRunner --tests "*reference/getting-started*"`.
 
 By default each `[source,console]` snippet runs as its own isolated test. You
 can manipulate the test execution in the following ways:


### PR DESCRIPTION
It looks like the `./gradlew` commands for testing snippets are a bit stale.
This should bring them up to date.

Thanks to @lockewritesdocs for pointing this out.