### PR TITLE
Increase default write queue size

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -26,6 +26,6 @@ Snapshot restore throttling::
 Thread pool write queue size::
 * The WRITE thread pool default queue size (`thread_pool.write.size`) has been
   increased from 200 to 4000. Additional memory-oriented back pressure has been
-  introduced with the `indexing_limits.memory.limit` setting. This setting
+  introduced with the `indexing_pressure.memory.limit` setting. This setting
   configures a limit to the number of bytes allowed to be consumed by outstanding
   indexing requests. {es-issue}59263[#59263]

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -25,7 +25,7 @@ Snapshot restore throttling::
 
 Thread pool write queue size::
 * The WRITE thread pool default queue size (`thread_pool.write.size`) has been
-  increased from 200 to 4000. Additional memory-oriented back pressure has been
+  increased from 200 to 10000. Additional memory-oriented back pressure has been
   introduced with the `indexing_pressure.memory.limit` setting. This setting
   configures a limit to the number of bytes allowed to be consumed by outstanding
   indexing requests. {es-issue}59263[#59263]

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -22,3 +22,10 @@ Snapshot restore throttling::
   default that's used for `indices.recovery.max_bytes_per_sec`. This means
   that no behavioral change will be observed by clusters where the recovery
   and restore settings had not been adapted from the defaults. {es-pull}58658[#58658]
+
+Thread pool write queue size::
+* The WRITE thread pool default queue size (`thread_pool.write.size`) has been
+  increased from 200 to 4000. Additional memory-oriented back pressure has been
+  introduced with the `indexing_limits.memory.limit` setting. This setting
+  configures a limit to the number of bytes allowed to be consumed by outstanding
+  indexing requests. {es-issue}59263[#59263]

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -25,7 +25,9 @@ Snapshot restore throttling::
 
 Thread pool write queue size::
 * The WRITE thread pool default queue size (`thread_pool.write.size`) has been
-  increased from 200 to 10000. Additional memory-oriented back pressure has been
-  introduced with the `indexing_pressure.memory.limit` setting. This setting
-  configures a limit to the number of bytes allowed to be consumed by outstanding
-  indexing requests. {es-issue}59263[#59263]
+  increased from 200 to 10000. A small queue size (200) caused issues when users
+  wanted to send small indexing requests with a high client count. Additional
+  memory-oriented back pressure has been introduced with the
+  `indexing_pressure.memory.limit` setting. This setting configures a limit to
+  the number of bytes allowed to be consumed by outstanding indexing requests.
+  {es-issue}59263[#59263]

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -172,7 +172,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         final int halfProcMaxAt10 = halfAllocatedProcessorsMaxTen(allocatedProcessors);
         final int genericThreadPoolMax = boundedBy(4 * allocatedProcessors, 128, 512);
         builders.put(Names.GENERIC, new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)));
-        builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, allocatedProcessors, 4000));
+        builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, allocatedProcessors, 10000));
         builders.put(Names.GET, new FixedExecutorBuilder(settings, Names.GET, allocatedProcessors, 1000));
         builders.put(Names.ANALYZE, new FixedExecutorBuilder(settings, Names.ANALYZE, 1, 16));
         builders.put(Names.SEARCH, new AutoQueueAdjustingExecutorBuilder(settings,

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -172,7 +172,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         final int halfProcMaxAt10 = halfAllocatedProcessorsMaxTen(allocatedProcessors);
         final int genericThreadPoolMax = boundedBy(4 * allocatedProcessors, 128, 512);
         builders.put(Names.GENERIC, new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)));
-        builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, allocatedProcessors, 200));
+        builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, allocatedProcessors, 4000));
         builders.put(Names.GET, new FixedExecutorBuilder(settings, Names.GET, allocatedProcessors, 1000));
         builders.put(Names.ANALYZE, new FixedExecutorBuilder(settings, Names.ANALYZE, 1, 16));
         builders.put(Names.SEARCH, new AutoQueueAdjustingExecutorBuilder(settings,


### PR DESCRIPTION
This commit increases the default write queue size to 10000. This is to
allow a greater number of pending indexing requests. This work is safe
as we have added additional memory limits. Relates to #59263.