### PR TITLE
Fix Snapshot not Starting in Partial Snapshot Corner Case (#59428)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1262,6 +1262,19 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         assertThat(snapshotResponse.get().getSnapshotInfo().state(), is(SnapshotState.FAILED));
     }
 
+    public void testPartialSnapshotAllShardsMissing() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "fs");
+        createIndex("some-index");
+        stopNode(dataNode);
+        ensureStableCluster(1);
+        final CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot(repoName, "test-snap")
+                .setPartial(true).setWaitForCompletion(true).get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().state(), is(SnapshotState.PARTIAL));
+    }
+
     private long calculateTotalFilesSize(List<Path> files) {
         return files.stream().mapToLong(f -> {
             try {


### PR DESCRIPTION
We were not handling the case where during a partial snapshot all
shards would enter a failed state right off the bat.

Closes #59384

backport of #59428 (actual fix was already backported, this just equalizes histories and brings in the test for the issue)