### PR TITLE
Fix estimate size of translog operations

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1156,7 +1156,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public long estimateSize() {
-            return ((id.length() + type.length()) * 2) + source.length() + 12;
+            return (2 * id.length())
+                + (2 * type.length())
+                + source.length()
+                + (routing != null ? 2 * routing.length() : 0)
+                + (4 * Long.BYTES); // timestamp, seq_no, primary_term, and version
         }
 
         public String type() {
@@ -1323,7 +1327,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public long estimateSize() {
-            return ((uid.field().length() + uid.text().length()) * 2) + 20;
+            return (id.length() * 2)
+                + (type.length() * 2)
+                + ((uid.field().length() * 2) + (uid.text().length()) * 2)
+                + (type.length() * 2)
+                + (3 * Long.BYTES); // seq_no, primary_term, and version;
         }
 
         public String type() {
@@ -1479,7 +1487,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public int hashCode() {
-            return 31 * 31 * 31 + 31 * 31 * Long.hashCode(seqNo) + 31 * Long.hashCode(primaryTerm) + reason().hashCode();
+            return 31 * 31 * Long.hashCode(seqNo) + 31 * Long.hashCode(primaryTerm) + reason().hashCode();
         }
 
         @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -145,8 +145,8 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
 
         final IndexShard indexShard = indexService.getShard(0);
         final Translog.Operation[] operations = ShardChangesAction.getOperations(indexShard, indexShard.getLastKnownGlobalCheckpoint(),
-            0, 12, indexShard.getHistoryUUID(), new ByteSizeValue(256, ByteSizeUnit.BYTES));
-        assertThat(operations.length, equalTo(12));
+            0, randomIntBetween(100, 500), indexShard.getHistoryUUID(), new ByteSizeValue(256, ByteSizeUnit.BYTES));
+        assertThat(operations.length, equalTo(8));
         assertThat(operations[0].seqNo(), equalTo(0L));
         assertThat(operations[1].seqNo(), equalTo(1L));
         assertThat(operations[2].seqNo(), equalTo(2L));
@@ -155,10 +155,6 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         assertThat(operations[5].seqNo(), equalTo(5L));
         assertThat(operations[6].seqNo(), equalTo(6L));
         assertThat(operations[7].seqNo(), equalTo(7L));
-        assertThat(operations[8].seqNo(), equalTo(8L));
-        assertThat(operations[9].seqNo(), equalTo(9L));
-        assertThat(operations[10].seqNo(), equalTo(10L));
-        assertThat(operations[11].seqNo(), equalTo(11L));
     }
 
     public void testGetOperationsAlwaysReturnAtLeastOneOp() throws Exception {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -146,7 +146,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         final IndexShard indexShard = indexService.getShard(0);
         final Translog.Operation[] operations = ShardChangesAction.getOperations(indexShard, indexShard.getLastKnownGlobalCheckpoint(),
             0, randomIntBetween(100, 500), indexShard.getHistoryUUID(), new ByteSizeValue(256, ByteSizeUnit.BYTES));
-        assertThat(operations.length, equalTo(8));
+        assertThat(operations.length, equalTo(7));
         assertThat(operations[0].seqNo(), equalTo(0L));
         assertThat(operations[1].seqNo(), equalTo(1L));
         assertThat(operations[2].seqNo(), equalTo(2L));
@@ -154,7 +154,6 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         assertThat(operations[4].seqNo(), equalTo(4L));
         assertThat(operations[5].seqNo(), equalTo(5L));
         assertThat(operations[6].seqNo(), equalTo(6L));
-        assertThat(operations[7].seqNo(), equalTo(7L));
     }
 
     public void testGetOperationsAlwaysReturnAtLeastOneOp() throws Exception {


### PR DESCRIPTION
Make sure that the estimateSize method includes all fields of translog operations.

Backport of #59206
