### PR TITLE
Remaining queries for script keyword fields

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldAutomatonQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldAutomatonQuery.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+
+public abstract class AbstractStringScriptFieldAutomatonQuery extends AbstractStringScriptFieldQuery {
+    private final BytesRefBuilder scratch = new BytesRefBuilder();
+    private final ByteRunAutomaton automaton;
+
+    public AbstractStringScriptFieldAutomatonQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        ByteRunAutomaton automaton
+    ) {
+        super(script, leafFactory, fieldName);
+        this.automaton = automaton;
+    }
+
+    @Override
+    protected final boolean matches(List<String> values) {
+        for (String value : values) {
+            scratch.copyChars(value);
+            if (automaton.run(scratch.bytes(), 0, scratch.length())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.consumeTermsMatching(this, fieldName(), () -> automaton);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQuery.java
@@ -6,26 +6,27 @@
 
 package org.elasticsearch.xpack.runtimefields.query;
 
+import org.elasticsearch.script.Script;
 import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
 
 import java.util.List;
 
 public class StringScriptFieldExistsQuery extends AbstractStringScriptFieldQuery {
-    public StringScriptFieldExistsQuery(StringScriptFieldScript.LeafFactory leafFactory, String fieldName) {
-        super(leafFactory, fieldName);
+    public StringScriptFieldExistsQuery(Script script, StringScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, leafFactory, fieldName);
     }
 
     @Override
-    public boolean matches(List<String> values) {
+    protected boolean matches(List<String> values) {
         return false == values.isEmpty();
     }
 
     @Override
     public final String toString(String field) {
         if (fieldName().contentEquals(field)) {
-            return "*";
+            return "ScriptFieldExists";
         }
-        return fieldName() + ":*";
+        return fieldName() + ":ScriptFieldExists";
     }
 
     // Superclass's equals and hashCode are great for this class

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldFuzzyQuery extends AbstractStringScriptFieldAutomatonQuery {
+    public static StringScriptFieldFuzzyQuery build(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String term,
+        int maxEdits,
+        int prefixLength,
+        boolean transpositions
+    ) {
+        int maxExpansions = 1; // We don't actually expand anything so the value here doesn't matter
+        FuzzyQuery delegate = new FuzzyQuery(new Term(fieldName, term), maxEdits, prefixLength, maxExpansions, transpositions);
+        ByteRunAutomaton automaton = delegate.getAutomata().runAutomaton;
+        return new StringScriptFieldFuzzyQuery(script, leafFactory, fieldName, automaton, delegate);
+    }
+
+    private final FuzzyQuery delegate;
+
+    private StringScriptFieldFuzzyQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        ByteRunAutomaton automaton,
+        FuzzyQuery delegate
+    ) {
+        super(script, leafFactory, fieldName, automaton);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public final String toString(String field) {
+        return delegate.toString(field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), delegate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldFuzzyQuery other = (StringScriptFieldFuzzyQuery) obj;
+        return delegate.equals(other.delegate);
+    }
+
+    FuzzyQuery delegate() {
+        return delegate;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQuery.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Objects;
+
+public class StringScriptFieldRangeQuery extends AbstractStringScriptFieldQuery {
+    private final String lowerValue;
+    private final String upperValue;
+    private final boolean includeLower;
+    private final boolean includeUpper;
+
+    public StringScriptFieldRangeQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String lowerValue,
+        String upperValue,
+        boolean includeLower,
+        boolean includeUpper
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lowerValue = Objects.requireNonNull(lowerValue);
+        this.upperValue = Objects.requireNonNull(upperValue);
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
+        assert lowerValue.compareTo(upperValue) <= 0;
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        for (String value : values) {
+            int lct = lowerValue.compareTo(value);
+            boolean lowerOk = includeLower ? lct <= 0 : lct < 0;
+            if (lowerOk) {
+                int uct = upperValue.compareTo(value);
+                boolean upperOk = includeUpper ? uct >= 0 : uct > 0;
+                if (upperOk) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.consumeTermsMatching(
+                this,
+                fieldName(),
+                () -> new ByteRunAutomaton(
+                    Automata.makeBinaryInterval(new BytesRef(lowerValue), includeLower, new BytesRef(upperValue), includeUpper)
+                )
+            );
+        }
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append(includeLower ? '[' : '{');
+        b.append(lowerValue).append(" TO ").append(upperValue);
+        b.append(includeUpper ? ']' : '}');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lowerValue, upperValue, includeLower, includeUpper);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldRangeQuery other = (StringScriptFieldRangeQuery) obj;
+        return lowerValue.equals(other.lowerValue)
+            && upperValue.equals(other.upperValue)
+            && includeLower == other.includeLower
+            && includeUpper == other.includeUpper;
+    }
+
+    String lowerValue() {
+        return lowerValue;
+    }
+
+    String upperValue() {
+        return upperValue;
+    }
+
+    boolean includeLower() {
+        return includeLower;
+    }
+
+    boolean includeUpper() {
+        return includeUpper;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutomatonQuery {
+    private final String pattern;
+    private final int flags;
+
+    public StringScriptFieldRegexpQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String pattern,
+        int flags,
+        int maxDeterminizedStates
+    ) {
+        super(
+            script,
+            leafFactory,
+            fieldName,
+            new ByteRunAutomaton(new RegExp(Objects.requireNonNull(pattern), flags).toAutomaton(maxDeterminizedStates))
+        );
+        this.pattern = pattern;
+        this.flags = flags;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        return b.append('/').append(pattern).append('/').toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pattern, flags);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldRegexpQuery other = (StringScriptFieldRegexpQuery) obj;
+        return pattern.equals(other.pattern) && flags == other.flags;
+    }
+
+    String pattern() {
+        return pattern;
+    }
+
+    int flags() {
+        return flags;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQuery.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.runtimefields.query;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.QueryVisitor;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
 
 import java.util.List;
@@ -17,13 +18,18 @@ import java.util.Set;
 public class StringScriptFieldTermsQuery extends AbstractStringScriptFieldQuery {
     private final Set<String> terms;
 
-    public StringScriptFieldTermsQuery(StringScriptFieldScript.LeafFactory leafFactory, String fieldName, Set<String> terms) {
-        super(leafFactory, fieldName);
+    public StringScriptFieldTermsQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        Set<String> terms
+    ) {
+        super(script, leafFactory, fieldName);
         this.terms = terms;
     }
 
     @Override
-    public boolean matches(List<String> values) {
+    protected boolean matches(List<String> values) {
         for (String value : values) {
             if (terms.contains(value)) {
                 return true;

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldWildcardQuery extends AbstractStringScriptFieldAutomatonQuery {
+    private final String pattern;
+
+    public StringScriptFieldWildcardQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String pattern
+    ) {
+        super(
+            script,
+            leafFactory,
+            fieldName,
+            new ByteRunAutomaton(WildcardQuery.toAutomaton(new Term(fieldName, Objects.requireNonNull(pattern))))
+        );
+        this.pattern = pattern;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().equals(field)) {
+            return pattern;
+        }
+        return fieldName() + ":" + pattern;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pattern);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldWildcardQuery other = (StringScriptFieldWildcardQuery) obj;
+        return pattern.equals(other.pattern);
+    }
+
+    String pattern() {
+        return pattern;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQueryTestCase.java
@@ -6,11 +6,22 @@
 
 package org.elasticsearch.xpack.runtimefields.query;
 
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 
 public abstract class AbstractStringScriptFieldQueryTestCase<T extends AbstractStringScriptFieldQuery> extends ESTestCase {
@@ -22,9 +33,15 @@ public abstract class AbstractStringScriptFieldQueryTestCase<T extends AbstractS
 
     protected abstract T mutate(T orig);
 
+    protected final Script randomScript() {
+        return new Script(randomAlphaOfLength(10));
+    }
+
     public final void testEqualsAndHashCode() {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::mutate);
     }
+
+    public abstract void testMatches();
 
     public final void testToString() {
         T query = createTestInstance();
@@ -34,4 +51,27 @@ public abstract class AbstractStringScriptFieldQueryTestCase<T extends AbstractS
     protected abstract void assertToString(T query);
 
     public abstract void testVisit();
+
+    /**
+     * {@link Query#visit Visit} a query, collecting {@link ByteRunAutomaton automata},
+     * failing if there are any terms or if there are more than one automaton.
+     */
+    protected final ByteRunAutomaton visitForSingleAutomata(T testQuery) {
+        List<ByteRunAutomaton> automata = new ArrayList<>();
+        testQuery.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                fail();
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                assertThat(query, sameInstance(testQuery));
+                assertThat(field, equalTo(testQuery.fieldName()));
+                automata.add(automaton.get());
+            }
+        });
+        assertThat(automata, hasSize(1));
+        return automata.get(0);
+    }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -18,22 +19,31 @@ import static org.hamcrest.Matchers.equalTo;
 public class StringScriptFieldExistsQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldExistsQuery> {
     @Override
     protected StringScriptFieldExistsQuery createTestInstance() {
-        return new StringScriptFieldExistsQuery(leafFactory, randomAlphaOfLength(5));
+        return new StringScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
     }
 
     @Override
     protected StringScriptFieldExistsQuery copy(StringScriptFieldExistsQuery orig) {
-        return new StringScriptFieldExistsQuery(leafFactory, orig.fieldName());
+        return new StringScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
     }
 
     @Override
     protected StringScriptFieldExistsQuery mutate(StringScriptFieldExistsQuery orig) {
-        return new StringScriptFieldExistsQuery(leafFactory, orig.fieldName() + "modified");
+        if (randomBoolean()) {
+            new StringScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new StringScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(List.of("test")));
+        assertFalse(createTestInstance().matches(List.of()));
     }
 
     @Override
     protected void assertToString(StringScriptFieldExistsQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo("*"));
+        assertThat(query.toString(query.fieldName()), equalTo("ScriptFieldExists"));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldFuzzyQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldFuzzyQuery> {
+    @Override
+    protected StringScriptFieldFuzzyQuery createTestInstance() {
+        String term = randomAlphaOfLength(6);
+        return StringScriptFieldFuzzyQuery.build(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            term,
+            randomIntBetween(0, 2),
+            randomIntBetween(0, term.length()),
+            randomBoolean()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldFuzzyQuery copy(StringScriptFieldFuzzyQuery orig) {
+        return StringScriptFieldFuzzyQuery.build(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.delegate().getTerm().bytes().utf8ToString(),
+            orig.delegate().getMaxEdits(),
+            orig.delegate().getPrefixLength(),
+            orig.delegate().getTranspositions()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldFuzzyQuery mutate(StringScriptFieldFuzzyQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String term = orig.delegate().getTerm().bytes().utf8ToString();
+        int maxEdits = orig.delegate().getMaxEdits();
+        int prefixLength = orig.delegate().getPrefixLength();
+        boolean transpositions = orig.delegate().getTranspositions();
+        switch (randomInt(5)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term += "modified";
+                break;
+            case 3:
+                maxEdits = randomValueOtherThan(maxEdits, () -> randomIntBetween(0, 2));
+                break;
+            case 4:
+                prefixLength += 1;
+                break;
+            case 5:
+                transpositions = !transpositions;
+                break;
+            default:
+                fail();
+        }
+        return StringScriptFieldFuzzyQuery.build(script, leafFactory, fieldName, term, maxEdits, prefixLength, transpositions);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldFuzzyQuery query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 1, 0, false);
+        assertTrue(query.matches(List.of("foo")));
+        assertTrue(query.matches(List.of("foa")));
+        assertTrue(query.matches(List.of("foo", "bar")));
+        assertFalse(query.matches(List.of("bar")));
+        query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 0, 0, false);
+        assertTrue(query.matches(List.of("foo")));
+        assertFalse(query.matches(List.of("foa")));
+        query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 2, 0, false);
+        assertTrue(query.matches(List.of("foo")));
+        assertTrue(query.matches(List.of("foa")));
+        assertTrue(query.matches(List.of("faa")));
+        assertFalse(query.matches(List.of("faaa")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldFuzzyQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.delegate().getTerm().bytes().utf8ToString()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldFuzzyQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = query.delegate().getTerm().bytes();
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.delegate().getTerm().bytes().utf8ToString() + "a");
+        assertThat(
+            automaton.run(term.bytes, term.offset, term.length),
+            is(query.delegate().getMaxEdits() > 0 && query.delegate().getPrefixLength() < term.length)
+        );
+        term = new BytesRef(query.delegate().getTerm().bytes().utf8ToString() + "abba");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldPrefixQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldPrefixQuery> {
+    @Override
+    protected StringScriptFieldPrefixQuery createTestInstance() {
+        return new StringScriptFieldPrefixQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected StringScriptFieldPrefixQuery copy(StringScriptFieldPrefixQuery orig) {
+        return new StringScriptFieldPrefixQuery(orig.script(), leafFactory, orig.fieldName(), orig.prefix());
+    }
+
+    @Override
+    protected StringScriptFieldPrefixQuery mutate(StringScriptFieldPrefixQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String prefix = orig.prefix();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                prefix += "modified";
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldPrefixQuery(script, leafFactory, fieldName, prefix);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldPrefixQuery query = new StringScriptFieldPrefixQuery(randomScript(), leafFactory, "test", "foo");
+        assertTrue(query.matches(List.of("foo")));
+        assertTrue(query.matches(List.of("foooo")));
+        assertFalse(query.matches(List.of("fo")));
+        assertTrue(query.matches(List.of("fo", "foo")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldPrefixQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.prefix()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldPrefixQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef(query.prefix());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.prefix() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef("a" + query.prefix());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldRangeQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldRangeQuery> {
+    @Override
+    protected StringScriptFieldRangeQuery createTestInstance() {
+        String lower = randomAlphaOfLength(3);
+        String upper = randomValueOtherThan(lower, () -> randomAlphaOfLength(3));
+        if (lower.compareTo(upper) > 0) {
+            String tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new StringScriptFieldRangeQuery(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            lower,
+            upper,
+            randomBoolean(),
+            randomBoolean()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRangeQuery copy(StringScriptFieldRangeQuery orig) {
+        return new StringScriptFieldRangeQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.lowerValue(),
+            orig.upperValue(),
+            orig.includeLower(),
+            orig.includeUpper()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRangeQuery mutate(StringScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String lower = orig.lowerValue();
+        String upper = orig.upperValue();
+        boolean includeLower = orig.includeLower();
+        boolean includeUpper = orig.includeUpper();
+        switch (randomInt(5)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                lower += "modified";
+                break;
+            case 3:
+                upper += "modified";
+                break;
+            case 4:
+                includeLower = !includeLower;
+                break;
+            case 5:
+                includeUpper = !includeUpper;
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldRangeQuery(script, leafFactory, fieldName, lower, upper, includeLower, includeUpper);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldRangeQuery query = new StringScriptFieldRangeQuery(randomScript(), leafFactory, "test", "a", "b", true, true);
+        assertTrue(query.matches(List.of("a")));
+        assertTrue(query.matches(List.of("ab")));
+        assertTrue(query.matches(List.of("b")));
+        assertFalse(query.matches(List.of("ba")));
+        assertTrue(query.matches(List.of("a", "c")));
+        query = new StringScriptFieldRangeQuery(randomScript(), leafFactory, "test", "a", "b", false, false);
+        assertFalse(query.matches(List.of("a")));
+        assertTrue(query.matches(List.of("ab")));
+        assertFalse(query.matches(List.of("b")));
+        assertFalse(query.matches(List.of("ba")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldRangeQuery query) {
+        assertThat(query.toString(query.fieldName()), containsString(query.includeLower() ? "[" : "{"));
+        assertThat(query.toString(query.fieldName()), containsString(query.includeUpper() ? "]" : "}"));
+        assertThat(query.toString(query.fieldName()), containsString(query.lowerValue() + " TO " + query.upperValue()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldRangeQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef(query.lowerValue() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.lowerValue());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(query.includeLower()));
+        term = new BytesRef(query.upperValue() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+        term = new BytesRef(query.upperValue());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(query.includeUpper()));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.script.Script;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldRegexpQuery> {
+    @Override
+    protected StringScriptFieldRegexpQuery createTestInstance() {
+        return new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(6),
+            randomInt(0xFFFF),
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRegexpQuery copy(StringScriptFieldRegexpQuery orig) {
+        return new StringScriptFieldRegexpQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.pattern(),
+            orig.flags(),
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRegexpQuery mutate(StringScriptFieldRegexpQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String pattern = orig.pattern();
+        int flags = orig.flags();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                pattern += "modified";
+                break;
+            case 3:
+                flags = randomValueOtherThan(flags, () -> randomInt(0xFFFF));
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldRegexpQuery(script, leafFactory, fieldName, pattern, flags, Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldRegexpQuery query = new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            "a.+b",
+            0,
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+        assertTrue(query.matches(List.of("astuffb")));
+        assertFalse(query.matches(List.of("fffff")));
+        assertFalse(query.matches(List.of("ab")));
+        assertFalse(query.matches(List.of("aasdf")));
+        assertFalse(query.matches(List.of("dsfb")));
+        assertTrue(query.matches(List.of("astuffb", "fffff")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldRegexpQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("/" + query.pattern() + "/"));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldRegexpQuery query = new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            "a.+b",
+            0,
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef("astuffb");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldWildcardQuery> {
+    @Override
+    protected StringScriptFieldWildcardQuery createTestInstance() {
+        return new StringScriptFieldWildcardQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected StringScriptFieldWildcardQuery copy(StringScriptFieldWildcardQuery orig) {
+        return new StringScriptFieldWildcardQuery(orig.script(), leafFactory, orig.fieldName(), orig.pattern());
+    }
+
+    @Override
+    protected StringScriptFieldWildcardQuery mutate(StringScriptFieldWildcardQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String pattern = orig.pattern();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                pattern += "modified";
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldWildcardQuery(script, leafFactory, fieldName, pattern);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        assertTrue(query.matches(List.of("astuffb")));
+        assertFalse(query.matches(List.of("fffff")));
+        assertFalse(query.matches(List.of("a")));
+        assertFalse(query.matches(List.of("b")));
+        assertFalse(query.matches(List.of("aasdf")));
+        assertFalse(query.matches(List.of("dsfb")));
+        assertTrue(query.matches(List.of("astuffb", "fffff")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldWildcardQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("/" + query.pattern() + "/"));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef("astuffb");
+        assertTrue(automaton.run(term.bytes, term.offset, term.length));
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -90,6 +90,58 @@ setup:
   - match: {hits.hits.1._source.voltage: 5.2}
 
 ---
+"fuzzy query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            fuzzy:
+              day_of_week:
+                value: Manday
+                fuzziness: 1
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"prefix query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            prefix:
+              day_of_week: M
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"range query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              day_of_week:
+                gt: M
+                lt: N
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"regexp query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            regexp:
+              day_of_week: M[aeiou]nday
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
 "term query":
   - do:
       search:
@@ -114,3 +166,15 @@ setup:
   - match: {hits.total.value: 2}
   - match: {hits.hits.0._source.voltage: 5.8}
   - match: {hits.hits.1._source.voltage: 5.2}
+
+---
+"wildcard query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            wildcard:
+              day_of_week: M*ay
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}


### PR DESCRIPTION
Adds the remaining queries for scripted keyword fields and handles a few
leftover TODOs, mostly around `hashCode` and `equals`.
