### PR TITLE
Reduce precision in geotile circuit breaker tests to 5

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -466,7 +466,7 @@ public class GeoGridTilerTests extends ESTestCase {
 
     private void testCircuitBreaker(GeoGridTiler tiler) throws IOException {
         Polygon polygon = GeometryTestUtils.randomPolygon(false);
-        int precision = randomIntBetween(0, 7);
+        int precision = randomIntBetween(0, 5);
         TriangleTreeReader reader = triangleTreeReader(polygon, GeoShapeCoordinateEncoder.INSTANCE);
         MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
 


### PR DESCRIPTION
PR #57962 increased the precision from 6 to 7 without realizing the effects on CI — This resulted in out of memory exceptions in CI.

This commit reduces the precision down to 5.