### PR TITLE
Scripting: fix generateContextDoc path and url

### DIFF
--- a/docs/painless/painless-api-reference/index.asciidoc
+++ b/docs/painless/painless-api-reference/index.asciidoc
@@ -2,8 +2,8 @@
 
 [cols="<3,^3,^3"]
 |====
-|Aggregation Selector | <<painless-api-reference-shared, Shared API>> | 
-|Aggs | <<painless-api-reference-shared, Shared API>> | 
+|Aggregation Selector | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-aggregation-selector, Specialized API>>
+|Aggs | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-aggs, Specialized API>>
 |Aggs Combine | <<painless-api-reference-shared, Shared API>> | 
 |Aggs Init | <<painless-api-reference-shared, Shared API>> | 
 |Aggs Map | <<painless-api-reference-shared, Shared API>> | 
@@ -11,18 +11,18 @@
 |Analysis | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-analysis, Specialized API>>
 |Bucket Aggregation | <<painless-api-reference-shared, Shared API>> | 
 |Field | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-field, Specialized API>>
-|Filter | <<painless-api-reference-shared, Shared API>> | 
+|Filter | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-filter, Specialized API>>
 |Ingest | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-ingest, Specialized API>>
 |Interval | <<painless-api-reference-shared, Shared API>> | 
 |Moving Function | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-moving-function, Specialized API>>
-|Number Sort | <<painless-api-reference-shared, Shared API>> | 
+|Number Sort | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-number-sort, Specialized API>>
 |Painless Test | <<painless-api-reference-shared, Shared API>> | 
 |Processor Conditional | <<painless-api-reference-shared, Shared API>> | 
 |Score | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-score, Specialized API>>
 |Script Heuristic | <<painless-api-reference-shared, Shared API>> | 
 |Similarity | <<painless-api-reference-shared, Shared API>> | 
 |Similarity Weight | <<painless-api-reference-shared, Shared API>> | 
-|String Sort | <<painless-api-reference-shared, Shared API>> | 
+|String Sort | <<painless-api-reference-shared, Shared API>> | <<painless-api-reference-string-sort, Specialized API>>
 |Template | <<painless-api-reference-shared, Shared API>> | 
 |Terms Set | <<painless-api-reference-shared, Shared API>> | 
 |Update | <<painless-api-reference-shared, Shared API>> | 
@@ -32,8 +32,13 @@
 |====
 
 include::painless-api-reference-shared/index.asciidoc[]
+include::painless-api-reference-aggregation-selector/index.asciidoc[]
+include::painless-api-reference-aggs/index.asciidoc[]
 include::painless-api-reference-analysis/index.asciidoc[]
 include::painless-api-reference-field/index.asciidoc[]
+include::painless-api-reference-filter/index.asciidoc[]
 include::painless-api-reference-ingest/index.asciidoc[]
 include::painless-api-reference-moving-function/index.asciidoc[]
+include::painless-api-reference-number-sort/index.asciidoc[]
 include::painless-api-reference-score/index.asciidoc[]
+include::painless-api-reference-string-sort/index.asciidoc[]

--- a/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/index.asciidoc
@@ -11,16 +11,6 @@ The following specialized API is available in the Aggregation Selector context.
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-aggregation-selector-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-aggregation-selector-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/index.asciidoc
@@ -1,0 +1,36 @@
+// This file is auto-generated. Do not edit.
+
+[[painless-api-reference-aggregation-selector]]
+=== Aggregation Selector API
+
+The following specialized API is available in the Aggregation Selector context.
+
+* See the <<painless-api-reference-shared, Shared API>> for further API available in all contexts.
+
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-aggregation-selector-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-aggregation-selector-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-aggregation-selector-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-aggregation-selector-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-aggregation-selector-IntervalYearMonth, IntervalYearMonth>>
+
+include::packages.asciidoc[]
+

--- a/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Aggregation Selector API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-aggregation-selector-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Aggregation Selector API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-aggregation-selector-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === Aggregation Selector API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggregation-selector/packages.asciidoc
@@ -1,11 +1,11 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
+=== Aggregation Selector API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalEqlScriptUtils]]
+[[painless-api-reference-aggregation-selector-InternalEqlScriptUtils]]
 ==== InternalEqlScriptUtils
 * static String between(String, String, String, Boolean, Boolean)
 * static Boolean cidrMatch(String, List)
