### PR TITLE
[DOCS] EQL: Update EQL search response format

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -18,16 +18,18 @@ event.
 [source,console]
 ----
 PUT /my_index/_bulk?refresh
-{"index":{"_index" : "my_index", "_id" : "1"}}
-{ "@timestamp": "2020-12-06T11:04:05.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "edwCRnyD","sequence": 1 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "my_index", "_id" : "2"}}
-{ "@timestamp": "2020-12-06T11:04:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "dGCHwoeS", "sequence": 2 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "my_index", "_id" : "3"}}
-{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "cMyt5SZ2", "sequence": 3 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "my_index", "_id" : "4"}}
-{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "bYA7gPay", "sequence": 4 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "my_index", "_id" : "5"}}
-{ "@timestamp": "2020-12-07T11:07:09.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "aR3NWVOs", "sequence": 5 }, "process": { "name": "regsvr32.exe", "path": "C:\\Windows\\System32\\regsvr32.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-06T11:04:05.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "edwCRnyD", "sequence": 1 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-06T11:04:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "dGCHwoeS", "sequence": 2 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "cMyt5SZ2", "sequence": 3 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "bYA7gPay", "sequence": 4 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:09.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "aR3NWVOs", "sequence": 5 }, "process": { "name": "regsvr32.exe", "executable": "C:\\Windows\\System32\\regsvr32.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:10.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "GTSmSqgz0U", "sequence": 6, "type": "termination" }, "process": { "name": "regsvr32.exe", "executable": "C:\\Windows\\System32\\regsvr32.exe" } }
 ----
 // TESTSETUP
 ////
@@ -304,6 +306,7 @@ parameter. If both parameters are specified, only the query parameter is used.
 `id`::
 +
 --
+(string)
 Identifier for the search.
 
 This search ID is only provided if one of the following conditions is met:
@@ -540,7 +543,7 @@ the events in ascending, lexicographic order.
     "events": [
       {
         "_index": "my_index",
-        "_id": "2",
+        "_id": "fwGeywNsBl8Y9Ys1x51b",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-06T11:04:07.000Z",
@@ -561,13 +564,13 @@ the events in ascending, lexicographic order.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       },
       {
         "_index": "my_index",
-        "_id": "4",
+        "_id": "AtOJ4UjUBAAx3XR5kcCM",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-07T11:07:08.000Z",
@@ -588,7 +591,7 @@ the events in ascending, lexicographic order.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       }
@@ -597,6 +600,8 @@ the events in ascending, lexicographic order.
 }
 ----
 // TESTRESPONSE[s/"took": 6/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "fwGeywNsBl8Y9Ys1x51b"/"_id": $body.hits.events.0._id/]
+// TESTRESPONSE[s/"_id": "AtOJ4UjUBAAx3XR5kcCM"/"_id": $body.hits.events.1._id/]
 
 [[eql-search-api-sequence-ex]]
 ===== Sequence query example
@@ -615,7 +620,7 @@ that:
 +
 --
 * An `event.category` of `process`
-* A `process.path` that contains the substring `regsvr32`
+* A `process.executable` that contains the substring `regsvr32`
 --
 
 These events must also share the same `agent.id` value.
@@ -627,7 +632,7 @@ GET /my_index/_eql/search
   "query": """
     sequence by agent.id
       [ file where file.name == "cmd.exe" and agent.id != "my_user" ]
-      [ process where stringContains(process.path, "regsvr32") ]
+      [ process where stringContains(process.executable, "regsvr32") ]
   """
 }
 ----
