### PR TITLE
Ignore multiple matching templates warning in specific tests. (#59692)

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -95,6 +95,7 @@ public class IndexingIT extends AbstractRollingTestCase {
             }
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
+            useIgnoreMultipleMatchingTemplatesWarningsHandler(createTestIndex);
             client().performRequest(createTestIndex);
             allowedWarnings("index [test_index] matches multiple legacy templates [global, prevent-bwc-deprecation-template], " +
                 "composable templates will only match a single template");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -93,6 +93,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.sort;
@@ -1421,6 +1422,21 @@ public abstract class ESRestTestCase extends ESTestCase {
                 assertThat("Expecting non-null license status", status, notNullValue());
                 assertThat("Expecting active license", status, equalTo("active"));
             }
+        });
+    }
+
+    static final Pattern CREATE_INDEX_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile("^index \\[(.+)\\] matches multiple legacy " +
+        "templates \\[(.+)\\], composable templates will only match a single template$");
+
+    static final Pattern PUT_TEMPLATE_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile("^index template \\[(.+)\\] has index patterns " +
+        "\\[(.+)\\] matching patterns from existing older templates \\[(.+)\\] with patterns \\((.+)\\); this template \\[(.+)\\] will " +
+        "take precedence during new index creation$");
+
+    protected static void useIgnoreMultipleMatchingTemplatesWarningsHandler(Request request) throws IOException {
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        options.setWarningsHandler(warnings -> {
+            return warnings.stream().anyMatch(message -> CREATE_INDEX_MULTIPLE_MATCHING_TEMPLATES.matcher(message).matches() ||
+                PUT_TEMPLATE_MULTIPLE_MATCHING_TEMPLATES.matcher(message).matches());
         });
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/ESRestTestCaseTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.rest;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.regex.Matcher;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class ESRestTestCaseTests extends ESTestCase {
+
+    public void testIgnoreMatchMultipleTemplatesPattern() {
+        String input = "index [test_index] matches multiple legacy templates [global, prevent-bwc-deprecation-template], " +
+            "composable templates will only match a single template";
+        Matcher matcher = ESRestTestCase.CREATE_INDEX_MULTIPLE_MATCHING_TEMPLATES.matcher(input);
+        assertThat(matcher.matches(), is(true));
+        assertThat(matcher.group(1), equalTo("test_index"));
+        assertThat(matcher.group(2), equalTo("global, prevent-bwc-deprecation-template"));
+
+        input = "index template [1] has index patterns [logs-*] matching patterns from existing older templates [global] " +
+            "with patterns (global => [*]); this template [1] will take precedence during new index creation";
+        matcher = ESRestTestCase.PUT_TEMPLATE_MULTIPLE_MATCHING_TEMPLATES.matcher(input);
+        assertThat(matcher.matches(), is(true));
+        assertThat(matcher.group(1), equalTo("1"));
+        assertThat(matcher.group(2), equalTo("logs-*"));
+        assertThat(matcher.group(3), equalTo("global"));
+        assertThat(matcher.group(4), equalTo("global => [*]"));
+        assertThat(matcher.group(5), equalTo("1"));
+    }
+
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -37,6 +37,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
                 "    }";
             Request request = new Request("PUT", "/_index_template/1");
             request.setJsonEntity(requestBody);
+            useIgnoreMultipleMatchingTemplatesWarningsHandler(request);
             client().performRequest(request);
 
             StringBuilder b = new StringBuilder();


### PR DESCRIPTION
Backport of #59692 to 7.x branch.

Closes #59679
