### PR TITLE
[ML] Fix result processor test for random annotation

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doThrow;
@@ -292,6 +293,9 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(bulkAnnotationsPersister).persistAnnotation(annotation);
+        if (annotation.getEvent() == Annotation.Event.CATEGORIZATION_STATUS_CHANGE) {
+            verify(auditor).warning(eq(JOB_ID), anyString());
+        }
     }
 
     public void testProcessResult_modelSizeStats() {


### PR DESCRIPTION
It was failing for the case where a categorization status change
annotation is now being mirrored to an auditor notification.

The problem was introduced in #59377.

The fix is already in #59393, so this doesn't need backporting.