### PR TITLE
Draft of System Index Protections

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -514,7 +514,7 @@ public class RequestConvertersTests extends ESTestCase {
         } else {
             expectedParams.put("slices", "1");
         }
-        setRandomIndicesOptions(updateByQueryRequest::setIndicesOptions, updateByQueryRequest::indicesOptions, expectedParams);
+        setRandomIndicesOptions(updateByQueryRequest::indicesOptions, updateByQueryRequest::indicesOptions, expectedParams);
         setRandomTimeout(updateByQueryRequest::setTimeout, ReplicationRequest.DEFAULT_TIMEOUT, expectedParams);
         Request request = RequestConverters.updateByQuery(updateByQueryRequest);
         StringJoiner joiner = new StringJoiner("/", "/", "");
@@ -574,7 +574,7 @@ public class RequestConvertersTests extends ESTestCase {
         } else {
             expectedParams.put("slices", "1");
         }
-        setRandomIndicesOptions(deleteByQueryRequest::setIndicesOptions, deleteByQueryRequest::indicesOptions, expectedParams);
+        setRandomIndicesOptions(deleteByQueryRequest::indicesOptions, deleteByQueryRequest::indicesOptions, expectedParams);
         setRandomTimeout(deleteByQueryRequest::setTimeout, ReplicationRequest.DEFAULT_TIMEOUT, expectedParams);
         expectedParams.put("wait_for_completion", Boolean.TRUE.toString());
         Request request = RequestConverters.deleteByQuery(deleteByQueryRequest);
@@ -1197,7 +1197,7 @@ public class RequestConvertersTests extends ESTestCase {
             searchRequest.indicesOptions(IndicesOptions.fromOptions(randomlyGenerated.ignoreUnavailable(),
                     randomlyGenerated.allowNoIndices(), randomlyGenerated.expandWildcardsOpen(), randomlyGenerated.expandWildcardsClosed(),
                     msearchDefault.expandWildcardsHidden(), msearchDefault.allowAliasesToMultipleIndices(),
-                    msearchDefault.forbidClosedIndices(), msearchDefault.ignoreAliases(), msearchDefault.ignoreThrottled()));
+                    msearchDefault.forbidClosedIndices(), msearchDefault.ignoreAliases(), msearchDefault.ignoreThrottled(), false));
             multiSearchRequest.add(searchRequest);
         }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -1055,7 +1055,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.setRouting("=cat"); // <1>
             // end::update-by-query-request-routing
             // tag::update-by-query-request-indicesOptions
-            request.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
+            request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
             // end::update-by-query-request-indicesOptions
 
             // tag::update-by-query-execute
@@ -1167,7 +1167,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.setRouting("=cat"); // <1>
             // end::delete-by-query-request-routing
             // tag::delete-by-query-request-indicesOptions
-            request.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
+            request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
             // end::delete-by-query-request-indicesOptions
 
             // tag::delete-by-query-execute

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
@@ -114,8 +114,10 @@ public class RankEvalRequest extends ActionRequest implements IndicesRequest.Rep
         return indicesOptions;
     }
 
-    public void indicesOptions(IndicesOptions indicesOptions) {
+    @Override
+    public IndicesRequest indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = Objects.requireNonNull(indicesOptions, "indicesOptions must not be null");
+        return this;
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -1210,7 +1210,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         // And querying using a wildcard with indices options set to expand hidden
         searchResponse = client().prepareSearch("alias*")
             .setQuery(QueryBuilders.matchAllQuery())
-            .setIndicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, true, false, false)).get();
+            .setIndicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, true, false, false, false)).get();
         assertHits(searchResponse.getHits(), "1", "2", "3");
 
         // And that querying the alias with a wildcard and no expand options fails

