### PR TITLE
Only install stack templates via elected master node

### DIFF
--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -137,4 +137,15 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
     protected String getOrigin() {
         return ClientHelper.STACK_ORIGIN;
     }
+
+    @Override
+    protected boolean requiresMasterNode() {
+        // Stack templates use the composable index template and component APIs,
+        // these APIs aren't supported in 7.7 and earlier and in mixed cluster
+        // environments this can cause a lot of ActionNotFoundTransportException
+        // errors in the logs during rolling upgrades. If these templates
+        // are only installed via elected master node then the APIs are always
+        // there and the ActionNotFoundTransportException errors are then prevented.
+        return true;
+    }
 }


### PR DESCRIPTION
Backport of #59624 to 7.9 branch.

to avoid many error stacktraces in logs during a rolling upgrade.

Stack templates use the composable index template and component APIs,these APIs
aren't supported in 7.7 and earlier and in mixed cluster
environments this can cause a lot of ActionNotFoundTransportException
errors in the logs during rolling upgrades. If these templates
are only installed via elected master node then the APIs are always
there and the ActionNotFoundTransportException errors are then prevented.
