### PR TITLE
Make MappedFieldType#meta final

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -324,7 +324,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
         FieldType other = mergeWith.fieldType;
         MappedFieldType otherm = mergeWith.mappedFieldType;
-        this.mappedFieldType.updateMeta(otherm.meta());
 
         boolean indexed =  fieldType.indexOptions() != IndexOptions.NONE;
         boolean mergeWithIndexed = other.indexOptions() != IndexOptions.NONE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -63,10 +63,10 @@ public abstract class MappedFieldType {
     private final boolean docValues;
     private final boolean isIndexed;
     private final TextSearchInfo textSearchInfo;
+    private final Map<String, String> meta;
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
-    private Map<String, String> meta;
 
     public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues, TextSearchInfo textSearchInfo, Map<String, String> meta) {
         setBoost(1.0f);
@@ -334,13 +334,6 @@ public abstract class MappedFieldType {
      */
     public Map<String, String> meta() {
         return meta;
-    }
-
-    /**
-     * Associate metadata with this field.
-     */
-    public void updateMeta(Map<String, String> meta) {
-        this.meta = Map.copyOf(Objects.requireNonNull(meta));
     }
 
     /**


### PR DESCRIPTION
The `MappedFieldType#updateMeta` method was used for testing equality checks, but we
no longer need these after #59212 , so we can remove this method and make `meta` final.