### PR TITLE
[DOCS] Add data streams to rollup APIs

### DIFF
--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -14,7 +14,7 @@ experimental[]
 [[rollup-get-rollup-index-caps-request]]
 ==== {api-request-title}
 
-`GET <index>/_rollup/data`
+`GET <target>/_rollup/data`
 
 [[rollup-get-rollup-index-caps-prereqs]]
 ==== {api-prereq-title}
@@ -38,9 +38,9 @@ and what aggregations can be performed on each job?
 [[rollup-get-rollup-index-caps-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
-  (Required, string) Index or index-pattern of concrete rollup indices to check
-  for capabilities.
+`<target>`::
+(Required, string) Data stream or index to check for rollup capabilities.
+Wildcard (`*`) expressions are supported.
 
 [[rollup-get-rollup-index-caps-example]]
 ==== {api-examples-title}

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -41,7 +41,7 @@ Rules for the `<target>` parameter:
 - At least one data stream, index, or wildcard expression must be specified.
 This target can include a rollup or non-rollup index. For data streams, the
 stream's backing indices can only serve as non-rollup indices. Omitting the
-index parameter, or using `_all`, is not permitted.
+`<target>` parameter or using `_all`, is not permitted.
 - Multiple non-rollup indices may be specified
 - Only one rollup index may be specified. If more than one are supplied, an
 exception occurs.

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Rollup search</titleabbrev>
 ++++
 
-Enables searching rolled-up data using the standard query DSL.  
+Enables searching rolled-up data using the standard query DSL.
 
 experimental[]
 
@@ -27,7 +27,7 @@ expect given the original query.
 [[rollup-search-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
+`<target>`::
 +
 --
 (Required, string)
@@ -36,16 +36,18 @@ the request. Wildcard expressions (`*`) are supported.
 
 This target can include both rollup and non-rollup indices.
 
-Rules for the `index` parameter:
+Rules for the `<target>` parameter:
 
-- At least one data stream, index, or wildcard expression must be specified. This target can include a
-rollup or non-rollup index.  Omitting the index parameter, or using `_all`, is
-not permitted.
+- At least one data stream, index, or wildcard expression must be specified.
+This target can include a rollup or non-rollup index. For data streams, the
+stream's backing indices can only serve as non-rollup indices. Omitting the
+index parameter, or using `_all`, is not permitted.
 - Multiple non-rollup indices may be specified
 - Only one rollup index may be specified. If more than one are supplied, an
 exception occurs.
 - Wildcard expressions may be used, but if they match more than one rollup index an
-exception occurs.
+exception occurs. However, you can use an expression to match multiple non-rollup
+indices or data streams.
 --
 
 [[rollup-search-request-body]]

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -41,11 +41,11 @@ Rules for the `<target>` parameter:
 - At least one data stream, index, or wildcard expression must be specified.
 This target can include a rollup or non-rollup index. For data streams, the
 stream's backing indices can only serve as non-rollup indices. Omitting the
-`<target>` parameter or using `_all`, is not permitted.
-- Multiple non-rollup indices may be specified
+`<target>` parameter or using `_all` is not permitted.
+- Multiple non-rollup indices may be specified.
 - Only one rollup index may be specified. If more than one are supplied, an
 exception occurs.
-- Wildcard expressions may be used, but if they match more than one rollup index an
+- Wildcard expressions may be used, but, if they match more than one rollup index, an
 exception occurs. However, you can use an expression to match multiple non-rollup
 indices or data streams.
 --

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -13,7 +13,7 @@ experimental[]
 [[rollup-search-request]]
 ==== {api-request-title}
 
-`GET <index>/_rollup_search`
+`GET <target>/_rollup_search`
 
 [[rollup-search-desc]]
 ==== {api-description-title}
@@ -28,19 +28,25 @@ expect given the original query.
 ==== {api-path-parms-title}
 
 `<index>`::
-  (Required, string) Index, indices or index-pattern to execute a rollup search
-  against.  This can include both rollup and non-rollup indices.
++
+--
+(Required, string)
+Comma-separated list of data streams and indices used to limit
+the request. Wildcard expressions (`*`) are supported.
+
+This target can include both rollup and non-rollup indices.
 
 Rules for the `index` parameter:
 
-- At least one index/index-pattern must be specified. This can be either a
+- At least one data stream, index, or wildcard expression must be specified. This target can include a
 rollup or non-rollup index.  Omitting the index parameter, or using `_all`, is
 not permitted.
 - Multiple non-rollup indices may be specified
 - Only one rollup index may be specified. If more than one are supplied, an
 exception occurs.
-- Index patterns may be used, but if they match more than one rollup index an
+- Wildcard expressions may be used, but if they match more than one rollup index an
 exception occurs.
+--
 
 [[rollup-search-request-body]]
 ==== {api-request-body-title}


### PR DESCRIPTION
Makes the following API docs aware of data streams:

* Get rollup index capabilities API
* Rollup search