### PR TITLE
Ensure precommit runs as part of check

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
@@ -66,10 +66,10 @@ public abstract class PrecommitPlugin implements Plugin<Project> {
                 t.setDescription("Runs all non-test checks");
             });
 
-            project.getPluginManager().withPlugin("java", p -> {
-                project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit));
-                project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit));
-            });
+            project.getPluginManager().withPlugin("lifecycle-base", p ->
+                project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit)));
+            project.getPluginManager().withPlugin("java", p ->
+                project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit)));
         }
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
@@ -66,10 +66,13 @@ public abstract class PrecommitPlugin implements Plugin<Project> {
                 t.setDescription("Runs all non-test checks");
             });
 
-            project.getPluginManager().withPlugin("lifecycle-base", p ->
-                project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit)));
-            project.getPluginManager().withPlugin("java", p ->
-                project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit)));
+            project.getPluginManager()
+                .withPlugin(
+                    "lifecycle-base",
+                    p -> project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit))
+                );
+            project.getPluginManager()
+                .withPlugin("java", p -> project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit)));
         }
     }
 }


### PR DESCRIPTION
Precommit is setup to run as a dependency of the check task, but
unfortunately this wiring was only happening when the java plugin (but
not java-base plugin) was applied. This commit moves the wiring to occur
whenever the check task exists, which is with the lifecycle-base plugin.