### PR TITLE
[DOCS] Reformat Painless snippets to use two-space indents

### DIFF
--- a/docs/painless/painless-contexts/painless-field-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-field-context.asciidoc
@@ -64,21 +64,21 @@ Submit the following request:
 ----
 GET seats/_search
 {
-    "query" : {
-        "match_all": {}
+  "query": {
+    "match_all": {}
+  },
+  "script_fields": {
+    "day-of-week": {
+      "script": {
+        "source": "doc['datetime'].value.getDayOfWeek()"
+      }
     },
-    "script_fields" : {
-        "day-of-week" : {
-            "script" : {
-                "source": "doc['datetime'].value.getDayOfWeek()"
-            }
-        },
-        "number-of-actors" : {
-            "script" : {
-                "source": "params['_source']['actors'].length"
-            }
-        }
+    "number-of-actors": {
+      "script": {
+        "source": "params['_source']['actors'].length"
+      }
     }
+  }
 }
 ----
 // TEST[skip: requires setup from other pages]

--- a/docs/painless/painless-contexts/painless-filter-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-filter-context.asciidoc
@@ -45,20 +45,20 @@ all available theatre seats for evening performances that are under $18.
 ----
 GET seats/_search
 {
-    "query": {
-        "bool" : {
-            "filter" : {
-                "script" : {
-                    "script" : {
-                        "source" : "doc['sold'].value == false && doc['cost'].value < params.cost",
-                        "params" : {
-                            "cost" : 18
-                        }
-                    }
-                }
+  "query": {
+    "bool": {
+      "filter": {
+        "script": {
+          "script": {
+            "source": "doc['sold'].value == false && doc['cost'].value < params.cost",
+            "params": {
+              "cost": 18
             }
+          }
         }
+      }
     }
+  }
 }
 ----
 // TEST[skip: requires setup from other pages]

--- a/docs/painless/painless-contexts/painless-ingest-processor-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-ingest-processor-context.asciidoc
@@ -126,13 +126,13 @@ Submit the following request:
 ----
 PUT /_ingest/pipeline/seats
 {
-    "description": "update datetime for seats",
-    "processors": [
-      {
-        "script": {
-          "source": "String[] dateSplit = ctx.date.splitOnToken('-'); String year = dateSplit[0].trim(); String month = dateSplit[1].trim(); if (month.length() == 1) { month = '0' + month; } String day = dateSplit[2].trim(); if (day.length() == 1) { day = '0' + day; } boolean pm = ctx.time.substring(ctx.time.length() - 2).equals('PM'); String[] timeSplit = ctx.time.substring(0, ctx.time.length() - 2).splitOnToken(':'); int hours = Integer.parseInt(timeSplit[0].trim()); int minutes = Integer.parseInt(timeSplit[1].trim()); if (pm) { hours += 12; } String dts = year + '-' + month + '-' + day + 'T' + (hours < 10 ? '0' + hours : '' + hours) + ':' + (minutes < 10 ? '0' + minutes : '' + minutes) + ':00+08:00'; ZonedDateTime dt = ZonedDateTime.parse(dts, DateTimeFormatter.ISO_OFFSET_DATE_TIME); ctx.datetime = dt.getLong(ChronoField.INSTANT_SECONDS)*1000L;"
-        }
+  "description": "update datetime for seats",
+  "processors": [
+    {
+      "script": {
+        "source": "String[] dateSplit = ctx.date.splitOnToken('-'); String year = dateSplit[0].trim(); String month = dateSplit[1].trim(); if (month.length() == 1) { month = '0' + month; } String day = dateSplit[2].trim(); if (day.length() == 1) { day = '0' + day; } boolean pm = ctx.time.substring(ctx.time.length() - 2).equals('PM'); String[] timeSplit = ctx.time.substring(0, ctx.time.length() - 2).splitOnToken(':'); int hours = Integer.parseInt(timeSplit[0].trim()); int minutes = Integer.parseInt(timeSplit[1].trim()); if (pm) { hours += 12; } String dts = year + '-' + month + '-' + day + 'T' + (hours < 10 ? '0' + hours : '' + hours) + ':' + (minutes < 10 ? '0' + minutes : '' + minutes) + ':00+08:00'; ZonedDateTime dt = ZonedDateTime.parse(dts, DateTimeFormatter.ISO_OFFSET_DATE_TIME); ctx.datetime = dt.getLong(ChronoField.INSTANT_SECONDS)*1000L;"
       }
-    ]
+    }
+  ]
 }
 ----

--- a/docs/painless/painless-contexts/painless-min-should-match-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-min-should-match-context.asciidoc
@@ -56,19 +56,23 @@ two of the three specified actors.
 ----
 GET seats/_search
 {
-    "query" : {
-        "terms_set": {
-            "actors" : {
-                "terms" : ["smith", "earns", "black"],
-                "minimum_should_match_script": {
-                    "source": "Math.min(params['num_terms'], params['min_actors_to_see'])",
-                    "params" : {
-                        "min_actors_to_see" : 2
-                    }
-                }
-            }
+  "query": {
+    "terms_set": {
+      "actors": {
+        "terms": [
+          "smith",
+          "earns",
+          "black"
+        ],
+        "minimum_should_match_script": {
+          "source": "Math.min(params['num_terms'], params['min_actors_to_see'])",
+          "params": {
+            "min_actors_to_see": 2
+          }
         }
+      }
     }
+  }
 }
 ----
 // TEST[skip: requires setup from other pages]

--- a/docs/painless/painless-contexts/painless-score-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-score-context.asciidoc
@@ -41,18 +41,20 @@ scored higher.
 --------------------------------------------------
 GET /seats/_search
 {
-    "query": {
-        "function_score": {
-            "query": {
-                "match": { "sold": "false" }
-            },
-            "script_score" : {
-                "script" : {
-                  "source": "1.0 / doc['row'].value"
-                }
-            }
+  "query": {
+    "function_score": {
+      "query": {
+        "match": {
+          "sold": "false"
         }
+      },
+      "script_score": {
+        "script": {
+          "source": "1.0 / doc['row'].value"
+        }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:seats]

--- a/docs/painless/painless-contexts/painless-sort-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-sort-context.asciidoc
@@ -38,23 +38,24 @@ To sort results by the length of the `theatre` field, submit the following query
 ----
 GET /_search
 {
-    "query" : {
-        "term" : { "sold" : "true" }
-    },
-    "sort" : {
-        "_script" : {
-            "type" : "number",
-            "script" : {
-                "lang": "painless",
-                "source": "doc['theatre'].value.length() * params.factor",
-                "params" : {
-                    "factor" : 1.1
-                }
-            },
-            "order" : "asc"
-        }
+  "query": {
+    "term": {
+      "sold": "true"
     }
+  },
+  "sort": {
+    "_script": {
+      "type": "number",
+      "script": {
+        "lang": "painless",
+        "source": "doc['theatre'].value.length() * params.factor",
+        "params": {
+          "factor": 1.1
+        }
+      },
+      "order": "asc"
+    }
+  }
 }
-
 ----
 // TEST[setup:seats]

--- a/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
@@ -62,30 +62,31 @@ sold and lowers the price by 2:
 --------------------------------------------------
 POST /seats/_update_by_query
 {
-    "query": {
-        "bool": {
-            "filter": [
-            {
-                "range": {
-                    "row": {
-                        "lte": 3
-                    }
-                }
-            },
-            {
-                "match": {
-                    "sold": false
-                }
-            }]
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "row": {
+              "lte": 3
+            }
+          }
+        },
+        {
+          "match": {
+            "sold": false
+          }
         }
-    },
-    "script": {
-        "source": "ctx._source.cost -= params.discount",
-        "lang": "painless",
-        "params": {
-            "discount": 2
-        }
+      ]
     }
+  },
+  "script": {
+    "source": "ctx._source.cost -= params.discount",
+    "lang": "painless",
+    "params": {
+      "discount": 2
+    }
+  }
 }
 --------------------------------------------------
 // TEST[setup:seats]

--- a/docs/painless/painless-contexts/painless-update-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-context.asciidoc
@@ -63,13 +63,13 @@ to the actual price paid after discounts:
 --------------------------------------------------
 POST /seats/_update/3
 {
-    "script": {
-        "source": "ctx._source.sold = true; ctx._source.cost = params.sold_cost",
-        "lang": "painless",
-        "params": {
-            "sold_cost": 26
-        }
+  "script": {
+    "source": "ctx._source.sold = true; ctx._source.cost = params.sold_cost",
+    "lang": "painless",
+    "params": {
+      "sold_cost": 26
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:seats]

--- a/docs/painless/painless-guide/painless-datetime.asciidoc
+++ b/docs/painless/painless-guide/painless-datetime.asciidoc
@@ -459,9 +459,9 @@ source document is most commonly accessible through an input called
 [source,JSON]
 ----
 {
-    ...
-    "input_datetime": 434931327000
-    ...
+  ...
+  "input_datetime": 434931327000
+  ...
 }
 ----
 +
@@ -482,9 +482,9 @@ ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, ZoneId.of('Z'));
 [source,JSON]
 ----
 {
-    ...
-    "input_datetime": "1983-10-13T22:15:30Z"
-    ...
+  ...
+  "input_datetime": "1983-10-13T22:15:30Z"
+  ...
 }
 ----
 +
@@ -523,17 +523,17 @@ document is most commonly accessible through an input called `doc`.
 [source,JSON]
 ----
 {
-    "mappings": {
-        ...
-        "properties": {
-            ...
-            "input_datetime": {
-                "type": "date"
-            }
-            ...
-        }
-        ...
+  "mappings": {
+    ...
+    "properties": {
+      ...
+      "input_datetime": {
+        "type": "date"
+      }
+      ...
     }
+    ...
+  }
 }
 ----
 +
@@ -559,20 +559,20 @@ query
 [source,JSON]
 ----
 {
-    "mappings": {
-        ...
-        "properties": {
-            ...
-            "start": {
-                "type": "date"
-            },
-            "end": {
-                "type": "date"
-            }
-            ...
-        }
-        ...
+  "mappings": {
+    ...
+    "properties": {
+      ...
+      "start": {
+        "type": "date"
+      },
+      "end": {
+        "type": "date"
+      }
+      ...
     }
+    ...
+  }
 }
 ----
 +
@@ -627,17 +627,17 @@ preferred as there is no need to parse it for comparison.
 [source,JSON]
 ----
 {
-    "mappings": {
+  "mappings": {
+      ...
+      "properties": {
         ...
-        "properties": {
-            ...
-            "input_datetime": {
-                "type": "date"
-            }
-            ...
-        }
-        ...
+        "input_datetime": {
+        "type": "date"
+      }
+      ...
     }
+    ...
+  }
 }
 ----
 +
@@ -677,17 +677,17 @@ long elapsedTime = now - millisDateTime;
 [source,JSON]
 ----
 {
-    "mappings": {
-        ...
-        "properties": {
-            ...
-            "input_datetime": {
-                "type": "date"
-            }
-            ...
-        }
-        ...
+  "mappings": {
+    ...
+    "properties": {
+      ...
+      "input_datetime": {
+        "type": "date"
+      }
+      ...
     }
+    ...
+  }
 }
 ----
 +
@@ -732,19 +732,19 @@ examples into an Elasticsearch cluster:
 ----
 PUT /messages
 {
-    "mappings": {
-        "properties": {
-            "priority": {
-                "type": "integer"
-            },
-            "datetime": {
-                "type": "date"
-            },
-            "message": {
-                "type": "text"
-            }
-        }
+  "mappings": {
+    "properties": {
+      "priority": {
+        "type": "integer"
+      },
+      "datetime": {
+        "type": "date"
+      },
+      "message": {
+        "type": "text"
+      }
     }
+  }
 }
 ----
 +
@@ -788,13 +788,13 @@ display the number of messages from each day-of-the-week.
 ----
 GET /messages/_search?pretty=true
 {
-    "aggs": {
-        "day-of-week-count": {
-            "terms": {
-                "script": "return doc[\"datetime\"].value.getDayOfWeekEnum();"
-            }
-        }
+  "aggs": {
+    "day-of-week-count": {
+      "terms": {
+        "script": "return doc[\"datetime\"].value.getDayOfWeekEnum();"
+      }
     }
+  }
 }
 ----
 // TEST[continued]
@@ -811,13 +811,13 @@ display the number of messages received in the morning versus the evening.
 ----
 GET /messages/_search?pretty=true
 {
-    "aggs": {
-        "am-pm-count": {
-            "terms": {
-                "script": "return doc[\"datetime\"].value.getHour() < 12 ? \"AM\" : \"PM\";"
-            }
-        }
+  "aggs": {
+    "am-pm-count": {
+      "terms": {
+        "script": "return doc[\"datetime\"].value.getHour() < 12 ? \"AM\" : \"PM\";"
+      }
     }
+  }
 }
 ----
 // TEST[continued]
@@ -833,19 +833,19 @@ The following example uses a
 ----
 GET /_search?pretty=true
 {
-    "query" : {
-        "match_all": {}
-    },
-    "script_fields" : {
-        "message_age" : {
-            "script" : {
-                "source": "ZonedDateTime now = ZonedDateTime.ofInstant(Instant.ofEpochMilli(params[\"now\"]), ZoneId.of(\"Z\")); ZonedDateTime mdt = doc[\"datetime\"].value; String age; long years = mdt.until(now, ChronoUnit.YEARS); age = years + \"Y \"; mdt = mdt.plusYears(years); long months = mdt.until(now, ChronoUnit.MONTHS); age += months + \"M \"; mdt = mdt.plusMonths(months); long days = mdt.until(now, ChronoUnit.DAYS); age += days + \"D \"; mdt = mdt.plusDays(days); long hours = mdt.until(now, ChronoUnit.HOURS); age += hours + \"h \"; mdt = mdt.plusHours(hours); long minutes = mdt.until(now, ChronoUnit.MINUTES); age += minutes + \"m \"; mdt = mdt.plusMinutes(minutes); long seconds = mdt.until(now, ChronoUnit.SECONDS); age += hours + \"s\"; return age;",
-                "params": {
-                    "now": 1574005645830
-                }
-            }
+  "query": {
+    "match_all": {}
+  },
+  "script_fields": {
+    "message_age": {
+      "script": {
+        "source": "ZonedDateTime now = ZonedDateTime.ofInstant(Instant.ofEpochMilli(params[\"now\"]), ZoneId.of(\"Z\")); ZonedDateTime mdt = doc[\"datetime\"].value; String age; long years = mdt.until(now, ChronoUnit.YEARS); age = years + \"Y \"; mdt = mdt.plusYears(years); long months = mdt.until(now, ChronoUnit.MONTHS); age += months + \"M \"; mdt = mdt.plusMonths(months); long days = mdt.until(now, ChronoUnit.DAYS); age += days + \"D \"; mdt = mdt.plusDays(days); long hours = mdt.until(now, ChronoUnit.HOURS); age += hours + \"h \"; mdt = mdt.plusHours(hours); long minutes = mdt.until(now, ChronoUnit.MINUTES); age += minutes + \"m \"; mdt = mdt.plusMinutes(minutes); long seconds = mdt.until(now, ChronoUnit.SECONDS); age += hours + \"s\"; return age;",
+        "params": {
+          "now": 1574005645830
         }
+      }
     }
+  }
 }
 ----
 // TEST[continued]


### PR DESCRIPTION
Reformats snippets in the Painless docs to use two-space indentation.

No substantive changes were made to the snippets.

Relates to #50606.