--- a/server/src/internalClusterTest/java/org/elasticsearch/client/SystemIndexClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/client/SystemIndexClientIT.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+
+//@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
+public class SystemIndexClientIT extends ESIntegTestCase {
+
+    private SystemIndexClient systemIndexClient(Collection<SystemIndexDescriptor> ownedSystemIndices) {
+//        assertThat("SystemIndexClient requires a NodeClient", client(), instanceOf(NodeClient.class));
+        NodeClient client = null;
+        for (Client thisClient : internalCluster().getClients()) {
+            if (thisClient instanceof NodeClient) {
+                client = (NodeClient) thisClient;
+                break;
+            }
+        }
+        assertNotNull(client);
+        return new SystemIndexClient(client,
+            ownedSystemIndices,
+            () -> client().admin().cluster().prepareState().get().getState(),
+            new IndexNameExpressionResolver());
+    }
+
+    public void testCanAccessSystemIndices() throws Exception {
+        final String systemIndex = ".system-index";
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(systemIndex)
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_INDEX_SYSTEM, true).build())
+            .get();
+        assertAcked(createResponse);
+
+        List<SystemIndexDescriptor> descriptors = Collections.singletonList(new SystemIndexDescriptor(".system*", "testing"));
+        Client systemIndexClient = systemIndexClient(descriptors);
+        IndexResponse indexResponse = systemIndexClient.prepareIndex(systemIndex)
+            .setSource("{\"testfield\": 1}", XContentType.JSON).get();
+        assertThat(indexResponse.status().getStatus(), allOf(greaterThanOrEqualTo(200), lessThan(300)));
+        indexResponse = systemIndexClient.prepareIndex(systemIndex)
+            .setSource("{\"testfield\": 2}", XContentType.JSON).get();
+        assertThat(indexResponse.status().getStatus(), allOf(greaterThanOrEqualTo(200), lessThan(300)));
+        refresh();
+
+//        QueryBuilder query = randomFrom(QueryBuilders.matchQuery("testfield", "testvalue"), QueryBuilders.matchAllQuery());
+        QueryBuilder query = QueryBuilders.matchQuery("testfield", 1);
+
+        {
+            SearchResponse searchResponse = systemIndexClient.prepareSearch(systemIndex)
+                .setQuery(query)
+                .get();
+            assertHitCount(searchResponse, 1);
+
+            searchResponse = systemIndexClient.prepareSearch(systemIndex)
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addSort("testfield", SortOrder.ASC)
+                .get();
+            assertHitCount(searchResponse, 2);
+        }
+
+        {
+            String indexPattern = ".system*";
+            SearchResponse searchResponse = systemIndexClient.prepareSearch(indexPattern)
+                .setQuery(query)
+                .get();
+            assertHitCount(searchResponse, 1);
+
+            searchResponse = systemIndexClient.prepareSearch(".system*")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addSort("testfield", SortOrder.ASC)
+                .get();
+            assertHitCount(searchResponse, 2);
+        }
+    }
+
+    public void testSystemIndexAccessThroughDefaultClientBlocked() {
+        final String systemIndex = ".system-index";
+        CreateIndexResponse createResponse = client().admin().indices().prepareCreate(systemIndex)
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_INDEX_SYSTEM, true).build())
+            .get();
+        assertAcked(createResponse);
+
+        List<SystemIndexDescriptor> descriptors = Collections.singletonList(new SystemIndexDescriptor(".system*", "testing"));
+        Client systemIndexClient = systemIndexClient(descriptors);
+        IndexResponse indexResponse = systemIndexClient.prepareIndex(systemIndex)
+            .setSource("{\"testfield\": 1}", XContentType.JSON).get();
+        assertThat(indexResponse.status().getStatus(), allOf(greaterThanOrEqualTo(200), lessThan(300)));
+        indexResponse = systemIndexClient.prepareIndex(systemIndex)
+            .setSource("{\"testfield\": 2}", XContentType.JSON).get();
+        assertThat(indexResponse.status().getStatus(), allOf(greaterThanOrEqualTo(200), lessThan(300)));
+        refresh();
+
+        QueryBuilder query = QueryBuilders.matchQuery("testfield", 1);
+
+        {
+            SearchResponse searchResponse = client().prepareSearch(".system*")
+                .setQuery(query)
+                .get();
+            assertHitCount(searchResponse, 0);
+
+            searchResponse = client().prepareSearch(".system*")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addSort("testfield", SortOrder.ASC)
+                .get();
+            assertHitCount(searchResponse, 0);
+        }
+
+        {
+            SearchResponse searchResponse = client().prepareSearch(systemIndex)
+                .setQuery(query)
+                .get();
+            assertHitCount(searchResponse, 0);
+
+            searchResponse = client().prepareSearch(systemIndex)
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addSort("testfield", SortOrder.ASC)
+                .get();
+            assertHitCount(searchResponse, 0);
+        }
+    }
+
+
+}

