### PR TITLE
Enable replication retries on 7.9+

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -102,7 +102,7 @@ public abstract class TransportReplicationAction<
      * The timeout for retrying replication requests.
      */
     public static final Setting<TimeValue> REPLICATION_RETRY_TIMEOUT =
-        Setting.timeSetting("indices.replication.retry_timeout", TimeValue.timeValueSeconds(0), Setting.Property.Dynamic,
+        Setting.timeSetting("indices.replication.retry_timeout", TimeValue.timeValueSeconds(60), Setting.Property.Dynamic,
             Setting.Property.NodeScope);
 
     /**


### PR DESCRIPTION
Currently the work to support replication retries is present on 7.9.
This commit enables these retries by setting the replication timeout to
60s.