@@ -22,11 +22,11 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
+=== Aggregation Selector API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalQlScriptUtils]]
+[[painless-api-reference-aggregation-selector-InternalQlScriptUtils]]
 ==== InternalQlScriptUtils
 * static Number add(Number, Number)
 * static Boolean and(Boolean, Boolean)
@@ -58,29 +58,29 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-geo"]
+=== Aggregation Selector API for package org.elasticsearch.xpack.sql.expression.literal.geo
+See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-GeoShape]]
+[[painless-api-reference-aggregation-selector-GeoShape]]
 ==== GeoShape
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.interval
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggregation-selector-org-elasticsearch-xpack-sql-expression-literal-interval"]
+=== Aggregation Selector API for package org.elasticsearch.xpack.sql.expression.literal.interval
+See the <<painless-api-reference-aggregation-selector, Aggregation Selector API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-IntervalDayTime]]
+[[painless-api-reference-aggregation-selector-IntervalDayTime]]
 ==== IntervalDayTime
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[[painless-api-reference-field-IntervalYearMonth]]
+[[painless-api-reference-aggregation-selector-IntervalYearMonth]]
 ==== IntervalYearMonth
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()

--- a/docs/painless/painless-api-reference/painless-api-reference-aggs/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggs/index.asciidoc
@@ -1,0 +1,36 @@
+// This file is auto-generated. Do not edit.
+
+[[painless-api-reference-aggs]]
+=== Aggs API
+
+The following specialized API is available in the Aggs context.
+
+* See the <<painless-api-reference-shared, Shared API>> for further API available in all contexts.
+
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-aggs-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-aggs-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-aggs-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-aggs-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-aggs-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-aggs-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-aggs-IntervalYearMonth, IntervalYearMonth>>
+
+include::packages.asciidoc[]
+

--- a/docs/painless/painless-api-reference/painless-api-reference-aggs/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggs/index.asciidoc
@@ -11,16 +11,6 @@ The following specialized API is available in the Aggs context.
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-aggs-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-aggs-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-aggs-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-aggs-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-aggs/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggs/packages.asciidoc
@@ -1,11 +1,11 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
+=== Aggs API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalEqlScriptUtils]]
+[[painless-api-reference-aggs-InternalEqlScriptUtils]]
 ==== InternalEqlScriptUtils
 * static String between(String, String, String, Boolean, Boolean)
 * static Boolean cidrMatch(String, List)
@@ -22,11 +22,11 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
+=== Aggs API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalQlScriptUtils]]
+[[painless-api-reference-aggs-InternalQlScriptUtils]]
 ==== InternalQlScriptUtils
 * static Number add(Number, Number)
 * static Boolean and(Boolean, Boolean)
@@ -58,29 +58,29 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-geo"]
+=== Aggs API for package org.elasticsearch.xpack.sql.expression.literal.geo
+See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-GeoShape]]
+[[painless-api-reference-aggs-GeoShape]]
 ==== GeoShape
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.interval
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-interval"]
+=== Aggs API for package org.elasticsearch.xpack.sql.expression.literal.interval
+See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-IntervalDayTime]]
+[[painless-api-reference-aggs-IntervalDayTime]]
 ==== IntervalDayTime
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[[painless-api-reference-field-IntervalYearMonth]]
+[[painless-api-reference-aggs-IntervalYearMonth]]
 ==== IntervalYearMonth
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()

--- a/docs/painless/painless-api-reference/painless-api-reference-aggs/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-aggs/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Aggs API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-aggs-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Aggs API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-aggs-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-aggs-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === Aggs API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-aggs, Aggs API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-field/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-field/index.asciidoc
@@ -13,5 +13,30 @@ The following methods are directly callable without a class/instance qualifier. 
 * List domainSplit(String)
 * List domainSplit(String, Map)
 
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-field-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-field-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-field-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-field-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-field-IntervalYearMonth, IntervalYearMonth>>
+
 include::packages.asciidoc[]
 