--- a/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
@@ -54,5 +54,12 @@ public interface IndicesRequest {
          * Sets the indices that the action relates to.
          */
         IndicesRequest indices(String... indices);
+
+        /**
+         * Sets the indices options for this request
+         * @param options the new options
+         * @return the modified request
+         */
+        IndicesRequest indicesOptions(IndicesOptions options);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
@@ -507,6 +508,12 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         @Override
         public IndicesOptions indicesOptions() {
             return INDICES_OPTIONS;
+        }
+
+        @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            // G-> Is this the right behavior?
+            return this;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -133,6 +133,12 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
 
         @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            this.indicesOptions = options;
+            return this;
+        }
+
+        @Override
         public IndicesRequest indices(String... indices) {
             this.names = indices;
             return this;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -259,7 +259,8 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
         assert successfulOperations >= 0 : "successfulOperations must be >= 0 but was: " + successfulOperations;
         if (counter.countDown()) {
             if (successfulOps.get() == 0) {
-                listener.onFailure(new SearchPhaseExecutionException(phaseName, "all shards failed", failure, buildShardFailures()));
+                final ShardSearchFailure[] shardFailures = buildShardFailures();
+                listener.onFailure(new SearchPhaseExecutionException(phaseName, "all shards failed", failure, shardFailures));
             } else {
                 SearchPhase phase = nextPhaseSupplier.get();
                 try {

--- a/server/src/main/java/org/elasticsearch/client/SystemIndexClient.java
+++ b/server/src/main/java/org/elasticsearch/client/SystemIndexClient.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskListener;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.transport.RemoteClusterService;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class SystemIndexClient extends NodeClient {
+    private NodeClient in;
+    private final Collection<SystemIndexDescriptor> ownedSystemIndices;
+    private final IndexNameExpressionResolver indexResolver;
+    private final Supplier<ClusterState> clusterStateSupplier;
+
+    public SystemIndexClient(NodeClient in, Collection<SystemIndexDescriptor> ownedSystemIndices,
+                             Supplier<ClusterState> clusterStateSupplier, IndexNameExpressionResolver indexResolver) {
+        super(in.settings(), in.threadPool());
+        this.in = in;
+        this.ownedSystemIndices = ownedSystemIndices;
+        this.indexResolver = indexResolver;
+        this.clusterStateSupplier = clusterStateSupplier;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse>
+    void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
+        // G-> Fix this so it actually works correctly instead of for like 80% of cases. See how Security does this
+        try {
+            if (request instanceof IndicesRequest.Replaceable) {
+                resolveIndices((IndicesRequest.Replaceable) request);
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        in.execute(action, request, listener);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> Task executeLocally(ActionType<Response> action,
+                                                                                                Request request,
+                                                                                                ActionListener<Response> listener) {
+        if (request instanceof IndicesRequest.Replaceable) {
+            resolveIndices((IndicesRequest.Replaceable) request);
+        }
+        return in.executeLocally(action, request, listener);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> Task executeLocally(ActionType<Response> action,
+                                                                                                Request request,
+                                                                                                TaskListener<Response> listener) {
+        if (request instanceof IndicesRequest.Replaceable) {
+            resolveIndices((IndicesRequest.Replaceable) request);
+        }
+        return in.executeLocally(action, request, listener);
+    }
+
+    @Override
+    public void initialize(Map<ActionType, TransportAction> actions, TaskManager taskManager, Supplier<String> localNodeId,
+                           RemoteClusterService remoteClusterService) {
+        // Don't call super.initialize, just delegate the methods that use these.
+        in.initialize(actions, taskManager, localNodeId, remoteClusterService);
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        in.close();
+    }
+
+    @Override
+    public String getLocalNodeId() {
+        return in.getLocalNodeId();
+    }
+
+    @Override
+    public Client getRemoteClusterClient(String clusterAlias) {
+        return in.getRemoteClusterClient(clusterAlias);
+    }
+
+    private void resolveIndices(IndicesRequest.Replaceable request) {
+        ClusterState state = clusterStateSupplier.get();
+
+        // Tweak the indices options first, so the resolver can resolve system indices.
+        IndicesOptions originalOptions = request.indicesOptions();
+        EnumSet<IndicesOptions.Option> options = originalOptions.getOptions();
+        options.add(IndicesOptions.Option.ALLOW_SYSTEM_INDEX_ACCESS);
+        request.indicesOptions(new IndicesOptions(options, request.indicesOptions().getExpandWildcards()));
+
+        List<Index> indices = Arrays.asList(
+            indexResolver.concreteIndices(state, request, IndexNameExpressionResolver.Context.SystemIndexStrategy.INCLUDE)
+        );
+
+        if (indices.stream().anyMatch(index -> isSystemIndex(index, state))) {
+            List<Index> nonOwnedSystemIndices = indices.stream()
+                .filter(i -> isSystemIndex(i, state))
+                .filter(i -> isOwnedSystemIndex(i) == false)
+                .collect(Collectors.toList());
+            if (nonOwnedSystemIndices.isEmpty() == false) {
+                throw new IllegalArgumentException("attempted to access system indices which this plugin is not authorized for: "
+                    + nonOwnedSystemIndices);
+            }
+
+            String[] finalIndices = indices.stream()
+                .map(Index::getName)
+                .collect(Collectors.toList())
+                .toArray(Strings.EMPTY_ARRAY);
+            request.indices(finalIndices);
+        } else {
+            request.indicesOptions(originalOptions);
+        }
+    }
+
+    private boolean isSystemIndex(Index index, ClusterState state) {
+        final IndexMetadata indexMetadata = state.metadata().index(index);
+        return indexMetadata == null ? false : IndexMetadata.INDEX_SYSTEM_SETTING.get(indexMetadata.getSettings());
+    }
+
+    private boolean isOwnedSystemIndex(Index index) {
+        return ownedSystemIndices.stream().anyMatch(descriptor -> descriptor.matchesIndexPattern(index.getName()));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_HIDDEN_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_SYSTEM_SETTING;
 
 /**
  * An index abstraction is a reference to one or more concrete indices.
@@ -77,6 +78,8 @@ public interface IndexAbstraction {
      * @return whether this index abstraction is hidden or not
      */
     boolean isHidden();
+
+    boolean isSystem();
 
     /**
      * An index abstraction type.
@@ -160,6 +163,11 @@ public interface IndexAbstraction {
         public boolean isHidden() {
             return INDEX_HIDDEN_SETTING.get(concreteIndex.getSettings());
         }
+
+        @Override
+        public boolean isSystem() {
+            return INDEX_SYSTEM_SETTING.get(concreteIndex.getSettings());
+        }
     }
 
     /**
@@ -208,6 +216,13 @@ public interface IndexAbstraction {
         @Override
         public boolean isHidden() {
             return isHidden;
+        }
+
+        @Override
+        public boolean isSystem() {
+            //G-> This is probably not the best way to tell if an alias is a system-index-alias
+            // this should probably be checked on the alias layer and added as a property in the AliasMetadata
+            return referenceIndexMetadatas.stream().allMatch(indexMetadata -> INDEX_SYSTEM_SETTING.get(indexMetadata.getSettings()));
         }
 
         /**
@@ -323,6 +338,11 @@ public interface IndexAbstraction {
         @Override
         public boolean isHidden() {
             return false;
+        }
+
+        @Override
+        public boolean isSystem() {
+            return false; //G-> No system data streams, right?
         }
 
         public org.elasticsearch.cluster.metadata.DataStream getDataStream() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -322,6 +322,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Boolean> INDEX_HIDDEN_SETTING =
         Setting.boolSetting(SETTING_INDEX_HIDDEN, false, Property.Dynamic, Property.IndexScope);
 
+    public static final String SETTING_INDEX_SYSTEM = "index.system";
+    /**
+     * Whether the index is a system index or not. A system index is managed by a plugin or module,
+     * and can only be accessed externally via REST APIs provided by that plugin.
+     */
+    public static final Setting<Boolean> INDEX_SYSTEM_SETTING = Setting.boolSetting(SETTING_INDEX_SYSTEM, false,
+        Property.IndexScope, Property.InternalIndex);
+
     /**
      * an internal index format description, allowing us to find out if this index is upgraded or needs upgrading
      */

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -79,6 +79,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             IndexMetadata.INDEX_PRIORITY_SETTING,
             IndexMetadata.INDEX_DATA_PATH_SETTING,
             IndexMetadata.INDEX_HIDDEN_SETTING,
+            IndexMetadata.INDEX_SYSTEM_SETTING,
             IndexMetadata.INDEX_FORMAT_SETTING,
             SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
             SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -52,6 +54,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQueryRequest>
     implements IndicesRequest.Replaceable, ToXContentObject {
+    private static final Logger logger = LogManager.getLogger(DeleteByQueryRequest.class);
 
     public DeleteByQueryRequest() {
         this(new SearchRequest());
@@ -108,7 +111,8 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
     /**
      * Set the IndicesOptions for controlling unavailable indices
      */
-    public DeleteByQueryRequest setIndicesOptions(IndicesOptions indicesOptions) {
+    @Override
+    public DeleteByQueryRequest indicesOptions(IndicesOptions indicesOptions) {
         getSearchRequest().indicesOptions(indicesOptions);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
@@ -104,7 +104,8 @@ public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<Updat
     /**
      * Set the IndicesOptions for controlling unavailable indices
      */
-    public UpdateByQueryRequest setIndicesOptions(IndicesOptions indicesOptions) {
+    @Override
+    public UpdateByQueryRequest indicesOptions(IndicesOptions indicesOptions) {
         getSearchRequest().indicesOptions(indicesOptions);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -117,7 +117,7 @@ public interface ActionPlugin {
      *          throw new IllegalStateException("only GET requests are allowed");
      *        }
      *        originalHandler.handleRequest(request, channel, client);
-     *      };
+     *      }
      *    }
      * }
      * </pre>

--- a/server/src/main/java/org/elasticsearch/rest/SystemIndexRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/SystemIndexRestHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.client.SystemIndexClient;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class SystemIndexRestHandler implements RestHandler {
+    protected final Collection<SystemIndexDescriptor> descriptors;
+    protected final Supplier<ClusterState> clusterStateSupplier;
+    protected final IndexNameExpressionResolver indexNameExpressionResolver;
+    protected final RestHandler delegate;
+
+    public SystemIndexRestHandler(Collection<SystemIndexDescriptor> descriptors, Supplier<ClusterState> clusterStateSupplier,
+                                  IndexNameExpressionResolver indexNameExpressionResolver, RestHandler delegate) {
+        super();
+        this.descriptors = descriptors;
+        this.clusterStateSupplier = clusterStateSupplier;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+        final SystemIndexClient systemIndexClient = new SystemIndexClient(client, descriptors, clusterStateSupplier,
+            indexNameExpressionResolver);
+        delegate.handleRequest(request, channel, systemIndexClient);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return delegate.routes();
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return delegate.canTripCircuitBreaker();
+    }
+
+    @Override
+    public boolean supportsContentStream() {
+        return delegate.supportsContentStream();
+    }
+
+    @Override
+    public boolean allowsUnsafeBuffers() {
+        return delegate.allowsUnsafeBuffers();
+    }
+
+    @Override
+    public List<DeprecatedRoute> deprecatedRoutes() {
+        return delegate.deprecatedRoutes();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return delegate.replacedRoutes();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.search.sort;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiTerms;
@@ -70,6 +72,7 @@ import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
  * A sort builder to sort based on a document field.
  */
 public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
+    private static final Logger logger = LogManager.getLogger(FieldSortBuilder.class);
 
     public static final String NAME = "field_sort";
     public static final ParseField MISSING = new ParseField("missing");

--- a/server/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.EnumSet;
 
 import static org.elasticsearch.test.VersionUtils.randomCompatibleVersion;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -53,10 +54,22 @@ public class OriginalIndicesTests extends ESTestCase {
             // indices options are not equivalent when sent to an older version and re-read due
             // to the addition of hidden indices as expand to hidden indices is always true when
             // read from a prior version
-            if (out.getVersion().onOrAfter(Version.V_7_7_0) || originalIndices.indicesOptions().expandWildcardsHidden()) {
-                assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
-            } else if (originalIndices.indicesOptions().expandWildcardsHidden()) {
-                assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
+            // Options changes in 8.0.0 (for now, fix on backport!)
+            if (out.getVersion().before(Version.V_8_0_0)) {
+                EnumSet<IndicesOptions.Option> expectedOptions = originalIndices.indicesOptions().getOptions();
+                expectedOptions.add(IndicesOptions.Option.ALLOW_SYSTEM_INDEX_ACCESS);
+                assertEquals(expectedOptions, originalIndices2.indicesOptions().getOptions());
+            } else {
+                assertEquals(originalIndices.indicesOptions().getOptions(), originalIndices2.indicesOptions().getOptions());
+            }
+
+            // Wildcard states changed in 7.7.0
+            if (out.getVersion().before(Version.V_7_7_0)) {
+                EnumSet<IndicesOptions.WildcardStates> expectedWildcardOptions = originalIndices.indicesOptions().getExpandWildcards();
+                expectedWildcardOptions.add(IndicesOptions.WildcardStates.HIDDEN);
+                assertEquals(expectedWildcardOptions, originalIndices2.indicesOptions().getExpandWildcards());
+            } else {
+                assertEquals(originalIndices.indicesOptions().getExpandWildcards(), originalIndices2.indicesOptions().getExpandWildcards());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexRequestTests.java
@@ -36,7 +36,7 @@ public class ResolveIndexRequestTests extends AbstractWireSerializingTestCase<Re
         String[] names = generateRandomStringArray(1, 4, false);
         IndicesOptions indicesOptions = IndicesOptions.fromOptions(
             randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-            randomBoolean(), randomBoolean());
+            randomBoolean(), randomBoolean(), false);
         return new Request(names, indicesOptions);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -263,21 +263,21 @@ public class MultiSearchRequestTests extends ESTestCase {
 
     public void testWritingExpandWildcards() throws IOException {
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true, true, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "all");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "all");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true, false, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "open,closed");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "open,closed");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, true, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "open,hidden");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "open,hidden");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, false, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "open");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "open");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, true, true, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "closed,hidden");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "closed,hidden");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, true, false, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "closed");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "closed");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, false, true, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "hidden");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "hidden");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, false, false, randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean()), "none");
+            randomBoolean(), randomBoolean(), randomBoolean(), false), "none");
     }
 
     private void assertExpandWildcardsValue(IndicesOptions options, String expectedValue) throws IOException {
@@ -339,8 +339,7 @@ public class MultiSearchRequestTests extends ESTestCase {
                 randomlyGenerated.ignoreUnavailable(), randomlyGenerated.allowNoIndices(), randomlyGenerated.expandWildcardsOpen(),
                 randomlyGenerated.expandWildcardsClosed(), msearchDefault.expandWildcardsHidden(),
                 msearchDefault.allowAliasesToMultipleIndices(), msearchDefault.forbidClosedIndices(), msearchDefault.ignoreAliases(),
-                msearchDefault.ignoreThrottled()
-            ));
+                msearchDefault.ignoreThrottled(), msearchDefault.allowSystemIndices()));
 
             request.add(searchRequest);
         }

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -56,7 +56,7 @@ public class IndicesOptionsTests extends ESTestCase {
             Version version = randomVersionBetween(random(), Version.V_7_0_0, null);
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-                randomBoolean(), randomBoolean());
+                randomBoolean(), randomBoolean(), randomBoolean());
 
             BytesStreamOutput output = new BytesStreamOutput();
             output.setVersion(version);
