### PR TITLE
[7.x] [DOCS] Indicating that the size parameter defaults to 10. (#59438)

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -535,10 +535,10 @@ first (ascending order, `asc`) or last (descending order, `desc`).
 ==== Size
 
 The `size` parameter can be set to define how many composite buckets should be returned.
-Each composite bucket is considered as a single bucket so setting a size of 10 will return the
+Each composite bucket is considered as a single bucket, so setting a size of 10 will return the
 first 10 composite buckets created from the values source.
 The response contains the values for each composite bucket in an array containing the values extracted
-from each value source.
+from each value source. Defaults to `10`.
 
 ==== Pagination
 


### PR DESCRIPTION
7.x backport for #59438 

Relates to #59434 

