### PR TITLE
[DOCS] Fix syntax and wording in EQL docs

### DIFF
--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -13,16 +13,15 @@ EQL is schema-less and works well with most common log formats.
 [TIP]
 ====
 While no schema is required to use EQL in {es}, we recommend the
-{ecs-ref}[Elastic Common Schema (ECS)]. The EQL search API is designed to work
-with core ECS fields by default.
+{ecs-ref}[Elastic Common Schema (ECS)]. The <<eql-search-api,EQL search API>> is
+designed to work with core ECS fields by default.
 ====
 
 [discrete]
 [[eql-required-fields]]
 === Required fields
 
-In {es}, EQL assumes each document in a data stream or index corresponds to an
-event.
+EQL assumes each document in a data stream or index corresponds to an event.
 
 To search a data stream or index using EQL, each document in the data stream or
 index must contain the following field archetypes:
@@ -38,6 +37,6 @@ mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field.
 [NOTE]
 ====
 You cannot use a <<nested,`nested`>> field data type or the sub-fields of a
-`nested` field dataype as the timestamp or event category field. See
+`nested` field as the timestamp or event category field. See
 <<eql-nested-fields>>.
 ====

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -21,7 +21,8 @@ designed to work with core ECS fields by default.
 [[eql-required-fields]]
 === Required fields
 
-EQL assumes each document in a data stream or index corresponds to an event.
+In {es}, EQL assumes each document in a data stream or index corresponds to an
+event.
 
 To search a data stream or index using EQL, each document in the data stream or
 index must contain the following field archetypes:

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -8,7 +8,8 @@ experimental::[]
 To start using EQL in {es}, first ensure your event data meets
 <<eql-requirements,EQL requirements>>. You can then use the <<eql-search-api,EQL
 search API>> to search event data stored in one or more {es} data streams or
-indices.
+indices. The API requires a query written in {es}'s supported <<eql-syntax,EQL
+syntax>>.
 
 .*Example*
 [%collapsible]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -88,8 +88,7 @@ error for the entire query.
 
 [source,eql]
 ----
-process where process.parent.name == "foo"
-and process.parent.name == process.name
+process where process.parent.name == "foo" and process.parent.name == process.name
 ----
 
 Instead, you can rewrite the query to compare both the `process.parent.name`
@@ -97,8 +96,7 @@ and `process.name` fields to static values.
 
 [source,eql]
 ----
-process where process.parent.name == "foo"
-and process.name == "foo"
+process where process.parent.name == "foo" and process.name == "foo"
 ----
 ====
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -74,7 +74,7 @@ You can specify and combine these criteria using the following operators:
 
 You cannot use comparison operators to compare a variable, such as a field
 value, to another variable, even if those variables are modified using a
-<eql-functions,function>>.
+<<eql-functions,function>>.
 
 .*Example*
 [%collapsible]
@@ -88,7 +88,8 @@ error for the entire query.
 
 [source,eql]
 ----
-process where process.parent.name == "foo" and process.parent.name == process.name
+process where process.parent.name == "foo"
+and process.parent.name == process.name
 ----
 
 Instead, you can rewrite the query to compare both the `process.parent.name`
@@ -96,18 +97,19 @@ and `process.name` fields to static values.
 
 [source,eql]
 ----
-process where process.parent.name == "foo" and process.name == "foo"
+process where process.parent.name == "foo"
+and process.name == "foo"
 ----
 ====
 
 [IMPORTANT]
 ====
-Avoid using the equal operator (`==`) to perform exact matching on `text` field
-values.
+Avoid using the equal operator (`==`) to perform exact matching on
+<<text,`text`>> field values.
 
-By default, {es} changes the values of <<text,`text`>> fields as part of
-<<analysis, analysis>>. This can make finding exact matches for `text` field
-values difficult.
+By default, {es} changes the values of `text` fields as part of <<analysis,
+analysis>>. This can make finding exact matches for `text` field values
+difficult.
 
 To search `text` fields, consider using a <<eql-search-filter-query-dsl,query
 DSL filter>> that contains a <<query-dsl-match-query,`match`>> query.
@@ -350,8 +352,8 @@ the backslash remains in the resulting string.
 
 [NOTE]
 ====
-Raw strings cannot contain only a single backslash. Additionally, raw strings
-cannot end in an odd number of backslashes.
+Raw strings cannot contain only a single backslash or end in an odd number of
+backslashes.
 ====
 
 [discrete]
@@ -375,8 +377,8 @@ dots (`.`), hyphens (`-`), or spaces, must be escaped using backticks (+++`+++).
 
 You can use EQL sequences to describe and match an ordered series of events.
 Each item in a sequence is an event category and event condition,
-surrounded by square brackets. Events are listed in ascending chronological
-order, with the most recent event listed last.
+surrounded by square brackets (`[ ]`). Events are listed in ascending
+chronological order, with the most recent event listed last.
 
 [source,eql]
 ----


### PR DESCRIPTION
Fixes some broken Asciidoc syntax and awkward wording in the EQL docs.