### PR TITLE
Remove Dead Code from Closed Index Snapshot Logic (#56764)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -366,27 +366,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards =
                         shards(currentState, indexIds, useShardGenerations(version), repositoryData);
                 if (request.partial() == false) {
-                    Tuple<Set<String>, Set<String>> indicesWithMissingShards = indicesWithMissingShards(shards,
-                            currentState.metadata());
-                    Set<String> missing = indicesWithMissingShards.v1();
-                    Set<String> closed = indicesWithMissingShards.v2();
-                    if (missing.isEmpty() == false || closed.isEmpty() == false) {
-                        final StringBuilder failureMessage = new StringBuilder();
-                        if (missing.isEmpty() == false) {
-                            failureMessage.append("Indices don't have primary shards ");
-                            failureMessage.append(missing);
+                    Set<String> missing = new HashSet<>();
+                    for (ObjectObjectCursor<ShardId, SnapshotsInProgress.ShardSnapshotStatus> entry : shards) {
+                        if (entry.value.state() == ShardState.MISSING) {
+                            missing.add(entry.key.getIndex().getName());
                         }
-                        if (closed.isEmpty() == false) {
-                            if (failureMessage.length() > 0) {
-                                failureMessage.append("; ");
-                            }
-                            failureMessage.append("Indices are closed ");
-                        }
+                    }
+                    if (missing.isEmpty() == false) {
                         // TODO: We should just throw here instead of creating a FAILED and hence useless snapshot in the repository
                         newEntry = new SnapshotsInProgress.Entry(
                                 new Snapshot(repositoryName, snapshotId), request.includeGlobalState(), false,
                                 State.FAILED, indexIds, dataStreams, threadPool.absoluteTimeInMillis(), repositoryData.getGenId(), shards,
-                                failureMessage.toString(), userMeta, version);
+                                "Indices don't have primary shards " + missing, userMeta, version);
                     }
                 }
                 if (newEntry == null) {


### PR DESCRIPTION
The code path for closed indices is dead code here ever since #39644
because `shards(currentState, indexIds, ...)` does not set
`MISSING` on a closed index's shard that is assigned any longer. Before that change it would always set `MISSING` for a closed index's shard even it was assigned.
=> simplified the code accordingly.

backport of #56764 