### PR TITLE
[7.x] Data stream support for EQL search

### DIFF
--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.rest-resources'
 
 restResources {
   restApi {
-    includeCore '_common', 'bulk'
+    includeCore '_common', 'bulk', 'indices'
     includeXpack 'eql'
   }
 }

--- a/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/20_data_streams.yml
+++ b/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/20_data_streams.yml
@@ -1,0 +1,54 @@
+---
+"Verify data stream resolvability in EQL search API":
+  - skip:
+      version: " - 7.99.99"
+      reason: "change to 7.8.99 after backport"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [simple-data-stream1]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+          data_stream:
+            timestamp_field: '@timestamp'
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - create:
+              _index: simple-data-stream1
+              _id:    1
+          - event:
+              - category: process
+            "@timestamp": 2020-02-03T12:34:56Z
+            user: SYSTEM
+
+  - do:
+      eql.search:
+        index: simple-data-stream1
+        body:
+          query: "process where user = 'SYSTEM'"
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.user: "SYSTEM"}
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged


### PR DESCRIPTION
The underlying transport actions already supported data streams for this API so no production code changes were required. The PR adds only a test to verify that that the API works with data streams.

Relates to #53100.

Backport of #58861
