### PR TITLE
Add --force-yes to apt commands

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -186,7 +186,7 @@ def deb_common(config, name, extra: '')
     name,
     update_command: 'apt-get update',
     update_tracking_file: '/var/cache/apt/archives/last_update',
-    install_command: 'apt-get install -y',
+    install_command: 'apt-get install -y --force-yes',
     extra: extra_with_lintian
   )
 end
@@ -194,7 +194,7 @@ end
 def ubuntu_docker(config)
   config.vm.provision 'install Docker using apt', type: 'shell', inline: <<-SHELL
     # Install packages to allow apt to use a repository over HTTPS
-    apt-get install -y \
+    apt-get install -y --force-yes \
       apt-transport-https \
       ca-certificates \
       curl \
@@ -212,7 +212,7 @@ def ubuntu_docker(config)
 
     # Install Docker. Unlike Fedora and CentOS, this also start the daemon.
     apt-get update
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+    apt-get install -y --force-yes docker-ce docker-ce-cli containerd.io
 
     # Add vagrant to the Docker group, so that it can run commands
     usermod -aG docker vagrant
@@ -227,7 +227,7 @@ end
 def deb_docker(config)
   config.vm.provision 'install Docker using apt', type: 'shell', inline: <<-SHELL
     # Install packages to allow apt to use a repository over HTTPS
-    apt-get install -y \
+    apt-get install -y --force-yes \
       apt-transport-https \
       ca-certificates \
       curl \
@@ -245,7 +245,7 @@ def deb_docker(config)
 
     # Install Docker. Unlike Fedora and CentOS, this also start the daemon.
     apt-get update
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+    apt-get install -y --force-yes docker-ce docker-ce-cli containerd.io
 
     # Add vagrant to the Docker group, so that it can run commands
     usermod -aG docker vagrant


### PR DESCRIPTION
We use -y to automate apt install commands within vagrant provisioning.
However, this is sometimes insufficient, for example when a gpg
signature signing the package expires. This commit adds the extra
--force-yes flag, to tell apt-get we really mean business.

closes #59495