### PR TITLE
Pass script params through to fielddata impl

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBinaryFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBinaryFieldData.java
@@ -69,8 +69,12 @@ public final class ScriptBinaryFieldData extends AbstractIndexComponent
     private final StringScriptFieldScript.Factory scriptFactory;
     private final SetOnce<StringScriptFieldScript.LeafFactory> leafFactory = new SetOnce<>();
 
-    private ScriptBinaryFieldData(IndexSettings indexSettings, String fieldName,
-                                  Script script, StringScriptFieldScript.Factory scriptFactory) {
+    private ScriptBinaryFieldData(
+        IndexSettings indexSettings,
+        String fieldName,
+        Script script,
+        StringScriptFieldScript.Factory scriptFactory
+    ) {
         super(indexSettings);
         this.fieldName = fieldName;
         this.script = script;

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldType.java
@@ -72,7 +72,7 @@ public final class RuntimeKeywordMappedFieldType extends MappedFieldType {
     @Override
     public ScriptBinaryFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
         // TODO once we get SearchLookup as an argument, we can already call scriptFactory.newFactory here and pass through the result
-        return new ScriptBinaryFieldData.Builder(scriptFactory);
+        return new ScriptBinaryFieldData.Builder(script, scriptFactory);
     }
 
     private StringScriptFieldScript.LeafFactory leafFactory(QueryShardContext context) {

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldTypeTests.java
@@ -61,8 +61,10 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
             List<String> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                RuntimeKeywordMappedFieldType ft = build("for (def v : source.foo) {value(v.toString() + params.param)}",
-                    Map.of("param", "-suffix"));
+                RuntimeKeywordMappedFieldType ft = build(
+                    "for (def v : source.foo) {value(v.toString() + params.param)}",
+                    Map.of("param", "-suffix")
+                );
                 IndexMetadata imd = IndexMetadata.builder("test")
                     .settings(Settings.builder().put("index.version.created", Version.CURRENT))
                     .numberOfShards(1)

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeKeywordMappedFieldTypeTests.java
@@ -29,10 +29,12 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.painless.PainlessPlugin;
+import org.elasticsearch.painless.PainlessScriptEngine;
 import org.elasticsearch.plugins.ExtensiblePlugin.ExtensionLoader;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.runtimefields.RuntimeFields;
@@ -43,6 +45,7 @@ import org.elasticsearch.xpack.runtimefields.fielddata.ScriptBinaryFieldData;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 import static java.util.Collections.emptyMap;
@@ -58,7 +61,8 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
             List<String> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                RuntimeKeywordMappedFieldType ft = build("for (def v : source.foo) {value(v.toString())}");
+                RuntimeKeywordMappedFieldType ft = build("for (def v : source.foo) {value(v.toString() + params.param)}",
+                    Map.of("param", "-suffix"));
                 IndexMetadata imd = IndexMetadata.builder("test")
                     .settings(Settings.builder().put("index.version.created", Version.CURRENT))
                     .numberOfShards(1)
@@ -73,11 +77,11 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
                     }
 
                     @Override
-                    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
                         SortedBinaryDocValues dv = ifd.load(context).getBytesValues();
                         return new LeafCollector() {
                             @Override
-                            public void setScorer(Scorable scorer) throws IOException {}
+                            public void setScorer(Scorable scorer) {}
 
                             @Override
                             public void collect(int doc) throws IOException {
@@ -90,7 +94,7 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
                         };
                     }
                 });
-                assertThat(results, equalTo(List.of("1", "1", "2")));
+                assertThat(results, equalTo(List.of("1-suffix", "1-suffix", "2-suffix")));
             }
         }
     }
@@ -213,7 +217,8 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": 2}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(searcher.count(build("value(source.foo.toString())").termQuery("1", mockContext())), equalTo(1));
+                RuntimeKeywordMappedFieldType fieldType = build("value(source.foo.toString() + params.param)", Map.of("param", "-suffix"));
+                assertThat(searcher.count(fieldType.termQuery("1-suffix", mockContext())), equalTo(1));
             }
         }
     }
@@ -255,7 +260,14 @@ public class RuntimeKeywordMappedFieldTypeTests extends ESTestCase {
     }
 
     private RuntimeKeywordMappedFieldType build(String code) throws IOException {
-        Script script = new Script(code);
+        return build(new Script(code));
+    }
+
+    private RuntimeKeywordMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, PainlessScriptEngine.NAME, code, params));
+    }
+
+    private RuntimeKeywordMappedFieldType build(Script script) throws IOException {
         PainlessPlugin painlessPlugin = new PainlessPlugin();
         painlessPlugin.loadExtensions(new ExtensionLoader() {
             @Override


### PR DESCRIPTION
This addresses a TODO around using the script params, which are now parsed from the mappings. It also expand existing tests to verify that params are carried around and accessible in script for both fielddata and queries.

Relates to #59332