### PR TITLE
Add 'point' to the top-level field type docs.

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -22,10 +22,12 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<nested>>::    `nested` for arrays of JSON objects
 
 [float]
-=== Geo data types
+=== Spatial data types
 
 <<geo-point>>::     `geo_point` for lat/lon points
 <<geo-shape>>::     `geo_shape` for complex shapes like polygons
+<<point>>::         `point` for arbitrary cartesian points.
+<<shape>>::         `shape` for arbitrary cartesian geometries.
 
 [float]
 === Specialised data types
@@ -53,8 +55,6 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<alias>>::         Defines an alias to an existing field.
 
 <<flattened>>:: Allows an entire JSON object to be indexed as a single field.
-
-<<shape>>:: `shape` for arbitrary cartesian geometries.
 
 <<histogram>>:: `histogram` for pre-aggregated numerical values for percentiles aggregations.
 
@@ -116,6 +116,8 @@ include::types/numeric.asciidoc[]
 include::types/object.asciidoc[]
 
 include::types/percolator.asciidoc[]
+
+include::types/point.asciidoc[]
 
 include::types/range.asciidoc[]
 

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -190,7 +190,7 @@ are provided:
 |Strategy |Supported Shapes |Supported Queries |Multiple Shapes
 
 |`recursive`  |<<input-structure, All>> |`INTERSECTS`, `DISJOINT`, `WITHIN`, `CONTAINS` |Yes
-|`term` |<<point, Points>> |`INTERSECTS` |Yes
+|`term` |<<geo-point-type, Points>> |`INTERSECTS` |Yes
 
 |=======================================================================
 

--- a/docs/reference/mapping/types/point.asciidoc
+++ b/docs/reference/mapping/types/point.asciidoc
@@ -60,16 +60,16 @@ PUT my_index/_doc/5
 
 <1> Point expressed as an object, with `x` and `y` keys.
 <2> Point expressed as a string with the format: `"x,y"`.
-<4> Point expressed as an array with the format: [ `x`, `y`]
-<5> Point expressed as a http://docs.opengeospatial.org/is/12-063r5/12-063r5.html[Well-Known Text]
+<3> Point expressed as an array with the format: [ `x`, `y`]
+<4> Point expressed as a http://docs.opengeospatial.org/is/12-063r5/12-063r5.html[Well-Known Text]
 POINT with the format: `"POINT(x y)"`
 
 The coordinates provided to the indexer are single precision floating point values so
 the field guarantees the same accuracy provided by the java virtual machine (typically
 `1E-38`).
 
-[[geo-point-params]]
-==== Parameters for `geo_point` fields
+[[point-params]]
+==== Parameters for `point` fields
 
 The following parameters are accepted by `point` fields:
 
@@ -92,8 +92,8 @@ The following parameters are accepted by `point` fields:
     Accepts an point value which is substituted for any explicit `null` values.
     Defaults to `null`, which means the field is treated as missing.
 
-==== Sorting and Retrieving index Shapes
+==== Sorting and retrieving points
 
-It is currently not possible to sort shapes or retrieve their fields
+It is currently not possible to sort points or retrieve their fields
 directly. The `point` value is only retrievable through the `_source`
 field.

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -129,7 +129,7 @@ within coordinate arrays. This differs from many Geospatial APIs (e.g., `geo_sha
 typically use the colloquial latitude, longitude (Y, X) ordering.
 =============================================
 
-[[point]]
+[[point-shape]]
 [float]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 


### PR DESCRIPTION
Before it was missing from the list. This PR also renames the 'geo data types'
section to 'spatial data types' and consolidates the geo and cartesian types
into that section.