### PR TITLE
optimize RoutingNodesIntegrityTests.testBalanceIncrementallyStartNodes

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
@@ -140,9 +140,7 @@ public class RoutingNodesIntegrityTests extends ESAllocationTestCase {
         logger.info("Start the backup shard");
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);
 
-        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
-
-        logger.info("Add another node and perform rerouting, nothing will happen since primary not started");
+        logger.info("Add another node and perform rerouting, some shards will be relocating");
         clusterState = ClusterState.builder(clusterState)
                 .nodes(DiscoveryNodes.builder(clusterState.nodes()).add(newNode("node3"))).build();
         clusterState = strategy.reroute(clusterState, "reroute");


### PR DESCRIPTION
Remove duplicated `startInitializingShardsAndReroute` and correct the log info for `testBalanceIncrementallyStartNodes`.