### PR TITLE
Optimize variable in unassigned shards allocation logic.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -896,7 +896,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             ModelNode minNode = null;
             Decision decision = null;
             if (skippedNodes.size() >= nodes.size() && explain == false) {
-                // all nodes are skipped (eg: shard limited), so we know we won't be able to allocate this round,
+                // all nodes are skipped (eg: shard limited node), so we know we won't be able to allocate this round,
                 // so if we are not in explain mode, short circuit
                 return AllocateUnassignedDecision.no(AllocationStatus.DECIDERS_NO, null);
             }


### PR DESCRIPTION
Relate discussion in https://github.com/elastic/elasticsearch/pull/51632.
`throttledNodes` in the following section is easy to be throught as node concurrent throttle, use a better name instead and add some comments to make logic easy understand.

https://github.com/elastic/elasticsearch/blob/381f8d3c64efef69011b60dbeebaa985309160ed/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java#L834-L850