### PR TITLE
Revert "Mute AzureSearchableSnapshotsIT (#58775)"

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/azure/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
@@ -6,13 +6,11 @@
 
 package org.elasticsearch.xpack.searchablesnapshots;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.settings.Settings;
 
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.not;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58260")
 public class AzureSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
 
     @Override


### PR DESCRIPTION
This reverts commit 74a78b3a7b87448c5add84466b6a9cf61e0fe29a on 7.9.

The test is unmuted on master (#59600) for 2 days and did not fail so far.