### PR TITLE
[DOCS] Adds extra ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -10,6 +10,8 @@ coming::[7.8.1]
 Machine Learning::
 * Better interrupt handling during named pipe connection {ml-pull}1311[#1311]
 * Trap potential cause of SIGFPE {ml-pull}1351[#1351] (issue: {ml-issue}1348[#1348])
+* Correct inference model definition for MSLE regression models {ml-pull}1375[#1375]
+* Fix cause of SIGSEGV of classification and regression {ml-pull}1379[#1379]
 
 [[release-notes-7.8.0]]
 == {es} version 7.8.0


### PR DESCRIPTION
Following the rebuild of 7.8.1 two extra ml-cpp PRs will
now be released in 7.8.1.

Followup to #59188