### PR TITLE
Update ICU Analyzer Documentation

### DIFF
--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -30,7 +30,7 @@ include::install_remove.asciidoc[]
 ==== ICU Analyzer
 
 The `icu_analyzer` analyzer performs basic normalization, tokenization and character folding, using the
-`icu_normalizer` char filter, `icu_tokenizer` and `icu_normalizer` token filter
+`icu_normalizer` char filter, `icu_tokenizer` and `icu_folding` token filter
 
 The following parameters are accepted:
 


### PR DESCRIPTION
I was testing the `icu_analyzer` for a project I was working on, and was very confused why it was folding diacritical marks as well, so I read the source [here](https://github.com/elastic/elasticsearch/blob/master/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuAnalyzerProvider.java), and it seems the `icu_analyzer` uses the `ICUFoldingFilter` which corresponds to the `icu_folding` token filter.  

This PR fixes the documentation so that others don't fall into the same trap I did.
