### PR TITLE
[7.x] [DOCS] Update ds overview for optional `@timestamp` mapping (#59558)

### DIFF
--- a/docs/reference/data-streams/data-streams-overview.asciidoc
+++ b/docs/reference/data-streams/data-streams-overview.asciidoc
@@ -17,9 +17,12 @@ the stream's backing indices. It contains:
 
 * A name or wildcard (`*`) pattern for the data stream.
 
-* The data stream's _timestamp field_. This field must be mapped as a
-  <<date,`date`>> or <<date_nanos,`date_nanos`>> field data type and must be
-  included in every document indexed to the data stream.
+* An optional mapping for the data stream's `@timestamp` field.
++
+A `@timestamp` field must be included in every document indexed to the data
+stream. This field must be mapped as a <<date,`date`>> or
+<<date_nanos,`date_nanos`>> field data type. If no mapping is specified in the
+index template, the `date` field data type with default options is used.
 
 * The mappings and settings applied to each backing index when it's created.
 


### PR DESCRIPTION
7.x backport of #59558