### PR TITLE
[7.x][ML] Improve error for non-included field with unsupported type …

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -241,7 +241,11 @@ public class ExtractedFieldsDetector {
                 }
             } else {
                 fieldsIterator.remove();
-                addExcludedField(field, "field not in includes list", fieldSelection);
+                if (hasCompatibleType(field)) {
+                    addExcludedField(field, "field not in includes list", fieldSelection);
+                } else {
+                    addExcludedField(field, "unsupported type; supported types are " + getSupportedTypes(), fieldSelection);
+                }
             }
         }
     }


### PR DESCRIPTION
…(#59424)

When a field is not included yet its type is unsupported, we currently
state that the reason the field is excluded is that it is not in the
includes list. However, this implies the user could include it but
if the user tried to do so, they would get a failure as they would
be including a field with unsupported type.

This commit improves this by stating the reason a not included field
with unsupported type is excluded is because of its type.

Backport of #59424
