### PR TITLE
[DOCS] Add data streams to searchable snapshot API docs

### DIFF
--- a/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
@@ -32,7 +32,7 @@ For more information, see <<security-privileges>>.
 [[searchable-snapshots-api-clear-cache-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
+`<target>`::
 (Optional, string)
 A comma-separated list of data streams and indices for which the
 searchable snapshots cache must be cleared.

--- a/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
@@ -15,7 +15,7 @@ Clear the cache of searchable snapshots.
 
 `POST /_searchable_snapshots/cache/clear`
 
-`POST /<index>/_searchable_snapshots/cache/clear`
+`POST /<target>/_searchable_snapshots/cache/clear`
 
 [[searchable-snapshots-api-clear-cache-prereqs]]
 ==== {api-prereq-title}
@@ -34,7 +34,7 @@ For more information, see <<security-privileges>>.
 
 `<index>`::
 (Optional, string)
-A comma-separated list of index names for which the
+A comma-separated list of data streams and indices for which the
 searchable snapshots cache must be cleared.
 
 

--- a/docs/reference/searchable-snapshots/apis/get-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/get-stats.asciidoc
@@ -15,7 +15,7 @@ Retrieve various statistics about searchable snapshots.
 
 `GET /_searchable_snapshots/stats`
 
-`GET /<index>/_searchable_snapshots/stats`
+`GET /<target>/_searchable_snapshots/stats`
 
 [[searchable-snapshots-api-stats-prereqs]]
 ==== {api-prereq-title}
@@ -32,9 +32,9 @@ For more information, see <<security-privileges>>.
 [[searchable-snapshots-api-stats-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
+`<target>`::
 (Optional, string)
-A comma-separated list of index names for which the
+A comma-separated list of data streams and indices for which the
 statistics must be retrieved.
 
 


### PR DESCRIPTION
Updates the existing docs for the clear searchable snapshots cache
and get searchable snapshot stats APIs to make them aware of
data streams.

Relates to #55726