### PR TITLE
Support prefix search for API key names (#59113)

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
@@ -30,12 +30,12 @@ The following parameters can be specified in the query parameters of a GET reque
 pertain to retrieving api keys:
 
 `id`::
-(Optional, string) An API key id. This parameter cannot be used with any of 
+(Optional, string) An API key id. This parameter cannot be used with any of
 `name`, `realm_name` or `username` are used.
 
 `name`::
 (Optional, string) An API key name. This parameter cannot be used with any of
-`id`, `realm_name` or `username` are used.
+`id`, `realm_name` or `username` are used. It supports prefix search with wildcard.
 
 `realm_name`::
 (Optional, string) The name of an authentication realm. This parameter cannot be
@@ -47,7 +47,7 @@ either `id` or `name` or when `owner` flag is set to `true`.
 
 `owner`::
 (Optional, boolean) A boolean flag that can be used to query API keys owned
-by the currently authenticated user. Defaults to false. 
+by the currently authenticated user. Defaults to false.
 The 'realm_name' or 'username' parameters cannot be specified when this
 parameter is set to 'true' as they are assumed to be the currently authenticated ones.
 
@@ -98,6 +98,14 @@ You can use the following example to retrieve the API key by name:
 [source,console]
 --------------------------------------------------
 GET /_security/api_key?name=my-api-key
+--------------------------------------------------
+// TEST[continued]
+
+API key name supports prefix search by using wildcard:
+
+[source,console]
+--------------------------------------------------
+GET /_security/api_key?name=my-*
 --------------------------------------------------
 // TEST[continued]
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -830,8 +830,12 @@ public class ApiKeyService {
             if (Strings.hasText(userName)) {
                 boolQuery.filter(QueryBuilders.termQuery("creator.principal", userName));
             }
-            if (Strings.hasText(apiKeyName)) {
-                boolQuery.filter(QueryBuilders.termQuery("name", apiKeyName));
+            if (Strings.hasText(apiKeyName) && "*".equals(apiKeyName) == false) {
+                if (apiKeyName.endsWith("*")) {
+                    boolQuery.filter(QueryBuilders.prefixQuery("name", apiKeyName.substring(0, apiKeyName.length() - 1)));
+                } else {
+                    boolQuery.filter(QueryBuilders.termQuery("name", apiKeyName));
+                }
             }
             if (Strings.hasText(apiKeyId)) {
                 boolQuery.filter(QueryBuilders.termQuery("_id", apiKeyId));


### PR DESCRIPTION
This PR adds minimum support for prefix search of API Key name. It only touches API key name and leave all other query parameters, e.g. realm name, username unchanged.