@@ -662,7 +667,7 @@ the events in ascending, lexicographic order.
         "events": [
           {
             "_index": "my_index",
-            "_id": "4",
+            "_id": "AtOJ4UjUBAAx3XR5kcCM",
             "_version": 1,
             "_seq_no": 3,
             "_primary_term": 1,
@@ -686,13 +691,13 @@ the events in ascending, lexicographic order.
               },
               "process": {
                 "name": "cmd.exe",
-                "path": "C:\\Windows\\System32\\cmd.exe"
+                "executable": "C:\\Windows\\System32\\cmd.exe"
               }
             }
           },
           {
             "_index": "my_index",
-            "_id": "5",
+            "_id": "yDwnGIJouOYGBzP0ZE9n",
             "_version": 1,
             "_seq_no": 4,
             "_primary_term": 1,
@@ -709,7 +714,7 @@ the events in ascending, lexicographic order.
               },
               "process": {
                 "name": "regsvr32.exe",
-                "path": "C:\\Windows\\System32\\regsvr32.exe"
+                "executable": "C:\\Windows\\System32\\regsvr32.exe"
               }
             }
           }
@@ -720,3 +725,5 @@ the events in ascending, lexicographic order.
 }
 ----
 // TESTRESPONSE[s/"took": 6/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "AtOJ4UjUBAAx3XR5kcCM"/"_id": $body.hits.sequences.0.events.0._id/]
+// TESTRESPONSE[s/"_id": "yDwnGIJouOYGBzP0ZE9n"/"_id": $body.hits.sequences.0.events.1._id/]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -631,7 +631,6 @@ GET /my_index/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.\*events\.\*fields/]
 
 The API returns the following response. The `hits.sequences.join_keys` property
 contains the shared `agent.id` value for each matching event. Matching events in

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -433,9 +433,24 @@ Name of the index containing the event.
 
 `_id`::
 (string)
-(string)
 Unique identifier for the event.
 This ID is only unique within the index.
+
+`_version`::
+(integer)
+Version of the document (event). This version is incremented each time the document is
+updated.
+
+`_seq_no`::
+(integer)
+Sequence number assigned to the document (event).
++
+Sequence numbers are used to ensure an older version of a document
+doesn’t overwrite a newer version. See <<optimistic-concurrency-control>>.
+
+`_primary_term`::
+(integer)
+Primary term assigned to the document. See <<optimistic-concurrency-control>>.
 
 `_score`::
 (float)
@@ -445,14 +460,6 @@ Positive 32-bit floating point number used to determine the relevance of the
 `_source`::
 (object)
 Original JSON body passed for the event at index time.
-
-`sort`::
-(array)
-Array of field values used to sort the event.
-+
-By default, the first item in the array is the event's
-<<eql-search-api-timestamp-field,timestamp value>>, converted to milliseconds
-since the https://en.wikipedia.org/wiki/Unix_time[Unix epoch].
 ======
 =====
 
@@ -483,14 +490,6 @@ Positive 32-bit floating point number used to determine the relevance of the
 `_source`::
 (object)
 Original JSON body passed for the event at index time.
-
-`sort`::
-(array)
-Array of field values used to sort the event.
-+
-By default, the first item in the array is the event's
-<<eql-search-api-timestamp-field,timestamp value>>, converted to milliseconds
-since the https://en.wikipedia.org/wiki/Unix_time[Unix epoch].
 =====
 ====
 
