### PR TITLE
Change 7.9.99 -> 7.99.99 in tests

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/110_script_score_boost.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/110_script_score_boost.yml
@@ -1,7 +1,7 @@
 # Integration tests for ScriptScoreQuery using Painless
 setup:
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason: "boost was corrected in script_score query from 8.0"
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -532,7 +532,7 @@ setup:
 ---
 "histogram with hard bounds":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason:  hard_bounds were introduced in 8.0.0
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
@@ -37,8 +37,8 @@ setup:
 ---
 "date_histogram on range with hard bounds":
   - skip:
-      version: " - 7.9.99"
-      reason:  hard_bounds introduced in 8.0.0
+      version: " - 7.99.99"
+      reason:  waiting for backport
 
   - do:
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
@@ -29,7 +29,7 @@ setup:
 "Request with negative from value url parameter":
 
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason: waiting for backport
 
   - do:
@@ -43,7 +43,7 @@ setup:
 "Request with negative from value in body":
 
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason: waiting for backport
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -172,7 +172,7 @@ setup:
 ---
 "Get snapshot info with metadata":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason: "8.0 changes get snapshots response format"
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
@@ -282,7 +282,7 @@ setup:
 ---
 "Indexing a document into a data stream without a timestamp field":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.99.99"
       reason: "enable in 7.9+ when backported"
       features: allowed_warnings
 


### PR DESCRIPTION
Since we most likely going to have 7.10 we should update version
in tests skips to 7.99.99.

