### PR TITLE
Check for ml privilege when using the Inference Aggregation

### DIFF
--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -184,6 +184,7 @@ integTest.runner {
     'ml/job_groups/Test put job with id that matches an existing group',
     'ml/job_groups/Test put job with invalid group',
     'ml/ml_info/Test ml info',
+    'ml/pipeline_inference/Test setting results field is invalid',
     'ml/post_data/Test Flush data with invalid parameters',
     'ml/post_data/Test flushing and posting a closed job',
     'ml/post_data/Test open and close with non-existent job id',

--- a/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
@@ -71,7 +71,7 @@ public class MlWithSecurityInsufficientRoleIT extends MlWithSecurityIT {
                 assertThat(ae.getMessage(), containsString("returned [403 Forbidden]"));
                 assertThat(ae.getMessage(),
                     either(containsString("is unauthorized for user [no_ml]"))
-                        .or(containsString("user [no_ml] does not have the privilege to get trained models so cannot use ml inference")));
+                        .or(containsString("user [no_ml] does not have the privilege to get trained models")));
             }
         }
     }

--- a/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
@@ -83,11 +83,8 @@ public class MlWithSecurityInsufficientRoleIT extends MlWithSecurityIT {
 
     @SuppressWarnings("unchecked")
     static boolean containsKey(String key, Map<String, Object> mapOfMaps) {
-        Set<String> keys = mapOfMaps.keySet();
-        for (String keyEntry : keys) {
-            if (key.equals(keyEntry)) {
-                return true;
-            }
+        if (mapOfMaps.containsKey(key)) {
+            return true;
         }
 
         Set<Map.Entry<String, Object>> entries = mapOfMaps.entrySet();

--- a/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
@@ -71,7 +71,7 @@ public class MlWithSecurityInsufficientRoleIT extends MlWithSecurityIT {
                 assertThat(ae.getMessage(), containsString("returned [403 Forbidden]"));
                 assertThat(ae.getMessage(),
                     either(containsString("is unauthorized for user [no_ml]"))
-                        .or(containsString("user [no_ml] is not an ml user and does not have sufficient privilege to use ml inference")));
+                        .or(containsString("user [no_ml] does not have the privilege to get trained models so cannot use ml inference")));
             }
         }
     }

--- a/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;

--- a/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/test/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;
@@ -48,13 +49,14 @@ public class MlWithSecurityUserRoleIT extends MlWithSecurityIT {
                     String apiName = ((DoSection) section).getApiCallSection().getApi();
 
                     if (apiName.startsWith("ml.") && isAllowed(apiName) == false) {
-                        fail("should have failed because of missing role");
+                        fail("call to ml endpoint [" + apiName + "] should have failed because of missing role");
                     }
                 }
             }
         } catch (AssertionError ae) {
             assertThat(ae.getMessage(),
-                    either(containsString("action [cluster:monitor/xpack/ml")).or(containsString("action [cluster:admin/xpack/ml")));
+                either(containsString("action [cluster:monitor/xpack/ml"))
+                    .or(containsString("action [cluster:admin/xpack/ml")));
             assertThat(ae.getMessage(), containsString("returned [403 Forbidden]"));
             assertThat(ae.getMessage(), containsString("is unauthorized for user [ml_user]"));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregationBuilder.java
@@ -216,7 +216,7 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
         context.registerAsyncAction((client, listener) -> {
             if (licenseState.isSecurityEnabled()) {
                 // check the user has ml privileges
-                SecurityContext securityContext =new SecurityContext(Settings.EMPTY, client.threadPool().getThreadContext());
+                SecurityContext securityContext = new SecurityContext(Settings.EMPTY, client.threadPool().getThreadContext());
                 useSecondaryAuthIfAvailable(securityContext, () -> {
                     final String username = securityContext.getUser().principal();
                     final HasPrivilegesRequest privRequest = new HasPrivilegesRequest();
@@ -230,9 +230,8 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
                             if (r.isCompleteMatch()) {
                                 modelLoadAction.accept(client, listener);
                             } else {
-                                listener.onFailure(Exceptions.authorizationError(
-                                    "user [" + username + "] does not have the privilege to get trained models " +
-                                        "so cannot use ml inference"));
+                                listener.onFailure(Exceptions.authorizationError("user [" + username
+                                    + "] does not have the privilege to get trained models so cannot use ml inference"));
                             }
                         },
                         listener::onFailure);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/pipeline_inference.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/pipeline_inference.yml
@@ -139,6 +139,7 @@ setup:
             }
           }
   - match: { aggregations.good.buckets.0.regression_agg.value: 2.0 }
+
 ---
 "Test pipeline agg referencing a single bucket":
 


### PR DESCRIPTION
Before running the inference pipeline aggregation check the user has permission to access the Get trained models endpoint (`_ml/inference/`)

If the user does not have sufficient privilege a `security_exception` is thrown with the message `user [dave] is not an ml user and does not have sufficient privilege to use ml inference`. Any suggestions for an alternative message are welcome. 

 Non issue as the change comes under #58193