@@ -665,6 +664,9 @@ the events in ascending, lexicographic order.
           {
             "_index": "my_index",
             "_id": "4",
+            "_version": 1,
+            "_seq_no": 3,
+            "_primary_term": 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:08.000Z",
@@ -692,6 +694,9 @@ the events in ascending, lexicographic order.
           {
             "_index": "my_index",
             "_id": "5",
+            "_version": 1,
+            "_seq_no": 4,
+            "_primary_term": 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:09.000Z",
@@ -716,4 +721,3 @@ the events in ascending, lexicographic order.
 }
 ----
 // TESTRESPONSE[s/"took": 6/"took": $body.took/]
-// TESTRESPONSE[skip: response format updated]

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -22,18 +22,18 @@ The following <<docs-bulk,bulk API>> request adds some example log data to the
 [source,console]
 ----
 PUT /sec_logs/_bulk?refresh
-{"index":{"_index" : "sec_logs", "_id" : "1"}}
-{ "@timestamp": "2020-12-06T11:04:05.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "edwCRnyD","sequence": 1 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "sec_logs", "_id" : "2"}}
-{ "@timestamp": "2020-12-06T11:04:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "dGCHwoeS", "sequence": 2 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "sec_logs", "_id" : "3"}}
-{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "cMyt5SZ2", "sequence": 3 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "sec_logs", "_id" : "4"}}
-{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "bYA7gPay", "sequence": 4 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
-{"index":{"_index" : "sec_logs", "_id" : "5"}}
-{ "@timestamp": "2020-12-07T11:07:09.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "aR3NWVOs", "sequence": 5 }, "process": { "name": "regsvr32.exe", "path": "C:\\Windows\\System32\\regsvr32.exe" } }
-{"index":{"_index" : "sec_logs", "_id" : "6"}}
-{ "@timestamp": "2020-12-07T11:07:10.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "GTSmSqgz0U", "sequence": 6, "type": "termination" }, "process": { "name": "regsvr32.exe", "path": "C:\\Windows\\System32\\regsvr32.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-06T11:04:05.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "edwCRnyD", "sequence": 1 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-06T11:04:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "dGCHwoeS", "sequence": 2 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "cMyt5SZ2", "sequence": 3 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file", "id": "bYA7gPay", "sequence": 4 }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "executable": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:09.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "aR3NWVOs", "sequence": 5 }, "process": { "name": "regsvr32.exe", "executable": "C:\\Windows\\System32\\regsvr32.exe" } }
+{"index":{ }}
+{ "@timestamp": "2020-12-07T11:07:10.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process", "id": "GTSmSqgz0U", "sequence": 6, "type": "termination" }, "process": { "name": "regsvr32.exe", "executable": "C:\\Windows\\System32\\regsvr32.exe" } }
 ----
 // TESTSETUP
 
@@ -86,7 +86,7 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
     "events": [
        {
         "_index": "sec_logs",
-        "_id": "1",
+        "_id": "OQmfCaduce8zoHT93o4H",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-06T11:04:05.000Z",
@@ -100,13 +100,13 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       },
       {
         "_index": "sec_logs",
-        "_id": "3",
+        "_id": "xLkCaj4EujzdNSxfYLbO",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-07T11:06:07.000Z",
@@ -120,7 +120,7 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       }
@@ -129,6 +129,8 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
 }
 ----
 // TESTRESPONSE[s/"took": 60/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "OQmfCaduce8zoHT93o4H"/"_id": $body.hits.events.0._id/]
+// TESTRESPONSE[s/"_id": "xLkCaj4EujzdNSxfYLbO"/"_id": $body.hits.events.1._id/]
 ====
 
 [discrete]
@@ -190,7 +192,7 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
         "events": [
           {
             "_index": "sec_logs",
-            "_id": "4",
+            "_id": "AtOJ4UjUBAAx3XR5kcCM",
             "_version" : 1,
             "_seq_no" : 3,
             "_primary_term" : 1,
@@ -214,13 +216,13 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
               },
               "process": {
                 "name": "cmd.exe",
-                "path": "C:\\Windows\\System32\\cmd.exe"
+                "executable": "C:\\Windows\\System32\\cmd.exe"
               }
             }
           },
           {
             "_index": "sec_logs",
-            "_id": "5",
+            "_id": "yDwnGIJouOYGBzP0ZE9n",
             "_version" : 1,
             "_seq_no" : 4,
             "_primary_term" : 1,
@@ -237,7 +239,7 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
               },
               "process": {
                 "name": "regsvr32.exe",
-                "path": "C:\\Windows\\System32\\regsvr32.exe"
+                "executable": "C:\\Windows\\System32\\regsvr32.exe"
               }
             }
           }
@@ -248,6 +250,8 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
 }
 ----
 // TESTRESPONSE[s/"took": 60/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "AtOJ4UjUBAAx3XR5kcCM"/"_id": $body.hits.sequences.0.events.0._id/]
