### PR TITLE
Cleanup and Optimize Multiple Serialization Spots

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -111,10 +111,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
     
     MultiSearchTemplateResponse(StreamInput in) throws IOException {
         super(in);
-        items = new Item[in.readVInt()];
-        for (int i = 0; i < items.length; i++) {
-            items[i] = new Item(in);
-        }
+        items = in.readArray(Item::new, Item[]::new);
         if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
             tookInMillis = in.readVLong();
         } else {
@@ -148,10 +145,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(items.length);
-        for (Item item : items) {
-            item.writeTo(out);
-        }
+        out.writeArray(items);
         if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
             out.writeVLong(tookInMillis);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -62,15 +61,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
 
     public ClusterHealthRequest(StreamInput in) throws IOException {
         super(in);
-        int size = in.readVInt();
-        if (size == 0) {
-            indices = Strings.EMPTY_ARRAY;
-        } else {
-            indices = new String[size];
-            for (int i = 0; i < indices.length; i++) {
-                indices[i] = in.readString();
-            }
-        }
+        indices = in.readStringArray();
         timeout = in.readTimeValue();
         if (in.readBoolean()) {
             waitForStatus = ClusterHealthStatus.readFrom(in);
@@ -95,10 +86,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         if (indices == null) {
             out.writeVInt(0);
         } else {
-            out.writeVInt(indices.length);
-            for (String index : indices) {
-                out.writeString(index);
-            }
+            out.writeStringArray(indices);
         }
         out.writeTimeValue(timeout);
         if (waitForStatus == null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -41,19 +41,13 @@ public class ClusterSearchShardsGroup implements Writeable, ToXContentObject {
 
     ClusterSearchShardsGroup(StreamInput in) throws IOException {
         shardId = new ShardId(in);
-        shards = new ShardRouting[in.readVInt()];
-        for (int i = 0; i < shards.length; i++) {
-            shards[i] = new ShardRouting(shardId, in);
-        }
+        shards = in.readArray(i -> new ShardRouting(shardId, i), ShardRouting[]::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardId.writeTo(out);
-        out.writeVInt(shards.length);
-        for (ShardRouting shardRouting : shards) {
-            shardRouting.writeToThin(out);
-        }
+        out.writeArray((o, s) -> s.writeToThin(o), shards);
     }
 
     public ShardId getShardId() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -50,10 +50,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
 
     public ClusterSearchShardsRequest(StreamInput in) throws IOException {
         super(in);
-        indices = new String[in.readVInt()];
-        for (int i = 0; i < indices.length; i++) {
-            indices[i] = in.readString();
-        }
+        indices = in.readStringArray();
 
         routing = in.readOptionalString();
         preference = in.readOptionalString();
@@ -64,12 +61,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-
-        out.writeVInt(indices.length);
-        for (String index : indices) {
-            out.writeString(index);
-        }
-
+        out.writeStringArray(indices);
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -74,12 +74,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
     SnapshotStatus(StreamInput in) throws IOException {
         snapshot = new Snapshot(in);
         state = State.fromValue(in.readByte());
-        int size = in.readVInt();
-        List<SnapshotIndexShardStatus> builder = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            builder.add(new SnapshotIndexShardStatus(in));
-        }
-        shards = Collections.unmodifiableList(builder);
+        shards = Collections.unmodifiableList(in.readList(SnapshotIndexShardStatus::new));
         includeGlobalState = in.readOptionalBoolean();
         final long startTime = in.readLong();
         final long time = in.readLong();
@@ -175,10 +170,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         snapshot.writeTo(out);
         out.writeByte(state.value());
-        out.writeVInt(shards.size());
-        for (SnapshotIndexShardStatus shard : shards) {
-            shard.writeTo(out);
-        }
+        out.writeList(shards);
         out.writeOptionalBoolean(includeGlobalState);
         out.writeLong(stats.getStartTime());
         out.writeLong(stats.getTime());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -45,12 +44,7 @@ public class SnapshotsStatusResponse extends ActionResponse implements ToXConten
 
     public SnapshotsStatusResponse(StreamInput in) throws IOException {
         super(in);
-        int size = in.readVInt();
-        List<SnapshotStatus> builder = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            builder.add(new SnapshotStatus(in));
-        }
-        snapshots = Collections.unmodifiableList(builder);
+        snapshots = Collections.unmodifiableList(in.readList(SnapshotStatus::new));
     }
 
     SnapshotsStatusResponse(List<SnapshotStatus> snapshots) {
@@ -68,10 +62,7 @@ public class SnapshotsStatusResponse extends ActionResponse implements ToXConten
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(snapshots.size());
-        for (SnapshotStatus snapshotInfo : snapshots) {
-            snapshotInfo.writeTo(out);
-        }
+        out.writeList(snapshots);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -33,9 +33,9 @@ import java.io.IOException;
 
 public class ClusterStatsNodeResponse extends BaseNodeResponse {
 
-    private NodeInfo nodeInfo;
-    private NodeStats nodeStats;
-    private ShardStats[] shardsStats;
+    private final NodeInfo nodeInfo;
+    private final NodeStats nodeStats;
+    private final ShardStats[] shardsStats;
     private ClusterHealthStatus clusterStatus;
 
     public ClusterStatsNodeResponse(StreamInput in) throws IOException {
@@ -46,11 +46,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         this.nodeInfo = new NodeInfo(in);
         this.nodeStats = new NodeStats(in);
-        int size = in.readVInt();
-        shardsStats = new ShardStats[size];
-        for (int i = 0; i < size; i++) {
-            shardsStats[i] = new ShardStats(in);
-        }
+        shardsStats = in.readArray(ShardStats::new, ShardStats[]::new);
     }
 
     public ClusterStatsNodeResponse(DiscoveryNode node, @Nullable ClusterHealthStatus clusterStatus,
@@ -97,9 +93,6 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         nodeInfo.writeTo(out);
         nodeStats.writeTo(out);
-        out.writeVInt(shardsStats.length);
-        for (ShardStats ss : shardsStats) {
-            ss.writeTo(out);
-        }
+        out.writeArray(shardsStats);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -27,21 +27,16 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 public class PendingClusterTasksResponse extends ActionResponse implements Iterable<PendingClusterTask>, ToXContentObject {
 
-    private List<PendingClusterTask> pendingTasks;
+    private final List<PendingClusterTask> pendingTasks;
 
     public PendingClusterTasksResponse(StreamInput in) throws IOException {
         super(in);
-        int size = in.readVInt();
-        pendingTasks = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            pendingTasks.add(new PendingClusterTask(in));
-        }
+        pendingTasks = in.readList(PendingClusterTask::new);
     }
 
     PendingClusterTasksResponse(List<PendingClusterTask> pendingTasks) {
@@ -108,10 +103,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(pendingTasks.size());
-        for (PendingClusterTask task : pendingTasks) {
-            task.writeTo(out);
-        }
+        out.writeList(pendingTasks);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -386,21 +386,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
 
         public Response(StreamInput in) throws IOException {
-            this.indices = new ArrayList<>();
-            int count = in.readVInt();
-            for (int k = 0; k < count; k++) {
-                indices.add(new ResolvedIndex(in));
-            }
-            this.aliases = new ArrayList<>();
-            count = in.readVInt();
-            for (int k = 0; k < count; k++) {
-                aliases.add(new ResolvedAlias(in));
-            }
-            this.dataStreams = new ArrayList<>();
-            count = in.readVInt();
-            for (int k = 0; k < count; k++) {
-                dataStreams.add(new ResolvedDataStream(in));
-            }
+            this.indices = in.readList(ResolvedIndex::new);
+            this.aliases = in.readList(ResolvedAlias::new);
+            this.dataStreams = in.readList(ResolvedDataStream::new);
         }
 
         public List<ResolvedIndex> getIndices() {
@@ -417,18 +405,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVInt(indices.size());
-            for (ResolvedIndex index : indices) {
-                index.writeTo(out);
-            }
-            out.writeVInt(aliases.size());
-            for (ResolvedAlias alias : aliases) {
-                alias.writeTo(out);
-            }
-            out.writeVInt(dataStreams.size());
-            for (ResolvedDataStream dataStream : dataStreams) {
-                dataStream.writeTo(out);
-            }
+            out.writeList(indices);
+            out.writeList(aliases);
+            out.writeList(dataStreams);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -26,16 +26,14 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.engine.Segment;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 public class ShardSegments implements Writeable, Iterable<Segment> {
 
-    private ShardRouting shardRouting;
+    private final ShardRouting shardRouting;
 
-    private List<Segment> segments;
+    private final List<Segment> segments;
 
     ShardSegments(ShardRouting shardRouting, List<Segment> segments) {
         this.shardRouting = shardRouting;
@@ -44,15 +42,7 @@ public class ShardSegments implements Writeable, Iterable<Segment> {
 
     ShardSegments(StreamInput in) throws IOException {
         shardRouting = new ShardRouting(in);
-        int size = in.readVInt();
-        if (size == 0) {
-            segments = Collections.emptyList();
-        } else {
-            segments = new ArrayList<>(size);
-            for (int i = 0; i < size; i++) {
-                segments.add(new Segment(in));
-            }
-        }
+        segments = in.readList(Segment::new);
     }
 
     @Override
@@ -91,9 +81,6 @@ public class ShardSegments implements Writeable, Iterable<Segment> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardRouting.writeTo(out);
-        out.writeVInt(segments.size());
-        for (Segment segment : segments) {
-            segment.writeTo(out);
-        }
+        out.writeList(segments);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
@@ -30,17 +30,13 @@ import java.util.Iterator;
 
 public class IndexShardStats implements Iterable<ShardStats>, Writeable {
 
-    private ShardId shardId;
+    private final ShardId shardId;
 
-    private ShardStats[] shards;
+    private final ShardStats[] shards;
 
     public IndexShardStats(StreamInput in) throws IOException {
         shardId = new ShardId(in);
-        int shardSize = in.readVInt();
-        shards = new ShardStats[shardSize];
-        for (int i = 0; i < shardSize; i++) {
-            shards[i] = new ShardStats(in);
-        }
+        shards = in.readArray(ShardStats::new, ShardStats[]::new);
     }
 
     public IndexShardStats(ShardId shardId, ShardStats[] shards) {
@@ -98,9 +94,6 @@ public class IndexShardStats implements Iterable<ShardStats>, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardId.writeTo(out);
-        out.writeVInt(shards.length);
-        for (ShardStats stats : shards) {
-            stats.writeTo(out);
-        }
+        out.writeArray(shards);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -85,10 +85,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
     public BulkRequest(StreamInput in) throws IOException {
         super(in);
         waitForActiveShards = ActiveShardCount.readFrom(in);
-        int size = in.readVInt();
-        for (int i = 0; i < size; i++) {
-            requests.add(DocWriteRequest.readDocumentRequest(null, in));
-        }
+        requests.addAll(in.readList(i -> DocWriteRequest.readDocumentRequest(null, i)));
         refreshPolicy = RefreshPolicy.readFrom(in);
         timeout = in.readTimeValue();
     }
@@ -354,10 +351,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         waitForActiveShards.writeTo(out);
-        out.writeVInt(requests.size());
-        for (DocWriteRequest<?> request : requests) {
-            DocWriteRequest.writeDocumentRequest(out, request);
-        }
+        out.writeCollection(requests, DocWriteRequest::writeDocumentRequest);
         refreshPolicy.writeTo(out);
         out.writeTimeValue(timeout);
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -52,18 +52,13 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
 
     public static final long NO_INGEST_TOOK = -1L;
 
-    private BulkItemResponse[] responses;
-    private long tookInMillis;
-    private long ingestTookInMillis;
-
-    BulkResponse() {}
+    private final BulkItemResponse[] responses;
+    private final long tookInMillis;
+    private final long ingestTookInMillis;
 
     public BulkResponse(StreamInput in) throws IOException {
         super(in);
-        responses = new BulkItemResponse[in.readVInt()];
-        for (int i = 0; i < responses.length; i++) {
-            responses[i] = new BulkItemResponse(in);
-        }
+        responses = in.readArray(BulkItemResponse::new, BulkItemResponse[]::new);
         tookInMillis = in.readVLong();
         ingestTookInMillis = in.readZLong();
     }
@@ -140,10 +135,7 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(responses.length);
-        for (BulkItemResponse response : responses) {
-            response.writeTo(out);
-        }
+        out.writeArray(responses);
         out.writeVLong(tookInMillis);
         out.writeZLong(ingestTookInMillis);
     }

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -253,12 +253,7 @@ public class MultiGetRequest extends ActionRequest
         preference = in.readOptionalString();
         refresh = in.readBoolean();
         realtime = in.readBoolean();
-
-        int size = in.readVInt();
-        items = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            items.add(new Item(in));
-        }
+        items = in.readList(Item::new);
     }
 
     public List<Item> getItems() {
@@ -497,10 +492,6 @@ public class MultiGetRequest extends ActionRequest
         }
     }
 
-    public static void parseIds(XContentParser parser, List<Item> items) throws IOException {
-        parseIds(parser, items, null, null, null, null);
-    }
-
     @Override
     public Iterator<Item> iterator() {
         return Collections.unmodifiableCollection(items).iterator();
@@ -512,11 +503,7 @@ public class MultiGetRequest extends ActionRequest
         out.writeOptionalString(preference);
         out.writeBoolean(refresh);
         out.writeBoolean(realtime);
-
-        out.writeVInt(items.size());
-        for (Item item : items) {
-            item.writeTo(out);
-        }
+        out.writeList(items);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -124,10 +124,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
 
     MultiGetResponse(StreamInput in) throws IOException {
         super(in);
-        responses = new MultiGetItemResponse[in.readVInt()];
-        for (int i = 0; i < responses.length; i++) {
-            responses[i] = new MultiGetItemResponse(in);
-        }
+        responses = in.readArray(MultiGetItemResponse::new, MultiGetItemResponse[]::new);
     }
 
     public MultiGetItemResponse[] getResponses() {
@@ -231,9 +228,6 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(responses.length);
-        for (MultiGetItemResponse response : responses) {
-            response.writeTo(out);
-        }
+        out.writeArray(responses);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -122,10 +122,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     public MultiSearchResponse(StreamInput in) throws IOException {
         super(in);
-        items = new Item[in.readVInt()];
-        for (int i = 0; i < items.length; i++) {
-            items[i] = new Item(in);
-        }
+        items = in.readArray(Item::new, Item[]::new);
         tookInMillis = in.readVLong();
     }
 
@@ -155,10 +152,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(items.length);
-        for (Item item : items) {
-            item.writeTo(out);
-        }
+        out.writeArray(items);
         out.writeVLong(tookInMillis);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -104,18 +104,8 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
         }
 
         private DiffableStringMapDiff(StreamInput in) throws IOException {
-            deletes = new ArrayList<>();
-            upserts = new HashMap<>();
-            int deletesCount = in.readVInt();
-            for (int i = 0; i < deletesCount; i++) {
-                deletes.add(in.readString());
-            }
-            int upsertsCount = in.readVInt();
-            for (int i = 0; i < upsertsCount; i++) {
-                String key = in.readString();
-                String newValue = in.readString();
-                upserts.put(key, newValue);
-            }
+            deletes = in.readStringList();
+            upserts = in.readMap(StreamInput::readString, StreamInput::readString);
         }
 
         public List<String> getDeletes() {
@@ -132,15 +122,8 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVInt(deletes.size());
-            for (String delete : deletes) {
-                out.writeString(delete);
-            }
-            out.writeVInt(upserts.size());
-            for (Map.Entry<String, String> entry : upserts.entrySet()) {
-                out.writeString(entry.getKey());
-                out.writeString(entry.getValue());
-            }
+            out.writeStringCollection(deletes);
+            out.writeMap(upserts, StreamOutput::writeString, StreamOutput::writeString);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -33,7 +33,6 @@ import org.elasticsearch.node.Node;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -249,11 +248,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         this.hostName = in.readString().intern();
         this.hostAddress = in.readString().intern();
         this.address = new TransportAddress(in);
-        int size = in.readVInt();
-        this.attributes = new HashMap<>(size);
-        for (int i = 0; i < size; i++) {
-            this.attributes.put(in.readString(), in.readString());
-        }
+        this.attributes = in.readMap(StreamInput::readString, StreamInput::readString);
         int rolesSize = in.readVInt();
         final Set<DiscoveryNodeRole> roles = new HashSet<>(rolesSize);
         for (int i = 0; i < rolesSize; i++) {
@@ -281,11 +276,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         out.writeString(hostName);
         out.writeString(hostAddress);
         address.writeTo(out);
-        out.writeVInt(attributes.size());
-        for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeString(entry.getValue());
-        }
+        out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
         out.writeVInt(roles.size());
         for (final DiscoveryNodeRole role : roles) {
             out.writeString(role.roleName());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeKey.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeKey.java
@@ -37,18 +37,12 @@ class CompositeKey implements Writeable {
     }
 
     CompositeKey(StreamInput in) throws IOException {
-        values = new Comparable[in.readVInt()];
-        for (int i = 0; i < values.length; i++) {
-            values[i] = (Comparable) in.readGenericValue();
-        }
+        values = in.readArray(i -> (Comparable) i.readGenericValue(), Comparable[]::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(values.length);
-        for (int i = 0; i < values.length; i++) {
-            out.writeGenericValue(values[i]);
-        }
+        out.writeArray(StreamOutput::writeGenericValue, values);
     }
 
     Comparable[] values() {


### PR DESCRIPTION
Follow up to #59606 using some of the new infrastructure and making similar cleanups (and due to at times better handling of size hints and empty collections also optimizations in the stream utility methods this also means speedups) in various spots in the core codebase.