@@ -74,6 +74,11 @@ public class IndicesOptionsTests extends ESTestCase {
                 assertThat(indicesOptions2.expandWildcardsHidden(), is(true));
             } else {
                 assertThat(indicesOptions2.expandWildcardsHidden(), equalTo(indicesOptions.expandWildcardsHidden()));
+            }
+            if (version.before(Version.V_8_0_0)) {
+                assertThat(indicesOptions2.allowSystemIndices(), is(true));
+            } else {
+                assertThat(indicesOptions2.allowSystemIndices(), equalTo(indicesOptions.allowSystemIndices()));
             }
 
             assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
@@ -93,10 +98,11 @@ public class IndicesOptionsTests extends ESTestCase {
         final boolean forbidClosedIndices = randomBoolean();
         final boolean ignoreAliases = randomBoolean();
         final boolean ignoreThrottled = randomBoolean();
+        final boolean allowSystemIndex = randomBoolean();
 
         IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
             expandToClosedIndices, expandToHiddenIndices, allowAliasesToMultipleIndices, forbidClosedIndices, ignoreAliases,
-            ignoreThrottled);
+            ignoreThrottled, allowSystemIndex);
 
         assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
         assertThat(indicesOptions.allowNoIndices(), equalTo(allowNoIndices));
