### PR TITLE
[DOCS] Adding get snapshot status API docs

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -11,6 +11,42 @@ Retrieves a detailed description of the current state for each shard participati
 ----
 PUT /index_1
 
+PUT /index_1/_doc/1
+{
+  "title": "Elastic, Vol.1", "category": "Non-Fiction",
+  "author": {
+    "first_name": "Elk",
+    "last_name": "Stack"
+  }
+}
+
+PUT /index_1/_doc/2
+{
+  "title": "Elastic, Vol.2", "category": "Non-Fiction",
+  "author": {
+    "first_name": "Elk",
+    "last_name": "Stack"
+  }
+}
+
+PUT /index_1/_doc/3
+{
+  "title": "Elastic, Vol.3", "category": "Non-Fiction",
+  "author": {
+    "first_name": "Elk",
+    "last_name": "Stack"
+  }
+}
+
+PUT /index_1/_doc/4
+{
+  "title": "Elastic, Vol.4", "category": "Non-Fiction",
+  "author": {
+    "first_name": "Elk",
+    "last_name": "Stack"
+  }
+}
+
 PUT /_snapshot/my_repository
 {
   "type": "fs",
@@ -274,8 +310,6 @@ The following request returns detailed status information for `snapshot_2` in th
 GET /_snapshot/my_repository/snapshot_2/_status
 ----
 
-The API returns the following response:
-
 [source,console-result]
 ----
 {
@@ -283,93 +317,80 @@ The API returns the following response:
     {
       "snapshot" : "snapshot_2",
       "repository" : "my_repository",
-      "uuid" : "ITWHQY2fR2OqX-TYt6mUNA",
+      "uuid" : "lNeQD1SvTQCqqJUMQSwmGg",
       "state" : "SUCCESS",
       "include_global_state" : false,
       "shards_stats" : {
         "initializing" : 0,
         "started" : 0,
         "finalizing" : 0,
-        "done" : 10,
+        "done" : 1,
         "failed" : 0,
-        "total" : 10
+        "total" : 1
       },
       "stats" : {
         "incremental" : {
-          "file_count" : 72,
-          "size_in_bytes" : 11013810
+          "file_count" : 3,
+          "size_in_bytes" : 5969
         },
         "total" : {
-          "file_count" : 76,
-          "size_in_bytes" : 11014642
+          "file_count" : 4,
+          "size_in_bytes" : 6024
         },
-        "start_time_in_millis" : 1594158151205,
-        "time_in_millis" : 1011
+        "start_time_in_millis" : 1594829326691,
+        "time_in_millis" : 205
       },
       "indices" : {
         "index_1" : {
-            "shards_stats" : {
-              "initializing" : 0,
-              "started" : 0,
-              "finalizing" : 0,
-              "done" : 1,
-              "failed" : 0,
-              "total" : 1
+          "shards_stats" : {
+            "initializing" : 0,
+            "started" : 0,
+            "finalizing" : 0,
+            "done" : 1,
+            "failed" : 0,
+            "total" : 1
+          },
+          "stats" : {
+            "incremental" : {
+              "file_count" : 3,
+              "size_in_bytes" : 5969
             },
-            "stats" : {
-              "incremental" : {
-                "file_count" : 4,
-                "size_in_bytes" : 5587
-              },
-              "total" : {
-                "file_count" : 4,
-                "size_in_bytes" : 5587
-              },
-              "start_time_in_millis" : 1594754139076,
-              "time_in_millis" : 0
+            "total" : {
+              "file_count" : 4,
+              "size_in_bytes" : 6024
             },
-            "shards" : {
-              "0" : {
-                "stage" : "DONE",
-                "stats" : {
-                  "incremental" : {
-                    "file_count" : 4,
-                    "size_in_bytes" : 5587
-                  },
-                  "total" : {
-                    "file_count" : 4,
-                    "size_in_bytes" : 5587
-                  },
-                  "start_time_in_millis" : 1594754139076,
-                  "time_in_millis" : 0
-                }
+            "start_time_in_millis" : 1594829326896,
+            "time_in_millis" : 0
+          },
+          "shards" : {
+            "0" : {
+              "stage" : "DONE",
+              "stats" : {
+                "incremental" : {
+                  "file_count" : 3,
+                  "size_in_bytes" : 5969
+                },
+                "total" : {
+                  "file_count" : 4,
+                  "size_in_bytes" : 6024
+                },
+                "start_time_in_millis" : 1594829326896,
+                "time_in_millis" : 0
               }
             }
           }
-       }
+        }
+      }
     }
   ]
 }
-
 ----
-// TESTRESPONSE[s/"uuid" : "ITWHQY2fR2OqX-TYt6mUNA"/"uuid" : $body.snapshots.0.uuid/]
+// TESTRESPONSE[s/"uuid" : "lNeQD1SvTQCqqJUMQSwmGg"/"uuid" : $body.snapshots.0.uuid/]
+// TESTRESPONSE[s/"size_in_bytes" : 6024/"size_in_bytes" : $body.snapshots.0.stats.total.size_in_bytes/]
 // TESTRESPONSE[s/"done" : 10/"done" : $body.snapshots.0.shards_stats.done/]
 // TESTRESPONSE[s/"total" : 10/"total" : $body.snapshots.0.shards_stats.total/]
-// TESTRESPONSE[s/"size_in_bytes" : 11013810/"size_in_bytes" : $body.snapshots.0.stats.incremental.size_in_bytes/]
-// TESTRESPONSE[s/"size_in_bytes" : 11014642/"size_in_bytes" : $body.snapshots.0.stats.total.size_in_bytes/]
-// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.stats.total.size_in_bytes/]
-// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.stats.incremental.size_in_bytes/]
-// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.shards.0.stats.incremental.size_in_bytes/]
-// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.shards.0.stats.total.size_in_bytes/]
-// TESTRESPONSE[s/"file_count" : 72/"file_count" : $body.snapshots.0.stats.incremental.file_count/]
-// TESTRESPONSE[s/"file_count" : 76/"file_count" : $body.snapshots.0.stats.total.file_count/]
-// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.stats.incremental.file_count/]
-// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.stats.total.file_count/]
-// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.shards.0.stats.incremental.file_count/]
-// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.shards.0.stats.total.file_count/]
-// TESTRESPONSE[s/"start_time_in_millis" : 1594158151205/"start_time_in_millis" : $body.snapshots.0.stats.start_time_in_millis/]
-// TESTRESPONSE[s/"start_time_in_millis" : 1594158151205/"start_time_in_millis" : $body.snapshots.0.indices.index_1.start_time_in_millis/]
-// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]
-// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.indices.index_1.time_in_millis/]
-// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.indices.index_1.shards.0.time_in_millis/]
-// TESTRESPONSE[s/"start_time_in_millis" : 1594754139076/"start_time_in_millis" : $body.snapshots.0.indices.index_1.shards.0.stats.start_time_in_millis/]
+// TESTRESPONSE[s/"start_time_in_millis" : 1594829326691/"start_time_in_millis" : $body.snapshots.0.stats.start_time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis" : 205/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]
+// TESTRESPONSE[s/"file_count" : 3/"file_count" : $body.snapshots.0.stats.incremental.file_count/]
+// TESTRESPONSE[s/"size_in_bytes" : 5969/"size_in_bytes" : $body.snapshots.0.stats.incremental.size_in_bytes/]
+// TESTRESPONSE[s/"start_time_in_millis" : 1594829326896/"start_time_in_millis" : $body.snapshots.0.indices.index_1.stats.start_time_in_millis/]

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -1,0 +1,88 @@
+[[get-snapshot-status-api]]
+=== Get snapshot status API
+++++
+<titleabbrev>Get snapshot status</titleabbrev>
+++++
+
+Returns a complete breakdown of the current state for each shard participating in the snapshot.
+
+////
+[source,console]
+----
+PUT /_snapshot/my_repository
+{
+  "type": "fs",
+  "settings": {
+    "location": "my_backup_location"
+  }
+}
+
+PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
+
+PUT /_snapshot/my_repository/snapshot_2?wait_for_completion=true
+----
+// TESTSETUP
+////
+
+[source,console]
+----
+GET /_snapshot/my_repository/my_snapshot/_status
+----
+
+[[get-snapshot-status-api-request]]
+==== {api-request-title}
+
+`GET /_snapshot/<repository>/<snapshot>/_status`
+
+[[get-snapshot-status-api-desc]]
+==== {api-description-title}
+
+Use the get snapshot status API to return detailed information about snapshots currently running in the cluster.
+
+If you specify both the repository name and snapshot, the request returns detailed status information for the given snapshot, even if not currently running.
+
+[[get-snapshot-status-api-example]]
+==== {api-example-title}
+
+The following request returns information for `snapshot_2` in the `my_repository` repository.
+
+[source,console]
+----
+GET /_snapshot/my_repository/snapshot_2/_status
+----
+
+[source,console-result]
+----
+{
+  "snapshots" : [
+    {
+      "snapshot" : "snapshot_2",
+      "repository" : "my_repository",
+      "uuid" : "9A-ovGyBTFKj7C98VleZNQ",
+      "state" : "SUCCESS",
+      "include_global_state" : false,
+      "shards_stats" : {
+        "initializing" : 0,
+        "started" : 0,
+        "finalizing" : 0,
+        "done" : 0,
+        "failed" : 0,
+        "total" : 0
+      },
+      "stats" : {
+        "incremental" : {
+          "file_count" : 0,
+          "size_in_bytes" : 0
+        },
+        "total" : {
+          "file_count" : 0,
+          "size_in_bytes" : 0
+        },
+        "start_time_in_millis" : 1594158151205,
+        "time_in_millis" : 0
+      },
+      "indices" : { }
+    }
+  ]
+}
+----

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -232,12 +232,12 @@ The total time, in milliseconds, that it took for the snapshot process
 to complete.
 ====
 
-`indices`::
+`<index>`::
 (list of objects)
 List of objects containing information about the
 indices included in the snapshot.
 +
-.Properties of `indices`
+.Properties of `<index>`
 [%collapsible%open]
 ====
 `shards_stats`::

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -179,6 +179,7 @@ indices included in the snapshot.
 See <<get-snapshot-status-shards-stats,`shards_stats`>>.
 
 `stats`::
+(object)
 See <<get-snapshot-status-stats,`stats`>>.
 
 `shards`::

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -223,6 +223,6 @@ The API returns the following response:
   ]
 }
 ----
-// TESTRESPONSE[s/"uuid": "ITWHQY2fR2OqX-TYt6mUNA"/"uuid": $body.snapshots.0.uuid/]
-// TESTRESPONSE[s/"start_time_in_millis": 1594158151205/"start_time_in_millis": $body.snapshots.0.start_time_in_millis/]
-// TESTRESPONSE[s/"time_in_millis": 0/"time_in_millis": $body.snapshots.0.time_in_millis/]
+// TESTRESPONSE[s/"uuid" : "ITWHQY2fR2OqX-TYt6mUNA"/"uuid" : $body.snapshots.0.uuid/]
+// TESTRESPONSE[s/"start_time_in_millis" : 1594158151205/"start_time_in_millis" : $body.snapshots.0.stats.start_time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis" : 0/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -51,7 +51,7 @@ Snapshot repository name used to limit the request.
 Omitting a repository name retrieves a list of all snapshots currently running in the cluster.
 
 `<snapshot>`::
-(Required, string)
+(Optional, string)
 Comma-separated list of snapshot names to retrieve status for.
 
 [role="child_attributes"]

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -176,6 +176,7 @@ indices included in the snapshot.
 [%collapsible%open]
 ====
 `shards_stats`::
+(object)
 See <<get-snapshot-status-shards-stats,`shards_stats`>>.
 
 `stats`::

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get snapshot status</titleabbrev>
 ++++
 
-Returns a complete breakdown of the current state for each shard participating in the snapshot.
+Retrieves a complete breakdown of the current state for each shard participating in the snapshot.
 
 ////
 [source,console]
@@ -37,9 +37,144 @@ GET /_snapshot/my_repository/my_snapshot/_status
 [[get-snapshot-status-api-desc]]
 ==== {api-description-title}
 
-Use the get snapshot status API to return detailed information about snapshots currently running in the cluster.
+Use the get snapshot status API to retrieve detailed information about snapshots currently running in the cluster.
 
-If you specify both the repository name and snapshot, the request returns detailed status information for the given snapshot, even if not currently running.
+If you specify both the repository name and snapshot, the request retrieves detailed status information for the given snapshot, even if not currently running.
+
+[[get-snapshot-status-api-path-params]]
+==== {api-path-parms-title}
+
+`<repository>`::
+(Required, string)
+Snapshot repository name used to limit the request.
++
+Omitting a repository name retrieves a list of all snapshots currently running in the cluster.
+
+`<snapshot>`::
+(Required, string)
+Comma-separated list of snapshot names to retrieve status for.
+
+[role="child_attributes"]
+[[get-snapshot-status-api-request-body]]
+==== {api-request-body-title}
+
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, the request returns an error for any snapshots that are unavailable. Defaults to `false`.
++
+If `true`, the request ignores snapshots that are unavailable, such as those that are corrupted or temporarily cannot be returned.
+
+[role="child_attributes"]
+[[get-snapshot-status-api-response-body]]
+==== {api-response-body-title}
+
+`snapshot`::
+(string)
+Name of the snapshot.
+
+`uuid`::
+(string)
+Universally unique identifier (UUID) of the snapshot.
+
+`state`::
++
+--
+(string)
+The snapshot `state` can be one of the following values:
+
+.Values for `state`
+[%collapsible%open]
+====
+`IN_PROGRESS`::
+  The snapshot is currently running.
+
+`SUCCESS`::
+  The snapshot finished and all shards were stored successfully.
+
+`FAILED`::
+  The snapshot finished with an error and failed to store any data.
+
+`PARTIAL`::
+  The global cluster state was stored, but data of at least one shard was not stored successfully.
+  The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
+  that were not processed correctly.
+====
+--
+
+`include_global_state`::
+(boolean)
+Indicates whether the current cluster state is included in the snapshot.
+
+`shards_stats`::
+(object)
+Contains a count of shards in the snapshot.
++
+.Properties of `shards`
+[%collapsible%open]
+====
+`initializing`::
+(integer)
+Number of shards that are still initializing.
+
+`started`::
+(integer)
+Number of shards that have started but not are not finalized.
+
+`finalizing`::
+(integer)
+Number of shards that are finalizing but are not done.
+
+`done`::
+(integer)
+Number of shards that initialized, started, and finalized successfully.
+
+`failed`::
+(integer)
+Number of shards that failed to be included in the snapshot.
+
+`total`::
+(integer)
+Total number of shards included in the snapshot.
+====
+
+`stats`::
+(object)
+Provides details on the number (`file_count`) and size (`size_in_bytes`) of files included in the snapshot.
++
+.Properties of `stats`
+[%collapsible%open]
+====
+`incremental`::
+(object)
+Number and size of files that are not already in the repository and need to be copied as part of the incremental snapshot.
+
+`processed`::
+(object)
+Number and size of files that are still being copied.
+
+`total`::
+(object)
+Total number and size of files that are referenced by the snapshot.
+
+`start_time_in_millis`::
+(long)
+The time, in milliseconds, when the snapshot creation process started.
+
+`time_in_millis`::
+(long)
+The total time, in milliseconds, that
+====
+
+`indices`::
+(list of objects)
+List of objects containing information about the
+indices included in the snapshot.
++
+Detailed information for each index includes:
+
+* `shards_stats`
+* `stats`
+* `shards`
 
 [[get-snapshot-status-api-example]]
 ==== {api-example-title}
@@ -51,6 +186,8 @@ The following request returns information for `snapshot_2` in the `my_repository
 GET /_snapshot/my_repository/snapshot_2/_status
 ----
 
+The API returns the following response:
+
 [source,console-result]
 ----
 {
@@ -58,9 +195,9 @@ GET /_snapshot/my_repository/snapshot_2/_status
     {
       "snapshot" : "snapshot_2",
       "repository" : "my_repository",
-      "uuid" : "9A-ovGyBTFKj7C98VleZNQ",
+      "uuid" : "ITWHQY2fR2OqX-TYt6mUNA",
       "state" : "SUCCESS",
-      "include_global_state" : false,
+      "include_global_state" : true,
       "shards_stats" : {
         "initializing" : 0,
         "started" : 0,
@@ -86,3 +223,6 @@ GET /_snapshot/my_repository/snapshot_2/_status
   ]
 }
 ----
+// TESTRESPONSE[s/"uuid": "ITWHQY2fR2OqX-TYt6mUNA"/"uuid": $body.snapshots.0.uuid/]
+// TESTRESPONSE[s/"start_time_in_millis": 1594158151205/"start_time_in_millis": $body.snapshots.0.start_time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis": 0/"time_in_millis": $body.snapshots.0.time_in_millis/]

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -9,6 +9,8 @@ Retrieves a detailed description of the current state for each shard participati
 ////
 [source,console]
 ----
+PUT /index_1
+
 PUT /_snapshot/my_repository
 {
   "type": "fs",
@@ -19,7 +21,16 @@ PUT /_snapshot/my_repository
 
 PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
 
-PUT /_snapshot/my_repository/snapshot_2?wait_for_completion=true
+PUT _snapshot/my_repository/snapshot_2?wait_for_completion=true
+{
+  "indices": [],
+  "ignore_unavailable": true,
+  "include_global_state": false,
+  "metadata": {
+    "taken_by": "Elastic Machine",
+    "taken_because": "backup testing"
+  }
+}
 ----
 // TESTSETUP
 ////
@@ -41,6 +52,10 @@ Use the get snapshot status API to retrieve detailed information about snapshots
 
 If you specify both the repository name and snapshot, the request retrieves detailed status information for the given snapshot, even if not currently running.
 
+WARNING: Using this API to return any status results other than the currently running snapshots (`_current`) can be very expensive. Each request to retrieve snapshot status results in file reads from every shard in a snapshot, for each snapshot.
++
+For example, if you have 100 snapshots with 1,000 shards each, the API request will result in 100,000 file reads (100 snapshots * 1,000 shards). Depending on the latency of your file storage, the request can take extremely long to retrieve results.
+
 [[get-snapshot-status-api-path-params]]
 ==== {api-path-parms-title}
 
@@ -48,7 +63,7 @@ If you specify both the repository name and snapshot, the request retrieves deta
 (Required, string)
 Snapshot repository name used to limit the request. Wildcard (`*`) expressions are supported.
 +
-To retrieve a list of all snapshots in the cluster, omit this and the `<snapshot>` parameter.
+Use `_current` after the repository name to limit the request only to the currently running snapshots. This usage is preferred to return only snapshots that are currently running and not degrade response time.
 
 `<snapshot>`::
 (Required, string)
@@ -155,23 +170,30 @@ Provides details on the number (`file_count`) and size (`size_in_bytes`) of file
 ====
 `incremental`::
 (object)
-Number and size of files that are not already in the repository and need to be copied as part of the incremental snapshot.
+Number and size of files that still need to be copied as part of the incremental snapshot.
++
+For completed snapshots, this property indicates the number and size
+of files that were not already in the repository and were copied as
+part of the incremental snapshot.
 
 `processed`::
 (object)
-Number and size of files that are still being copied.
+Number and size of files that have already been uploaded to the snapshot. After a file is uploaded, the processed `file_count` and `size_in_bytes` are incremented in `stats`.
 
 `total`::
 (object)
 Total number and size of files that are referenced by the snapshot.
 
+[[get-snapshot-status-start-time]]
 `start_time_in_millis`::
 (long)
 The time, in milliseconds, when the snapshot creation process started.
 
+[[get-snapshot-status-total-time]]
 `time_in_millis`::
 (long)
-The total time, in milliseconds, that
+The total time, in milliseconds, that it took for the snapshot process
+to complete.
 ====
 
 `indices`::
@@ -183,9 +205,11 @@ indices included in the snapshot.
 [%collapsible%open]
 ====
 `shards_stats`::
+(object)
 See <<get-snapshot-status-shards-stats,`shards_stats`>>.
 
 `stats`::
+(object)
 See <<get-snapshot-status-stats,`stats`>>.
 
 `shards`::
@@ -204,20 +228,39 @@ Indicates the current state of the shards that include the snapshot.
 [%collapsible%open]
 ======
 `DONE`::
-Number of shards containing a completed copy of the snapshot.
+Number of shards in the snapshot that were successfully stored in the repository.
 
 `FAILURE`::
-Number of shards containing a failed copy of the snapshot.
+Number of shards in the snapshot that were not successfully stored in
+the repository.
 
 `FINALIZE`::
-Number of shards containing a copy of the snapshot in the finalizing stage.
+Number of shards in the snapshot that are in the finalizing stage
+of being stored in the repository.
 
 `INIT`::
-Number of shards containing a copy of the snapshot in the initializing stage.
+Number of shards in the snapshot that are in the initializing stage
+of being stored in the repository.
 
 `STARTED`::
-Number of shards containing a copy of the snapshot in the started stage.
+Number of shards in the snapshot that are in the started stage
+of being stored in the repository.
 ======
+`stats`::
+(object)
+See <<get-snapshot-status-stats,`stats`>>.
+
+`total`::
+(object)
+Total number and size of files that are referenced by the snapshot.
+
+`start_time_in_millis`::
+(long)
+See <<get-snapshot-status-start-time,`start_time_in_millis`>>.
+
+`time_in_millis`::
+(long)
+See <<get-snapshot-status-total-time,`time_in_millis`>>.
 =====
 ====
 
@@ -242,32 +285,91 @@ The API returns the following response:
       "repository" : "my_repository",
       "uuid" : "ITWHQY2fR2OqX-TYt6mUNA",
       "state" : "SUCCESS",
-      "include_global_state" : true,
+      "include_global_state" : false,
       "shards_stats" : {
         "initializing" : 0,
         "started" : 0,
         "finalizing" : 0,
-        "done" : 0,
+        "done" : 10,
         "failed" : 0,
-        "total" : 0
+        "total" : 10
       },
       "stats" : {
         "incremental" : {
-          "file_count" : 0,
-          "size_in_bytes" : 0
+          "file_count" : 72,
+          "size_in_bytes" : 11013810
         },
         "total" : {
-          "file_count" : 0,
-          "size_in_bytes" : 0
+          "file_count" : 76,
+          "size_in_bytes" : 11014642
         },
         "start_time_in_millis" : 1594158151205,
-        "time_in_millis" : 0
+        "time_in_millis" : 1011
       },
-      "indices" : { }
+      "indices" : {
+        "index_1" : {
+            "shards_stats" : {
+              "initializing" : 0,
+              "started" : 0,
+              "finalizing" : 0,
+              "done" : 1,
+              "failed" : 0,
+              "total" : 1
+            },
+            "stats" : {
+              "incremental" : {
+                "file_count" : 4,
+                "size_in_bytes" : 5587
+              },
+              "total" : {
+                "file_count" : 4,
+                "size_in_bytes" : 5587
+              },
+              "start_time_in_millis" : 1594754139076,
+              "time_in_millis" : 0
+            },
+            "shards" : {
+              "0" : {
+                "stage" : "DONE",
+                "stats" : {
+                  "incremental" : {
+                    "file_count" : 4,
+                    "size_in_bytes" : 5587
+                  },
+                  "total" : {
+                    "file_count" : 4,
+                    "size_in_bytes" : 5587
+                  },
+                  "start_time_in_millis" : 1594754139076,
+                  "time_in_millis" : 0
+                }
+              }
+            }
+          }
+       }
     }
   ]
 }
+
 ----
 // TESTRESPONSE[s/"uuid" : "ITWHQY2fR2OqX-TYt6mUNA"/"uuid" : $body.snapshots.0.uuid/]
+// TESTRESPONSE[s/"done" : 10/"done" : $body.snapshots.0.shards_stats.done/]
+// TESTRESPONSE[s/"total" : 10/"total" : $body.snapshots.0.shards_stats.total/]
+// TESTRESPONSE[s/"size_in_bytes" : 11013810/"size_in_bytes" : $body.snapshots.0.stats.incremental.size_in_bytes/]
+// TESTRESPONSE[s/"size_in_bytes" : 11014642/"size_in_bytes" : $body.snapshots.0.stats.total.size_in_bytes/]
+// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.stats.total.size_in_bytes/]
+// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.stats.incremental.size_in_bytes/]
+// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.shards.0.stats.incremental.size_in_bytes/]
+// TESTRESPONSE[s/"size_in_bytes" : 5587/"size_in_bytes" : $body.snapshots.0.indices.index_1.shards.0.stats.total.size_in_bytes/]
+// TESTRESPONSE[s/"file_count" : 72/"file_count" : $body.snapshots.0.stats.incremental.file_count/]
+// TESTRESPONSE[s/"file_count" : 76/"file_count" : $body.snapshots.0.stats.total.file_count/]
+// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.stats.incremental.file_count/]
+// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.stats.total.file_count/]
+// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.shards.0.stats.incremental.file_count/]
+// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.indices.index_1.shards.0.stats.total.file_count/]
 // TESTRESPONSE[s/"start_time_in_millis" : 1594158151205/"start_time_in_millis" : $body.snapshots.0.stats.start_time_in_millis/]
-// TESTRESPONSE[s/"time_in_millis" : 0/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]
+// TESTRESPONSE[s/"start_time_in_millis" : 1594158151205/"start_time_in_millis" : $body.snapshots.0.indices.index_1.start_time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.indices.index_1.time_in_millis/]
+// TESTRESPONSE[s/"time_in_millis" : 1011/"time_in_millis" : $body.snapshots.0.indices.index_1.shards.0.time_in_millis/]
+// TESTRESPONSE[s/"start_time_in_millis" : 1594754139076/"start_time_in_millis" : $body.snapshots.0.indices.index_1.shards.0.stats.start_time_in_millis/]

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -45,14 +45,18 @@ If you specify both the repository name and snapshot, the request retrieves deta
 ==== {api-path-parms-title}
 
 `<repository>`::
-(Optional, string)
-Snapshot repository name used to limit the request.
+(Required, string)
+Snapshot repository name used to limit the request. Wildcard (`*`) expressions are supported.
 +
-Omitting a repository name retrieves a list of all snapshots currently running in the cluster.
+To retrieve a list of all snapshots in the cluster, omit this and the `<snapshot>` parameter.
 
 `<snapshot>`::
-(Optional, string)
+(Required, string)
 Comma-separated list of snapshot names to retrieve status for.
++
+To retrieve a list of all snapshots in a specified repository, omit this parameter.
++
+NOTE: Wildcard (`*`) expressions are not supported for `<snapshot>`.
 
 [role="child_attributes"]
 [[get-snapshot-status-api-request-body]]
@@ -67,6 +71,9 @@ If `true`, the request ignores snapshots that are unavailable, such as those tha
 [role="child_attributes"]
 [[get-snapshot-status-api-response-body]]
 ==== {api-response-body-title}
+`repository`::
+(string)
+Name of the repository that includes the snapshot.
 
 `snapshot`::
 (string)
@@ -176,11 +183,9 @@ indices included in the snapshot.
 [%collapsible%open]
 ====
 `shards_stats`::
-(object)
 See <<get-snapshot-status-shards-stats,`shards_stats`>>.
 
 `stats`::
-(object)
 See <<get-snapshot-status-stats,`stats`>>.
 
 `shards`::
@@ -219,7 +224,7 @@ Number of shards containing a copy of the snapshot in the started stage.
 [[get-snapshot-status-api-example]]
 ==== {api-example-title}
 
-The following request returns information for `snapshot_2` in the `my_repository` repository.
+The following request returns detailed status information for `snapshot_2` in the `my_repository` repository. This response includes additional information beyond the <<get-snapshot-api,Get snapshot API>>, such as shard status and file statistics.
 
 [source,console]
 ----

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get snapshot status</titleabbrev>
 ++++
 
-Retrieves a complete breakdown of the current state for each shard participating in the snapshot.
+Retrieves a detailed description of the current state for each shard participating in the snapshot.
 
 ////
 [source,console]
@@ -80,24 +80,24 @@ Universally unique identifier (UUID) of the snapshot.
 +
 --
 (string)
-The snapshot `state` can be one of the following values:
+Indicates the current snapshot state.
 
 .Values for `state`
 [%collapsible%open]
 ====
-`IN_PROGRESS`::
-  The snapshot is currently running.
-
-`SUCCESS`::
-  The snapshot finished and all shards were stored successfully.
-
 `FAILED`::
   The snapshot finished with an error and failed to store any data.
+
+`IN_PROGRESS`::
+  The snapshot is currently running.
 
 `PARTIAL`::
   The global cluster state was stored, but data of at least one shard was not stored successfully.
   The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
   that were not processed correctly.
+
+`SUCCESS`::
+  The snapshot finished and all shards were stored successfully.
 ====
 --
 
@@ -105,11 +105,12 @@ The snapshot `state` can be one of the following values:
 (boolean)
 Indicates whether the current cluster state is included in the snapshot.
 
+[[get-snapshot-status-shards-stats]]
 `shards_stats`::
 (object)
 Contains a count of shards in the snapshot.
 +
-.Properties of `shards`
+.Properties of `shards_stats`
 [%collapsible%open]
 ====
 `initializing`::
@@ -137,6 +138,7 @@ Number of shards that failed to be included in the snapshot.
 Total number of shards included in the snapshot.
 ====
 
+[[get-snapshot-status-stats]]
 `stats`::
 (object)
 Provides details on the number (`file_count`) and size (`size_in_bytes`) of files included in the snapshot.
@@ -170,11 +172,47 @@ The total time, in milliseconds, that
 List of objects containing information about the
 indices included in the snapshot.
 +
-Detailed information for each index includes:
+.Properties of `indices`
+[%collapsible%open]
+====
+`shards_stats`::
+See <<get-snapshot-status-shards-stats,`shards_stats`>>.
 
-* `shards_stats`
-* `stats`
-* `shards`
+`stats`::
+See <<get-snapshot-status-stats,`stats`>>.
+
+`shards`::
+(list of objects)
+List of objects containing information about the
+shards that include the snapshot.
++
+.Properties of `shards`
+[%collapsible%open]
+=====
+`stage`::
+(string)
+Indicates the current state of the shards that include the snapshot.
++
+.Properties of `stage`
+[%collapsible%open]
+======
+`DONE`::
+Number of shards containing a completed copy of the snapshot.
+
+`FAILURE`::
+Number of shards containing a failed copy of the snapshot.
+
+`FINALIZE`::
+Number of shards containing a copy of the snapshot in the finalizing stage.
+
+`INIT`::
+Number of shards containing a copy of the snapshot in the initializing stage.
+
+`STARTED`::
+Number of shards containing a copy of the snapshot in the started stage.
+======
+=====
+====
 
 [[get-snapshot-status-api-example]]
 ==== {api-example-title}

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -45,7 +45,7 @@ If you specify both the repository name and snapshot, the request retrieves deta
 ==== {api-path-parms-title}
 
 `<repository>`::
-(Required, string)
+(Optional, string)
 Snapshot repository name used to limit the request.
 +
 Omitting a repository name retrieves a list of all snapshots currently running in the cluster.

--- a/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
+++ b/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
@@ -26,6 +26,7 @@ content may not be included yet.
 === Snapshot management APIs
 * <<create-snapshot-api,Create snapshot>>
 * <<get-snapshot-api,Get snapshot>>
+* <<get-snapshot-status-api,Get snapshot status>>
 * <<delete-snapshot-api,Delete snapshot>>
 
 include::put-repo-api.asciidoc[]
@@ -35,4 +36,5 @@ include::delete-repo-api.asciidoc[]
 include::clean-up-repo-api.asciidoc[]
 include::create-snapshot-api.asciidoc[]
 include::get-snapshot-api.asciidoc[]
+include::get-snapshot-status-api.asciidoc[]
 include::delete-snapshot-api.asciidoc[]


### PR DESCRIPTION
Adds a new page for the [Get snapshot status API](https://elasticsearch_59355.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-snapshot-status-api.html).

Backports:

* 7.x #59670
* 7.9 #59711
* 7.8 #59712

Relates to #56069 