### PR TITLE
Replace number in REST API specs with more specific types

### DIFF
--- a/rest-api-spec/README.markdown
+++ b/rest-api-spec/README.markdown
@@ -84,9 +84,9 @@ In the documentation, you will find the `type` field, which documents which type
 | `string` | A string value  |
 | `enum` | A set of named constants *(a single value should be sent in the querystring)*  |
 | `int` | A signed 32-bit integer with a minimum value of -2<sup>31</sup> and a maximum value of 2<sup>31</sup>-1.  |
-| `double` | A [double-precision 64-bit IEEE 754](https://en.wikipedia.org/wiki/Floating-point_arithmetic) floating point number, restricted to finite values.  |
 | `long` | A signed 64-bit integer with a minimum value of -2<sup>63</sup> and a maximum value of 2<sup>63</sup>-1. *(Note: the max safe integer for JSON is 2<sup>53</sup>-1)* |
-| `number` | Alias for `double`. *(deprecated, a more specific type should be used)*  |
+| `float` | A [single-precision 32-bit IEEE 754](https://en.wikipedia.org/wiki/Floating-point_arithmetic) floating point number, restricted to finite values.  |
+| `double` | A [double-precision 64-bit IEEE 754](https://en.wikipedia.org/wiki/Floating-point_arithmetic) floating point number, restricted to finite values.  |
 | `boolean` | Boolean fields accept JSON true and false values  |
 
 ## Backwards compatibility

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -49,7 +49,7 @@
         "default": "5d"
       },
       "batched_reduce_size":{
-        "type":"number",
+        "type":"int",
         "description":"The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",
         "default":5
       },
@@ -91,7 +91,7 @@
         "description":"A comma-separated list of fields to return as the docvalue representation of a field for each hit"
       },
       "from":{
-        "type":"number",
+        "type":"int",
         "description":"Starting offset (default: 0)"
       },
       "ignore_unavailable":{
@@ -143,7 +143,7 @@
         "description":"Search operation type"
       },
       "size":{
-        "type":"number",
+        "type":"int",
         "description":"Number of hits to return (default: 10)"
       },
       "sort":{
@@ -163,7 +163,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "terminate_after":{
-        "type":"number",
+        "type":"int",
         "description":"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats":{
@@ -185,7 +185,7 @@
         "description":"Specify suggest mode"
       },
       "suggest_size":{
-        "type":"number",
+        "type":"int",
         "description":"How many suggestions to return in response"
       },
       "suggest_text":{
@@ -222,7 +222,7 @@
         "description":"Specify whether to return sequence number and primary term of the last modification of each hit"
       },
       "max_concurrent_shard_requests":{
-        "type":"number",
+        "type":"int",
         "description":"The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default":5
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -81,7 +81,7 @@
         "description":"Return settings in flat format (default: false)"
       },
       "wait_for_metadata_version":{
-        "type":"number",
+        "type":"long",
         "description":"Wait for the metadata version to be equal or greater than the specified metadata version"
       },
       "wait_for_timeout":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -60,7 +60,7 @@
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       },
       "min_score":{
-        "type":"number",
+        "type":"float",
         "description":"Include only documents with a specific `_score` value in the result"
       },
       "preference":{
@@ -101,7 +101,7 @@
         "description":"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "terminate_after":{
-        "type":"number",
+        "type":"int",
         "description":"The maximum count for each shard, upon reaching which the query execution will terminate early"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -54,7 +54,7 @@
         "description":"Explicit operation timeout"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -52,15 +52,15 @@
         "description":"Explicit operation timeout"
       },
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the delete operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the delete operation if the last operation that has changed the document has the specified primary term"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -49,7 +49,7 @@
         "description":"The field to use as default where no field prefix is given in the query string"
       },
       "from":{
-        "type":"number",
+        "type":"int",
         "description":"Starting offset (default: 0)"
       },
       "ignore_unavailable":{
@@ -114,7 +114,7 @@
         "description":"Explicit timeout for each search request. Defaults to no timeout."
       },
       "max_docs":{
-        "type":"number",
+        "type":"long",
         "description":"Maximum number of documents to process (default: all documents)"
       },
       "sort":{
@@ -122,7 +122,7 @@
         "description":"A comma-separated list of <field>:<direction> pairs"
       },
       "terminate_after":{
-        "type":"number",
+        "type":"int",
         "description":"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats":{
@@ -151,7 +151,7 @@
         "description":"Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size":{
-        "type":"number",
+        "type":"int",
         "default":100,
         "description":"Size on the scroll request powering the delete by query"
       },
@@ -161,12 +161,12 @@
         "description":"Should the request should block until the delete by query is complete."
       },
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "default":0,
         "description":"The throttle for this request in sub-requests per second. -1 means no throttle."
       },
       "slices":{
-        "type":"number|string",
+        "type":"int|string",
         "default":1,
         "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
@@ -27,7 +27,7 @@
     },
     "params":{
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "required":true,
         "description":"The throttle to set on this request in floating sub-requests per second. -1 means set no throttle."
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -63,7 +63,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -59,7 +59,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -63,7 +63,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -59,7 +59,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -74,7 +74,7 @@
         "description":"Explicit operation timeout"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{
@@ -87,11 +87,11 @@
         "description":"Specific version type"
       },
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the index operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the index operation if the last operation that has changed the document has the specified primary term"
       },
       "pipeline":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -57,7 +57,7 @@
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       },
       "max_num_segments":{
-        "type":"number",
+        "type":"int",
         "description":"The number of segments the index should be merged into (default: dynamic)"
       },
       "only_expunge_deletes":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -29,7 +29,7 @@
     },
     "params":{
       "order":{
-        "type":"number",
+        "type":"int",
         "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
       },
       "create":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -34,7 +34,7 @@
     },
     "params":{
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "required":false,
         "description":"The desired requests per second for the deletion processes."
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -44,7 +44,7 @@
         "description":"Search operation type"
       },
       "max_concurrent_searches":{
-        "type":"number",
+        "type":"int",
         "description":"Controls the maximum number of concurrent searches the multi search api will execute"
       },
       "typed_keys":{
@@ -52,11 +52,11 @@
         "description":"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "pre_filter_shard_size":{
-        "type":"number",
+        "type":"int",
         "description":"A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint."
       },
       "max_concurrent_shard_requests":{
-        "type":"number",
+        "type":"int",
         "description":"The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default":5
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -48,7 +48,7 @@
         "description":"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "max_concurrent_searches":{
-        "type":"number",
+        "type":"int",
         "description":"Controls the maximum number of concurrent searches the multi search api will execute"
       },
       "rest_total_hits_as_int":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -81,7 +81,7 @@
         "description":"Specifies if requests are real-time as opposed to near-real-time (default: true)."
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -37,11 +37,11 @@
         "description":"The interval for the second sampling of threads"
       },
       "snapshots":{
-        "type":"number",
+        "type":"int",
         "description":"Number of samples of thread stacktrace (default: 10)"
       },
       "threads":{
-        "type":"number",
+        "type":"int",
         "description":"Specify the number of threads to provide information for (default: 3)"
       },
       "ignore_idle_threads":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -40,7 +40,7 @@
         "description":"Should the request should block until the reindex is complete."
       },
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "default":0,
         "description":"The throttle to set on this request in sub-requests per second. -1 means no throttle."
       },
