### PR TITLE
Correct cluster state in cluster state health tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -481,7 +481,8 @@ public class ClusterStateHealthTests extends ESTestCase {
             }
         }
         routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
-        clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        clusterStates.add(clusterState);
 
         // some replicas started
         indexRoutingTable = routingTable.index(indexName);
@@ -497,7 +498,8 @@ public class ClusterStateHealthTests extends ESTestCase {
             }
         }
         routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
-        clusterStates.add(ClusterState.builder(clusterState).routingTable(routingTable).build());
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        clusterStates.add(clusterState);
 
         // all replicas started
         boolean replicaStateChanged = false;


### PR DESCRIPTION
I think we should keep cluster state's progressive relationship, return the correct complete `clusterState` from common `generateClusterStates` function, even all the cases are not broken right now.