### PR TITLE
[7.x] Reenable BWC tests for data streams

### DIFF
--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/100_delete_by_query.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/100_delete_by_query.yml
@@ -3,7 +3,7 @@
   - skip:
       features: allowed_warnings
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
 
   - do:
       allowed_warnings:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
@@ -1,8 +1,6 @@
 setup:
   - skip:
       features: allowed_warnings
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
   - do:
       allowed_warnings:
         - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
@@ -32,8 +30,8 @@ setup:
 ---
 "Create data stream":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -106,8 +104,8 @@ setup:
 ---
 "Create data stream with invalid name":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       catch: bad_request
@@ -121,8 +119,8 @@ setup:
 ---
 "Get data stream":
   - skip:
-      version: " - 7.9.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -186,8 +184,8 @@ setup:
 ---
 "Delete data stream with backing indices":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -230,8 +228,8 @@ setup:
 ---
 "append-only writes to backing indices prohobited":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/110_update_by_query.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/110_update_by_query.yml
@@ -3,7 +3,7 @@
   - skip:
       features: allowed_warnings
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
 
   - do:
       allowed_warnings:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/20_unsupported_apis.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/20_unsupported_apis.yml
@@ -1,8 +1,8 @@
 ---
 "Test apis that do not supported data streams":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -49,8 +49,8 @@
 ---
 "Prohibit clone on data stream's write index":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -98,8 +98,8 @@
 ---
 "Prohibit shrink on data stream's write index":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -135,8 +135,8 @@
 ---
 "Close write index for data stream fails":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -166,7 +166,7 @@
 ---
 "Prohibit split on data stream's write index":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.8.99"
       reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/30_auto_create_data_stream.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/30_auto_create_data_stream.yml
@@ -1,8 +1,8 @@
 ---
 "Put index template":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/40_supported_apis.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/40_supported_apis.yml
@@ -2,8 +2,6 @@
 setup:
   - skip:
       features: allowed_warnings
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
   - do:
       allowed_warnings:
         - "index template [logs_template] has index patterns [logs-foobar] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logs_template] will take precedence during new index creation"
@@ -26,8 +24,8 @@ teardown:
 ---
 "Verify get index api":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.get:
@@ -39,8 +37,8 @@ teardown:
 ---
 "Verify get mapping api":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.get_mapping:
@@ -51,8 +49,8 @@ teardown:
 ---
 "Verify shard stores api":
   - skip:
-      version: " - 7.9.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -103,8 +101,9 @@ teardown:
 ---
 "Verify search shards api":
   - skip:
+      features: allowed_warnings
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
 
   - do:
       allowed_warnings:
@@ -136,7 +135,7 @@ teardown:
   - skip:
       features: allowed_warnings
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
 
   - do:
       allowed_warnings:
@@ -168,7 +167,7 @@ teardown:
 "Open write index for data stream opens all backing indices":
   - skip:
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -231,7 +230,7 @@ teardown:
 "Verify rank eval with data streams":
   - skip:
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/50_delete_backing_indices.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/50_delete_backing_indices.yml
@@ -1,8 +1,6 @@
 setup:
   - skip:
       features: allowed_warnings
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
   - do:
       allowed_warnings:
         - "index template [my-template] has index patterns [simple-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
@@ -15,8 +13,8 @@ setup:
 ---
 "Delete backing index on data stream":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -67,8 +65,8 @@ setup:
 ---
 "Attempt to delete write index on data stream is rejected":
   - skip:
-      version: " - 7.9.99"
-      reason:  "enable in 7.9+ when backported9+"
+      version: " - 7.8.99"
+      reason:  "data streams available in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/60_get_backing_indices.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/60_get_backing_indices.yml
@@ -1,8 +1,8 @@
 ---
 "Get backing indices for data stream":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/70_rollover_data_streams.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/70_rollover_data_streams.yml
@@ -1,8 +1,8 @@
 ---
 "Roll over a data stream":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/80_resolve_index_data_streams.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/80_resolve_index_data_streams.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "resolve index api only supported in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -65,8 +65,8 @@ setup:
 ---
 "Resolve index with indices, aliases, and data streams":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "resolve index api only supported in 7.9+"
 
   - do:
       indices.resolve_index:
@@ -109,7 +109,7 @@ setup:
 ---
 "Resolve index with hidden and closed indices":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.8.99"
       reason: change after backporting
 
   - do:

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/90_reindex.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/90_reindex.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 7.99.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do :
@@ -24,7 +24,7 @@ teardown:
 "Reindex from data stream into another data stream":
   - skip:
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -57,7 +57,7 @@ teardown:
 "Reindex from index into data stream":
   - skip:
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -90,7 +90,7 @@ teardown:
 "Reindex from data stream into an index":
   - skip:
       version: " - 7.8.99"
-      reason: "data streams only supported in 7.9+"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -362,17 +362,17 @@
   - do:
       index:
         index:  simple-data-stream1
-        body:   { max: 2 }
+        body:   { max: 2, '@timestamp': '2020-12-12'  }
 
   - do:
       index:
         index:  simple-data-stream1
-        body:   { max: 1 }
+        body:   { max: 1, '@timestamp': '2020-12-12'  }
 
   - do:
       index:
         index:  simple-data-stream1
-        body:   { max: 3 }
+        body:   { max: 3, '@timestamp': '2020-12-12'  }
 
   - do:
       indices.refresh:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -152,8 +152,8 @@
 ---
 "Verify data stream resolvability in ILM remove policy API":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -241,8 +241,8 @@
 ---
 "Verify data stream resolvability for graph explore API":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -297,8 +297,8 @@
 ---
 "Verify data stream resolvability in migrations API":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -336,8 +336,8 @@
 ---
 "Verify data stream resolvability in async search":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:
@@ -406,8 +406,8 @@
 ---
 "Verify data stream resolvability in rollup search":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/50_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/50_data_streams.yml
@@ -320,13 +320,7 @@ teardown:
         name: my-template1
         body:
           index_patterns: [simple*]
-          template:
-            mappings:
-              properties:
-                '@timestamp':
-                  type: date
-          data_stream:
-            timestamp_field: '@timestamp'
+          data_stream: {}
 
   - do:
       security.put_role:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/50_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/50_data_streams.yml
@@ -2,8 +2,8 @@
 setup:
   - skip:
       features: ["headers", "allowed_warnings"]
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
 
   - do:
       cluster.health:
@@ -88,8 +88,8 @@ teardown:
 ---
 "Test backing indices inherit parent data stream privileges":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: ["headers"]
 
   - do: # superuser
@@ -150,8 +150,8 @@ teardown:
 ---
 "Test that requests not supporting data streams do not include data streams among authorized indices":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: ["headers"]
 
   - do: # superuser
@@ -182,8 +182,8 @@ teardown:
 ---
 "Test that create data stream is limited to authorized namespace":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
 
   - do:
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
@@ -205,8 +205,8 @@ teardown:
 ---
 "Test that get data stream is limited to authorized namespace":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
 
   - do: # superuser
       indices.create_data_stream:
@@ -270,8 +270,8 @@ teardown:
 ---
 "Test that delete data stream is limited to authorized namespace":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
 
   - do: # superuser
       indices.create_data_stream:
@@ -309,8 +309,8 @@ teardown:
 ---
 "auto_configure privilege permits auto-create of data streams":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
       features: ["headers", "allowed_warnings"]
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/55_auto_configure.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/55_auto_configure.yml
@@ -2,8 +2,8 @@
 setup:
   - skip:
       features: ["headers", "allowed_warnings"]
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "auto_configure available in 7.9+"
 
   - do:
       cluster.health:
@@ -58,8 +58,8 @@ teardown:
 ---
 "auto_configure privilege permits auto-create of indices":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.8.99 after backport"
+      version: " - 7.8.99"
+      reason: "auto_configure available in 7.9+"
       features: ["headers", "allowed_warnings"]
 
   # should succeed because test_user is authorized for auto_configure on index-auto-configure


### PR DESCRIPTION
Relates to #53100 

Backport of #59483
