### PR TITLE
Remove node-level canAllocate override

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -74,14 +74,6 @@ public abstract class AllocationDecider {
     }
 
     /**
-     * Returns a {@link Decision} whether the given node can allow any allocation at all at this state of the
-     * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
-     */
-    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-        return Decision.ALWAYS;
-    }
-
-    /**
      * Returns a {@link Decision} whether shards of the given index should be auto-expanded to this node at this state of the
      * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
      */

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -177,25 +177,6 @@ public class AllocationDeciders extends AllocationDecider {
     }
 
     @Override
-    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-        Decision.Multi ret = new Decision.Multi();
-        for (AllocationDecider allocationDecider : allocations) {
-            Decision decision = allocationDecider.canAllocate(node, allocation);
-            // short track if a NO is returned.
-            if (decision == Decision.NO) {
-                if (!allocation.debugDecision()) {
-                    return decision;
-                } else {
-                    ret.add(decision);
-                }
-            } else {
-                addDecision(ret, decision, allocation);
-            }
-        }
-        return ret;
-    }
-
-    @Override
     public Decision canRebalance(RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
@@ -129,33 +129,4 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
             nodeShardCount, indexShardLimit, clusterShardLimit);
     }
 
-    @Override
-    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-        // Only checks the node-level limit, not the index-level
-        // Capture the limit here in case it changes during this method's
-        // execution
-        final int clusterShardLimit = this.clusterShardLimit;
-
-        if (clusterShardLimit <= 0) {
-            return allocation.decision(Decision.YES, NAME, "total shard limits are disabled: [cluster: %d] <= 0",
-                    clusterShardLimit);
-        }
-
-        int nodeShardCount = 0;
-        for (ShardRouting nodeShard : node) {
-            // don't count relocating shards...
-            if (nodeShard.relocating()) {
-                continue;
-            }
-            nodeShardCount++;
-        }
-        if (clusterShardLimit >= 0 && nodeShardCount >= clusterShardLimit) {
-            return allocation.decision(Decision.NO, NAME,
-                "too many shards [%d] allocated to this node, cluster setting [%s=%d]",
-                nodeShardCount, CLUSTER_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), clusterShardLimit);
-        }
-        return allocation.decision(Decision.YES, NAME,
-            "the shard count [%d] for this node is under the cluster level node limit [%d]",
-            nodeShardCount, clusterShardLimit);
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
@@ -71,14 +71,7 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
         Settings settings = Settings.builder()
                                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
                                 .build();
-        AllocationDecider decider = new TestAllocateDecision(Decision.THROTTLE) {
-            // the only allocation decider that implements this is ShardsLimitAllocationDecider and it always
-            // returns only YES or NO, never THROTTLE
-            @Override
-            public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-                return randomBoolean() ? Decision.YES : Decision.NO;
-            }
-        };
+        AllocationDecider decider = new TestAllocateDecision(Decision.THROTTLE);
         // if deciders THROTTLE allocating a primary shard, stay in YELLOW state
         runAllocationTest(
             settings, indexName, Collections.singleton(decider), ClusterHealthStatus.YELLOW

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -79,11 +79,6 @@ public class AllocationDecidersTests extends ESTestCase {
             }
 
             @Override
-            public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-                return Decision.YES;
-            }
-
-            @Override
             public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
                 return Decision.YES;
             }
@@ -109,7 +104,6 @@ public class AllocationDecidersTests extends ESTestCase {
         verify(deciders.canAllocate(shardRouting, routingNode, allocation), matcher);
         verify(deciders.canAllocate(idx, routingNode, allocation), matcher);
         verify(deciders.canAllocate(shardRouting, allocation), matcher);
-        verify(deciders.canAllocate(routingNode, allocation), matcher);
         verify(deciders.canRebalance(shardRouting, allocation), matcher);
         verify(deciders.canRebalance(allocation), matcher);
         verify(deciders.canRemain(shardRouting, routingNode, allocation), matcher);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
@@ -220,12 +220,6 @@ public class EnableAllocationShortCircuitTests extends ESAllocationTestCase {
                 canAllocateAttempts++;
                 return super.canAllocate(indexMetadata, node, allocation);
             }
-
-            @Override
-            public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-                canAllocateAttempts++;
-                return super.canAllocate(node, allocation);
-            }
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -222,11 +222,6 @@ public abstract class ESAllocationTestCase extends ESTestCase {
         public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
             return decision;
         }
-
-        @Override
-        public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
-            return decision;
-        }
     }
 
     /** A lock {@link AllocationService} allowing tests to override time */


### PR DESCRIPTION
Today there is a node-level `canAllocate` override which the balancer
uses to ignore certain nodes to which it is certain no more shards can
be allocated. In fact this override only ignores nodes which have hit
the rarely-used `cluster.routing.allocation.total_shards_per_node`
limit, so this optimization doesn't have a meaningful impact on real
clusters.

This commit removes this unnecessary fast path from the balancer, and
also removes all the machinery needed to support it.