### PR TITLE
CCR recoveries using wrong setting for chunk sizes

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/CombinedRateLimiter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CombinedRateLimiter.java
@@ -56,4 +56,8 @@ public class CombinedRateLimiter {
         rateLimit = maxBytesPerSec.getBytes() > 0;
         rateLimiter.setMBPerSec(maxBytesPerSec.getMbFrac());
     }
+
+    public double getMBPerSec() {
+        return rateLimiter.getMBPerSec();
+    }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
@@ -106,7 +106,7 @@ public final class CcrSettings {
         this.recoveryActivityTimeout = INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING.get(settings);
         this.recoveryActionTimeout = INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.get(settings);
         this.ccrRateLimiter = new CombinedRateLimiter(RECOVERY_MAX_BYTES_PER_SECOND.get(settings));
-        this.chunkSize = RECOVERY_MAX_BYTES_PER_SECOND.get(settings);
+        this.chunkSize = RECOVERY_CHUNK_SIZE.get(settings);
         this.maxConcurrentFileChunks = INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(RECOVERY_MAX_BYTES_PER_SECOND, this::setMaxBytesPerSec);
         clusterSettings.addSettingsUpdateConsumer(RECOVERY_CHUNK_SIZE, this::setChunkSize);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrSettingsTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrSettingsTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ccr;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.test.ESTestCase;
+
+public class CcrSettingsTests extends ESTestCase {
+
+    public void testDefaultSettings() {
+        final Settings settings = Settings.EMPTY;
+        final CcrSettings ccrSettings = new CcrSettings(settings,
+            new ClusterSettings(settings, Sets.newHashSet(CcrSettings.RECOVERY_CHUNK_SIZE,
+                CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND, CcrSettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING,
+                CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING)));
+        assertEquals(CcrSettings.RECOVERY_CHUNK_SIZE.get(settings), ccrSettings.getChunkSize());
+        assertEquals(CcrSettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings).intValue(),
+            ccrSettings.getMaxConcurrentFileChunks());
+        assertEquals(CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING.get(settings),
+            ccrSettings.getRecoveryActivityTimeout());
+        assertEquals(CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.get(settings),
+            ccrSettings.getRecoveryActionTimeout());
+        assertEquals(CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND.get(settings).getMbFrac(),
+            ccrSettings.getRateLimiter().getMBPerSec(), 0.0d);
+    }
+}


### PR DESCRIPTION
The default chunk size for CCR file-based recoveries was wrongly set to 40MB instead of 1MB.