--- a/docs/painless/painless-api-reference/painless-api-reference-field/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-field/index.asciidoc
@@ -17,16 +17,6 @@ The following methods are directly callable without a class/instance qualifier. 
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-field-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-field-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-field/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-field/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-field-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-field-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-filter/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-filter/index.asciidoc
@@ -11,16 +11,6 @@ The following specialized API is available in the Filter context.
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-filter-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-filter-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-filter-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-filter-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-filter/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-filter/index.asciidoc
@@ -1,0 +1,36 @@
+// This file is auto-generated. Do not edit.
+
+[[painless-api-reference-filter]]
+=== Filter API
+
+The following specialized API is available in the Filter context.
+
+* See the <<painless-api-reference-shared, Shared API>> for further API available in all contexts.
+
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-filter-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-filter-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-filter-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-filter-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-filter-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-filter-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-filter-IntervalYearMonth, IntervalYearMonth>>
+
+include::packages.asciidoc[]
+

--- a/docs/painless/painless-api-reference/painless-api-reference-filter/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-filter/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Filter API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-filter-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Filter API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-filter-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === Filter API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-filter/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-filter/packages.asciidoc
@@ -1,11 +1,11 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
+=== Filter API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalEqlScriptUtils]]
+[[painless-api-reference-filter-InternalEqlScriptUtils]]
 ==== InternalEqlScriptUtils
 * static String between(String, String, String, Boolean, Boolean)
 * static Boolean cidrMatch(String, List)
@@ -22,11 +22,11 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
+=== Filter API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalQlScriptUtils]]
+[[painless-api-reference-filter-InternalQlScriptUtils]]
 ==== InternalQlScriptUtils
 * static Number add(Number, Number)
 * static Boolean and(Boolean, Boolean)
@@ -58,29 +58,29 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-geo"]
+=== Filter API for package org.elasticsearch.xpack.sql.expression.literal.geo
+See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-GeoShape]]
+[[painless-api-reference-filter-GeoShape]]
 ==== GeoShape
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.interval
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-filter-org-elasticsearch-xpack-sql-expression-literal-interval"]
+=== Filter API for package org.elasticsearch.xpack.sql.expression.literal.interval
+See the <<painless-api-reference-filter, Filter API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-IntervalDayTime]]
+[[painless-api-reference-filter-IntervalDayTime]]
 ==== IntervalDayTime
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[[painless-api-reference-field-IntervalYearMonth]]
+[[painless-api-reference-filter-IntervalYearMonth]]
 ==== IntervalYearMonth
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()

--- a/docs/painless/painless-api-reference/painless-api-reference-number-sort/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-number-sort/index.asciidoc
@@ -11,16 +11,6 @@ The following specialized API is available in the Number Sort context.
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-number-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-number-sort-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-number-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-number-sort-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-number-sort/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-number-sort/index.asciidoc
@@ -1,0 +1,36 @@
+// This file is auto-generated. Do not edit.
+
+[[painless-api-reference-number-sort]]
+=== Number Sort API
+
+The following specialized API is available in the Number Sort context.
+
+* See the <<painless-api-reference-shared, Shared API>> for further API available in all contexts.
+
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-number-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-number-sort-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-number-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-number-sort-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-number-sort-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-number-sort-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-number-sort-IntervalYearMonth, IntervalYearMonth>>
+
+include::packages.asciidoc[]
+

--- a/docs/painless/painless-api-reference/painless-api-reference-number-sort/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-number-sort/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Number Sort API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-number-sort-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Number Sort API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-number-sort-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === Number Sort API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-number-sort/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-number-sort/packages.asciidoc
@@ -1,11 +1,11 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
+=== Number Sort API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalEqlScriptUtils]]
+[[painless-api-reference-number-sort-InternalEqlScriptUtils]]
 ==== InternalEqlScriptUtils
 * static String between(String, String, String, Boolean, Boolean)
 * static Boolean cidrMatch(String, List)
@@ -22,11 +22,11 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
+=== Number Sort API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalQlScriptUtils]]
+[[painless-api-reference-number-sort-InternalQlScriptUtils]]
 ==== InternalQlScriptUtils
 * static Number add(Number, Number)
 * static Boolean and(Boolean, Boolean)
