### PR TITLE
Enforce fail on deprecated gradle usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ options.forkOptions.memoryMaximumSize=2g
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
 systemProp.org.gradle.dependency.duplicate.project.detection=false
+
+# Enforce the build to fail on deprecated gradle api usage
+systemProp.org.gradle.warning.mode=fail

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -85,6 +85,7 @@ ext.expansions = [
 
 processTestResources {
   from(sourceSets.test.resources.srcDirs) {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     include '**/*.yml'
     inputs.properties(expansions)
     MavenFilteringHack.filter(it, expansions)

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -10,6 +10,7 @@ testFixtures.useFixture ":x-pack:test:smb-fixture"
 
 // add test resources from security, so tests can use example certs
 processTestResources {
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   from(project(xpackModule('core')).sourceSets.test.resources.srcDirs)
   from(project(xpackModule('security')).sourceSets.test.resources.srcDirs)
 }


### PR DESCRIPTION
This enforces the Gradle build to fail if a deprecated Gradle API was used in the build. 

This guarantees us that we don't let deprecations sneak back into the build over time. A side effect of this though is, that when updating gradle versions, we need to tackle new deprecations as part of the update. 