### PR TITLE
[DOCS] Fixed wrong link to lucene docs in ‘index-modules-similarity’

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -97,13 +97,13 @@ from randomness] framework. This similarity has the following options:
 
 `after_effect`::
     Possible values: {lucene-core-javadoc}/org/apache/lucene/search/similarities/AfterEffectB.html[`b`] and
-    {lucene-core-javadoc}/org/apache/lucene/search/similarities/AfterEffectB.html[`l`].
+    {lucene-core-javadoc}/org/apache/lucene/search/similarities/AfterEffectL.html[`l`].
 
 `normalization`::
     Possible values: {lucene-core-javadoc}/org/apache/lucene/search/similarities/Normalization.NoNormalization.html[`no`],
     {lucene-core-javadoc}/org/apache/lucene/search/similarities/NormalizationH1.html[`h1`],
     {lucene-core-javadoc}/org/apache/lucene/search/similarities/NormalizationH2.html[`h2`],
-    {lucene-core-javadoc}/org/apache/lucene/search/similarities/NormalizationH1.html[`h3`] and
+    {lucene-core-javadoc}/org/apache/lucene/search/similarities/NormalizationH3.html[`h3`] and
     {lucene-core-javadoc}/org/apache/lucene/search/similarities/NormalizationZ.html[`z`].
 
 All options but the first option need a normalization value.


### PR DESCRIPTION
Fixed two wrong links.