@@ -108,6 +114,7 @@ public class IndicesOptionsTests extends ESTestCase {
         assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
         assertEquals(ignoreAliases, indicesOptions.ignoreAliases());
         assertEquals(ignoreThrottled, indicesOptions.ignoreThrottled());
+        assertEquals(allowSystemIndex, indicesOptions.allowSystemIndices());
     }
 
     public void testFromOptionsWithDefaultOptions() {
@@ -117,7 +124,7 @@ public class IndicesOptionsTests extends ESTestCase {
         boolean expandToClosedIndices = randomBoolean();
 
         IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
         IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
                 expandToClosedIndices, defaultOptions);
@@ -130,6 +137,7 @@ public class IndicesOptionsTests extends ESTestCase {
         assertEquals(defaultOptions.allowAliasesToMultipleIndices(), indicesOptions.allowAliasesToMultipleIndices());
         assertEquals(defaultOptions.forbidClosedIndices(), indicesOptions.forbidClosedIndices());
         assertEquals(defaultOptions.ignoreAliases(), indicesOptions.ignoreAliases());
+        assertEquals(defaultOptions.allowSystemIndices(), indicesOptions.allowSystemIndices());
     }
 
     public void testFromParameters() {
@@ -166,7 +174,7 @@ public class IndicesOptionsTests extends ESTestCase {
         String allowNoIndicesString = Boolean.toString(allowNoIndices);
 
         IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), false);
 
         IndicesOptions updatedOptions = IndicesOptions.fromParameters(expandWildcardsString, ignoreUnavailableString,
                 allowNoIndicesString, ignoreThrottled, defaultOptions);
@@ -183,12 +191,12 @@ public class IndicesOptionsTests extends ESTestCase {
 
     public void testEqualityAndHashCode() {
         IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-            randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+            randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(indicesOptions, opts -> {
             return IndicesOptions.fromOptions(opts.ignoreUnavailable(), opts.allowNoIndices(), opts.expandWildcardsOpen(),
                 opts.expandWildcardsClosed(), opts.expandWildcardsHidden(), opts.allowAliasesToMultipleIndices(),
-                opts.forbidClosedIndices(), opts.ignoreAliases(), opts.ignoreThrottled());
+                opts.forbidClosedIndices(), opts.ignoreAliases(), opts.ignoreThrottled(), opts.allowSystemIndices());
         }, opts -> {
             boolean mutated = false;
             boolean ignoreUnavailable = opts.ignoreUnavailable();
@@ -200,6 +208,7 @@ public class IndicesOptionsTests extends ESTestCase {
             boolean forbidClosed = opts.forbidClosedIndices();
             boolean ignoreAliases = opts.ignoreAliases();
             boolean ignoreThrottled = opts.ignoreThrottled();
+            boolean allowSystemIndices = opts.allowSystemIndices();
             while (mutated == false) {
                 if (randomBoolean()) {
                     ignoreUnavailable = !ignoreUnavailable;
@@ -237,9 +246,13 @@ public class IndicesOptionsTests extends ESTestCase {
                     ignoreThrottled = !ignoreThrottled;
                     mutated = true;
                 }
+                if (randomBoolean()) {
+                    allowSystemIndices = !allowSystemIndices;
+                    mutated = true;
+                }
             }
             return IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandOpen, expandClosed, expandHidden,
-                allowAliasesToMulti, forbidClosed, ignoreAliases, ignoreThrottled);
+                allowAliasesToMulti, forbidClosed, ignoreAliases, ignoreThrottled, allowSystemIndices);
         });
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -262,7 +262,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
 
         {
             IndicesOptions indicesAliasesAndExpandHiddenOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false,
-                true, true, false, false, false);
+                true, true, false, false, false, false);
             IndexNameExpressionResolver.Context indicesAliasesDataStreamsAndHiddenIndices = new IndexNameExpressionResolver.Context(state,
                 indicesAliasesAndExpandHiddenOptions, false, false, true);
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -38,7 +38,7 @@ public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
 
         UpdateByQueryRequest request = new UpdateByQueryRequest();
         request.indices(indices);
-        request.setIndicesOptions(indicesOptions);
+         request.indicesOptions(indicesOptions);
         for (int i = 0; i < numIndices; i++) {
             assertEquals(indices[i], request.indices()[i]);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -136,7 +136,7 @@ public abstract class TestCluster implements Closeable {
             try {
                 // include wiping hidden indices!
                 assertAcked(client().admin().indices().prepareDelete(indices)
-                    .setIndicesOptions(IndicesOptions.fromOptions(false, true, true, true, true, false, false, true, false)));
+                    .setIndicesOptions(IndicesOptions.fromOptions(false, true, true, true, true, false, false, true, false, true)));
             } catch (IndexNotFoundException e) {
                 // ignore
             } catch (IllegalArgumentException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/migration/IndexUpgradeInfoRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/migration/IndexUpgradeInfoRequest.java
@@ -55,8 +55,10 @@ public class IndexUpgradeInfoRequest extends MasterNodeReadRequest<IndexUpgradeI
         return indicesOptions;
     }
 
-    public void indicesOptions(IndicesOptions indicesOptions) {
+    @Override
+    public IndicesRequest indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
+        return this;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
@@ -97,6 +97,12 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
             this.names = indices;
             return this;
         }
+
+        @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            // G-> Is this the right behavior?
+            return this;
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
@@ -98,6 +98,11 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             this.names = indices;
             return this;
         }
+
+        @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            return this; //G-> Is this the right behavior?
+        }
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
@@ -7,8 +7,8 @@ package org.elasticsearch.xpack.core.deprecation;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
@@ -240,6 +240,12 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         @Override
         public IndicesOptions indicesOptions() {
             return INDICES_OPTIONS;
+        }
+
+        @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            //G-> Is this the right behavior?
+            return this;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -132,7 +132,8 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
         }
 
         public ResolverContext(long startTime) {
-            super(null, null, startTime, false, false, false, false);
+            super(null, null, startTime, false, false, false, false,
+                SystemIndexStrategy.INCLUDE); //G-> Is INCLUDE the right value here?
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
@@ -8,8 +8,8 @@ package org.elasticsearch.xpack.core.ilm.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.ParseField;
@@ -132,8 +132,10 @@ public class RemoveIndexLifecyclePolicyAction extends ActionType<RemoveIndexLife
             return indices;
         }
 
