### PR TITLE
[DOCS] Indicating that the composite aggregation size parameter defaults to 10

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -535,10 +535,10 @@ first (ascending order, `asc`) or last (descending order, `desc`).
 ==== Size
 
 The `size` parameter can be set to define how many composite buckets should be returned.
-Each composite bucket is considered as a single bucket so setting a size of 10 will return the
+Each composite bucket is considered as a single bucket, so setting a size of 10 will return the
 first 10 composite buckets created from the values source.
 The response contains the values for each composite bucket in an array containing the values extracted
-from each value source.
+from each value source. Defaults to `10`.
 
 ==== Pagination
 


### PR DESCRIPTION
Explicitly indicating the default value for the `size` parameter of composite aggregations.

7.x backport #59461 
7.8 backport #59438 

Resolves #59434 