@@ -58,29 +58,29 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-geo"]
+=== Number Sort API for package org.elasticsearch.xpack.sql.expression.literal.geo
+See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-GeoShape]]
+[[painless-api-reference-number-sort-GeoShape]]
 ==== GeoShape
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.interval
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-number-sort-org-elasticsearch-xpack-sql-expression-literal-interval"]
+=== Number Sort API for package org.elasticsearch.xpack.sql.expression.literal.interval
+See the <<painless-api-reference-number-sort, Number Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-IntervalDayTime]]
+[[painless-api-reference-number-sort-IntervalDayTime]]
 ==== IntervalDayTime
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[[painless-api-reference-field-IntervalYearMonth]]
+[[painless-api-reference-number-sort-IntervalYearMonth]]
 ==== IntervalYearMonth
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()

--- a/docs/painless/painless-api-reference/painless-api-reference-score/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-score/index.asciidoc
@@ -10,7 +10,7 @@ The following specialized API is available in the Score context.
 ==== Static Methods
 The following methods are directly callable without a class/instance qualifier. Note parameters denoted by a (*) are treated as read-only values.
 
-* double cosineSimilarity(List *, String)
+* double cosineSimilarity(List *, String *)
 * double decayDateExp(String *, String *, String *, double *, JodaCompatibleZonedDateTime)
 * double decayDateGauss(String *, String *, String *, double *, JodaCompatibleZonedDateTime)
 * double decayDateLinear(String *, String *, String *, double *, JodaCompatibleZonedDateTime)
@@ -20,7 +20,9 @@ The following methods are directly callable without a class/instance qualifier. 
 * double decayNumericExp(double *, double *, double *, double *, double)
 * double decayNumericGauss(double *, double *, double *, double *, double)
 * double decayNumericLinear(double *, double *, double *, double *, double)
-* double dotProduct(List, String)
+* double dotProduct(List *, String *)
+* double l1norm(List *, String *)
+* double l2norm(List *, String *)
 * double randomScore(int *)
 * double randomScore(int *, String *)
 * double saturation(double, double)
@@ -30,8 +32,8 @@ The following methods are directly callable without a class/instance qualifier. 
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.index.query
-<<painless-api-reference-score-org-elasticsearch-index-query, Expand details for org.elasticsearch.index.query>>
+==== org.elasticsearch.xpack.vectors.query
+<<painless-api-reference-score-org-elasticsearch-xpack-vectors-query, Expand details for org.elasticsearch.xpack.vectors.query>>
 
 * <<painless-api-reference-score-DenseVectorScriptDocValues, DenseVectorScriptDocValues>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-score/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-score/packages.asciidoc
@@ -1,8 +1,8 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-score-org-elasticsearch-index-query"]
-=== Score API for package org.elasticsearch.index.query
+[role="exclude",id="painless-api-reference-score-org-elasticsearch-xpack-vectors-query"]
+=== Score API for package org.elasticsearch.xpack.vectors.query
 See the <<painless-api-reference-score, Score API>> for a high-level overview of all packages and classes.
 
 [[painless-api-reference-score-DenseVectorScriptDocValues]]
@@ -59,3 +59,5 @@ See the <<painless-api-reference-score, Score API>> for a high-level overview of
 * def[] {java11-javadoc}/java.base/java/util/Collection.html#toArray()[toArray]()
 * def[] {java11-javadoc}/java.base/java/util/Collection.html#toArray(java.lang.Object%5B%5D)[toArray](def[])
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
+
+

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
@@ -426,6 +426,7 @@ The following classes are available grouped by their respective packages. Click 
 <<painless-api-reference-shared-org-elasticsearch-script, Expand details for org.elasticsearch.script>>
 
 * <<painless-api-reference-shared-JodaCompatibleZonedDateTime, JodaCompatibleZonedDateTime>>
+* <<painless-api-reference-shared-ScoreScript-ExplanationHolder, ScoreScript.ExplanationHolder>>
 
 ==== org.elasticsearch.search.lookup
 <<painless-api-reference-shared-org-elasticsearch-search-lookup, Expand details for org.elasticsearch.search.lookup>>

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
@@ -426,7 +426,6 @@ The following classes are available grouped by their respective packages. Click 
 <<painless-api-reference-shared-org-elasticsearch-script, Expand details for org.elasticsearch.script>>
 
 * <<painless-api-reference-shared-JodaCompatibleZonedDateTime, JodaCompatibleZonedDateTime>>
