### PR TITLE
[DOCS] Add data streams to ILM explain API

### DIFF
--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -6,12 +6,14 @@
 <titleabbrev>Explain lifecycle</titleabbrev>
 ++++
 
-Shows an index's current lifecycle status.
+Retrieves the current lifecycle status for one or more indices. For data
+streams, the API retrieves the current lifecycle status for the stream's backing
+indices.
 
 [[ilm-explain-lifecycle-request]]
 ==== {api-request-title}
 
-`GET <index>/_ilm/explain`
+`GET <target>/_ilm/explain`
 
 [[ilm-explain-lifecycle-prereqs]]
 ==== {api-prereq-title}
@@ -31,8 +33,12 @@ about any failures.
 [[ilm-explain-lifecycle-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
-  (Required, string) Identifier for the index.
+`<target>`::
+(Required, string)
+Comma-separated list of data streams, indices, and index aliases to target.
+Wildcard expressions (`*`) are supported.
++
+To target all data streams and indices in a cluster, use `_all` or `*`.
 
 [[ilm-explain-lifecycle-query-params]]
 ==== {api-query-parms-title}


### PR DESCRIPTION
Makes the existing ILM explain API docs aware of data streams.