### PR TITLE
[DOCS] Document custom routing support for ds

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -163,6 +163,9 @@ Each bulk item can include the routing value using the
 `routing` field. It automatically follows the behavior of the
 index / delete operation based on the `_routing` mapping.
 
+NOTE: Data streams do not support custom routing. Instead, target the
+appropriate backing index for the stream.
+
 [float]
 [[bulk-wait-for-active-shards]]
 ===== Wait For Active Shards

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -302,6 +302,9 @@ additional document parsing pass. If the `_routing` mapping is defined
 and set to be `required`, the index operation will fail if no routing
 value is provided or extracted.
 
+NOTE: Data streams do not support custom routing. Instead, target the
+appropriate backing index for the stream.
+
 [float]
 [[index-distributed]]
 ===== Distributed

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -43,6 +43,9 @@ GET my_index/_search
 
 <1> Querying on the `_routing` field (also see the <<query-dsl-ids-query,`ids` query>>)
 
+NOTE: Data streams do not support custom routing. Instead, target the
+appropriate backing index for the stream.
+
 ==== Searching with custom routing
 
 Custom routing can reduce the impact of searches.  Instead of having to fan


### PR DESCRIPTION
Updates existing index and bulk index docs to note that
data streams do not support custom routing.

Relates to #58749