### PR TITLE
Fix the test version in highlighters test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/40_keyword_ignore.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/40_keyword_ignore.yml
@@ -24,7 +24,7 @@ setup:
 ---
 "Plain Highligher should skip highlighting ignored keyword values":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.6.99"
       reason: "skip highlighting of ignored values was introduced in 7.7"
   - do:
       search:
@@ -45,7 +45,7 @@ setup:
 ---
 "Unified Highligher should skip highlighting ignored keyword values":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.6.99"
       reason: "skip highlighting of ignored values was introduced in 7.7"
   - do:
       search:


### PR DESCRIPTION
This was supposed to be done after the backport but was missed.

Related to #53408