-        public void indicesOptions(IndicesOptions indicesOptions) {
+        @Override
+        public IndicesRequest indicesOptions(IndicesOptions indicesOptions) {
             this.indicesOptions = indicesOptions;
+            return this;
         }
 
         public IndicesOptions indicesOptions() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -69,6 +69,12 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
         }
 
         @Override
+        public IndicesRequest indicesOptions(IndicesOptions options) {
+            this.options = options;
+            return this;
+        }
+
+        @Override
         public String[] indices() {
             return indices;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDataFrameAnalyticsAction.java
@@ -270,7 +270,7 @@ public class TransportDeleteDataFrameAnalyticsAction
                                       ActionListener<BulkByScrollResponse> listener) {
         DeleteByQueryRequest request = new DeleteByQueryRequest(index);
         request.setQuery(query);
-        request.setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));
+        request.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));
         request.setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
         request.setAbortOnVersionConflict(false);
         request.setRefresh(true);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -318,7 +318,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
                             new ConstantScoreQueryBuilder(new TermQueryBuilder(Job.ID.getPreferredName(), jobId));
                         DeleteByQueryRequest request = new DeleteByQueryRequest(indexNames.get())
                             .setQuery(query)
-                            .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpenHidden()))
+                            .indicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpenHidden()))
                             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
                             .setAbortOnVersionConflict(false)
                             .setRefresh(true);