+// TESTRESPONSE[s/"_id": "yDwnGIJouOYGBzP0ZE9n"/"_id": $body.hits.sequences.0.events.1._id/]
 
 You can use the <<eql-with-maxspan-keywords,`with maxspan` keywords>> to
 constrain a sequence to a specified timespan.
@@ -325,7 +329,7 @@ contains the shared `agent.id` value for each matching event.
         "events": [
           {
             "_index": "sec_logs",
-            "_id": "4",
+            "_id": "AtOJ4UjUBAAx3XR5kcCM",
             "_version": 1,
             "_seq_no": 3,
             "_primary_term": 1,
@@ -349,13 +353,13 @@ contains the shared `agent.id` value for each matching event.
               },
               "process": {
                 "name": "cmd.exe",
-                "path": "C:\\Windows\\System32\\cmd.exe"
+                "executable": "C:\\Windows\\System32\\cmd.exe"
               }
             }
           },
           {
             "_index": "sec_logs",
-            "_id": "5",
+            "_id": "yDwnGIJouOYGBzP0ZE9n",
             "_version": 1,
             "_seq_no": 4,
             "_primary_term": 1,
@@ -372,7 +376,7 @@ contains the shared `agent.id` value for each matching event.
               },
               "process": {
                 "name": "regsvr32.exe",
-                "path": "C:\\Windows\\System32\\regsvr32.exe"
+                "executable": "C:\\Windows\\System32\\regsvr32.exe"
               }
             }
           }
@@ -383,6 +387,8 @@ contains the shared `agent.id` value for each matching event.
 }
 ----
 // TESTRESPONSE[s/"took": 60/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "AtOJ4UjUBAAx3XR5kcCM"/"_id": $body.hits.sequences.0.events.0._id/]
+// TESTRESPONSE[s/"_id": "yDwnGIJouOYGBzP0ZE9n"/"_id": $body.hits.sequences.0.events.1._id/]
 
 You can use the <<eql-until-keyword,`until` keyword>> to specify an expiration
 event for sequences. Matching sequences must end before this event.
@@ -479,7 +485,7 @@ GET /sec_logs/_eql/search
 {
   "tiebreaker_field": "event.id",
   "query": """
-    process where process.name == "cmd.exe" and stringContains(process.path, "System32")
+    process where process.name == "cmd.exe" and stringContains(process.executable, "System32")
   """
 }
 ----
@@ -502,7 +508,7 @@ The API returns the following response.
     "events": [
       {
         "_index": "sec_logs",
-        "_id": "1",
+        "_id": "OQmfCaduce8zoHT93o4H",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-06T11:04:05.000Z",
@@ -516,13 +522,13 @@ The API returns the following response.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       },
       {
         "_index": "sec_logs",
-        "_id": "3",
+        "_id": "xLkCaj4EujzdNSxfYLbO",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-07T11:06:07.000Z",
@@ -536,7 +542,7 @@ The API returns the following response.
           },
           "process": {
             "name": "cmd.exe",
-            "path": "C:\\Windows\\System32\\cmd.exe"
+            "executable": "C:\\Windows\\System32\\cmd.exe"
           }
         }
       }
@@ -545,6 +551,8 @@ The API returns the following response.
 }
 ----
 // TESTRESPONSE[s/"took": 34/"took": $body.took/]
+// TESTRESPONSE[s/"_id": "OQmfCaduce8zoHT93o4H"/"_id": $body.hits.events.0._id/]
+// TESTRESPONSE[s/"_id": "xLkCaj4EujzdNSxfYLbO"/"_id": $body.hits.events.1._id/]
 ====
 
 
@@ -849,11 +857,11 @@ search API's `case_sensitive` parameter to toggle case sensitivity on or off.
 [%collapsible]
 ====
 The following search request contains a query that matches `process` events
-with a `process.path` containing `System32`.
+with a `process.executable` containing `System32`.
 
 Because the `case_sensitive` parameter is `true`, this query only matches
