### PR TITLE
[CI][Transform] add debug logs to help debugging #52931

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -72,6 +72,8 @@ public class TransformUsageIT extends TransformRestTestCase {
 
         Request getRequest = new Request("GET", getTransformEndpoint() + "test_usage/_stats");
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
+        // temporary debug logs for https://github.com/elastic/elasticsearch/issues/52931
+        logger.info("test_usage/_stats response: [{}]", stats);
         Map<String, Double> expectedStats = new HashMap<>();
         for (String statName : PROVIDED_STATS) {
             @SuppressWarnings("unchecked")
@@ -82,6 +84,8 @@ public class TransformUsageIT extends TransformRestTestCase {
 
         getRequest = new Request("GET", getTransformEndpoint() + "test_usage_continuous/_stats");
         stats = entityAsMap(client().performRequest(getRequest));
+        // temporary debug logs for https://github.com/elastic/elasticsearch/issues/52931
+        logger.info("test_usage_continuous/_stats response: [{}]", stats);
         for (String statName : PROVIDED_STATS) {
             @SuppressWarnings("unchecked")
             List<Object> specificStatistic = (List<Object>) (XContentMapValues.extractValue("transforms.stats." + statName, stats));


### PR DESCRIPTION
add debug logs to help debugging #52931

Motivation: The problem is a off-by-one in a counter, probably caused by 2 parallel threads: one is finishing the worker, one is triggering a new run (likely while the other one is saving state). When `_stats` is called its either answered from the still running task or from the persisted state. The added logs should tell us which path was taken (the task based one contains node information, the persisted one not).

(The CI failure rarely happens, probably it takes some time until we hit it again and can inspect the logs)

It seems sufficient to only merge this to master.