### PR TITLE
Mute DoubleBounds testXContentRoundTrip test

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DoubleBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DoubleBoundsTests.java
@@ -79,6 +79,7 @@ public class DoubleBoundsTests extends ESTestCase {
         assertEquals(origBytes, readBytes);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/59475")
     public void testXContentRoundTrip() throws Exception {
         DoubleBounds orig = randomBounds();
 


### PR DESCRIPTION
Temporary muting this test until #59475 is merged

Relates #59475