-`process.path` values containing `System32` with the exact same capitalization.
-A `process.path` value containing `system32` or `SYSTEM32` would not match this
+`process.executable` values containing `System32` with the exact same capitalization.
+A `process.executable` value containing `system32` or `SYSTEM32` would not match this
 query.
 
 [source,console]
@@ -863,7 +871,7 @@ GET /sec_logs/_eql/search
   "keep_on_completion": true,
   "case_sensitive": true,
   "query": """
-    process where stringContains(process.path, "System32")
+    process where stringContains(process.executable, "System32")
   """
 }
 ----

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -192,6 +192,9 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
           {
             "_index": "sec_logs",
             "_id": "4",
+            "_version" : 1,
+            "_seq_no" : 3,
+            "_primary_term" : 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:08.000Z",
@@ -219,6 +222,9 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
           {
             "_index": "sec_logs",
             "_id": "5",
+            "_version" : 1,
+            "_seq_no" : 4,
+            "_primary_term" : 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:09.000Z",
@@ -243,7 +249,6 @@ the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
 }
 ----
 // TESTRESPONSE[s/"took": 60/"took": $body.took/]
-// TESTRESPONSE[skip: response format updated]
 
 You can use the <<eql-with-maxspan-keywords,`with maxspan` keywords>> to
 constrain a sequence to a specified timespan.
@@ -324,6 +329,9 @@ contains the shared `agent.id` value for each matching event.
           {
             "_index": "sec_logs",
             "_id": "4",
+            "_version": 1,
+            "_seq_no": 3,
+            "_primary_term": 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:08.000Z",
@@ -351,6 +359,9 @@ contains the shared `agent.id` value for each matching event.
           {
             "_index": "sec_logs",
             "_id": "5",
+            "_version": 1,
+            "_seq_no": 4,
+            "_primary_term": 1,
             "_score": null,
             "_source": {
               "@timestamp": "2020-12-07T11:07:09.000Z",
@@ -375,7 +386,6 @@ contains the shared `agent.id` value for each matching event.
 }
 ----
 // TESTRESPONSE[s/"took": 60/"took": $body.took/]
-// TESTRESPONSE[skip: response format updated]
 
 You can use the <<eql-until-keyword,`until` keyword>> to specify an expiration
 event for sequences. Matching sequences must end before this event.
@@ -494,7 +504,7 @@ The API returns the following response.
       "relation": "eq"
     },
     "events": [
-        {
+      {
         "_index": "sec_logs",
         "_id": "1",
         "_score": null,
@@ -513,8 +523,8 @@ The API returns the following response.
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
         }
-        },
-        {
+      },
+      {
         "_index": "sec_logs",
         "_id": "3",
         "_score": null,
@@ -532,8 +542,8 @@ The API returns the following response.
             "name": "cmd.exe",
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
-        }   
         }
+      }
     ]
   }
 }

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -167,7 +167,6 @@ GET /sec_logs/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.events\.\*fields/]
 
 The API returns the following response. Matching events in
 the `hits.sequences.events` property are sorted by
@@ -268,7 +267,6 @@ GET /sec_logs/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.events\.\*fields/]
 
 You can further constrain matching event sequences using the
 <<eql-by-keyword,`by` keyword>>.
@@ -303,7 +301,6 @@ GET /sec_logs/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.\*events\.\*fields/]
 
 The API returns the following response. The `hits.sequences.join_keys` property
 contains the shared `agent.id` value for each matching event.
@@ -406,7 +403,6 @@ GET /sec_logs/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.\*events\.\*fields/]
 ====
 
 [discrete]


### PR DESCRIPTION
Changes:
* Documents the `_version`, `_seq_no`, and `_primary_term` response properties for sequence queries.
* Removes unneeded `// TEST` comments related to the `fields` response property for sequence queries.
* Removes the `sort` property.
* Updates sample data and snippets to be more realistic (auto-gen IDs) and ECS-compliant (changes `process.path` -> `process.executable`)

Relates to #59552