### PR TITLE
Ensure fixture runtime dependencies are built before starting containers

### DIFF
--- a/test/fixtures/azure-fixture/build.gradle
+++ b/test/fixtures/azure-fixture/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 preProcessFixture {
-  dependsOn jar
+  dependsOn jar, configurations.runtimeClasspath
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/test/fixtures/gcs-fixture/build.gradle
+++ b/test/fixtures/gcs-fixture/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 preProcessFixture {
-  dependsOn jar
+  dependsOn jar, configurations.runtimeClasspath
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/test/fixtures/s3-fixture/build.gradle
+++ b/test/fixtures/s3-fixture/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 preProcessFixture {
-  dependsOn jar
+  dependsOn jar, configurations.runtimeClasspath
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {


### PR DESCRIPTION
This pull request fixes a race condition in the build where runtime dependencies needed to start certain test fixtures may not exist before attempting to start the fixture Docker containers. This manifests as an odd error regarding missing service port information but the root cause is the containers actually failing to start from a `ClassNotFoundException`. The issue is that an explicit dependency on the runtime classpath was missing, so there was no guarantee that the upstream Jars actually were built before attempting to start the fixture. We fix this by adding the runtime classpath configuration as an explicit task dependency.

Closes #58795