### PR TITLE
Default gateway.auto_import_dangling_indices to false

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -10,7 +10,7 @@ your application to {es} 7.9.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_79_script_cache_changes>>
-* <<breaking_78_settings_changes>>
+* <<breaking_79_settings_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -75,21 +75,23 @@ context.  For example, for the `processor_conditional` context, use
 === Settings changes
 
 [[deprecate_auto_import_dangling_indices]]
-.Automatically importing dangling indices is deprecated.
+.Automatically importing dangling indices is disabled by default.
 
 [%collapsible]
 ====
 *Details* +
-<<dangling-indices,Dangling indices>> will no longer be imported
-automatically by default. A new
-<<dangling-indices-api,Dangling indices API>> is now available, which you
-can use to list, import, or delete. Because importing dangling indices
-automatically into the cluster is unsafe, use the dedicated API instead.
+Automatically importing <<dangling-indices,dangling indices>> into the cluster
+is unsafe and is now disabled by default. This feature will be removed entirely
+in {es} 8.0.0.
 
 *Impact* +
-Automatically importing dangling indices is now deprecated, disabled by
-default, and will be removed in (es) 8.0. If you need to re-enable
-auto-imports, set `gateway.auto_import_dangling_indices` to `true`.
+Use the <<dangling-indices-api,Dangling indices API>> to list, delete or import
+any dangling indices manually.
+
+Alternatively you can enable automatic imports of dangling indices, recovering
+the unsafe behaviour of earlier versions, by setting
+`gateway.auto_import_dangling_indices` to `true`. This setting is deprecated
+and will be removed in {es} 8.0.0. We do not recommend using this setting.
 
 ====
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -10,6 +10,7 @@ your application to {es} 7.9.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_79_script_cache_changes>>
+* <<breaking_78_settings_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -66,6 +67,29 @@ To avoid deprecation warnings, discontinue use of the `script.max_compilations_r
 setting. You may use `script.context.$CONTEXT.max_compilations_rate` for the particular
 context.  For example, for the `processor_conditional` context, use
 `script.context.processor_conditional.max_compilations_rate`.
+
+====
+
+[discrete]
+[[breaking_79_settings_changes]]
+=== Settings changes
+
+[[deprecate_auto_import_dangling_indices]]
+.Automatically importing dangling indices is deprecated.
+
+[%collapsible]
+====
+*Details* +
+<<dangling-indices,Dangling indices>> will no longer be imported
+automatically by default. A new
+<<dangling-indices-api,Dangling indices API>> is now available, which you
+can use to list, import, or delete. Because importing dangling indices
+automatically into the cluster is unsafe, use the dedicated API instead.
+
+*Impact* +
+Automatically importing dangling indices is now deprecated, disabled by
+default, and will be removed in (es) 8.0. If you need to re-enable
+auto-imports, set `gateway.auto_import_dangling_indices` to `true`.
 
 ====
 //end::notable-breaking-changes[]

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -34,6 +34,6 @@ Thread pool write queue size::
 
 Dangling indices::
 * Automatically importing dangling indices is now deprecated, disabled by
-  default, and will be removed in (es) 8.0. See the
+  default, and will be removed in {es} 8.0. See the
   <<deprecate_auto_import_dangling_indices,migration notes>>.
   {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -33,11 +33,7 @@ Thread pool write queue size::
   {es-issue}59263[#59263]
 
 Dangling indices::
-* A new <<dangling-indices-api,Dangling indices API>> is now available, which you
-  can use to list, import, or delete
-  <<dangling-indices,dangling indices>>. Because importing dangling indices
-  into the cluster using `gateway.auto_import_dangling_indices` is unsafe, use the dedicated API instead.
-  
-  Automatically importing dangling indices is now deprecated, disabled by default, and will be removed in (es) 8.0. If you need to re-enable auto-imports, set
-  `gateway.auto_import_dangling_indices` to `true`
-   {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])
+* Automatically importing dangling indices is now deprecated, disabled by
+  default, and will be removed in (es) 8.0. See the
+  <<deprecate_auto_import_dangling_indices,migration notes>>.
+  {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -33,11 +33,11 @@ Thread pool write queue size::
   {es-issue}59263[#59263]
 
 Dangling indices::
-* A new <<dangling-indices-api,Dangling indices API>> is now available. You
-  can use it to list, import or delete
-  <<dangling-indices,dangling indices>>. Because of this, automatically
-  importing dangling indices is now disabled by default. There are several
-  issues with this behavior, and you should use the dedicated API instead.
-  If you need to re-enable auto-imports, set
-  `gateway.auto_import_dangling_indices` to `true`.  Auto-imports are now
-  deprecated and will be removed in 8.0 {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])
+* A new <<dangling-indices-api,Dangling indices API>> is now available, which you
+  can use to list, import, or delete
+  <<dangling-indices,dangling indices>>. Because importing dangling indices
+  into the cluster using `gateway.auto_import_dangling_indices` is unsafe, use the dedicated API instead.
+  
+  Automatically importing dangling indices is now deprecated, disabled by default, and will be removed in (es) 8.0. If you need to re-enable auto-imports, set
+  `gateway.auto_import_dangling_indices` to `true`
+   {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -31,3 +31,13 @@ Thread pool write queue size::
   `indexing_pressure.memory.limit` setting. This setting configures a limit to
   the number of bytes allowed to be consumed by outstanding indexing requests.
   {es-issue}59263[#59263]
+
+Dangling indices::
+* A new <<dangling-indices-api,Dangling indices API>> is now available. You
+  can use it to list, import or delete
+  <<dangling-indices,dangling indices>>. Because of this, automatically
+  importing dangling indices is now disabled by default. There are several
+  issues with this behavior, and you should use the dedicated API instead.
+  If you need to re-enable auto-imports, set
+  `gateway.auto_import_dangling_indices` to `true`.  Auto-imports are now
+  deprecated and will be removed in 8.0 {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
@@ -314,11 +315,15 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
     public void testAllMasterEligibleNodesFailedDanglingIndexImport() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
+        Settings settings = Settings.builder()
+            .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+            .build();
+
         logger.info("--> start mixed data and master-eligible node and bootstrap cluster");
-        String masterNode = internalCluster().startNode(); // node ordinal 0
+        String masterNode = internalCluster().startNode(settings); // node ordinal 0
 
         logger.info("--> start data-only node and ensure 2 nodes stable cluster");
-        String dataNode = internalCluster().startDataOnlyNode(); // node ordinal 1
+        String dataNode = internalCluster().startDataOnlyNode(settings); // node ordinal 1
         ensureStableCluster(2);
 
         logger.info("--> index 1 doc and ensure index is green");
@@ -332,11 +337,18 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(true));
 
         logger.info("--> stop data-only node and detach it from the old cluster");
-        Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
+        Settings dataNodeDataPathSettings = Settings.builder()
+            .put(internalCluster().dataPathSettings(dataNode), true)
+            .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+            .build();
         assertBusy(() -> internalCluster().getInstance(GatewayMetaState.class, dataNode).allPendingAsyncStatesWritten());
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(dataNode));
         final Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataNodeDataPathSettings).build());
+            Settings.builder()
+                .put(internalCluster().getDefaultSettings())
+                .put(dataNodeDataPathSettings)
+                .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
+                .build());
         detachCluster(environment, false);
 
         logger.info("--> stop master-eligible node, clear its data and start it again - new cluster should form");

--- a/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -64,7 +64,7 @@ public class DanglingIndicesState implements ClusterStateListener {
      */
     public static final Setting<Boolean> AUTO_IMPORT_DANGLING_INDICES_SETTING = Setting.boolSetting(
         "gateway.auto_import_dangling_indices",
-        true,
+        false,
         Setting.Property.NodeScope,
         Setting.Property.Deprecated
     );


### PR DESCRIPTION
Backport of #58898.

Part of #48366. Now that there is a dedicated API for dangling indices, the auto-import behaviour can default to off. Also add a note to the breaking changes for 7.9.0.