### PR TITLE
[DOCS] Add data streams to index APIs

### DIFF
--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Get index</titleabbrev>
 ++++
 
-Returns information about one or more indexes.
+Returns information about one or more indices. For data streams, the API
+returns information about the stream's backing indices.
 
 [source,console]
 --------------------------------------------------
@@ -15,20 +16,19 @@ GET /twitter
 [[get-index-api-request]]
 ==== {api-request-title}
 
-`GET /<index>`
+`GET /<target>`
 
 
 [[get-index-api-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
 +
---
-(Required, string) Comma-separated list or wildcard expression of index names
-used to limit the request.
-
-Use a value of `_all` to retrieve information for all indices in the cluster.
---
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[get-index-api-query-params]]

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -23,7 +23,7 @@ GET /twitter
 ==== {api-path-parms-title}
 
 `<target>`::
-(Optional, string)
+(Required, string)
 Comma-separated list of data streams, indices, and index aliases used to limit
 the request. Wildcard expressions (`*`) are supported.
 +

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -60,7 +60,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 The get mapping API can be used to get more than one data stream or index with a
 single call. General usage of the API follows the following syntax:
 `host:port/<target>/_mapping` where `<target>` can accept a comma-separated
-list of names. To get mappings for all indices in a cluster, use `_all` or `*` for `<target>`
+list of names. To get mappings for all data streams and indices in a cluster, use `_all` or `*` for `<target>`
 or omit the `<target>` parameter.
 The following are some examples:
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Get mapping</titleabbrev>
 ++++
 
-Retrieves <<mapping,mapping definitions>> for indices in a cluster.
+Retrieves <<mapping,mapping definitions>> for one or more indices. For data
+streams, the API retrieves mappings for the stream's backing indices.
 
 [source,console]
 --------------------------------------------------
@@ -17,13 +18,19 @@ GET /twitter/_mapping
 
 `GET /_mapping`
 
-`GET /<index>/_mapping`
+`GET /<target>/_mapping`
 
 
 [[get-mapping-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
++
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[get-mapping-api-query-params]]
@@ -48,12 +55,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 ==== {api-examples-title}
 
 [[get-mapping-api-multi-ex]]
-===== Multiple indices
+===== Multiple data streams and indices
 
-The get mapping API can be used to get more than one index with a
+The get mapping API can be used to get more than one data stream or index with a
 single call. General usage of the API follows the following syntax:
-`host:port/{index}/_mapping` where  `{index}` can accept a comma-separated
-list of names. To get mappings for all indices you can use `_all` for `{index}`.
+`host:port/<target>/_mapping` where `<target>` can accept a comma-separated
+list of names. To get mappings for all indices in a cluster, use `_all` or `*` for `<target>`
+or omit the `<target>` parameter.
 The following are some examples:
 
 [source,console]
@@ -63,11 +71,13 @@ GET /twitter,kimchy/_mapping
 // TEST[setup:twitter]
 // TEST[s/^/PUT kimchy\nPUT book\n/]
 
-If you want to get mappings of all indices and types then the following
-two examples are equivalent:
+If you want to get mappings of all indices in a cluster, the following
+examples are equivalent:
 
 [source,console]
 --------------------------------------------------
+GET /*/_mapping
+
 GET /_all/_mapping
 
 GET /_mapping

--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Get index settings</titleabbrev>
 ++++
 
-Returns setting information for an index.
+Returns setting information for one or more indices. For data streams, the API
+returns setting information for the stream's backing indices.
 
 [source,console]
 --------------------------------------------------
@@ -16,17 +17,21 @@ GET /twitter/_settings
 [[get-index-settings-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_settings`
+`GET /<target>/_settings`
 
-`GET /<index>/_settings/<setting>`
+`GET /<target>/_settings/<setting>`
 
 
 [[get-index-settings-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
 +
-Use a value of `_all` to retrieve information for all indices in the cluster.
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 `<setting>`::
 (Optional, string) Comma-separated list or wildcard expression of setting names
@@ -58,10 +63,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 [[get-index-settings-api-example]]
 ==== {api-examples-title}
 
-===== Multiple indices
+===== Multiple data streams and indices
 
-The get settings API can be used to get settings for more than one index with a
-single call. To get settings for all indices you can use `_all` for `<index>`.
+The get settings API can be used to get settings for more than one data stream or index with a
+single call. To get settings for all indices in a cluster, you can use `_all` or `*` for `<target>`.
 Wildcard expressions are also supported. The following are some examples:
 
 [source,console]

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -5,7 +5,9 @@
 ++++
 
 
-Returns information about ongoing and completed shard recoveries.
+Returns information about ongoing and completed shard recoveries for one or more
+indices. For data streams, the API returns information for the stream's backing
+indices.
 
 [source,console]
 ----
@@ -17,7 +19,7 @@ GET /twitter/_recovery
 [[index-recovery-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_recovery`
+`GET /<target>/_recovery`
 
 `GET /_recovery`
 
@@ -41,9 +43,13 @@ include::{es-repo-dir}/glossary.asciidoc[tag=recovery-triggers]
 [[index-recovery-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
 +
-Use a value of `_all` to retrieve information for all indices in the cluster.
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[index-recovery-api-query-params]]
@@ -165,7 +171,7 @@ Statistics about time to open and start the index.
 
 
 [[index-recovery-api-multi-ex]]
-===== Get recovery information for several indices
+===== Get recovery information for several data streams and indices
 
 [source,console]
 --------------------------------------------------
@@ -175,7 +181,7 @@ GET index1,index2/_recovery?human
 
 
 [[index-recovery-api-all-ex]]
-===== Get segment information for all indices
+===== Get segment information for all data streams and indices in a cluster
 
 //////////////////////////
 Here we create a repository and snapshot index1 in

--- a/docs/reference/indices/refresh.asciidoc
+++ b/docs/reference/indices/refresh.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Refresh</titleabbrev>
 ++++
 
-Refreshes one or more indices.
+Refreshes one or more indices. For data streams, the API refreshes the stream's
+backing indices.
 
 [source,console]
 ----
@@ -16,9 +17,9 @@ POST /twitter/_refresh
 [[refresh-api-request]]
 ==== {api-request-title}
 
-`POST <index>/_refresh`
+`POST <target>/_refresh`
 
-`GET <index>/_refresh`
+`GET <target>/_refresh`
 
 `POST /_refresh`
 
@@ -29,6 +30,7 @@ POST /twitter/_refresh
 ==== {api-description-title}
 
 Use the refresh API to explicitly refresh one or more indices.
+If the request targets a data stream, it refreshes the stream's backing indices.
 A _refresh_ makes all operations performed on an index
 since the last refresh
 available for search.
@@ -87,7 +89,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailab
 
 
 [[refresh-api-multiple-ex]]
-===== Refresh several indices
+===== Refresh several data streams and indices
 
 [source,console]
 ----
@@ -97,7 +99,7 @@ POST /kimchy,elasticsearch/_refresh
 
 
 [[refresh-api-all-ex]]
-===== Refresh all indices
+===== Refresh all data streams and indices in a cluster
 
 [source,console]
 ----

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -5,7 +5,8 @@
 ++++
 
 Returns low-level information about the https://lucene.apache.org/core/[Lucene]
-segments in index shards.
+segments in index shards. For data streams, the API returns information about
+the stream's backing indices.
 
 [source,console]
 ----
@@ -17,7 +18,7 @@ GET /twitter/_segments
 [[index-segments-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_segments`
+`GET /<target>/_segments`
 
 `GET /_segments`
 
@@ -25,7 +26,13 @@ GET /twitter/_segments
 [[index-segments-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
++
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[index-segments-api-query-params]]
@@ -102,7 +109,7 @@ Contains information about whether high compression was enabled.
 ==== {api-examples-title}
 
 
-===== Get segment information for a specific index
+===== Get segment information for a specific data stream or index
 
 [source,console]
 --------------------------------------------------
@@ -111,7 +118,7 @@ GET /test/_segments
 // TEST[s/^/PUT test\n{"settings":{"number_of_shards":1, "number_of_replicas": 0}}\nPOST test\/_doc\?refresh\n{"test": "test"}\n/]
 
 
-===== Get segment information for several indices
+===== Get segment information for several data streams and indices
 
 [source,console]
 --------------------------------------------------
@@ -120,7 +127,7 @@ GET /test1,test2/_segments
 // TEST[s/^/PUT test1\nPUT test2\n/]
 
 
-===== Get segment information for all indices
+===== Get segment information for all data streams and indices in a cluster
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/indices/stats.asciidoc
+++ b/docs/reference/indices/stats.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Index stats</titleabbrev>
 ++++
 
-Returns statistics for an index.
+Returns statistics for one or more indices. For data streams, the API retrieves
+statistics for the stream's backing indices.
 
 [source,console]
 ----
@@ -16,9 +17,9 @@ GET /twitter/_stats
 [[index-stats-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_stats/<index-metric>`
+`GET /<target>/_stats/<index-metric>`
 
-`GET /<index>/_stats`
+`GET /<target>/_stats`
 
 `GET /_stats`
 
@@ -26,7 +27,8 @@ GET /twitter/_stats
 [[index-stats-api-desc]]
 ==== {api-description-title}
 
-Use the index stats API to get high-level aggregation and statistics for an index.
+Use the index stats API to get high-level aggregation and statistics for one or
+more data streams and indices.
 
 By default,
 the returned statistics are index-level
@@ -51,10 +53,13 @@ to which the shard contributed.
 [[index-stats-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases used to limit
+the request. Wildcard expressions (`*`) are supported.
 +
-To retrieve statistics for all indices,
-use a value of `_all` or `*` or omit this parameter.
+To target all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-metric]
 
@@ -91,7 +96,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-unloaded-segme
 
 
 [[index-stats-api-multiple-ex]]
-===== Get statistics for multiple indices
+===== Get statistics for multiple data streams and indices
 
 [source,console]
 --------------------------------------------------
@@ -101,7 +106,7 @@ GET /index1,index2/_stats
 
 
 [[index-stats-api-all-ex]]
-===== Get statistics for all indices
+===== Get statistics for all data streams and indices in a cluster
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Makes existing docs for the following APIs aware of data streams:

* Get index API
* Get mapping API
* Get index settings API
* Index recovery API
* Index segments API
* Index stats API
* Refresh API

Relates to #55726