### PR TITLE
EQL: Fix async EQL Rest test (#59556)

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/10_basic.yml
@@ -32,11 +32,10 @@ setup:
       eql.search:
         index: eql_test
         wait_for_completion_timeout: "0ms"
+        keep_on_completion: true
         body:
           query: "process where user = 'SYSTEM'"
 
-  - match: {is_running: true}
-  - match: {is_partial: true}
   - is_true: id
   - set: {id: id}
 


### PR DESCRIPTION
Unfortunately, we cannot guarantee that the execution will be truly
async even with 0ms timeout since we cannot block the execution. So, we need
to modify the test to work in both async and non-async mode.

Closes #59416