-* <<painless-api-reference-shared-ScoreScript-ExplanationHolder, ScoreScript.ExplanationHolder>>
 
 ==== org.elasticsearch.search.lookup
 <<painless-api-reference-shared-org-elasticsearch-search-lookup, Expand details for org.elasticsearch.search.lookup>>

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
@@ -7117,6 +7117,7 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 ==== UUID
 * static UUID {java11-javadoc}/java.base/java/util/UUID.html#fromString(java.lang.String)[fromString](String)
 * static UUID {java11-javadoc}/java.base/java/util/UUID.html#nameUUIDFromBytes(byte%5B%5D)[nameUUIDFromBytes](byte[])
+* static UUID {java11-javadoc}/java.base/java/util/UUID.html#randomUUID()[randomUUID]()
 * {java11-javadoc}/java.base/java/util/UUID.html#<init>(long,long)[UUID](long, long)
 * int {java11-javadoc}/java.base/java/util/UUID.html#clockSequence()[clockSequence]()
 * int {java11-javadoc}/java.base/java/util/UUID.html#compareTo(java.util.UUID)[compareTo](UUID)
@@ -8565,8 +8566,12 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 
 [[painless-api-reference-shared-JodaCompatibleZonedDateTime]]
 ==== JodaCompatibleZonedDateTime
