### PR TITLE
[DOCS] Simplify index template snippets for data streams

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -52,31 +52,13 @@ PUT /_ilm/policy/logs_policy
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  }
+  "data_stream": { }
 }
 
 PUT /_index_template/new_logs_data_stream
 {
   "index_patterns": [ "new_logs*" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  }
+  "data_stream": { }
 }
 
 PUT /_data_stream/logs
@@ -120,13 +102,10 @@ for a new field, `message`, to the template.
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
     "mappings": {
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "message": {                              <1>
           "type": "text"
         }
@@ -187,13 +166,10 @@ mapping parameter to `true`.
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
     "mappings": {
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "host": {
           "properties": {
             "ip": {
@@ -271,15 +247,8 @@ template's `index.refresh_interval` index setting to `30s` (30 seconds).
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    },
     "settings": {
       "index.refresh_interval": "30s"             <1>
     }
@@ -335,15 +304,8 @@ The following <<indices-templates,put index template API>> requests adds new
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    },
     "settings": {
       "sort.field": [ "@timestamp"],             <1>
       "sort.order": [ "desc"]                    <2>
@@ -448,7 +410,7 @@ uses the `logs_data_stream` template as its basis, with the following changes:
 PUT /_index_template/new_logs_data_stream
 {
   "index_patterns": [ "new_logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -172,7 +172,7 @@ configures the `logs_data_stream` template.
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
+  "data_stream": { },
   "template": {
     "settings": {
       "index.lifecycle.name": "logs_policy"

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -19,16 +19,7 @@ the following:
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  }
+  "data_stream": { }
 }
 
 PUT /_data_stream/logs

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -121,19 +121,12 @@ with the options you specify.
 PUT _index_template/timeseries_template
 {
   "index_patterns": ["timeseries"],                   <1>
-  "data_stream": {},
+  "data_stream": { },
   "template": {
     "settings": {
       "number_of_shards": 1,
       "number_of_replicas": 1,
       "index.lifecycle.name": "timeseries_policy"     <2>
-    },
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"                              <3>
-        }
-      }
     }
   }
 }
@@ -142,8 +135,6 @@ PUT _index_template/timeseries_template
 
 <1> Apply the template when a document is indexed into the `timeseries` target.
 <2> The name of the {ilm-init} policy used to manage the data stream.
-<3> A <<date,`date`>> or <<date_nanos,`date_nanos`>> field mapping for the
-"@timestamp" field the data stream will use.
 ====
 
 [discrete]

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -16,16 +16,7 @@ See <<set-up-a-data-stream>>.
 PUT /_index_template/template
 {
   "index_patterns": ["my-data-stream*"],
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  },
-  "data_stream": {}
+  "data_stream": { }
 }
 ----
 ////

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -14,16 +14,7 @@ indices. See <<delete-a-data-stream>>.
 PUT /_index_template/template
 {
   "index_patterns": ["my-data-stream*"],
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  },
-  "data_stream": {}
+  "data_stream": { }
 }
 
 PUT /_data_stream/my-data-stream

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -35,10 +35,9 @@ PUT /_ilm/policy/my-lifecycle-policy
 PUT /_index_template/my-index-template
 {
   "index_patterns": [ "my-data-stream*" ],
-  "data_stream": { },
-    "settings": {
-      "index.lifecycle.name": "my-lifecycle-policy"
-    }
+  "data_stream": {},
+  "settings": {
+    "index.lifecycle.name": "my-lifecycle-policy"
   }
 }
 

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -35,15 +35,7 @@ PUT /_ilm/policy/my-lifecycle-policy
 PUT /_index_template/my-index-template
 {
   "index_patterns": [ "my-data-stream*" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    },
+  "data_stream": { },
     "settings": {
       "index.lifecycle.name": "my-lifecycle-policy"
     }

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -36,8 +36,10 @@ PUT /_index_template/my-index-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": {},
-  "settings": {
-    "index.lifecycle.name": "my-lifecycle-policy"
+  "template": {
+    "settings": {
+      "index.lifecycle.name": "my-lifecycle-policy"
+    }
   }
 }
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -487,16 +487,7 @@ a `data_stream` definition can be added to a composable template.
 PUT /_index_template/template_1
 {
   "index_patterns": ["logs-*"],
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  },
-  "data_stream": {}
+  "data_stream": { }
 }
 --------------------------------------------------
 

--- a/docs/reference/indices/resolve.asciidoc
+++ b/docs/reference/indices/resolve.asciidoc
@@ -30,16 +30,7 @@ PUT /my-index/_alias/f-alias
 PUT /_index_template/foo_data_stream
 {
   "index_patterns": [ "foo" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  }
+  "data_stream": { }
 }
 
 PUT /_data_stream/foo

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -230,16 +230,7 @@ The API returns the following response:
 PUT _index_template/template
 {
   "index_patterns": ["my-data-stream*"],
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  },
-  "data_stream": {}
+  "data_stream": { }
 }
 -----------------------------------
 // TEST

--- a/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
@@ -43,16 +43,7 @@ backing indices, the user can retrieve a document directly from `.ds-logs-000002
 PUT /_index_template/logs_data_stream
 {
   "index_patterns": [ "logs*" ],
-  "data_stream": {},
-  "template": {
-    "mappings": {
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
-      }
-    }
-  }
+  "data_stream": { }
 }
 
 PUT /_data_stream/logs


### PR DESCRIPTION
Removes the `@timestamp` field mapping from several data stream index
template snippets.

With #59317, the `@timestamp` field defaults to a `date` field data type
for data streams.