@@ -452,7 +452,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(Quantiles.documentId(jobId));
         DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
             .setQuery(query)
-            .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
+            .indicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
             .setAbortOnVersionConflict(false)
             .setRefresh(true);
 
@@ -479,7 +479,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(CategorizerState.documentId(jobId, docNum));
         DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
             .setQuery(query)
-            .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
+            .indicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
             .setAbortOnVersionConflict(false)
             .setRefresh(true);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -83,7 +83,7 @@ public class JobDataDeleter {
 
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indices.toArray(new String[0]))
             .setRefresh(true)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(idsToDelete.toArray(new String[0])));
 
         // _doc is the most efficient sort order and will also disable scoring
@@ -125,7 +125,7 @@ public class JobDataDeleter {
         QueryBuilder query = QueryBuilders.constantScoreQuery(boolQuery);
         DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(AnnotationIndex.READ_ALIAS_NAME)
             .setQuery(query)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(true)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
@@ -153,7 +153,7 @@ public class JobDataDeleter {
             .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).gte(cutoffEpochMs));
         DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId))
             .setQuery(query)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(true)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
@@ -176,7 +176,7 @@ public class JobDataDeleter {
         QueryBuilder query = QueryBuilders.constantScoreQuery(QueryBuilders.termQuery(Result.IS_INTERIM.getPreferredName(), true));
         DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId))
             .setQuery(query)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(false)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
