### PR TITLE
[7.x] [DOCS] Document index aliases do not support data streams (#59321)

### DIFF
--- a/docs/reference/indices/add-alias.asciidoc
+++ b/docs/reference/indices/add-alias.asciidoc
@@ -37,6 +37,8 @@ to add to the alias.
 +
 To add all indices in the cluster to the alias,
 use a value of `_all`.
++
+NOTE: You cannot add <<data-streams,data streams>> to an index alias.
 
 `<alias>`::
 (Required, string)

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -75,6 +75,8 @@ used to perform the action.
 +
 If the `indices` parameter is not specified,
 this parameter is required.
++
+NOTE: You cannot add <<data-streams,data streams>> to an index alias.
 
 `indices`::
 (Array)
@@ -83,6 +85,8 @@ used to perform the action.
 +
 If the `index` parameter is not specified,
 this parameter is required.
++
+NOTE: You cannot add <<data-streams,data streams>> to an index alias.
 
 `alias`::
 (String)


### PR DESCRIPTION
7.x backport of #59321