### PR TITLE
EQL: Fix bug in returning results

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -288,6 +288,8 @@ public class TumblingWindow implements Executable {
     private void payload(ActionListener<Payload> listener) {
         List<Sequence> completed = matcher.completed();
 
+        log.trace("Sending payload for [{}] sequences", completed.size());
+
         if (completed.isEmpty()) {
             listener.onResponse(new EmptyPayload(Type.SEQUENCE, timeTook()));
             matcher.clear();


### PR DESCRIPTION
Using serialization/deserialization when dealing with non-trivial
documents causes the process to get stuck not to mention it is expensive.
Use a much more trivial approach at the expense of losing information
(we're just interested in the source after all).