### PR TITLE
Revert "Mute AzureSearchableSnapshotsIT (#58775)"

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/azure/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
@@ -6,13 +6,11 @@
 
 package org.elasticsearch.xpack.searchablesnapshots;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.settings.Settings;
 
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.not;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58260")
 public class AzureSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
 
     @Override


### PR DESCRIPTION
This reverts commit 96803525b9472fee558e855b8c6a61b274c8cc6f.

Relates https://github.com/elastic/elasticsearch/issues/58260#issuecomment-658692396
Closes #58260