### PR TITLE
Fix auditing of nameless API Keys

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -832,8 +832,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             logEntry.with(PRINCIPAL_FIELD_NAME, authentication.getUser().principal());
             logEntry.with(AUTHENTICATION_TYPE_FIELD_NAME, authentication.getAuthenticationType().toString());
             if (Authentication.AuthenticationType.API_KEY == authentication.getAuthenticationType()) {
-                logEntry.with(API_KEY_ID_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY))
-                        .with(API_KEY_NAME_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY));
+                logEntry.with(API_KEY_ID_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY));
+                String apiKeyName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY);
+                if (apiKeyName != null) {
+                    logEntry.with(API_KEY_NAME_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY));
+                }
                 String creatorRealmName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_CREATOR_REALM_NAME);
                 if (creatorRealmName != null) {
                     // can be null for API keys created before version 7.7

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -835,7 +835,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 logEntry.with(API_KEY_ID_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY));
                 String apiKeyName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY);
                 if (apiKeyName != null) {
-                    logEntry.with(API_KEY_NAME_FIELD_NAME, (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY));
+                    logEntry.with(API_KEY_NAME_FIELD_NAME, apiKeyName);
                 }
                 String creatorRealmName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_CREATOR_REALM_NAME);
                 if (creatorRealmName != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -1461,9 +1461,11 @@ public class LoggingAuditTrailTests extends ESTestCase {
         if (Authentication.AuthenticationType.API_KEY == authentication.getAuthenticationType()) {
             assert false == authentication.getUser().isRunAs();
             checkedFields.put(LoggingAuditTrail.API_KEY_ID_FIELD_NAME,
-                    (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY))
-                    .put(LoggingAuditTrail.API_KEY_NAME_FIELD_NAME,
-                            (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY));
+                    (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY));
+            String apiKeyName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY);
+            if (apiKeyName != null) {
+                checkedFields.put(LoggingAuditTrail.API_KEY_NAME_FIELD_NAME, apiKeyName);
+            }
             String creatorRealmName = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_CREATOR_REALM_NAME);
             if (creatorRealmName != null) {
                 checkedFields.put(LoggingAuditTrail.PRINCIPAL_REALM_FIELD_NAME, creatorRealmName);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -866,8 +866,16 @@ public class ApiKeyServiceTests extends ESTestCase {
             AuthenticationResult authenticationResult = authenticationResultFuture.get();
             if (randomBoolean()) {
                 // maybe remove realm name to simulate old API Key authentication
+                assert authenticationResult.getStatus() == AuthenticationResult.Status.SUCCESS;
                 Map<String, Object> authenticationResultMetadata = new HashMap<>(authenticationResult.getMetadata());
                 authenticationResultMetadata.remove(ApiKeyService.API_KEY_CREATOR_REALM_NAME);
+                authenticationResult = AuthenticationResult.success(authenticationResult.getUser(), authenticationResultMetadata);
+            }
+            if (randomBoolean()) {
+                // simulate authentication with nameless API Key, see https://github.com/elastic/elasticsearch/issues/59484
+                assert authenticationResult.getStatus() == AuthenticationResult.Status.SUCCESS;
+                Map<String, Object> authenticationResultMetadata = new HashMap<>(authenticationResult.getMetadata());
+                authenticationResultMetadata.remove(ApiKeyService.API_KEY_NAME_KEY);
                 authenticationResult = AuthenticationResult.success(authenticationResult.getUser(), authenticationResultMetadata);
             }
 


### PR DESCRIPTION
API keys can be created nameless using the grant endpoint, see https://github.com/elastic/elasticsearch/issues/59484 (it's a bug).

This change ensures auditing doesn't throw when such an API Key is used for authentication.