@@ -50,12 +50,12 @@
         "default":"5m"
       },
       "slices":{
-        "type":"number|string",
+        "type":"int|string",
         "default":1,
         "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       },
       "max_docs":{
-        "type":"number",
+        "type":"long",
         "description":"Maximum number of documents to process (default: all documents)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -27,7 +27,7 @@
     },
     "params":{
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "required":true,
         "description":"The throttle to set on this request in floating sub-requests per second. -1 means set no throttle."
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -74,7 +74,7 @@
         "description":"A comma-separated list of fields to return as the docvalue representation of a field for each hit"
       },
       "from":{
-        "type":"number",
+        "type":"int",
         "description":"Starting offset (default: 0)"
       },
       "ignore_unavailable":{
@@ -130,7 +130,7 @@
         "description":"Search operation type"
       },
       "size":{
-        "type":"number",
+        "type":"int",
         "description":"Number of hits to return (default: 10)"
       },
       "sort":{
@@ -150,7 +150,7 @@
         "description":"A list of fields to extract and return from the _source field"
       },
       "terminate_after":{
-        "type":"number",
+        "type":"int",
         "description":"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats":{
@@ -172,7 +172,7 @@
         "description":"Specify suggest mode"
       },
       "suggest_size":{
-        "type":"number",
+        "type":"int",
         "description":"How many suggestions to return in response"
       },
       "suggest_text":{
@@ -213,17 +213,17 @@
         "description":"Specify if request cache should be used for this request or not, defaults to index level setting"
       },
       "batched_reduce_size":{
-        "type":"number",
+        "type":"int",
         "description":"The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.",
         "default":512
       },
       "max_concurrent_shard_requests":{
-        "type":"number",
+        "type":"int",
         "description":"The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default":5
       },
       "pre_filter_shard_size":{
-        "type":"number",
+        "type":"int",
         "description":"A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint."
       },
       "rest_total_hits_as_int":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
@@ -28,11 +28,11 @@
     },
     "params":{
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the update operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the update operation if the last operation that has changed the document has the specified primary term"
       },
       "refresh":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -29,27 +29,27 @@
     },
     "params":{
       "blob_count":{
-        "type":"number",
+        "type":"int",
         "description":"Number of blobs to create during the test. Defaults to 100."
       },
       "concurrency":{
-        "type":"number",
+        "type":"int",
         "description":"Number of operations to run concurrently during the test. Defaults to 10."
       },
       "read_node_count":{
-        "type":"number",
+        "type":"int",
         "description":"Number of nodes on which to read a blob after writing. Defaults to 10."
       },
       "early_read_node_count":{
-        "type":"number",
+        "type":"int",
         "description":"Number of nodes on which to perform an early read on a blob, i.e. before writing has completed. Early reads are rare actions so the 'rare_action_probability' parameter is also relevant. Defaults to 2."
       },
       "seed":{
-        "type":"number",
+        "type":"long",
         "description":"Seed for the random number generator used to create the test workload. Defaults to a random value."
       },
       "rare_action_probability":{
-        "type":"number",
+        "type":"double",
         "description":"Probability of taking a rare action such as an early read or an overwrite. Defaults to 0.02."
       },
       "max_blob_size":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -87,7 +87,7 @@
         "description":"Specifies if request is real-time as opposed to near-real-time (default: true)."
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "version_type":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -27,12 +27,12 @@
     },
     "params":{
       "from":{
-        "type":"number",
+        "type":"int",
         "required":false,
         "description":"skips a number of transform stats, defaults to 0"
       },
       "size":{
-        "type":"number",
+        "type":"int",
         "required":false,
         "description":"specifies a max number of transform stats to get, defaults to 100"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -61,7 +61,7 @@
         "description":"If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "retry_on_conflict":{
-        "type":"number",
+        "type":"int",
         "description":"Specify how many times should the operation be retried when a conflict occurs (default: 0)"
       },
       "routing":{
@@ -73,11 +73,11 @@
         "description":"Explicit operation timeout"
       },
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the update operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only perform the update operation if the last operation that has changed the document has the specified primary term"
       },
       "require_alias": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -49,7 +49,7 @@
         "description":"The field to use as default where no field prefix is given in the query string"
       },
       "from":{
-        "type":"number",
+        "type":"int",
         "description":"Starting offset (default: 0)"
       },
       "ignore_unavailable":{
@@ -118,7 +118,7 @@
         "description":"Explicit timeout for each search request. Defaults to no timeout."
       },
       "max_docs":{
-        "type":"number",
+        "type":"long",
         "description":"Maximum number of documents to process (default: all documents)"
       },
       "sort":{
@@ -126,7 +126,7 @@
         "description":"A comma-separated list of <field>:<direction> pairs"
       },
       "terminate_after":{
-        "type":"number",
+        "type":"int",
         "description":"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats":{
@@ -159,7 +159,7 @@
         "description":"Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size":{
-        "type":"number",
+        "type":"int",
         "default":100,
         "description":"Size on the scroll request powering the update by query"
       },
@@ -169,12 +169,12 @@
         "description":"Should the request should block until the update by query operation is complete."
       },
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "default":0,
         "description":"The throttle to set on this request in sub-requests per second. -1 means no throttle."
       },
       "slices":{
-        "type":"number|string",
+        "type":"int|string",
         "default":1,
         "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -27,7 +27,7 @@
     },
     "params":{
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "required":true,
         "description":"The throttle to set on this request in floating sub-requests per second. -1 means set no throttle."
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
@@ -33,15 +33,15 @@
         "description":"Specify whether the watch is in/active by default"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only update the watch if the last operation that has changed the watch has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only update the watch if the last operation that has changed the watch has the specified primary term"
       }
     },

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -248,7 +248,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "pattern": "^list|date|time|string|enum|int|double|long|boolean|number$",
+                    "pattern": "^list|date|time|string|enum|int|double|float|long|boolean$",
                     "title": "The type of the parameter."
                 },
                 "options": {

--- a/rest-api-spec/src/yamlRestTestV7Compat/resources/rest-api-spec/api/indices.put_template_with_param.json
+++ b/rest-api-spec/src/yamlRestTestV7Compat/resources/rest-api-spec/api/indices.put_template_with_param.json
@@ -33,7 +33,7 @@
         "description":"The indices that this template should apply to, replaced by index_patterns within the template definition."
       },
       "order":{
-        "type":"number",
+        "type":"int",
         "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
       },
       "create":{

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-watcher.put_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-watcher.put_watch.json
@@ -37,15 +37,15 @@
         "description":"Specify whether the watch is in/active by default"
       },
       "version":{
-        "type":"number",
+        "type":"long",
         "description":"Explicit version number for concurrency control"
       },
       "if_seq_no":{
-        "type":"number",
+        "type":"long",
         "description":"only update the watch if the last operation that has changed the watch has the specified sequence number"
       },
       "if_primary_term":{
-        "type":"number",
+        "type":"long",
         "description":"only update the watch if the last operation that has changed the watch has the specified primary term"
       }
     },

--- a/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-ml.delete_expired_data.json
+++ b/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-ml.delete_expired_data.json
@@ -41,7 +41,7 @@
     },
     "params":{
       "requests_per_second":{
-        "type":"number",
+        "type":"float",
         "required":false,
         "description":"The desired requests per second for the deletion processes."
       },


### PR DESCRIPTION
This commit updates the REST API specs to replace the number type with the specific numeric type used when parsing the value
in Elasticsearch. Specific types are useful for clients that generate code from the REST API specs.