-* boolean equals(Object)
+* int {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#compareTo(java.time.chrono.ChronoZonedDateTime)[compareTo](ChronoZonedDateTime)
+* boolean {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#equals(java.lang.Object)[equals](Object)
+* String {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#format(java.time.format.DateTimeFormatter)[format](DateTimeFormatter)
+* int {java11-javadoc}/java.base/java/time/temporal/TemporalAccessor.html#get(java.time.temporal.TemporalField)[get](TemporalField)
 * int getCenturyOfEra()
+* Chronology {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#getChronology()[getChronology]()
 * int getDayOfMonth()
 * int getDayOfWeek()
 * DayOfWeek getDayOfWeekEnum()
@@ -8574,6 +8579,7 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * int getEra()
 * int getHour()
 * int getHourOfDay()
+* long {java11-javadoc}/java.base/java/time/temporal/TemporalAccessor.html#getLong(java.time.temporal.TemporalField)[getLong](TemporalField)
 * long getMillis()
 * int getMillisOfDay()
 * int getMillisOfSecond()
@@ -8584,6 +8590,7 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * int getMonthOfYear()
 * int getMonthValue()
 * int getNano()
+* ZoneOffset {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#getOffset()[getOffset]()
 * int getSecond()
 * int getSecondOfDay()
 * int getSecondOfMinute()
@@ -8592,11 +8599,12 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * int getYear()
 * int getYearOfCentury()
 * int getYearOfEra()
-* ZoneId getZone()
-* int hashCode()
-* boolean isAfter(JodaCompatibleZonedDateTime)
-* boolean isBefore(JodaCompatibleZonedDateTime)
-* boolean isEqual(JodaCompatibleZonedDateTime)
+* ZoneId {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#getZone()[getZone]()
+* int {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#hashCode()[hashCode]()
+* boolean {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#isAfter(java.time.chrono.ChronoZonedDateTime)[isAfter](ChronoZonedDateTime)
+* boolean {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#isBefore(java.time.chrono.ChronoZonedDateTime)[isBefore](ChronoZonedDateTime)
+* boolean {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#isEqual(java.time.chrono.ChronoZonedDateTime)[isEqual](ChronoZonedDateTime)
+* boolean {java11-javadoc}/java.base/java/time/temporal/TemporalAccessor.html#isSupported(java.time.temporal.TemporalField)[isSupported](TemporalField)
 * ZonedDateTime minus(TemporalAmount)
 * ZonedDateTime minus(long, TemporalUnit)
 * ZonedDateTime minusDays(long)
@@ -8617,14 +8625,19 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * ZonedDateTime plusSeconds(long)
 * ZonedDateTime plusWeeks(long)
 * ZonedDateTime plusYears(long)
-* Instant toInstant()
+* def {java11-javadoc}/java.base/java/time/temporal/TemporalAccessor.html#query(java.time.temporal.TemporalQuery)[query](TemporalQuery)
+* ValueRange {java11-javadoc}/java.base/java/time/temporal/TemporalAccessor.html#range(java.time.temporal.TemporalField)[range](TemporalField)
+* long {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#toEpochSecond()[toEpochSecond]()
+* Instant {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#toInstant()[toInstant]()
 * LocalDate toLocalDate()
 * LocalDateTime toLocalDateTime()
+* LocalTime {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#toLocalTime()[toLocalTime]()
 * OffsetDateTime toOffsetDateTime()
-* String toString()
+* String {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#toString()[toString]()
 * String toString(String)
 * String toString(String, Locale)
 * ZonedDateTime truncatedTo(TemporalUnit)
+* long {java11-javadoc}/java.base/java/time/temporal/Temporal.html#until(java.time.temporal.Temporal,java.time.temporal.TemporalUnit)[until](Temporal, TemporalUnit)
 * ZonedDateTime with(TemporalAdjuster)
 * ZonedDateTime with(TemporalField, long)
 * ZonedDateTime withDayOfMonth(int)
@@ -8640,6 +8653,14 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * ZonedDateTime withYear(int)
 * ZonedDateTime withZoneSameInstant(ZoneId)
 * ZonedDateTime withZoneSameLocal(ZoneId)
+
+
+[[painless-api-reference-shared-ScoreScript-ExplanationHolder]]
+==== ScoreScript.ExplanationHolder
+* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
+* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
+* void set(String)
+* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
 [role="exclude",id="painless-api-reference-shared-org-elasticsearch-search-lookup"]

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
@@ -8655,14 +8655,6 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 * ZonedDateTime withZoneSameLocal(ZoneId)
 
 
-[[painless-api-reference-shared-ScoreScript-ExplanationHolder]]
-==== ScoreScript.ExplanationHolder
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* void set(String)
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-shared-org-elasticsearch-search-lookup"]
 === Shared API for package org.elasticsearch.search.lookup
 See the <<painless-api-reference-shared, Shared API>> for a high-level overview of all packages and classes.

--- a/docs/painless/painless-api-reference/painless-api-reference-string-sort/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-string-sort/index.asciidoc
@@ -11,16 +11,6 @@ The following specialized API is available in the String Sort context.
 The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
 
 
-==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-<<painless-api-reference-string-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-string-sort-InternalEqlScriptUtils, InternalEqlScriptUtils>>
-
-==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-<<painless-api-reference-string-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
-
-* <<painless-api-reference-string-sort-InternalQlScriptUtils, InternalQlScriptUtils>>
-
 ==== org.elasticsearch.xpack.sql.expression.literal.geo
 <<painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-string-sort/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-string-sort/index.asciidoc
@@ -1,0 +1,36 @@
+// This file is auto-generated. Do not edit.
+
+[[painless-api-reference-string-sort]]
+=== String Sort API
+
+The following specialized API is available in the String Sort context.
+
+* See the <<painless-api-reference-shared, Shared API>> for further API available in all contexts.
+
+==== Classes By Package
+The following classes are available grouped by their respective packages. Click on a class to view details about the available methods and fields.
+
+
+==== org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+<<painless-api-reference-string-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.eql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-string-sort-InternalEqlScriptUtils, InternalEqlScriptUtils>>
+
+==== org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+<<painless-api-reference-string-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist, Expand details for org.elasticsearch.xpack.ql.expression.function.scalar.whitelist>>
+
+* <<painless-api-reference-string-sort-InternalQlScriptUtils, InternalQlScriptUtils>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.geo
+<<painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-geo, Expand details for org.elasticsearch.xpack.sql.expression.literal.geo>>
+
+* <<painless-api-reference-string-sort-GeoShape, GeoShape>>
+
+==== org.elasticsearch.xpack.sql.expression.literal.interval
+<<painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-interval, Expand details for org.elasticsearch.xpack.sql.expression.literal.interval>>
+
+* <<painless-api-reference-string-sort-IntervalDayTime, IntervalDayTime>>
+* <<painless-api-reference-string-sort-IntervalYearMonth, IntervalYearMonth>>
+
+include::packages.asciidoc[]
+

--- a/docs/painless/painless-api-reference/painless-api-reference-string-sort/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-string-sort/packages.asciidoc
@@ -1,11 +1,11 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
+=== String Sort API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
+See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalEqlScriptUtils]]
+[[painless-api-reference-string-sort-InternalEqlScriptUtils]]
 ==== InternalEqlScriptUtils
 * static String between(String, String, String, Boolean, Boolean)
 * static Boolean cidrMatch(String, List)
@@ -22,11 +22,11 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== Field API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
+=== String Sort API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
+See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-InternalQlScriptUtils]]
+[[painless-api-reference-string-sort-InternalQlScriptUtils]]
 ==== InternalQlScriptUtils
 * static Number add(Number, Number)
 * static Boolean and(Boolean, Boolean)
@@ -58,29 +58,29 @@ See the <<painless-api-reference-field, Field API>> for a high-level overview of
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-geo"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.geo
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-geo"]
+=== String Sort API for package org.elasticsearch.xpack.sql.expression.literal.geo
+See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-GeoShape]]
+[[painless-api-reference-string-sort-GeoShape]]
 ==== GeoShape
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[role="exclude",id="painless-api-reference-field-org-elasticsearch-xpack-sql-expression-literal-interval"]
-=== Field API for package org.elasticsearch.xpack.sql.expression.literal.interval
-See the <<painless-api-reference-field, Field API>> for a high-level overview of all packages and classes.
+[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-interval"]
+=== String Sort API for package org.elasticsearch.xpack.sql.expression.literal.interval
+See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
 
-[[painless-api-reference-field-IntervalDayTime]]
+[[painless-api-reference-string-sort-IntervalDayTime]]
 ==== IntervalDayTime
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
 * String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
 
 
-[[painless-api-reference-field-IntervalYearMonth]]
+[[painless-api-reference-string-sort-IntervalYearMonth]]
 ==== IntervalYearMonth
 * boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
 * int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()

--- a/docs/painless/painless-api-reference/painless-api-reference-string-sort/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-string-sort/packages.asciidoc
@@ -1,63 +1,6 @@
 // This file is auto-generated. Do not edit.
 
 
-[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-eql-expression-function-scalar-whitelist"]
-=== String Sort API for package org.elasticsearch.xpack.eql.expression.function.scalar.whitelist
-See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-string-sort-InternalEqlScriptUtils]]
-==== InternalEqlScriptUtils
-* static String between(String, String, String, Boolean, Boolean)
-* static Boolean cidrMatch(String, List)
-* static String concat(List)
-* static Boolean endsWith(String, String, Boolean)
-* static Integer indexOf(String, String, Number, Boolean)
-* static Integer length(String)
-* static Number number(String, Number)
-* static String string(Object)
-* static Boolean stringContains(String, String, Boolean)
-* static String substring(String, Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
-[role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-ql-expression-function-scalar-whitelist"]
-=== String Sort API for package org.elasticsearch.xpack.ql.expression.function.scalar.whitelist
-See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.
-
-[[painless-api-reference-string-sort-InternalQlScriptUtils]]
-==== InternalQlScriptUtils
-* static Number add(Number, Number)
-* static Boolean and(Boolean, Boolean)
-* static Number div(Number, Number)
-* static def docValue(Map, String)
-* static Boolean eq(Object, Object)
-* static Boolean gt(Object, Object)
-* static Boolean gte(Object, Object)
-* static Boolean in(Object, List)
-* static Boolean isNotNull(Object)
-* static Boolean isNull(Object)
-* static Boolean lt(Object, Object)
-* static Boolean lte(Object, Object)
-* static Number mod(Number, Number)
-* static Number mul(Number, Number)
-* static Number neg(Number)
-* static Boolean neq(Object, Object)
-* static Boolean not(Boolean)
-* static boolean nullSafeFilter(Boolean)
-* static double nullSafeSortNumeric(Number)
-* static String nullSafeSortString(Object)
-* static Boolean nulleq(Object, Object)
-* static Boolean or(Boolean, Boolean)
-* static Boolean regex(String, String)
-* static Boolean startsWith(String, String, Boolean)
-* static Number sub(Number, Number)
-* boolean {java11-javadoc}/java.base/java/lang/Object.html#equals(java.lang.Object)[equals](Object)
-* int {java11-javadoc}/java.base/java/lang/Object.html#hashCode()[hashCode]()
-* String {java11-javadoc}/java.base/java/lang/Object.html#toString()[toString]()
-
-
 [role="exclude",id="painless-api-reference-string-sort-org-elasticsearch-xpack-sql-expression-literal-geo"]
 === String Sort API for package org.elasticsearch.xpack.sql.expression.literal.geo
 See the <<painless-api-reference-string-sort, String Sort API>> for a high-level overview of all packages and classes.

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -97,12 +97,13 @@ testClusters {
 }
 
 task generateContextDoc(type: DefaultTestClustersTask) {
+  dependsOn sourceSets.doc.runtimeClasspath
   useCluster testClusters.generateContextCluster
   doFirst {
     project.javaexec {
       main = 'org.elasticsearch.painless.ContextDocGenerator'
       classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> testClusters.generateContextCluster.singleNode().getAllHttpSocketURI()}"
+      systemProperty "cluster.uri", "${-> testClusters.generateContextCluster.singleNode().getHttpSocketURI()}"
     }.assertNormalExitValue()
   }
 }

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -103,7 +103,7 @@ task generateContextDoc(type: DefaultTestClustersTask) {
     project.javaexec {
       main = 'org.elasticsearch.painless.ContextDocGenerator'
       classpath = sourceSets.doc.runtimeClasspath
-      systemProperty "cluster.uri", "${-> testClusters.generateContextCluster.singleNode().getHttpSocketURI()}"
+      systemProperty "cluster.uri", "${-> testClusters.generateContextCluster.singleNode().getAllHttpSocketURI().get(0)}"
     }.assertNormalExitValue()
   }
 }

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
@@ -801,7 +801,11 @@ public final class ContextDocGenerator {
                 javaName.equals("org.elasticsearch.xpack.sql.expression.function.scalar.geo.GeoShape") ||
                 javaName.equals("org.elasticsearch.xpack.sql.expression.function.scalar.whitelist.InternalSqlScriptUtils") ||
                 javaName.equals("org.elasticsearch.xpack.sql.expression.literal.IntervalDayTime") ||
-                javaName.equals("org.elasticsearch.xpack.sql.expression.literal.IntervalYearMonth");
+                javaName.equals("org.elasticsearch.xpack.sql.expression.literal.IntervalYearMonth") ||
+                javaName.equals("org.elasticsearch.xpack.eql.expression.function.scalar.whitelist.InternalEqlScriptUtils") ||
+                javaName.equals("org.elasticsearch.xpack.ql.expression.function.scalar.InternalQlScriptUtils") ||
+                javaName.equals("org.elasticsearch.xpack.ql.expression.function.scalar.whitelist.InternalQlScriptUtils") ||
+                javaName.equals("org.elasticsearch.script.ScoreScript.ExplanationHolder");
     }
 
     private ContextDocGenerator() {

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
@@ -805,7 +805,7 @@ public final class ContextDocGenerator {
                 javaName.equals("org.elasticsearch.xpack.eql.expression.function.scalar.whitelist.InternalEqlScriptUtils") ||
                 javaName.equals("org.elasticsearch.xpack.ql.expression.function.scalar.InternalQlScriptUtils") ||
                 javaName.equals("org.elasticsearch.xpack.ql.expression.function.scalar.whitelist.InternalQlScriptUtils") ||
-                javaName.equals("org.elasticsearch.script.ScoreScript.ExplanationHolder");
+                javaName.equals("org.elasticsearch.script.ScoreScript$ExplanationHolder");
     }
 
     private ContextDocGenerator() {


### PR DESCRIPTION
* Add doc runtime class path
* Use `getAllHttpSocketURI.get(0)` instead of `getAllHttpSocketURI` to get a single
  test cluster URL rather than a list