### PR TITLE
[ML] Fix NPE when starting classification with missing dependent_vari…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
@@ -113,7 +113,11 @@ public class ExtractedFieldsDetectorFactory {
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0).query(config.getSource().getParsedQuery());
         for (FieldCardinalityConstraint constraint : fieldCardinalityConstraints) {
-            for (FieldCapabilities fieldCaps : fieldCapabilitiesResponse.getField(constraint.getField()).values()) {
+            Map<String, FieldCapabilities> fieldCapsPerType = fieldCapabilitiesResponse.getField(constraint.getField());
+            if (fieldCapsPerType == null) {
+                throw ExceptionsHelper.badRequestException("no mappings could be found for field [{}]", constraint.getField());
+            }
+            for (FieldCapabilities fieldCaps : fieldCapsPerType.values()) {
                 if (fieldCaps.isAggregatable() == false) {
                     throw ExceptionsHelper.badRequestException("field [{}] of type [{}] is non-aggregatable",
                         fieldCaps.getName(), fieldCaps.getType());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
@@ -123,6 +123,7 @@
       catch: /Unable to start empty-with-compatible-fields as no documents in the source indices \[empty-index-with-compatible-fields\] contained all the fields selected for analysis/
       ml.start_data_frame_analytics:
         id: "empty-with-compatible-fields"
+
 ---
 "Test start with inconsistent body/param ids":
 
@@ -213,3 +214,32 @@
       catch: /Field \[keyword_field\] must have at least \[2\] distinct values but there were \[1\]/
       ml.start_data_frame_analytics:
         id: "classification-cardinality-limits"
+
+---
+"Test start classification analysis when the dependent variable is missing":
+  - do:
+      indices.create:
+        index: index-with-missing-dep-var
+        body:
+          mappings:
+            properties:
+              numeric_field: { type: "long" }
+
+  - do:
+      ml.put_data_frame_analytics:
+        id: "classification-missing-dep-var"
+        body: >
+          {
+            "source": {
+              "index": "index-with-missing-dep-var"
+            },
+            "dest": {
+              "index": "index-with-missing-dep-var-dest"
+            },
+            "analysis": { "classification": { "dependent_variable": "missing" } }
+          }
+
+  - do:
+      catch: /no mappings could be found for field \[missing\]/
+      ml.start_data_frame_analytics:
+        id: "classification-missing-dep-var"


### PR DESCRIPTION
…able

Since we have added checking the cardinality of the dependent_variable
for classification, we have introduced a bug where an NPE is thrown
if the dependent_variable is a missing field.

This commit is fixing this issue.