@@ -199,7 +199,7 @@ public class JobDataDeleter {
     public void deleteDatafeedTimingStats(ActionListener<BulkByScrollResponse> listener) {
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId))
             .setRefresh(true)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(DatafeedTimingStats.documentId(jobId)));
 
         // _doc is the most efficient sort order and will also disable scoring

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1330,7 +1330,7 @@ public class JobResultsProvider {
 
         UpdateByQueryRequest request = new UpdateByQueryRequest(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
             .setQuery(forecastQuery)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setMaxRetries(3)
             .setRefresh(true)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
@@ -135,7 +135,7 @@ public class UnusedStateRemover implements MlDataRemover {
         LOGGER.info("Found [{}] unused state documents; attempting to delete",
                 unusedDocIds.size());
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRequestsPerSecond(requestsPerSec)
             .setQuery(QueryBuilders.idsQuery().addIds(unusedDocIds.toArray(new String[0])));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -301,7 +301,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
             equalTo("cannot start datafeed [datafeed_id] because it failed resolving indices given [not_foo] and " +
                 "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, " +
                 "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, " +
-                "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true]] " +
+                "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, allow_system=false]] " +
                 "with exception [no such index [not_foo]]"));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
@@ -315,8 +315,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                 + "[cannot start datafeed [datafeed_id] because it failed resolving " +
             "indices given [not_foo] and indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, " +
             "expand_wildcards_open=true, expand_wildcards_closed=false, expand_wildcards_hidden=false, " +
-            "allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true" +
-            "]] with exception [no such index [not_foo]]]"));
+            "allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, " +
+            "allow_system=false]] with exception [no such index [not_foo]]]"));
     }
 
     public void testRemoteIndex() {
@@ -414,7 +414,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                 + "[cannot start datafeed [datafeed_id] because it failed resolving indices given [not_foo] and " +
             "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, " +
             "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, " +
-            "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true]] " +
+            "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, allow_system=false]] " +
             "with exception [no such index [not_foo]]]"));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.authz;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -47,6 +49,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField.NO_INDEX_PLACEHOLDER;
 
 class IndicesAndAliasesResolver {
+    private static final Logger logger = LogManager.getLogger(IndicesAndAliasesResolver.class);
 
     //`*,-*` what we replace indices and aliases with if we need Elasticsearch to return empty responses without throwing exception
     static final String[] NO_INDICES_OR_ALIASES_ARRAY = new String[] { "*", "-*" };
@@ -219,7 +222,8 @@ class IndicesAndAliasesResolver {
                 aliasesRequest.replaceAliases(NO_INDICES_OR_ALIASES_ARRAY);
             }
         }
-        return resolvedIndicesBuilder.build();
+        final ResolvedIndices finalResolvedIndices = resolvedIndicesBuilder.build();
+        return finalResolvedIndices;
     }
 
     /**

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -1481,7 +1481,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // closed + hidden, ignore aliases
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, true, true, false, true, false));
+        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, true, true, false, true, false, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("bar-closed", "foofoo-closed", "hidden-closed", ".hidden-closed"));
@@ -1497,7 +1497,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // allow no indices, do not expand to open or closed, expand hidden, ignore aliases
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, false, false, false, true, false, true, false));
+        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, false, false, false, true, false, true, false, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
@@ -1539,14 +1539,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // Make sure ignoring aliases works (visible only)
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, false, true, false));
+        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, false, true, false, false));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Make sure ignoring aliases works (including hidden)
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, false, true, false));
+        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, false, true, false, false));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("hidden-open"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
@@ -1559,7 +1559,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Resolve data streams:
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true, false));
             final List<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
             ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
             assertThat(resolvedIndices.getLocal(), contains("logs-foobar"));
@@ -1568,7 +1568,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Data streams with allow no indices:
             searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, true, true, true, false));
             resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
             // if data streams are to be ignored then this happens in IndexNameExpressionResolver:
             assertThat(resolvedIndices.getLocal(), contains("logs-foobar"));
@@ -1580,7 +1580,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Resolve *all* data streams:
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true, false));
             final List<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
             ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
             assertThat(resolvedIndices.getLocal(), containsInAnyOrder("logs-foo", "logs-foobar"));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -458,7 +458,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
                 if (requiredMatches.isOnlyExact()) {
                     foundIdsListener.onResponse(new Tuple<>((long) ids.size(), new ArrayList<>(ids)));
                 } else {
-                    foundIdsListener.onResponse(new Tuple<>(totalHits, new ArrayList<>(ids)));    
+                    foundIdsListener.onResponse(new Tuple<>(totalHits, new ArrayList<>(ids)));
                 }
             }, foundIdsListener::onFailure),
             client::search
@@ -744,7 +744,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
 
         deleteByQuery.setAbortOnVersionConflict(false)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen());
+            .indicesOptions(IndicesOptions.lenientExpandOpen());
 
         // disable scoring by using index order
         deleteByQuery.getSearchRequest().source().sort(SINGLE_MAPPING_NAME);


### PR DESCRIPTION
Implements protections for system indices, so that plugins can access
them, but they access to them is restricted from any other path.

This is still very rough, but should get the point accross.

---

I had a subtle bug I didn't notice until just an hour or two ago, and with the fix, writes directed at system indices to fail. I know where the problem is (in `TransportBulkAction`, index names are resolved again but don't pass through system indices), but haven't had time to fix it, so a giant pile of tests are going to fail on this as-is.

TODOs:
- [ ] Fix write requests
- [ ] Lots more tests
- [ ] Any documentation at all (Asciidoc, there's some light Javadoc)
- [ ] Address all of the `TODO`/`G->` comments