### PR TITLE
EQL: Do not create the index, if it's already there (#59745)

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/RestEqlUsageTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/RestEqlUsageTestCase.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
+import static org.elasticsearch.test.eql.DataLoader.testIndexName;
 
 /**
  * Tests a random number of queries that increase various (most of the times, one query will "touch" multiple metrics values) metrics. 
@@ -119,7 +120,12 @@ public abstract class RestEqlUsageTestCase extends ESRestTestCase {
     }
 
     public void testEqlRestUsage() throws IOException {
-        DataLoader.loadDatasetIntoEs(highLevelClient(), (t, u) -> createParser(t, u));
+        // create the index and load the data, if the index doesn't exist
+        // it doesn't matter if the index is already there (probably created by another test); _if_ its mapping is the expected one 
+        // it should be enough
+        if (client().performRequest(new Request("HEAD", "/" + testIndexName)).getStatusLine().getStatusCode() == 404) {
+            DataLoader.loadDatasetIntoEs(highLevelClient(), (t, u) -> createParser(t, u));
+        }
 
         //
         // random event queries


### PR DESCRIPTION
(cherry picked from commit d097447d257efdf0a36b1157e1f177aed86ecca1)