### PR TITLE
Allow runtime fields to depend on one another

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -297,8 +297,7 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public SearchLookup lookup() {
         if (lookup == null) {
-            lookup = new SearchLookup(getMapperService(),
-                    mappedFieldType -> indexFieldDataService.apply(mappedFieldType, fullyQualifiedIndex.getName()));
+            lookup = new SearchLookup(getMapperService(), this::getForField);
         }
         return lookup;
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -25,9 +25,10 @@ setup:
                 type: script
                 runtime_type: keyword
                 script: |
-                  String dow = doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT);
-                  if (dow.startsWith('T')) {
-                    value(dow);
+                  for (String dow: doc['day_of_week']) {
+                    if (dow.startsWith('T')) {
+                      value(dow);
+                    }
                   }
 
   - do:


### PR DESCRIPTION
This updates a test so that runtime fields depend on one another and
fixes support for it.

Relates to #59332
