### PR TITLE
Fix Snapshot Status API Docs Test

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -59,7 +59,7 @@ PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
 
 PUT _snapshot/my_repository/snapshot_2?wait_for_completion=true
 {
-  "indices": [],
+  "indices": ["index_1"],
   "ignore_unavailable": true,
   "include_global_state": false,
   "metadata": {
@@ -392,5 +392,6 @@ GET /_snapshot/my_repository/snapshot_2/_status
 // TESTRESPONSE[s/"start_time_in_millis" : 1594829326691/"start_time_in_millis" : $body.snapshots.0.stats.start_time_in_millis/]
 // TESTRESPONSE[s/"time_in_millis" : 205/"time_in_millis" : $body.snapshots.0.stats.time_in_millis/]
 // TESTRESPONSE[s/"file_count" : 3/"file_count" : $body.snapshots.0.stats.incremental.file_count/]
+// TESTRESPONSE[s/"file_count" : 4/"file_count" : $body.snapshots.0.stats.total.file_count/]
 // TESTRESPONSE[s/"size_in_bytes" : 5969/"size_in_bytes" : $body.snapshots.0.stats.incremental.size_in_bytes/]
 // TESTRESPONSE[s/"start_time_in_millis" : 1594829326896/"start_time_in_millis" : $body.snapshots.0.indices.index_1.stats.start_time_in_millis/]


### PR DESCRIPTION
We can't just assume a fixed number for the overall file count.
Depending on how the merging/flushing works out we won't always have
4 files for the index across all versions, systems etc.
Also, we could have x-pack concurrently create some system indices
which could mess up the total numbers here.
Fixed by only snapshotting a single index+shard in the snapshot that
we get the status for and verifying consistency instead of equality
for total file counts.

Closes #59767

Backports:
* 7.x #59787
* 7.9 #59789
* 7.8 #59790