### PR TITLE
Continue to accept unused 'universal' params in <8.0 indexes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -335,9 +335,9 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 }
                 Parameter<?> parameter = paramsMap.get(propName);
                 if (parameter == null) {
-                    if (checkForDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
+                    if (isDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
                         deprecationLogger.deprecate(propName,
-                            "Parameter [{}] is unused on type [{}] and will be removed in future", propName, type);
+                            "Parameter [{}] has no effect on type [{}] and will be removed in future", propName, type);
                         iterator.remove();
                         continue;
                     }
@@ -359,7 +359,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         private static final Set<String> DEPRECATED_PARAMS
             = Set.of("store", "meta", "index", "doc_values", "boost", "index_options", "similarity");
 
-        private boolean checkForDeprecatedParameter(String propName, Version indexCreatedVersion) {
+        private static boolean isDeprecatedParameter(String propName, Version indexCreatedVersion) {
             if (indexCreatedVersion.onOrAfter(Version.V_8_0_0)) {
                 return false;
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.FieldType;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -31,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -45,6 +48,8 @@ import java.util.function.Function;
  * {@link #getMergeBuilder()} method, initialised with the existing builder.
  */
 public abstract class ParametrizedFieldMapper extends FieldMapper {
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ParametrizedFieldMapper.class);
 
     /**
      * Creates a new ParametrizedFieldMapper
@@ -330,6 +335,12 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 }
                 Parameter<?> parameter = paramsMap.get(propName);
                 if (parameter == null) {
+                    if (checkForDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
+                        deprecationLogger.deprecate(propName,
+                            "Parameter [{}] is unused on type [{}] and will be removed in future", propName, type);
+                        iterator.remove();
+                        continue;
+                    }
                     throw new MapperParsingException("unknown parameter [" + propName
                         + "] on mapper [" + name + "] of type [" + type + "]");
                 }
@@ -340,6 +351,19 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 parameter.parse(name, propNode);
                 iterator.remove();
             }
+        }
+
+        // These parameters were previously *always* parsed by TypeParsers#parseField(), even if they
+        // made no sense; if we've got here, that means that they're not declared on a current mapper,
+        // and so we emit a deprecation warning rather than failing a previously working mapping.
+        private static final Set<String> DEPRECATED_PARAMS
+            = Set.of("store", "meta", "index", "doc_values", "boost", "index_options", "similarity");
+
+        private boolean checkForDeprecatedParameter(String propName, Version indexCreatedVersion) {
+            if (indexCreatedVersion.onOrAfter(Version.V_8_0_0)) {
+                return false;
+            }
+            return DEPRECATED_PARAMS.contains(propName);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -65,6 +65,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
             = Parameter.boolParam("fixed2", false, m -> toType(m).fixed2, false);
         final Parameter<String> variable
             = Parameter.stringParam("variable", true, m -> toType(m).variable, "default").acceptsNull();
+        final Parameter<Boolean> index = Parameter.boolParam("index", false, m -> toType(m).index, true);
 
         protected Builder(String name) {
             super(name);
@@ -72,7 +73,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
 
         @Override
         protected List<Parameter<?>> getParameters() {
-            return List.of(fixed, fixed2, variable);
+            return List.of(fixed, fixed2, variable, index);
         }
 
         @Override
@@ -97,6 +98,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         private final boolean fixed;
         private final boolean fixed2;
         private final String variable;
+        private final boolean index;
 
         protected TestMapper(String simpleName, String fullName, MultiFields multiFields, CopyTo copyTo,
                              ParametrizedMapperTests.Builder builder) {
@@ -104,6 +106,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
             this.fixed = builder.fixed.getValue();
             this.fixed2 = builder.fixed2.getValue();
             this.variable = builder.variable.getValue();
+            this.index = builder.index.getValue();
         }
 
         @Override
@@ -122,7 +125,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    private static TestMapper fromMapping(String mapping) {
+    private static TestMapper fromMapping(String mapping, Version version) {
         Mapper.TypeParser.ParserContext pc = new Mapper.TypeParser.ParserContext(s -> null, null, s -> {
             if (Objects.equals("keyword", s)) {
                 return new KeywordFieldMapper.TypeParser();
@@ -131,10 +134,14 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
                 return new BinaryFieldMapper.TypeParser();
             }
             return null;
-        }, Version.CURRENT, () -> null);
+        }, version, () -> null);
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)
             .build(new Mapper.BuilderContext(Settings.EMPTY, new ContentPath(0)));
+    }
+
+    private static TestMapper fromMapping(String mapping) {
+        return fromMapping(mapping, Version.CURRENT);
     }
 
     // defaults - create empty builder config, and serialize with and without defaults
@@ -152,7 +159,8 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         builder.startObject();
         mapper.toXContent(builder, params);
         builder.endObject();
-        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"fixed\":true,\"fixed2\":false,\"variable\":\"default\"}}",
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"fixed\":true," +
+                "\"fixed2\":false,\"variable\":\"default\",\"index\":true}}",
             Strings.toString(builder));
     }
 
@@ -243,8 +251,18 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
 
         indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, Strings.toString(indexService.mapperService().documentMapper()));
+    }
 
+    public void testDeprecatedParameters() throws IOException {
+        // 'index' is declared explicitly, 'store' is not, but is one of the previously always-accepted params
+        String mapping = "{\"type\":\"test_mapper\",\"index\":false,\"store\":true}";
+        TestMapper mapper = fromMapping(mapping, Version.V_7_8_0);
+        assertWarnings("Parameter [store] is unused on type [test_mapper] and will be removed in future");
+        assertFalse(mapper.index);
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"index\":false}}", Strings.toString(mapper));
 
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> fromMapping(mapping, Version.V_8_0_0));
+        assertEquals("unknown parameter [store] on mapper [field] of type [test_mapper]", e.getMessage());
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -257,7 +257,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         // 'index' is declared explicitly, 'store' is not, but is one of the previously always-accepted params
         String mapping = "{\"type\":\"test_mapper\",\"index\":false,\"store\":true}";
         TestMapper mapper = fromMapping(mapping, Version.V_7_8_0);
-        assertWarnings("Parameter [store] is unused on type [test_mapper] and will be removed in future");
+        assertWarnings("Parameter [store] has no effect on type [test_mapper] and will be removed in future");
         assertFalse(mapper.index);
         assertEquals("{\"field\":{\"type\":\"test_mapper\",\"index\":false}}", Strings.toString(mapper));
 


### PR DESCRIPTION
We have a number of parameters which are universally parsed by almost all
mappers, whether or not they make sense.  Migrating the binary and boolean
mappers to the new style of declaring their parameters explicitly has meant 
that these universal parameters stopped being accepted, which would break
existing mappings.

This commit adds some extra logic to ParametrizedFieldMapper that checks
for the existence of these universal parameters, and issues a warning on
7x indexes if it finds them.  Indexes created in 8.0 and beyond will throw an
error.

Fixes #59359 