### PR TITLE
WIP Add 'version_range' field

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -64,7 +64,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
@@ -142,7 +142,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             fieldType.queryBuilderField = queryBuilderField.fieldType();
             // Range field is of type ip, because that matches closest with BinaryRange field. Otherwise we would
             // have to introduce a new field type...
-            RangeFieldMapper rangeFieldMapper = createExtractedRangeFieldBuilder(RANGE_FIELD_NAME, RangeType.IP, context);
+            RangeFieldMapper rangeFieldMapper = createExtractedRangeFieldBuilder(RANGE_FIELD_NAME, CoreRangeType.IP, context);
             fieldType.rangeField = rangeFieldMapper.fieldType();
             NumberFieldMapper minimumShouldMatchFieldMapper = createMinimumShouldMatchField(context);
             fieldType.minimumShouldMatchField = minimumShouldMatchFieldMapper.fieldType();
@@ -170,7 +170,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             return builder.build(context);
         }
 
-        static RangeFieldMapper createExtractedRangeFieldBuilder(String name, RangeType rangeType, BuilderContext context) {
+        static RangeFieldMapper createExtractedRangeFieldBuilder(String name, CoreRangeType rangeType, BuilderContext context) {
             RangeFieldMapper.Builder builder = new RangeFieldMapper.Builder(name, rangeType, true);
             // For now no doc values, because in processQuery(...) only the Lucene range fields get added:
             builder.docValues(false);

--- a/server/src/main/java/org/apache/lucene/document/BinaryRange.java
+++ b/server/src/main/java/org/apache/lucene/document/BinaryRange.java
@@ -49,7 +49,7 @@ public final class BinaryRange extends Field {
     }
 
     /**
-     * Create a query for matching indexed ip ranges that {@code INTERSECT} the defined range.
+     * Create a query for matching indexed ranges that {@code INTERSECT} the defined range.
      * @param field         field name. must not be null.
      * @param encodedRange  Encoded range
      * @return query for matching intersecting encoded ranges (overlap, within, crosses, or contains)
@@ -57,6 +57,14 @@ public final class BinaryRange extends Field {
      */
     public static Query newIntersectsQuery(String field, byte[] encodedRange) {
         return newRelationQuery(field, encodedRange, RangeFieldQuery.QueryType.INTERSECTS);
+    }
+
+    public static Query newContainsQuery(String field, byte[] encodedRange) {
+        return newRelationQuery(field, encodedRange, RangeFieldQuery.QueryType.CONTAINS);
+    }
+
+    public static Query newWithinQuery(String field, byte[] encodedRange) {
+        return newRelationQuery(field, encodedRange, RangeFieldQuery.QueryType.WITHIN);
     }
 
     static Query newRelationQuery(String field, byte[] encodedRange, RangeFieldQuery.QueryType relation) {

--- a/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
@@ -32,7 +32,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -41,13 +41,13 @@ public final class BinaryDocValuesRangeQuery extends Query {
 
     private final String fieldName;
     private final QueryType queryType;
-    private final RangeType.LengthType lengthType;
+    private final CoreRangeType.LengthType lengthType;
     private final BytesRef from;
     private final BytesRef to;
     private final Object originalFrom;
     private final Object originalTo;
 
-    public BinaryDocValuesRangeQuery(String fieldName, QueryType queryType, RangeType.LengthType lengthType,
+    public BinaryDocValuesRangeQuery(String fieldName, QueryType queryType, CoreRangeType.LengthType lengthType,
                                      BytesRef from, BytesRef to,
                                      Object originalFrom, Object originalTo) {
         this.fieldName = fieldName;
@@ -87,11 +87,13 @@ public final class BinaryDocValuesRangeQuery extends Query {
                         int offset = in.getPosition();
                         for (int i = 0; i < numRanges; i++) {
                             int length = lengthType.readLength(bytes, offset);
+                            offset += lengthType.advanceBy();
                             otherFrom.offset = offset;
                             otherFrom.length = length;
                             offset += length;
 
                             length = lengthType.readLength(bytes, offset);
+                            offset += lengthType.advanceBy();
                             otherTo.offset = offset;
                             otherTo.length = length;
                             offset += length;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -437,13 +437,13 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
     }
 
-    abstract static class BinaryScriptDocValues<T> extends ScriptDocValues<T> {
+    public abstract static class BinaryScriptDocValues<T> extends ScriptDocValues<T> {
 
         private final SortedBinaryDocValues in;
         protected BytesRefBuilder[] values = new BytesRefBuilder[0];
         protected int count;
 
-        BinaryScriptDocValues(SortedBinaryDocValues in) {
+        public BinaryScriptDocValues(SortedBinaryDocValues in) {
             this.in = in;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CoreRangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CoreRangeType.java
@@ -1,0 +1,748 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANYDa
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.DoubleRange;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FloatRange;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.InetAddressRange;
+import org.apache.lucene.document.IntRange;
+import org.apache.lucene.document.LongRange;
+import org.apache.lucene.queries.BinaryDocValuesRangeQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.RangeFieldMapper.RangeFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/** Enum defining the type of range */
+public enum CoreRangeType implements RangeType {
+    IP("ip_range", LengthType.FIXED_16) {
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new InetAddressRange(name, (InetAddress)r.from, (InetAddress)r.to);
+        }
+
+        @Override
+        public Object parseValue(RangeFieldType fieldType, XContentParser parser, boolean coerce, Function<Object, Object> rounding)
+            throws IOException {
+            InetAddress address = InetAddresses.forString(parser.text());
+            return rounding.apply(address);
+        }
+
+        @Override
+        public InetAddress parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
+            if (value instanceof InetAddress) {
+                return (InetAddress) value;
+            } else {
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
+                }
+                return InetAddresses.forString(value.toString());
+            }
+        }
+
+        @Override
+        public Object formatValue(Object value, DateFormatter dateFormatter) {
+            return InetAddresses.toAddrString((InetAddress) value);
+        }
+
+        @Override
+        public InetAddress minValue() {
+            return InetAddressPoint.MIN_VALUE;
+        }
+        @Override
+        public InetAddress maxValue() {
+            return InetAddressPoint.MAX_VALUE;
+        }
+        @Override
+        public InetAddress nextUp(Object value) {
+            return InetAddressPoint.nextUp((InetAddress)value);
+        }
+        @Override
+        public InetAddress nextDown(Object value) {
+            return InetAddressPoint.nextDown((InetAddress)value);
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return BinaryRangeUtil.encodeIPRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            // TODO: Implement this.
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Double doubleValue (Object endpointValue) {
+            throw new UnsupportedOperationException("IP ranges cannot be safely converted to doubles");
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            if (includeFrom == false) {
+                from = nextUp(from);
+            }
+
+            if (includeTo == false) {
+                to = nextDown(to);
+            }
+
+            byte[] encodedFrom = InetAddressPoint.encode((InetAddress) from);
+            byte[] encodedTo = InetAddressPoint.encode((InetAddress) to);
+            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_16,
+                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
+        }
+
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, from, to, includeFrom, includeTo,
+                    (f, t) -> InetAddressRange.newWithinQuery(field, f, t));
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, from, to, includeFrom, includeTo,
+                    (f, t) -> InetAddressRange.newContainsQuery(field, f, t ));
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, from, to, includeFrom, includeTo,
+                    (f, t) -> InetAddressRange.newIntersectsQuery(field, f ,t ));
+        }
+
+        private Query createQuery(String field, Object lower, Object upper, boolean includeLower, boolean includeUpper,
+                BiFunction<InetAddress, InetAddress, Query> querySupplier) {
+            byte[] lowerBytes = InetAddressPoint.encode((InetAddress) lower);
+            byte[] upperBytes = InetAddressPoint.encode((InetAddress) upper);
+            if (Arrays.compareUnsigned(lowerBytes, 0, lowerBytes.length, upperBytes, 0, upperBytes.length) > 0) {
+                throw new IllegalArgumentException(
+                        "Range query `from` value (" + lower + ") is greater than `to` value (" + upper + ")");
+            }
+            InetAddress correctedFrom = includeLower ? (InetAddress) lower : nextUp(lower);
+            InetAddress correctedTo = includeUpper ? (InetAddress) upper : nextDown(upper);;
+            lowerBytes = InetAddressPoint.encode(correctedFrom);
+            upperBytes = InetAddressPoint.encode(correctedTo);
+            if (Arrays.compareUnsigned(lowerBytes, 0, lowerBytes.length, upperBytes, 0, upperBytes.length) > 0) {
+                return new MatchNoDocsQuery("float range didn't intersect anything");
+            } else {
+                return querySupplier.apply(correctedFrom, correctedTo);
+            }
+        }
+
+        @Override
+        public boolean isNumeric() {
+            return false;
+        }
+    },
+    DATE("date_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.LONG) {
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new LongRange(name, new long[] {((Number)r.from).longValue()}, new long[] {((Number)r.to).longValue()});
+        }
+
+        @Override
+        public Object parseValue(
+            RangeFieldMapper.RangeFieldType fieldType,
+            XContentParser parser,
+            boolean coerce,
+            Function<Object, Object> rounding
+        ) throws IOException {
+            Number value = parseValue(parser.text(), coerce, fieldType.dateMathParser);
+            return rounding.apply(value);
+        }
+
+        @Override
+        public Long parseValue(Object dateStr, boolean coerce, @Nullable DateMathParser dateMathParser) {
+            assert dateMathParser != null;
+            return dateMathParser.parse(dateStr.toString(), () -> {
+                throw new IllegalArgumentException("now is not used at indexing time");
+            }).toEpochMilli();
+        }
+
+        @Override
+        public Object formatValue(Object value, DateFormatter dateFormatter) {
+            long timestamp = (long) value;
+            ZonedDateTime dateTime = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC);
+            return dateFormatter.format(dateTime);
+        }
+
+        @Override
+        public Long minValue() {
+            return Long.MIN_VALUE;
+        }
+        @Override
+        public Long maxValue() {
+            return Long.MAX_VALUE;
+        }
+        @Override
+        public Long nextUp(Object value) {
+            return (long) LONG.nextUp(value);
+        }
+        @Override
+        public Long nextDown(Object value) {
+            return (long) LONG.nextDown(value);
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return LONG.encodeRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            return LONG.decodeRanges(bytes);
+        }
+
+        @Override
+        public Double doubleValue(Object endpointValue) {
+            return LONG.doubleValue(endpointValue);
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            return LONG.dvRangeQuery(field, queryType, from, to, includeFrom, includeTo);
+        }
+
+        @Override
+        public Query rangeQuery(String field, boolean hasDocValues, Object lowerTerm, Object upperTerm, boolean includeLower,
+                                boolean includeUpper, ShapeRelation relation, @Nullable ZoneId timeZone,
+                                @Nullable DateMathParser parser, QueryShardContext context) {
+            ZoneId zone = (timeZone == null) ? ZoneOffset.UTC : timeZone;
+
+            DateMathParser dateMathParser = (parser == null) ?
+                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser() : parser;
+            boolean roundUp = includeLower == false; // using "gt" should round lower bound up
+            Long low = lowerTerm == null ? minValue() :
+                dateMathParser.parse(lowerTerm instanceof BytesRef ? ((BytesRef) lowerTerm).utf8ToString() : lowerTerm.toString(),
+                    context::nowInMillis, roundUp, zone).toEpochMilli();
+            roundUp = includeUpper; // using "lte" should round upper bound up
+            Long high = upperTerm == null ? maxValue() :
+                dateMathParser.parse(upperTerm instanceof BytesRef ? ((BytesRef) upperTerm).utf8ToString() : upperTerm.toString(),
+                    context::nowInMillis, roundUp, zone).toEpochMilli();
+
+            return createRangeQuery(field, hasDocValues, low, high, includeLower, includeUpper, relation);
+        }
+
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
+            return LONG.withinQuery(field, from, to, includeLower, includeUpper);
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
+            return LONG.containsQuery(field, from, to, includeLower, includeUpper);
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
+            return LONG.intersectsQuery(field, from, to, includeLower, includeUpper);
+        }
+    },
+    // todo support half_float
+    FLOAT("float_range", LengthType.FIXED_4, NumberFieldMapper.NumberType.FLOAT) {
+        @Override
+        public Float minValue() {
+            return Float.NEGATIVE_INFINITY;
+        }
+        @Override
+        public Float maxValue() {
+            return Float.POSITIVE_INFINITY;
+        }
+        @Override
+        public Float nextUp(Object value) {
+            return Math.nextUp(((Number)value).floatValue());
+        }
+        @Override
+        public Float nextDown(Object value) {
+            return Math.nextDown(((Number)value).floatValue());
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return BinaryRangeUtil.encodeFloatRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            return BinaryRangeUtil.decodeFloatRanges(bytes);
+        }
+
+        @Override
+        public Double doubleValue(Object endpointValue) {
+            assert endpointValue instanceof Float;
+            return ((Float) endpointValue).doubleValue();
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            if (includeFrom == false) {
+                from = nextUp(from);
+            }
+
+            if (includeTo == false) {
+                to = nextDown(to);
+            }
+
+            byte[] encodedFrom = BinaryRangeUtil.encodeFloat((Float) from);
+            byte[] encodedTo = BinaryRangeUtil.encodeFloat((Float) to);
+            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_4,
+                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
+        }
+
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new FloatRange(name, new float[] {((Number)r.from).floatValue()}, new float[] {((Number)r.to).floatValue()});
+        }
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
+                    (f, t) -> FloatRange.newWithinQuery(field, new float[] { f }, new float[] { t }), CoreRangeType.FLOAT);
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
+                    (f, t) -> FloatRange.newContainsQuery(field, new float[] { f }, new float[] { t }), CoreRangeType.FLOAT);
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
+                    (f, t) -> FloatRange.newIntersectsQuery(field, new float[] { f }, new float[] { t }), CoreRangeType.FLOAT);
+        }
+    },
+    DOUBLE("double_range", LengthType.FIXED_8, NumberFieldMapper.NumberType.DOUBLE) {
+        @Override
+        public Double minValue() {
+            return Double.NEGATIVE_INFINITY;
+        }
+        @Override
+        public Double maxValue() {
+            return Double.POSITIVE_INFINITY;
+        }
+        @Override
+        public Double nextUp(Object value) {
+            return Math.nextUp(((Number)value).doubleValue());
+        }
+        @Override
+        public Double nextDown(Object value) {
+            return Math.nextDown(((Number)value).doubleValue());
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return BinaryRangeUtil.encodeDoubleRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            return BinaryRangeUtil.decodeDoubleRanges(bytes);
+        }
+
+        @Override
+        public Double doubleValue(Object endpointValue) {
+            assert endpointValue instanceof Double;
+            return (Double) endpointValue;
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            if (includeFrom == false) {
+                from = nextUp(from);
+            }
+
+            if (includeTo == false) {
+                to = nextDown(to);
+            }
+
+            byte[] encodedFrom = BinaryRangeUtil.encodeDouble((Double) from);
+            byte[] encodedTo = BinaryRangeUtil.encodeDouble((Double) to);
+            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_8,
+                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
+        }
+
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new DoubleRange(name, new double[] {((Number)r.from).doubleValue()}, new double[] {((Number)r.to).doubleValue()});
+        }
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
+                    (f, t) -> DoubleRange.newWithinQuery(field, new double[] { f }, new double[] { t }), CoreRangeType.DOUBLE);
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
+                    (f, t) -> DoubleRange.newContainsQuery(field, new double[] { f }, new double[] { t }), CoreRangeType.DOUBLE);
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
+                    (f, t) -> DoubleRange.newIntersectsQuery(field, new double[] { f }, new double[] { t }), CoreRangeType.DOUBLE);
+        }
+
+    },
+    // todo add BYTE support
+    // todo add SHORT support
+    INTEGER("integer_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.INTEGER) {
+        @Override
+        public Integer minValue() {
+            return Integer.MIN_VALUE;
+        }
+        @Override
+        public Integer maxValue() {
+            return Integer.MAX_VALUE;
+        }
+        @Override
+        public Integer nextUp(Object value) {
+            return ((Number)value).intValue() + 1;
+        }
+        @Override
+        public Integer nextDown(Object value) {
+            return ((Number)value).intValue() - 1;
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return LONG.encodeRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            return LONG.decodeRanges(bytes);
+        }
+
+        @Override
+        public Double doubleValue(Object endpointValue) {
+            return LONG.doubleValue(endpointValue);
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            return LONG.dvRangeQuery(field, queryType, from, to, includeFrom, includeTo);
+        }
+
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new IntRange(name, new int[] {((Number)r.from).intValue()}, new int[] {((Number)r.to).intValue()});
+        }
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Integer) from, (Integer) to, includeFrom, includeTo,
+                    (f, t) -> IntRange.newWithinQuery(field, new int[] { f }, new int[] { t }), CoreRangeType.INTEGER);
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field,  (Integer) from,  (Integer) to, includeFrom, includeTo,
+                    (f, t) -> IntRange.newContainsQuery(field, new int[] { f }, new int[] { t }), CoreRangeType.INTEGER);
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field,  (Integer) from,  (Integer) to, includeFrom, includeTo,
+                    (f, t) -> IntRange.newIntersectsQuery(field, new int[] { f }, new int[] { t }), CoreRangeType.INTEGER);
+        }
+    },
+    LONG("long_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.LONG) {
+        @Override
+        public Long minValue() {
+            return Long.MIN_VALUE;
+        }
+        @Override
+        public Long maxValue() {
+            return Long.MAX_VALUE;
+        }
+        @Override
+        public Long nextUp(Object value) {
+            return ((Number)value).longValue() + 1;
+        }
+        @Override
+        public Long nextDown(Object value) {
+            return ((Number)value).longValue() - 1;
+        }
+
+        @Override
+        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+            return BinaryRangeUtil.encodeLongRanges(ranges);
+        }
+
+        @Override
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+            return BinaryRangeUtil.decodeLongRanges(bytes);
+        }
+
+        @Override
+        public Double doubleValue(Object endpointValue) {
+            assert endpointValue instanceof Long;
+            return ((Long) endpointValue).doubleValue();
+        }
+
+        @Override
+        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
+                                  boolean includeTo) {
+            if (includeFrom == false) {
+                from = nextUp(from);
+            }
+
+            if (includeTo == false) {
+                to = nextDown(to);
+            }
+
+            byte[] encodedFrom = BinaryRangeUtil.encodeLong(((Number) from).longValue());
+            byte[] encodedTo = BinaryRangeUtil.encodeLong(((Number) to).longValue());
+            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.VARIABLE,
+                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
+        }
+
+        @Override
+        public Field getRangeField(String name, RangeFieldMapper.Range r) {
+            return new LongRange(name, new long[] {((Number)r.from).longValue()},
+                new long[] {((Number)r.to).longValue()});
+        }
+        @Override
+        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
+                    (f, t) -> LongRange.newWithinQuery(field, new long[] { f }, new long[] { t }), CoreRangeType.LONG);
+        }
+        @Override
+        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
+                    (f, t) -> LongRange.newContainsQuery(field, new long[] { f }, new long[] { t }), CoreRangeType.LONG);
+        }
+        @Override
+        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
+                    (f, t) -> LongRange.newIntersectsQuery(field, new long[] { f }, new long[] { t }), CoreRangeType.LONG);
+        }
+    };
+
+    CoreRangeType(String name, LengthType lengthType) {
+        this.name = name;
+        this.numberType = null;
+        this.lengthType = lengthType;
+    }
+
+    CoreRangeType(String name, LengthType lengthType, NumberFieldMapper.NumberType type) {
+        this.name = name;
+        this.numberType = type;
+        this.lengthType = lengthType;
+    }
+
+    /** Get the associated type name. */
+    public final String typeName() {
+        return name;
+    }
+
+    /**
+     * Internal helper to create the actual {@link Query} using the provided supplier function. Before creating the query we check if
+     * the intervals min &gt; max, in which case an {@link IllegalArgumentException} is raised. The method adapts the interval bounds
+     * based on whether the edges should be included or excluded. In case where after this correction the interval would be empty
+     * because min &gt; max, we simply return a {@link MatchNoDocsQuery}.
+     * This helper handles all {@link Number} cases and dates, the IP range type uses its own logic.
+     */
+    private static <T extends Comparable<T>> Query createQuery(String field, T from, T to, boolean includeFrom, boolean includeTo,
+            BiFunction<T, T, Query> querySupplier, CoreRangeType rangeType) {
+        if (from.compareTo(to) > 0) {
+            // wrong argument order, this is an error the user should fix
+            throw new IllegalArgumentException("Range query `from` value (" + from + ") is greater than `to` value (" + to + ")");
+        }
+
+        @SuppressWarnings("unchecked")
+        T correctedFrom = includeFrom ? from : (T) rangeType.nextUp(from);
+        @SuppressWarnings("unchecked")
+        T correctedTo =  includeTo ? to : (T) rangeType.nextDown(to);
+        if (correctedFrom.compareTo(correctedTo) > 0) {
+            return new MatchNoDocsQuery("range didn't intersect anything");
+        } else {
+            return querySupplier.apply(correctedFrom, correctedTo);
+        }
+    }
+
+    @Override
+    public abstract Field getRangeField(String name, RangeFieldMapper.Range range);
+
+    @Override
+    public Object parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
+        return numberType.parse(value, coerce);
+    }
+
+    /** parses from value. rounds according to included flag */
+    @Override
+    public Object parseValue(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce,
+                            Function<Object, Object> rounding) throws IOException {
+        Number value = numberType.parse(parser, coerce);
+        return rounding.apply(value);
+    }
+
+    @Override
+    public Query rangeQuery(String field, boolean hasDocValues, Object from, Object to, boolean includeFrom, boolean includeTo,
+                            ShapeRelation relation, @Nullable ZoneId timeZone, @Nullable DateMathParser dateMathParser,
+                            QueryShardContext context) {
+        Object lower = from == null ? minValue() : parseValue(from, false, dateMathParser);
+        Object upper = to == null ? maxValue() : parseValue(to, false, dateMathParser);
+        return createRangeQuery(field, hasDocValues, lower, upper, includeFrom, includeTo, relation);
+    }
+
+    protected final Query createRangeQuery(String field, boolean hasDocValues, Object lower, Object upper,
+                                           boolean includeFrom, boolean includeTo, ShapeRelation relation) {
+        Query indexQuery;
+        if (relation == ShapeRelation.WITHIN) {
+            indexQuery = withinQuery(field, lower, upper, includeFrom, includeTo);
+        } else if (relation == ShapeRelation.CONTAINS) {
+            indexQuery = containsQuery(field, lower, upper, includeFrom, includeTo);
+        } else {
+            indexQuery = intersectsQuery(field, lower, upper, includeFrom, includeTo);
+        }
+        if (hasDocValues) {
+            final BinaryDocValuesRangeQuery.QueryType queryType;
+            if (relation == ShapeRelation.WITHIN) {
+                queryType = BinaryDocValuesRangeQuery.QueryType.WITHIN;
+            } else if (relation == ShapeRelation.CONTAINS) {
+                queryType = BinaryDocValuesRangeQuery.QueryType.CONTAINS;
+            } else {
+                queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
+            }
+            Query dvQuery = dvRangeQuery(field, queryType, lower, upper, includeFrom, includeTo);
+            return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+        } else {
+            return indexQuery;
+        }
+    }
+
+    // No need to take into account Range#includeFrom or Range#includeTo, because from and to have already been
+    // rounded up via parseFrom and parseTo methods.
+    @Override
+    public abstract BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException;
+    @Override
+    public abstract List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes);
+
+    /**
+     * Given the Range.to or Range.from Object value from a Range instance, converts that value into a Double.  Before converting, it
+     * asserts that the object is of the expected type.  Operation is not supported on IP ranges (because of loss of precision)
+     *
+     * @param endpointValue Object value for Range.to or Range.from
+     * @return endpointValue as a Double
+     */
+    @Override
+    public abstract Double doubleValue(Object endpointValue);
+
+    public abstract Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to,
+                                       boolean includeFrom, boolean includeTo);
+
+    public final Mapper.TypeParser parser() {
+        return new ParametrizedFieldMapper.TypeParser((n, c) -> new RangeFieldMapper.Builder(n, this, c.getSettings()));
+    }
+
+    public final String name;
+    private final NumberFieldMapper.NumberType numberType;
+    private final LengthType lengthType;
+
+    @Override
+    public String getName() {
+        return name;
+    };
+
+    @Override
+    public LengthType getLengthType() {
+        return lengthType;
+    };
+
+    public enum LengthType {
+        FIXED_4 {
+            @Override
+            public int readLength(byte[] bytes, int offset) {
+                return 4;
+            }
+        },
+        FIXED_8 {
+            @Override
+            public int readLength(byte[] bytes, int offset) {
+                return 8;
+            }
+        },
+        FIXED_16 {
+            @Override
+            public int readLength(byte[] bytes, int offset) {
+                return 16;
+            }
+        },
+        VARIABLE {
+            @Override
+            public int readLength(byte[] bytes, int offset) {
+                // the first bit encodes the sign and the next 4 bits encode the number
+                // of additional bytes
+                int token = Byte.toUnsignedInt(bytes[offset]);
+                int length = (token >>> 3) & 0x0f;
+                if ((token & 0x80) == 0) {
+                    length = 0x0f - length;
+                }
+                return 1 + length;
+            }
+        },
+        FULL_BYTE {
+            @Override
+            public int readLength(byte[] bytes, int offset) {
+                return bytes[offset];
+            }
+
+            @Override
+            public int advanceBy() {
+                return 1;
+            };
+        };
+
+        /**
+         * Return the length of the value that starts at {@code offset} in {@code bytes}.
+         */
+        public abstract int readLength(byte[] bytes, int offset);
+
+        /**
+         * {@link #readLength(byte[], int)} may read the length of the following range from the offset position or return
+         * a fixed value, in which case {@link BinaryRangeUtil#decodeRanges(BytesRef, RangeType, org.elasticsearch.common.TriFunction)}
+         * doesn't need to advance its position in the bytes[]. For other LengthType this may need to be adjusted.
+         * @return the number of positions the offset needs to be advances after reading the length
+         */
+        public int advanceBy() {
+            return 0;
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -1,3 +1,24 @@
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -17,591 +38,60 @@
  * under the License.
  */
 
-package org.elasticsearch.index.mapper;
+public interface RangeType {
 
-import org.apache.lucene.document.DoubleRange;
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FloatRange;
-import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.document.InetAddressRange;
-import org.apache.lucene.document.IntRange;
-import org.apache.lucene.document.LongRange;
-import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.queries.BinaryDocValuesRangeQuery;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+    String getName();
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.function.BiFunction;
+    CoreRangeType.LengthType getLengthType();
 
-/** Enum defining the type of range */
-public enum RangeType {
-    IP("ip_range", LengthType.FIXED_16) {
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new InetAddressRange(name, (InetAddress)r.from, (InetAddress)r.to);
-        }
-        @Override
-        public InetAddress parseFrom(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
-                throws IOException {
-            InetAddress address = InetAddresses.forString(parser.text());
-            return included ? address : nextUp(address);
-        }
-        @Override
-        public InetAddress parseTo(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
-                throws IOException {
-            InetAddress address = InetAddresses.forString(parser.text());
-            return included ? address : nextDown(address);
-        }
+    List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes);
 
-        @Override
-        public InetAddress parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
-            if (value instanceof InetAddress) {
-                return (InetAddress) value;
-            } else {
-                if (value instanceof BytesRef) {
-                    value = ((BytesRef) value).utf8ToString();
-                }
-                return InetAddresses.forString(value.toString());
-            }
-        }
+    Double doubleValue(Object endpointValue);
 
-        @Override
-        public Object formatValue(Object value, DateFormatter dateFormatter) {
-            return InetAddresses.toAddrString((InetAddress) value);
-        }
+    BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException;
 
-        @Override
-        public InetAddress minValue() {
-            return InetAddressPoint.MIN_VALUE;
-        }
-        @Override
-        public InetAddress maxValue() {
-            return InetAddressPoint.MAX_VALUE;
-        }
-        @Override
-        public InetAddress nextUp(Object value) {
-            return InetAddressPoint.nextUp((InetAddress)value);
-        }
-        @Override
-        public InetAddress nextDown(Object value) {
-            return InetAddressPoint.nextDown((InetAddress)value);
-        }
+    Query rangeQuery(
+        String field,
+        boolean hasDocValues,
+        Object from,
+        Object to,
+        boolean includeFrom,
+        boolean includeTo,
+        ShapeRelation relation,
+        @Nullable ZoneId timeZone,
+        @Nullable DateMathParser dateMathParser,
+        QueryShardContext context
+    );
 
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return BinaryRangeUtil.encodeIPRanges(ranges);
-        }
+    Object minValue();
 
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            // TODO: Implement this.
-            throw new UnsupportedOperationException();
-        }
+    Object maxValue();
 
-        @Override
-        public Double doubleValue (Object endpointValue) {
-            throw new UnsupportedOperationException("IP ranges cannot be safely converted to doubles");
-        }
+    Object nextUp(Object value);
 
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            if (includeFrom == false) {
-                from = nextUp(from);
-            }
+    Object nextDown(Object value);
 
-            if (includeTo == false) {
-                to = nextDown(to);
-            }
+    Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
 
-            byte[] encodedFrom = InetAddressPoint.encode((InetAddress) from);
-            byte[] encodedTo = InetAddressPoint.encode((InetAddress) to);
-            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_16,
-                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
-        }
+    Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
 
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, from, to, includeFrom, includeTo,
-                    (f, t) -> InetAddressRange.newWithinQuery(field, f, t));
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, from, to, includeFrom, includeTo,
-                    (f, t) -> InetAddressRange.newContainsQuery(field, f, t ));
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, from, to, includeFrom, includeTo,
-                    (f, t) -> InetAddressRange.newIntersectsQuery(field, f ,t ));
-        }
+    Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
 
-        private Query createQuery(String field, Object lower, Object upper, boolean includeLower, boolean includeUpper,
-                BiFunction<InetAddress, InetAddress, Query> querySupplier) {
-            byte[] lowerBytes = InetAddressPoint.encode((InetAddress) lower);
-            byte[] upperBytes = InetAddressPoint.encode((InetAddress) upper);
-            if (Arrays.compareUnsigned(lowerBytes, 0, lowerBytes.length, upperBytes, 0, upperBytes.length) > 0) {
-                throw new IllegalArgumentException(
-                        "Range query `from` value (" + lower + ") is greater than `to` value (" + upper + ")");
-            }
-            InetAddress correctedFrom = includeLower ? (InetAddress) lower : nextUp(lower);
-            InetAddress correctedTo = includeUpper ? (InetAddress) upper : nextDown(upper);;
-            lowerBytes = InetAddressPoint.encode(correctedFrom);
-            upperBytes = InetAddressPoint.encode(correctedTo);
-            if (Arrays.compareUnsigned(lowerBytes, 0, lowerBytes.length, upperBytes, 0, upperBytes.length) > 0) {
-                return new MatchNoDocsQuery("float range didn't intersect anything");
-            } else {
-                return querySupplier.apply(correctedFrom, correctedTo);
-            }
-        }
-    },
-    DATE("date_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.LONG) {
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new LongRange(name, new long[] {((Number)r.from).longValue()}, new long[] {((Number)r.to).longValue()});
-        }
-        @Override
-        public Number parseFrom(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
-                throws IOException {
-            Number value = parseValue(parser.text(), coerce, fieldType.dateMathParser);
-            return included ? value : nextUp(value);
-        }
-        @Override
-        public Number parseTo(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
-                throws IOException{
-            Number value = parseValue(parser.text(), coerce, fieldType.dateMathParser);
-            return included ? value : nextDown(value);
-        }
+    Object parseValue(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, Function<Object, Object> rounding)
+        throws IOException;
 
-        @Override
-        public Long parseValue(Object dateStr, boolean coerce, @Nullable DateMathParser dateMathParser) {
-            assert dateMathParser != null;
-            return dateMathParser.parse(dateStr.toString(), () -> {
-                throw new IllegalArgumentException("now is not used at indexing time");
-            }).toEpochMilli();
-        }
+    Field getRangeField(String name, RangeFieldMapper.Range range);
 
-        @Override
-        public Object formatValue(Object value, DateFormatter dateFormatter) {
-            long timestamp = (long) value;
-            ZonedDateTime dateTime = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC);
-            return dateFormatter.format(dateTime);
-        }
+    Object parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser);
 
-        @Override
-        public Long minValue() {
-            return Long.MIN_VALUE;
-        }
-        @Override
-        public Long maxValue() {
-            return Long.MAX_VALUE;
-        }
-        @Override
-        public Long nextUp(Object value) {
-            return (long) LONG.nextUp(value);
-        }
-        @Override
-        public Long nextDown(Object value) {
-            return (long) LONG.nextDown(value);
-        }
-
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return LONG.encodeRanges(ranges);
-        }
-
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            return LONG.decodeRanges(bytes);
-        }
-
-        @Override
-        public Double doubleValue(Object endpointValue) {
-            return LONG.doubleValue(endpointValue);
-        }
-
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            return LONG.dvRangeQuery(field, queryType, from, to, includeFrom, includeTo);
-        }
-
-        @Override
-        public Query rangeQuery(String field, boolean hasDocValues, Object lowerTerm, Object upperTerm, boolean includeLower,
-                                boolean includeUpper, ShapeRelation relation, @Nullable ZoneId timeZone,
-                                @Nullable DateMathParser parser, QueryShardContext context) {
-            ZoneId zone = (timeZone == null) ? ZoneOffset.UTC : timeZone;
-
-            DateMathParser dateMathParser = (parser == null) ?
-                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser() : parser;
-            boolean roundUp = includeLower == false; // using "gt" should round lower bound up
-            Long low = lowerTerm == null ? minValue() :
-                dateMathParser.parse(lowerTerm instanceof BytesRef ? ((BytesRef) lowerTerm).utf8ToString() : lowerTerm.toString(),
-                    context::nowInMillis, roundUp, zone).toEpochMilli();
-            roundUp = includeUpper; // using "lte" should round upper bound up
-            Long high = upperTerm == null ? maxValue() :
-                dateMathParser.parse(upperTerm instanceof BytesRef ? ((BytesRef) upperTerm).utf8ToString() : upperTerm.toString(),
-                    context::nowInMillis, roundUp, zone).toEpochMilli();
-
-            return createRangeQuery(field, hasDocValues, low, high, includeLower, includeUpper, relation);
-        }
-
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
-            return LONG.withinQuery(field, from, to, includeLower, includeUpper);
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
-            return LONG.containsQuery(field, from, to, includeLower, includeUpper);
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeLower, boolean includeUpper) {
-            return LONG.intersectsQuery(field, from, to, includeLower, includeUpper);
-        }
-    },
-    // todo support half_float
-    FLOAT("float_range", LengthType.FIXED_4, NumberFieldMapper.NumberType.FLOAT) {
-        @Override
-        public Float minValue() {
-            return Float.NEGATIVE_INFINITY;
-        }
-        @Override
-        public Float maxValue() {
-            return Float.POSITIVE_INFINITY;
-        }
-        @Override
-        public Float nextUp(Object value) {
-            return Math.nextUp(((Number)value).floatValue());
-        }
-        @Override
-        public Float nextDown(Object value) {
-            return Math.nextDown(((Number)value).floatValue());
-        }
-
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return BinaryRangeUtil.encodeFloatRanges(ranges);
-        }
-
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            return BinaryRangeUtil.decodeFloatRanges(bytes);
-        }
-
-        @Override
-        public Double doubleValue(Object endpointValue) {
-            assert endpointValue instanceof Float;
-            return ((Float) endpointValue).doubleValue();
-        }
-
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            if (includeFrom == false) {
-                from = nextUp(from);
-            }
-
-            if (includeTo == false) {
-                to = nextDown(to);
-            }
-
-            byte[] encodedFrom = BinaryRangeUtil.encodeFloat((Float) from);
-            byte[] encodedTo = BinaryRangeUtil.encodeFloat((Float) to);
-            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_4,
-                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
-        }
-
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new FloatRange(name, new float[] {((Number)r.from).floatValue()}, new float[] {((Number)r.to).floatValue()});
-        }
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
-                    (f, t) -> FloatRange.newWithinQuery(field, new float[] { f }, new float[] { t }), RangeType.FLOAT);
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
-                    (f, t) -> FloatRange.newContainsQuery(field, new float[] { f }, new float[] { t }), RangeType.FLOAT);
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Float) from, (Float) to, includeFrom, includeTo,
-                    (f, t) -> FloatRange.newIntersectsQuery(field, new float[] { f }, new float[] { t }), RangeType.FLOAT);
-        }
-    },
-    DOUBLE("double_range", LengthType.FIXED_8, NumberFieldMapper.NumberType.DOUBLE) {
-        @Override
-        public Double minValue() {
-            return Double.NEGATIVE_INFINITY;
-        }
-        @Override
-        public Double maxValue() {
-            return Double.POSITIVE_INFINITY;
-        }
-        @Override
-        public Double nextUp(Object value) {
-            return Math.nextUp(((Number)value).doubleValue());
-        }
-        @Override
-        public Double nextDown(Object value) {
-            return Math.nextDown(((Number)value).doubleValue());
-        }
-
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return BinaryRangeUtil.encodeDoubleRanges(ranges);
-        }
-
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            return BinaryRangeUtil.decodeDoubleRanges(bytes);
-        }
-
-        @Override
-        public Double doubleValue(Object endpointValue) {
-            assert endpointValue instanceof Double;
-            return (Double) endpointValue;
-        }
-
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            if (includeFrom == false) {
-                from = nextUp(from);
-            }
-
-            if (includeTo == false) {
-                to = nextDown(to);
-            }
-
-            byte[] encodedFrom = BinaryRangeUtil.encodeDouble((Double) from);
-            byte[] encodedTo = BinaryRangeUtil.encodeDouble((Double) to);
-            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FIXED_8,
-                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
-        }
-
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new DoubleRange(name, new double[] {((Number)r.from).doubleValue()}, new double[] {((Number)r.to).doubleValue()});
-        }
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
-                    (f, t) -> DoubleRange.newWithinQuery(field, new double[] { f }, new double[] { t }), RangeType.DOUBLE);
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
-                    (f, t) -> DoubleRange.newContainsQuery(field, new double[] { f }, new double[] { t }), RangeType.DOUBLE);
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Double) from, (Double) to, includeFrom, includeTo,
-                    (f, t) -> DoubleRange.newIntersectsQuery(field, new double[] { f }, new double[] { t }), RangeType.DOUBLE);
-        }
-
-    },
-    // todo add BYTE support
-    // todo add SHORT support
-    INTEGER("integer_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.INTEGER) {
-        @Override
-        public Integer minValue() {
-            return Integer.MIN_VALUE;
-        }
-        @Override
-        public Integer maxValue() {
-            return Integer.MAX_VALUE;
-        }
-        @Override
-        public Integer nextUp(Object value) {
-            return ((Number)value).intValue() + 1;
-        }
-        @Override
-        public Integer nextDown(Object value) {
-            return ((Number)value).intValue() - 1;
-        }
-
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return LONG.encodeRanges(ranges);
-        }
-
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            return LONG.decodeRanges(bytes);
-        }
-
-        @Override
-        public Double doubleValue(Object endpointValue) {
-            return LONG.doubleValue(endpointValue);
-        }
-
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            return LONG.dvRangeQuery(field, queryType, from, to, includeFrom, includeTo);
-        }
-
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new IntRange(name, new int[] {((Number)r.from).intValue()}, new int[] {((Number)r.to).intValue()});
-        }
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Integer) from, (Integer) to, includeFrom, includeTo,
-                    (f, t) -> IntRange.newWithinQuery(field, new int[] { f }, new int[] { t }), RangeType.INTEGER);
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field,  (Integer) from,  (Integer) to, includeFrom, includeTo,
-                    (f, t) -> IntRange.newContainsQuery(field, new int[] { f }, new int[] { t }), RangeType.INTEGER);
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field,  (Integer) from,  (Integer) to, includeFrom, includeTo,
-                    (f, t) -> IntRange.newIntersectsQuery(field, new int[] { f }, new int[] { t }), RangeType.INTEGER);
-        }
-    },
-    LONG("long_range", LengthType.VARIABLE, NumberFieldMapper.NumberType.LONG) {
-        @Override
-        public Long minValue() {
-            return Long.MIN_VALUE;
-        }
-        @Override
-        public Long maxValue() {
-            return Long.MAX_VALUE;
-        }
-        @Override
-        public Long nextUp(Object value) {
-            return ((Number)value).longValue() + 1;
-        }
-        @Override
-        public Long nextDown(Object value) {
-            return ((Number)value).longValue() - 1;
-        }
-
-        @Override
-        public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
-            return BinaryRangeUtil.encodeLongRanges(ranges);
-        }
-
-        @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            return BinaryRangeUtil.decodeLongRanges(bytes);
-        }
-
-        @Override
-        public Double doubleValue(Object endpointValue) {
-            assert endpointValue instanceof Long;
-            return ((Long) endpointValue).doubleValue();
-        }
-
-        @Override
-        public Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to, boolean includeFrom,
-                                  boolean includeTo) {
-            if (includeFrom == false) {
-                from = nextUp(from);
-            }
-
-            if (includeTo == false) {
-                to = nextDown(to);
-            }
-
-            byte[] encodedFrom = BinaryRangeUtil.encodeLong(((Number) from).longValue());
-            byte[] encodedTo = BinaryRangeUtil.encodeLong(((Number) to).longValue());
-            return new BinaryDocValuesRangeQuery(field, queryType, LengthType.VARIABLE,
-                    new BytesRef(encodedFrom), new BytesRef(encodedTo), from, to);
-        }
-
-        @Override
-        public Field getRangeField(String name, RangeFieldMapper.Range r) {
-            return new LongRange(name, new long[] {((Number)r.from).longValue()},
-                new long[] {((Number)r.to).longValue()});
-        }
-        @Override
-        public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
-                    (f, t) -> LongRange.newWithinQuery(field, new long[] { f }, new long[] { t }), RangeType.LONG);
-        }
-        @Override
-        public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
-                    (f, t) -> LongRange.newContainsQuery(field, new long[] { f }, new long[] { t }), RangeType.LONG);
-        }
-        @Override
-        public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
-            return createQuery(field, (Long) from, (Long) to, includeFrom, includeTo,
-                    (f, t) -> LongRange.newIntersectsQuery(field, new long[] { f }, new long[] { t }), RangeType.LONG);
-        }
-    };
-
-    RangeType(String name, LengthType lengthType) {
-        this.name = name;
-        this.numberType = null;
-        this.lengthType = lengthType;
-    }
-
-    RangeType(String name, LengthType lengthType, NumberFieldMapper.NumberType type) {
-        this.name = name;
-        this.numberType = type;
-        this.lengthType = lengthType;
-    }
-
-    /** Get the associated type name. */
-    public final String typeName() {
-        return name;
-    }
-
-    /**
-     * Internal helper to create the actual {@link Query} using the provided supplier function. Before creating the query we check if
-     * the intervals min &gt; max, in which case an {@link IllegalArgumentException} is raised. The method adapts the interval bounds
-     * based on whether the edges should be included or excluded. In case where after this correction the interval would be empty
-     * because min &gt; max, we simply return a {@link MatchNoDocsQuery}.
-     * This helper handles all {@link Number} cases and dates, the IP range type uses its own logic.
-     */
-    private static <T extends Comparable<T>> Query createQuery(String field, T from, T to, boolean includeFrom, boolean includeTo,
-            BiFunction<T, T, Query> querySupplier, RangeType rangeType) {
-        if (from.compareTo(to) > 0) {
-            // wrong argument order, this is an error the user should fix
-            throw new IllegalArgumentException("Range query `from` value (" + from + ") is greater than `to` value (" + to + ")");
-        }
-
-        @SuppressWarnings("unchecked")
-        T correctedFrom = includeFrom ? from : (T) rangeType.nextUp(from);
-        @SuppressWarnings("unchecked")
-        T correctedTo =  includeTo ? to : (T) rangeType.nextDown(to);
-        if (correctedFrom.compareTo(correctedTo) > 0) {
-            return new MatchNoDocsQuery("range didn't intersect anything");
-        } else {
-            return querySupplier.apply(correctedFrom, correctedTo);
-        }
-    }
-
-    public abstract Field getRangeField(String name, RangeFieldMapper.Range range);
-    public List<IndexableField> createFields(ParseContext context, String name, RangeFieldMapper.Range range, boolean indexed,
-                                             boolean docValued, boolean stored) {
+    default List<IndexableField> createFields(
+        ParseContext context,
+        String name,
+        RangeFieldMapper.Range range,
+        boolean indexed,
+        boolean docValued,
+        boolean stored
+    ) {
         assert range != null : "range cannot be null when creating fields";
         List<IndexableField> fields = new ArrayList<>();
         if (indexed) {
@@ -622,134 +112,15 @@ public enum RangeType {
         return fields;
     }
 
-    public Object parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
-        return numberType.parse(value, coerce);
-    }
-
-    public Object formatValue(Object value, DateFormatter formatter) {
+    default Object formatValue(Object value, DateFormatter formatter) {
         return value;
     }
 
-    /** parses from value. rounds according to included flag */
-    public Object parseFrom(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce,
-                            boolean included) throws IOException {
-        Number value = numberType.parse(parser, coerce);
-        return included ? value : (Number)nextUp(value);
-    }
-    /** parses to value. rounds according to included flag */
-    public Object parseTo(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce,
-                          boolean included) throws IOException {
-        Number value = numberType.parse(parser, coerce);
-        return included ? value : (Number)nextDown(value);
-    }
-
-    public abstract Object minValue();
-    public abstract Object maxValue();
-    public abstract Object nextUp(Object value);
-    public abstract Object nextDown(Object value);
-    public abstract Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
-    public abstract Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
-    public abstract Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
-
-    public Query rangeQuery(String field, boolean hasDocValues, Object from, Object to, boolean includeFrom, boolean includeTo,
-                            ShapeRelation relation, @Nullable ZoneId timeZone, @Nullable DateMathParser dateMathParser,
-                            QueryShardContext context) {
-        Object lower = from == null ? minValue() : parseValue(from, false, dateMathParser);
-        Object upper = to == null ? maxValue() : parseValue(to, false, dateMathParser);
-        return createRangeQuery(field, hasDocValues, lower, upper, includeFrom, includeTo, relation);
-    }
-
-    protected final Query createRangeQuery(String field, boolean hasDocValues, Object lower, Object upper,
-                                           boolean includeFrom, boolean includeTo, ShapeRelation relation) {
-        Query indexQuery;
-        if (relation == ShapeRelation.WITHIN) {
-            indexQuery = withinQuery(field, lower, upper, includeFrom, includeTo);
-        } else if (relation == ShapeRelation.CONTAINS) {
-            indexQuery = containsQuery(field, lower, upper, includeFrom, includeTo);
-        } else {
-            indexQuery = intersectsQuery(field, lower, upper, includeFrom, includeTo);
-        }
-        if (hasDocValues) {
-            final BinaryDocValuesRangeQuery.QueryType queryType;
-            if (relation == ShapeRelation.WITHIN) {
-                queryType = BinaryDocValuesRangeQuery.QueryType.WITHIN;
-            } else if (relation == ShapeRelation.CONTAINS) {
-                queryType = BinaryDocValuesRangeQuery.QueryType.CONTAINS;
-            } else {
-                queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
-            }
-            Query dvQuery = dvRangeQuery(field, queryType, lower, upper, includeFrom, includeTo);
-            return new IndexOrDocValuesQuery(indexQuery, dvQuery);
-        } else {
-            return indexQuery;
-        }
-    }
-
-    // No need to take into account Range#includeFrom or Range#includeTo, because from and to have already been
-    // rounded up via parseFrom and parseTo methods.
-    public abstract BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException;
-    public abstract List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes);
-
     /**
-     * Given the Range.to or Range.from Object value from a Range instance, converts that value into a Double.  Before converting, it
-     * asserts that the object is of the expected type.  Operation is not supported on IP ranges (because of loss of precision)
-     *
-     * @param endpointValue Object value for Range.to or Range.from
-     * @return endpointValue as a Double
+     * most range types are numeric, overwrite if the implementing range type is not numeric, e.g. ip oder version_range do this
      */
-    public abstract Double doubleValue(Object endpointValue);
-
-    public boolean isNumeric() {
-        return numberType != null;
+    default boolean isNumeric() {
+        return true;
     }
 
-    public abstract Query dvRangeQuery(String field, BinaryDocValuesRangeQuery.QueryType queryType, Object from, Object to,
-                                       boolean includeFrom, boolean includeTo);
-
-    public final Mapper.TypeParser parser() {
-        return new ParametrizedFieldMapper.TypeParser((n, c) -> new RangeFieldMapper.Builder(n, this, c.getSettings()));
-    }
-
-    public final String name;
-    private final NumberFieldMapper.NumberType numberType;
-    public final LengthType lengthType;
-
-    public enum LengthType {
-        FIXED_4 {
-            @Override
-            public int readLength(byte[] bytes, int offset) {
-                return 4;
-            }
-        },
-        FIXED_8 {
-            @Override
-            public int readLength(byte[] bytes, int offset) {
-                return 8;
-            }
-        },
-        FIXED_16 {
-            @Override
-            public int readLength(byte[] bytes, int offset) {
-                return 16;
-            }
-        },
-        VARIABLE {
-            @Override
-            public int readLength(byte[] bytes, int offset) {
-                // the first bit encodes the sign and the next 4 bits encode the number
-                // of additional bytes
-                int token = Byte.toUnsignedInt(bytes[offset]);
-                int length = (token >>> 3) & 0x0f;
-                if ((token & 0x80) == 0) {
-                    length = 0x0f - length;
-                }
-                return 1 + length;
-            }
-        };
-
-        /**
-         * Return the length of the value that starts at {@code offset} in {@code bytes}.
-         */
-        public abstract int readLength(byte[] bytes, int offset);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -45,7 +45,7 @@ import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -105,7 +105,7 @@ public class IndicesModule extends AbstractModule {
         for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
             mappers.put(type.typeName(), type.parser());
         }
-        for (RangeType type : RangeType.values()) {
+        for (CoreRangeType type : CoreRangeType.values()) {
             mappers.put(type.typeName(), type.parser());
         }
         mappers.put(BooleanFieldMapper.CONTENT_TYPE, BooleanFieldMapper.PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -104,8 +105,8 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         // TODO: Stop using null here
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Range) valuesSourceConfig.getValuesSource() : null;
         this.formatter = valuesSourceConfig.format();
-        if (this.valuesSource.rangeType() != RangeType.DATE) {
-            throw new IllegalArgumentException("Expected date range type but found range type [" + this.valuesSource.rangeType().name
+        if (this.valuesSource.rangeType() != CoreRangeType.DATE) {
+            throw new IllegalArgumentException("Expected date range type but found range type [" + this.valuesSource.rangeType().getName()
                 + "]");
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
@@ -77,7 +77,7 @@ public class RangeHistogramAggregator extends AbstractHistogramAggregator {
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Range) valuesSourceConfig.getValuesSource() : null;
         if (this.valuesSource.rangeType().isNumeric() == false) {
             throw new IllegalArgumentException(
-                "Expected numeric range type but found non-numeric range [" + this.valuesSource.rangeType().name + "]"
+                "Expected numeric range type but found non-numeric range [" + this.valuesSource.rangeType().getName() + "]"
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -611,6 +611,7 @@ public abstract class ValuesSource {
                 return indexFieldData.load(context).getBytesValues();
             }
 
+            @Override
             public org.elasticsearch.index.fielddata.MultiGeoPointValues geoPointValues(LeafReaderContext context) {
                 return indexFieldData.load(context).getGeoPointValues();
             }

--- a/server/src/test/java/org/apache/lucene/queries/BaseRandomBinaryDocValuesRangeQueryTestCase.java
+++ b/server/src/test/java/org/apache/lucene/queries/BaseRandomBinaryDocValuesRangeQueryTestCase.java
@@ -24,7 +24,7 @@ import org.apache.lucene.search.BaseRangeFieldQueryTestCase;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -85,7 +85,7 @@ public abstract class BaseRandomBinaryDocValuesRangeQueryTestCase extends BaseRa
 
     protected abstract String fieldName();
 
-    protected abstract RangeType rangeType();
+    protected abstract CoreRangeType rangeType();
 
     protected abstract static class AbstractRange<T> extends Range {
 

--- a/server/src/test/java/org/apache/lucene/queries/BinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/BinaryDocValuesRangeQueryTests.java
@@ -27,7 +27,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class BinaryDocValuesRangeQueryTests extends ESTestCase {
 
     public void testBasics() throws Exception {
         String fieldName = "long_field";
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 // intersects (within)
@@ -128,7 +128,7 @@ public class BinaryDocValuesRangeQueryTests extends ESTestCase {
 
     public void testNoField() throws IOException {
         String fieldName = "long_field";
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
 
         // no field in index
         try (Directory dir = newDirectory()) {

--- a/server/src/test/java/org/apache/lucene/queries/DoubleRandomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/DoubleRandomBinaryDocValuesRangeQueryTests.java
@@ -18,7 +18,7 @@
  */
 package org.apache.lucene.queries;
 
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 public class DoubleRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryDocValuesRangeQueryTestCase {
 
@@ -28,8 +28,8 @@ public class DoubleRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinary
     }
 
     @Override
-    protected RangeType rangeType() {
-        return RangeType.DOUBLE;
+    protected CoreRangeType rangeType() {
+        return CoreRangeType.DOUBLE;
     }
 
     @Override

--- a/server/src/test/java/org/apache/lucene/queries/FloatRandomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/FloatRandomBinaryDocValuesRangeQueryTests.java
@@ -18,7 +18,7 @@
  */
 package org.apache.lucene.queries;
 
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 public class FloatRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryDocValuesRangeQueryTestCase {
 
@@ -28,8 +28,8 @@ public class FloatRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryD
     }
 
     @Override
-    protected RangeType rangeType() {
-        return RangeType.FLOAT;
+    protected CoreRangeType rangeType() {
+        return CoreRangeType.FLOAT;
     }
 
     @Override

--- a/server/src/test/java/org/apache/lucene/queries/InetAddressRandomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/InetAddressRandomBinaryDocValuesRangeQueryTests.java
@@ -20,7 +20,7 @@ package org.apache.lucene.queries;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.FutureArrays;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -34,8 +34,8 @@ public class InetAddressRandomBinaryDocValuesRangeQueryTests extends BaseRandomB
     }
 
     @Override
-    protected RangeType rangeType() {
-        return RangeType.IP;
+    protected CoreRangeType rangeType() {
+        return CoreRangeType.IP;
     }
 
     @Override

--- a/server/src/test/java/org/apache/lucene/queries/IntegerRandomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/IntegerRandomBinaryDocValuesRangeQueryTests.java
@@ -19,7 +19,7 @@
 package org.apache.lucene.queries;
 
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 public class IntegerRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryDocValuesRangeQueryTestCase {
 
@@ -29,8 +29,8 @@ public class IntegerRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinar
     }
 
     @Override
-    protected RangeType rangeType() {
-        return RangeType.INTEGER;
+    protected CoreRangeType rangeType() {
+        return CoreRangeType.INTEGER;
     }
 
     @Override

--- a/server/src/test/java/org/apache/lucene/queries/LongRandomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/apache/lucene/queries/LongRandomBinaryDocValuesRangeQueryTests.java
@@ -19,7 +19,7 @@
 package org.apache.lucene.queries;
 
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 
 public class LongRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryDocValuesRangeQueryTestCase {
 
@@ -29,8 +29,8 @@ public class LongRandomBinaryDocValuesRangeQueryTests extends BaseRandomBinaryDo
     }
 
     @Override
-    protected RangeType rangeType() {
-        return RangeType.LONG;
+    protected CoreRangeType rangeType() {
+        return CoreRangeType.LONG;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryRangeUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryRangeUtilTests.java
@@ -151,7 +151,7 @@ public class BinaryRangeUtilTests extends ESTestCase {
         for (long expected : cases) {
             byte[] encoded = BinaryRangeUtil.encodeLong(expected);
             int offset = 0;
-            int length = RangeType.LengthType.VARIABLE.readLength(encoded, offset);
+            int length = CoreRangeType.LengthType.VARIABLE.readLength(encoded, offset);
             assertEquals(expected, BinaryRangeUtil.decodeLong(encoded, offset,  length));
         }
     }
@@ -161,7 +161,7 @@ public class BinaryRangeUtilTests extends ESTestCase {
         for (int i = 0; i < iters; i++) {
             long start = randomLong();
             long end = randomLongBetween(start + 1, Long.MAX_VALUE);
-            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(RangeType.LONG, start, end, true, true);
+            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(CoreRangeType.LONG, start, end, true, true);
             List<RangeFieldMapper.Range> decoded = BinaryRangeUtil.decodeLongRanges(BinaryRangeUtil.encodeLongRanges(singleton(expected)));
             assertEquals(1, decoded.size());
             RangeFieldMapper.Range actual = decoded.get(0);
@@ -174,7 +174,7 @@ public class BinaryRangeUtilTests extends ESTestCase {
         for (int i = 0; i < iters; i++) {
             double start = randomDouble();
             double end = randomDoubleBetween(Math.nextUp(start), Double.MAX_VALUE, false);
-            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(RangeType.DOUBLE, start, end, true, true);
+            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(CoreRangeType.DOUBLE, start, end, true, true);
             List<RangeFieldMapper.Range> decoded = BinaryRangeUtil.decodeDoubleRanges(BinaryRangeUtil.encodeDoubleRanges(
                 singleton(expected)));
             assertEquals(1, decoded.size());
@@ -194,7 +194,7 @@ public class BinaryRangeUtilTests extends ESTestCase {
                 start = end;
                 end = temp;
             }
-            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(RangeType.FLOAT, start, end, true, true);
+            RangeFieldMapper.Range expected = new RangeFieldMapper.Range(CoreRangeType.FLOAT, start, end, true, true);
             List<RangeFieldMapper.Range> decoded = BinaryRangeUtil.decodeFloatRanges(BinaryRangeUtil.encodeFloatRanges(
                 singleton(expected)));
             assertEquals(1, decoded.size());
@@ -217,7 +217,7 @@ public class BinaryRangeUtilTests extends ESTestCase {
     }
 
     private RangeFieldMapper.Range createIPRange(String start, String end) {
-        return new RangeFieldMapper.Range(RangeType.IP, InetAddresses.forString(start), InetAddresses.forString(end),
+        return new RangeFieldMapper.Range(CoreRangeType.IP, InetAddresses.forString(start), InetAddresses.forString(end),
             true,  true);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldTypeTests.java
@@ -33,7 +33,7 @@ public class IpRangeFieldTypeTests extends FieldTypeTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
-        RangeFieldMapper mapper = new RangeFieldMapper.Builder("field", RangeType.IP, true).build(context);
+        RangeFieldMapper mapper = new RangeFieldMapper.Builder("field", CoreRangeType.IP, true).build(context);
         Map<String, Object> range = Map.of("gte", "2001:db8:0:0:0:0:2:1");
         assertEquals(List.of(Map.of("gte", "2001:db8::2:1")), fetchSourceValue(mapper.fieldType(), range));
         assertEquals(List.of("2001:db8::2:1/32"), fetchSourceValue(mapper.fieldType(), "2001:db8:0:0:0:0:2:1/32"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -322,7 +322,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
     public void testIllegalArguments() throws Exception {
         Exception e = expectThrows(
             MapperParsingException.class,
-            () -> createDocumentMapper(fieldMapping(b -> b.field("type", RangeType.INTEGER.name).field("format", DATE_FORMAT)))
+            () -> createDocumentMapper(fieldMapping(b -> b.field("type", CoreRangeType.INTEGER.name).field("format", DATE_FORMAT)))
         );
         assertThat(e.getMessage(), containsString("should not define a dateTimeFormatter"));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -70,7 +70,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testIntegerRangeQuery() throws Exception {
         Query query = new QueryStringQueryBuilder(INTEGER_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
         Query range = IntRange.newIntersectsQuery(INTEGER_RANGE_FIELD_NAME, new int[]{-450}, new int[]{45000});
-        Query dv = RangeType.INTEGER.dvRangeQuery(INTEGER_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.INTEGER.dvRangeQuery(INTEGER_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450, 45000, true, true);
         assertEquals(new IndexOrDocValuesQuery(range, dv), query);
     }
@@ -78,7 +78,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testLongRangeQuery() throws Exception {
         Query query = new QueryStringQueryBuilder(LONG_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
         Query range = LongRange.newIntersectsQuery(LONG_RANGE_FIELD_NAME, new long[]{-450}, new long[]{45000});
-        Query dv = RangeType.LONG.dvRangeQuery(LONG_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.LONG.dvRangeQuery(LONG_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450, 45000, true, true);
         assertEquals(new IndexOrDocValuesQuery(range, dv), query);
     }
@@ -86,7 +86,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testFloatRangeQuery() throws Exception {
         Query query = new QueryStringQueryBuilder(FLOAT_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
         Query range = FloatRange.newIntersectsQuery(FLOAT_RANGE_FIELD_NAME, new float[]{-450}, new float[]{45000});
-        Query dv = RangeType.FLOAT.dvRangeQuery(FLOAT_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.FLOAT.dvRangeQuery(FLOAT_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450.0f, 45000.0f, true, true);
         assertEquals(new IndexOrDocValuesQuery(range, dv), query);
     }
@@ -94,7 +94,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testDoubleRangeQuery() throws Exception {
         Query query = new QueryStringQueryBuilder(DOUBLE_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
         Query range = DoubleRange.newIntersectsQuery(DOUBLE_RANGE_FIELD_NAME, new double[]{-450}, new double[]{45000});
-        Query dv = RangeType.DOUBLE.dvRangeQuery(DOUBLE_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.DOUBLE.dvRangeQuery(DOUBLE_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450.0, 45000.0, true, true);
         assertEquals(new IndexOrDocValuesQuery(range, dv), query);
     }
@@ -109,7 +109,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
         Query range = LongRange.newIntersectsQuery(DATE_RANGE_FIELD_NAME,
             new long[]{ parser.parse(lowerBoundExact, () -> 0).toEpochMilli()},
             new long[]{ parser.parse(upperBoundExact, () -> 0).toEpochMilli()});
-        Query dv = RangeType.DATE.dvRangeQuery(DATE_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.DATE.dvRangeQuery(DATE_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS,
             parser.parse(lowerBoundExact, () -> 0).toEpochMilli(),
             parser.parse(upperBoundExact, () -> 0).toEpochMilli(), true, true);
@@ -134,7 +134,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
         InetAddress upper = InetAddresses.forString("192.168.0.5");
         Query query = new QueryStringQueryBuilder(IP_RANGE_FIELD_NAME + ":[192.168.0.1 TO 192.168.0.5]").toQuery(createShardContext());
         Query range = InetAddressRange.newIntersectsQuery(IP_RANGE_FIELD_NAME, lower, upper);
-        Query dv = RangeType.IP.dvRangeQuery(IP_RANGE_FIELD_NAME,
+        Query dv = CoreRangeType.IP.dvRangeQuery(IP_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS,
             lower, upper, true, true);
         assertEquals(new IndexOrDocValuesQuery(range, dv), query);

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -56,18 +56,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RangeFieldTypeTests extends FieldTypeTestCase {
-    RangeType type;
+    CoreRangeType type;
     protected static int DISTANCE = 10;
     private static long nowInMillis;
 
     @Before
     public void setupProperties() {
-        type = randomFrom(RangeType.values());
+        type = randomFrom(CoreRangeType.values());
         nowInMillis = randomNonNegativeLong();
     }
 
     private RangeFieldType createDefaultFieldType() {
-        if (type == RangeType.DATE) {
+        if (type == CoreRangeType.DATE) {
             return new RangeFieldType("field", RangeFieldMapper.Defaults.DATE_FORMATTER);
         }
         return new RangeFieldType("field", type);
@@ -323,7 +323,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery = LongRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.DATE.dvRangeQuery("field", queryType, from.getMillis(),
+        Query dvQuery = CoreRangeType.DATE.dvRangeQuery("field", queryType, from.getMillis(),
                 to.getMillis(), includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -343,7 +343,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery = IntRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.INTEGER.dvRangeQuery("field", queryType, from, to,
+        Query dvQuery = CoreRangeType.INTEGER.dvRangeQuery("field", queryType, from, to,
                 includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -363,7 +363,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery = LongRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.LONG.dvRangeQuery("field", queryType, from, to,
+        Query dvQuery = CoreRangeType.LONG.dvRangeQuery("field", queryType, from, to,
                 includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -383,7 +383,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery = FloatRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.FLOAT.dvRangeQuery("field", queryType, from, to,
+        Query dvQuery = CoreRangeType.FLOAT.dvRangeQuery("field", queryType, from, to,
                 includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -404,7 +404,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery =  DoubleRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.DOUBLE.dvRangeQuery("field", queryType, from, to,
+        Query dvQuery = CoreRangeType.DOUBLE.dvRangeQuery("field", queryType, from, to,
                 includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -425,7 +425,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             indexQuery = InetAddressRange.newIntersectsQuery("field", lower, upper);
             queryType = BinaryDocValuesRangeQuery.QueryType.INTERSECTS;
         }
-        Query dvQuery = RangeType.IP.dvRangeQuery("field", queryType, from, to,
+        Query dvQuery = CoreRangeType.IP.dvRangeQuery("field", queryType, from, to,
                 includeLower, includeUpper);
         return new IndexOrDocValuesQuery(indexQuery, dvQuery);
     }
@@ -465,9 +465,9 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testParseIp() {
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(InetAddresses.forString("::1"), randomBoolean(), null));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue("::1", randomBoolean(), null));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(new BytesRef("::1"), randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), CoreRangeType.IP.parseValue(InetAddresses.forString("::1"), randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), CoreRangeType.IP.parseValue("::1", randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), CoreRangeType.IP.parseValue(new BytesRef("::1"), randomBoolean(), null));
     }
 
     public void testTermQuery() throws Exception {
@@ -497,13 +497,13 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
-        MappedFieldType longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG, true)
+        MappedFieldType longMapper = new RangeFieldMapper.Builder("field", CoreRangeType.LONG, true)
             .build(context)
             .fieldType();
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
         assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
-        MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE, true)
+        MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", CoreRangeType.DATE, true)
             .format("yyyy/MM/dd||epoch_millis")
             .build(context)
             .fieldType();
@@ -516,13 +516,13 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
-        MappedFieldType longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG, true)
+        MappedFieldType longMapper = new RangeFieldMapper.Builder("field", CoreRangeType.LONG, true)
             .build(context)
             .fieldType();
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
         assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
-        MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE, true)
+        MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", CoreRangeType.DATE, true)
             .format("strict_date_time")
             .build(context)
             .fieldType();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
@@ -32,7 +32,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.metrics.InternalMin;
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     public void testDoubles() throws Exception {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -100,7 +100,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testLongs() throws Exception {
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -150,7 +150,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMultipleRanges() throws Exception {
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
@@ -199,7 +199,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMultipleRangesLotsOfOverlap() throws Exception {
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
@@ -236,7 +236,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testLongsIrrationalInterval() throws Exception {
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -282,7 +282,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMinDocCount() throws Exception {
-        RangeType rangeType = RangeType.LONG;
+        CoreRangeType rangeType = CoreRangeType.LONG;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -322,7 +322,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testOffset() throws Exception {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -376,7 +376,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testOffsetGtInterval() throws Exception {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
@@ -434,7 +434,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
 
     public void testIpRangesUnsupported() throws Exception {
-        RangeType rangeType = RangeType.IP;
+        CoreRangeType rangeType = CoreRangeType.IP;
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
@@ -464,11 +464,11 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             List<List<IndexableField>> docs = new ArrayList<>();
             for (int n = 0; n < 10000; n++) {
-                BytesRef outerRange = RangeType.LONG.encodeRanges(Set.of(
-                    new RangeFieldMapper.Range(RangeType.LONG, n % 100, n % 100 + 10, true, true)
+                BytesRef outerRange = CoreRangeType.LONG.encodeRanges(Set.of(
+                    new RangeFieldMapper.Range(CoreRangeType.LONG, n % 100, n % 100 + 10, true, true)
                 ));
-                BytesRef innerRange = RangeType.LONG.encodeRanges(Set.of(
-                    new RangeFieldMapper.Range(RangeType.LONG, n / 100, n / 100 + 10, true, true)
+                BytesRef innerRange = CoreRangeType.LONG.encodeRanges(Set.of(
+                    new RangeFieldMapper.Range(CoreRangeType.LONG, n / 100, n / 100 + 10, true, true)
                 ));
 
                 docs.add(List.of(
@@ -502,8 +502,8 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
             new MatchAllDocsQuery(),
             buildIndex,
             verify,
-            rangeField("outer", RangeType.LONG),
-            rangeField("inner", RangeType.LONG),
+            rangeField("outer", CoreRangeType.LONG),
+            rangeField("inner", CoreRangeType.LONG),
             longField("n")
         );
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptEngine;
@@ -157,7 +157,7 @@ public class MissingAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMatchSparseRangeField() throws IOException {
-        final RangeType rangeType = RangeType.DOUBLE;
+        final CoreRangeType rangeType = CoreRangeType.DOUBLE;
         final MappedFieldType aggFieldType = new RangeFieldMapper.RangeFieldType("agg_field", rangeType);
         final MappedFieldType anotherFieldType = new RangeFieldMapper.RangeFieldType("another_field", rangeType);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -47,7 +47,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.search.SearchHit;
@@ -281,7 +281,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testRangeField() throws Exception {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -45,7 +45,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -285,7 +285,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
      * Uses the significant terms aggregation on a range field
      */
     public void testRangeField() throws IOException {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         final RangeFieldMapper.Range range1 = new RangeFieldMapper.Range(rangeType, 1.0D, 5.0D, true, true);
         final RangeFieldMapper.Range range2 = new RangeFieldMapper.Range(rangeType, 6.0D, 10.0D, true, true);
         final String fieldName = "rangeField";

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -53,7 +53,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -948,7 +948,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         try (Directory directory = newDirectory()) {
             double start = randomDouble();
             double end = randomDoubleBetween(Math.nextUp(start), Double.MAX_VALUE, false);
-            RangeType rangeType = RangeType.DOUBLE;
+            CoreRangeType rangeType = CoreRangeType.DOUBLE;
             final RangeFieldMapper.Range range = new RangeFieldMapper.Range(rangeType, start, end, true, true);
             final String fieldName = "field";
             final BinaryDocValuesField field = new BinaryDocValuesField(fieldName, rangeType.encodeRanges(Collections.singleton(range)));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
@@ -56,7 +56,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testRangeFieldValues() throws IOException {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         final RangeFieldMapper.Range range1 = new RangeFieldMapper.Range(rangeType, 1.0D, 5.0D, true, true);
         final RangeFieldMapper.Range range2 = new RangeFieldMapper.Range(rangeType, 6.0D, 10.0D, true, true);
         final String fieldName = "rangeField";

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
@@ -101,9 +101,9 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
     public void testRangeField() throws IOException {
         // Currently fails (throws ClassCast exception), but should be fixed once HDRPercentileAggregation uses the ValuesSource registry
         final String fieldName = "range";
-        MappedFieldType fieldType = new RangeFieldMapper.RangeFieldType(fieldName, RangeType.DOUBLE);
-        RangeFieldMapper.Range range =new RangeFieldMapper.Range(RangeType.DOUBLE, 1.0D, 5.0D, true, true);
-        BytesRef encodedRange = RangeType.DOUBLE.encodeRanges(Collections.singleton(range));
+        MappedFieldType fieldType = new RangeFieldMapper.RangeFieldType(fieldName, CoreRangeType.DOUBLE);
+        RangeFieldMapper.Range range =new RangeFieldMapper.Range(CoreRangeType.DOUBLE, 1.0D, 5.0D, true, true);
+        BytesRef encodedRange = CoreRangeType.DOUBLE.encodeRanges(Collections.singleton(range));
         expectThrows(IllegalArgumentException.class,
             () -> testCase(new DocValuesFieldExistsQuery(fieldName), iw -> {
                 iw.addDocument(singleton(new BinaryDocValuesField(fieldName, encodedRange)));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptEngine;
@@ -252,7 +252,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testRangeFieldValues() throws IOException {
-        RangeType rangeType = RangeType.DOUBLE;
+        CoreRangeType rangeType = CoreRangeType.DOUBLE;
         final RangeFieldMapper.Range range1 = new RangeFieldMapper.Range(rangeType, 1.0D, 5.0D, true, true);
         final RangeFieldMapper.Range range2 = new RangeFieldMapper.Range(rangeType, 6.0D, 10.0D, true, true);
         final String fieldName = "rangeField";
@@ -414,7 +414,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
             case GEOPOINT:
                 return new GeoPointFieldMapper.GeoPointFieldType(name);
             case RANGE:
-                return new RangeFieldMapper.RangeFieldType(name, RangeType.DOUBLE);
+                return new RangeFieldMapper.RangeFieldType(name, CoreRangeType.DOUBLE);
             default:
                 throw new IllegalArgumentException("Test does not support value type [" + valueType + "]");
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -91,7 +91,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.ObjectMapper.Nested;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
-import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.CoreRangeType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
@@ -771,33 +771,33 @@ public abstract class AggregatorTestCase extends ESTestCase {
         } else if (vst.equals(CoreValuesSourceType.RANGE)) {
             Object start;
             Object end;
-            RangeType rangeType;
+            CoreRangeType rangeType;
 
-            if (typeName.equals(RangeType.DOUBLE.typeName())) {
+            if (typeName.equals(CoreRangeType.DOUBLE.typeName())) {
                 start = randomDouble();
-                end = RangeType.DOUBLE.nextUp(start);
-                rangeType = RangeType.DOUBLE;
-            } else if (typeName.equals(RangeType.FLOAT.typeName())) {
+                end = CoreRangeType.DOUBLE.nextUp(start);
+                rangeType = CoreRangeType.DOUBLE;
+            } else if (typeName.equals(CoreRangeType.FLOAT.typeName())) {
                 start = randomFloat();
-                end = RangeType.FLOAT.nextUp(start);
-                rangeType = RangeType.DOUBLE;
-            } else if (typeName.equals(RangeType.IP.typeName())) {
+                end = CoreRangeType.FLOAT.nextUp(start);
+                rangeType = CoreRangeType.DOUBLE;
+            } else if (typeName.equals(CoreRangeType.IP.typeName())) {
                 boolean v4 = randomBoolean();
                 start = randomIp(v4);
-                end = RangeType.IP.nextUp(start);
-                rangeType = RangeType.IP;
-            } else if (typeName.equals(RangeType.LONG.typeName())) {
+                end = CoreRangeType.IP.nextUp(start);
+                rangeType = CoreRangeType.IP;
+            } else if (typeName.equals(CoreRangeType.LONG.typeName())) {
                 start = randomLong();
-                end = RangeType.LONG.nextUp(start);
-                rangeType = RangeType.LONG;
-            } else if (typeName.equals(RangeType.INTEGER.typeName())) {
+                end = CoreRangeType.LONG.nextUp(start);
+                rangeType = CoreRangeType.LONG;
+            } else if (typeName.equals(CoreRangeType.INTEGER.typeName())) {
                 start = randomInt();
-                end = RangeType.INTEGER.nextUp(start);
-                rangeType = RangeType.INTEGER;
-            } else if (typeName.equals(RangeType.DATE.typeName())) {
+                end = CoreRangeType.INTEGER.nextUp(start);
+                rangeType = CoreRangeType.INTEGER;
+            } else if (typeName.equals(CoreRangeType.DATE.typeName())) {
                 start = randomNonNegativeLong();
-                end = RangeType.DATE.nextUp(start);
-                rangeType = RangeType.DATE;
+                end = CoreRangeType.DATE.nextUp(start);
+                rangeType = CoreRangeType.DATE;
             } else {
                 throw new IllegalStateException("Unknown type of range [" + typeName + "]");
             }
@@ -890,8 +890,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
     /**
      * Make a {@linkplain NumberFieldMapper.NumberFieldType} for a {@code range}.
      */
-    protected RangeFieldMapper.RangeFieldType rangeField(String name, RangeType rangeType) {
-        if (rangeType == RangeType.DATE) {
+    protected RangeFieldMapper.RangeFieldType rangeField(String name, CoreRangeType rangeType) {
+        if (rangeType == CoreRangeType.DATE) {
             return new RangeFieldMapper.RangeFieldType(name, RangeFieldMapper.Defaults.DATE_FORMATTER);
         }
         return new RangeFieldMapper.RangeFieldType(name, rangeType);

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldPlugin.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldPlugin.java
@@ -22,7 +22,12 @@ public class VersionFieldPlugin extends Plugin implements MapperPlugin {
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return Map.of(VersionStringFieldMapper.CONTENT_TYPE, VersionStringFieldMapper.PARSER);
+        return Map.of(
+            VersionStringFieldMapper.CONTENT_TYPE,
+            VersionStringFieldMapper.PARSER,
+            VersionRangeType.VERSION_RANGE_NAME,
+            VersionRangeType.PARSER
+        );
     }
 
     @Override

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionRangeType.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionRangeType.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.versionfield;
+
+import org.apache.lucene.document.BinaryRange;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.queries.BinaryDocValuesRangeQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.ByteArrayDataOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FutureArrays;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.CoreRangeType;
+import org.elasticsearch.index.mapper.CoreRangeType.LengthType;
+import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
+import org.elasticsearch.index.mapper.ParametrizedFieldMapper.TypeParser;
+import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.mapper.RangeFieldMapper.RangeFieldType;
+import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.apache.lucene.document.BinaryRange.BYTES;
+
+public class VersionRangeType implements RangeType {
+
+    public static final String VERSION_RANGE_NAME = "version_range";
+    private static final RangeType INSTANCE = new VersionRangeType();
+    static final TypeParser PARSER = new ParametrizedFieldMapper.TypeParser(
+        (n, c) -> new RangeFieldMapper.Builder(n, INSTANCE, c.getSettings())
+    );
+
+    private BytesRef MIN_VALUE = new BytesRef();
+    private BytesRef MAX_VALUE = new BytesRef(new byte[] { -1 });
+
+    private VersionRangeType() {
+        // singleton
+    }
+
+    @Override
+    public Field getRangeField(String name, RangeFieldMapper.Range r) {
+        return new BinaryRange(name, encode((BytesRef) r.getFrom(), (BytesRef) r.getTo()));
+    }
+
+    /** encode the min/max range and return the byte array */
+    private static byte[] encode(BytesRef min, BytesRef max) {
+        byte[] bytes = new byte[BYTES * 2];
+        int minBytesLength = Math.min(min.length, BYTES);
+        int maxBytesLength = Math.min(max.length, BYTES);
+        if (FutureArrays.compareUnsigned(
+            min.bytes,
+            min.offset,
+            min.offset + minBytesLength,
+            max.bytes,
+            max.offset,
+            max.offset + maxBytesLength
+        ) > 0) {
+            throw new IllegalArgumentException("min value cannot be greater than max value for version field");
+        }
+        System.arraycopy(min.bytes, 0 + min.offset, bytes, 0, minBytesLength);
+        System.arraycopy(max.bytes, 0 + max.offset, bytes, BYTES, maxBytesLength);
+        return bytes;
+    }
+
+    @Override
+    public BytesRef parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
+        return VersionEncoder.encodeVersion((String) value).bytesRef;
+    }
+
+    @Override
+    public BytesRef minValue() {
+        return MIN_VALUE;
+    }
+
+    @Override
+    public BytesRef maxValue() {
+        return MAX_VALUE;
+    }
+
+    @Override
+    public BytesRef encodeRanges(Set<RangeFieldMapper.Range> ranges) throws IOException {
+        int length = 0;
+        for (RangeFieldMapper.Range range : ranges) {
+            length += ((BytesRef) range.getFrom()).length;
+            length += ((BytesRef) range.getTo()).length;
+        }
+        final byte[] encoded = new byte[15 + length];
+        ByteArrayDataOutput out = new ByteArrayDataOutput(encoded);
+        out.writeVInt(ranges.size());
+        for (RangeFieldMapper.Range range : ranges) {
+            BytesRef fromValue = (BytesRef) range.getFrom();
+            byte[] encodedFromValue = fromValue.bytes;
+            int fromLength = ((BytesRef) range.getFrom()).length;
+            out.writeByte((byte) fromLength);
+            out.writeBytes(encodedFromValue, 0, fromLength);
+
+            BytesRef toValue = (BytesRef) range.getTo();
+            byte[] encodedToValue = toValue.bytes;
+            int toLength = ((BytesRef) range.getTo()).length;
+            out.writeByte((byte) toLength);
+            out.writeBytes(encodedToValue, 0, toLength);
+        }
+        return new BytesRef(encoded, 0, out.getPosition());
+    }
+
+    @Override
+    public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Double doubleValue(Object endpointValue) {
+        throw new UnsupportedOperationException("Version ranges cannot be safely converted to doubles");
+    }
+
+    @Override
+    public Query rangeQuery(
+        String field,
+        boolean hasDocValues,
+        Object from,
+        Object to,
+        boolean includeFrom,
+        boolean includeTo,
+        ShapeRelation relation,
+        @Nullable ZoneId timeZone,
+        @Nullable DateMathParser dateMathParser,
+        QueryShardContext context
+    ) {
+        Object lower = from == null ? minValue() : parse(from, false);
+        Object upper = to == null ? maxValue() : parse(to, false);
+        return createRangeQuery(field, hasDocValues, lower, upper, includeFrom, includeTo, relation);
+    }
+
+    private BytesRef parse(Object value, boolean coerce) {
+        if (value instanceof BytesRef) {
+            value = ((BytesRef) value).utf8ToString();
+        }
+        return VersionEncoder.encodeVersion(value.toString()).bytesRef;
+    }
+
+    protected final Query createRangeQuery(
+        String field,
+        boolean hasDocValues,
+        Object lower,
+        Object upper,
+        boolean includeFrom,
+        boolean includeTo,
+        ShapeRelation relation
+    ) {
+        if (hasDocValues == false) {
+            throw new IllegalArgumentException("range queries on `version_range` fields require doc_values.");
+        }
+        Query rangeQuery;
+        if (relation == ShapeRelation.WITHIN) {
+            rangeQuery = withinQuery(field, lower, upper, includeFrom, includeTo);
+        } else if (relation == ShapeRelation.CONTAINS) {
+            rangeQuery = containsQuery(field, lower, upper, includeFrom, includeTo);
+        } else {
+            rangeQuery = intersectsQuery(field, lower, upper, includeFrom, includeTo);
+        }
+        return rangeQuery;
+    }
+
+    @Override
+    public Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+        return createQuery(
+            field,
+            (BytesRef) from,
+            (BytesRef) to,
+            includeFrom,
+            includeTo,
+            (f, t) -> BinaryRange.newWithinQuery(field, encode(f, t)),
+            dvRangeQuery(field, BinaryDocValuesRangeQuery.QueryType.WITHIN, from, to, includeFrom, includeTo)
+        );
+    }
+
+    @Override
+    public Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+        return createQuery(
+            field,
+            (BytesRef) from,
+            (BytesRef) to,
+            includeFrom,
+            includeTo,
+            (f, t) -> BinaryRange.newContainsQuery(field, encode(f, t)),
+            dvRangeQuery(field, BinaryDocValuesRangeQuery.QueryType.CONTAINS, from, to, includeFrom, includeTo)
+        );
+    }
+
+    @Override
+    public Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo) {
+        return createQuery(
+            field,
+            (BytesRef) from,
+            (BytesRef) to,
+            includeFrom,
+            includeTo,
+            (f, t) -> BinaryRange.newIntersectsQuery(field, encode(f, t)),
+            dvRangeQuery(field, BinaryDocValuesRangeQuery.QueryType.INTERSECTS, from, to, includeFrom, includeTo)
+        );
+    }
+
+    private Query createQuery(
+        String field,
+        BytesRef lower,
+        BytesRef upper,
+        boolean includeFrom,
+        boolean includeTo,
+        BiFunction<BytesRef, BytesRef, Query> querySupplier,
+        Query dvRangeQuery
+    ) {
+        if (lower.compareTo(upper) > 0) {
+            throw new IllegalArgumentException(
+                "Version range query `from` value (" + lower + ") is greater than `to` value (" + upper + ")"
+            );
+        }
+        BytesRef correctedFrom = includeFrom ? lower : nextUp(lower);
+        BytesRef correctedTo = includeTo ? upper : nextDown(upper);
+        ;
+        byte[] lowerBytes = correctedFrom.bytes;
+        byte[] upperBytes = correctedTo.bytes;
+        if (Arrays.compareUnsigned(lowerBytes, 0, lowerBytes.length, upperBytes, 0, upperBytes.length) > 0) {
+            return new MatchNoDocsQuery("version range didn't intersect anything");
+        } else {
+            Query rangeFieldQuery = querySupplier.apply(lower, upper);
+            BooleanQuery conjunctionQuery = new BooleanQuery.Builder().add(new BooleanClause(rangeFieldQuery, Occur.MUST))
+                .add(new BooleanClause(dvRangeQuery, Occur.MUST))
+                .build();
+            return conjunctionQuery;
+        }
+    }
+
+    @Override
+    public BytesRef nextUp(Object value) {
+        BytesRef nextUp = BytesRef.deepCopyOf(((BytesRef) value));
+        // adding 1 to last byte should not overflow since values 128-255 are reserved for lengths and cannot come last
+        nextUp.bytes[nextUp.offset + nextUp.length - 1] = (byte) (nextUp.bytes[nextUp.offset + nextUp.length - 1] + 1);
+        return nextUp;
+    }
+
+    @Override
+    public BytesRef nextDown(Object value) {
+        BytesRef nextDown = BytesRef.deepCopyOf(((BytesRef) value));
+        // subtracting 1 from last byte should not underflow since 0 shouldn't be last byte in encoded version
+        nextDown.bytes[nextDown.offset + nextDown.length - 1] = (byte) (nextDown.bytes[nextDown.offset + nextDown.length - 1] - 1);
+        return nextDown;
+    }
+
+    private Query dvRangeQuery(
+        String field,
+        BinaryDocValuesRangeQuery.QueryType queryType,
+        Object from,
+        Object to,
+        boolean includeFrom,
+        boolean includeTo
+    ) {
+        BytesRef encodedFrom = (BytesRef) from;
+        BytesRef encodedTo = (BytesRef) to;
+        if (includeFrom == false) {
+            encodedFrom = nextUp(encodedFrom);
+        }
+
+        if (includeTo == false) {
+            encodedTo = nextDown(encodedTo);
+        }
+        return new BinaryDocValuesRangeQuery(field, queryType, LengthType.FULL_BYTE, encodedFrom, encodedTo, from, to);
+    }
+
+    @Override
+    public boolean isNumeric() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return VERSION_RANGE_NAME;
+    };
+
+    @Override
+    public CoreRangeType.LengthType getLengthType() {
+        return CoreRangeType.LengthType.VARIABLE;
+    }
+
+    @Override
+    public Object parseValue(RangeFieldType fieldType, XContentParser parser, boolean coerce, Function<Object, Object> rounding)
+        throws IOException {
+        BytesRef version = parseValue(parser.text(), coerce, null);
+        return rounding.apply(version);
+    };
+
+}

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionRangeTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionRangeTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.versionfield;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+
+import java.util.Collection;
+
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+
+public class VersionRangeTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(VersionFieldPlugin.class, LocalStateCompositeXPackPlugin.class);
+    }
+
+    public void testSimpleVersionRange() throws Exception {
+        createIndex(
+            "test",
+            Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).build(),
+            "_doc",
+            "versionrange",
+            "type=version_range"
+        );
+        ensureGreen();
+
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource("{\"versionrange\":{\"gt\":\"1.1.0\",\"lte\":\"2.2.3\"}}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+            .setId("2")
+            .setSource("{\"versionrange\":{\"gte\":\"4.0.0-beta.2\",\"lte\":\"4.0.0-rc5\"}}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+            .setId("3")
+            .setSource("{\"versionrange\":{\"gte\":\"8.0.0-alpha.1\",\"lte\":\"8.0.0-alpha.9\"}}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+            .setId("4")
+            .setSource("{\"versionrange\":{\"gte\":\"8.0.0-alpha.0\",\"lte\":\"8.0.0-alpha.0.1\"}}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        SearchResponse search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("0.1.6").lte("2.7.0").relation("within"))
+            .get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("1.1.6").lte("1.7.0").relation("contains")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("1.1.6").lte("3.7.0").relation("contains")).get();
+        assertHitCount(search, 0L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("1.8.6").lte("3.7.0").relation("intersects")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("3.0.0").lte("4.0.0").relation("within")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("3.0.0").lte("4.0.0-rc3").relation("within")).get();
+        assertHitCount(search, 0L);
+
+        search = client().prepareSearch().setQuery(termQuery("versionrange", "4.0.0-rc3")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("8.0.0-alpha.2").lte("8.0.0-alpha.4").relation("contains"))
+            .get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("1.0.0").lte("1.1.0").relation("intersects")).get();
+        assertHitCount(search, 0L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("1.0.0").lte("1.1.0.0").relation("intersects")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gte("2.2.3").lte("3.0.0").relation("intersects")).get();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch().setQuery(rangeQuery("versionrange").gt("2.2.3").lte("3.0.0").relation("intersects")).get();
+        assertHitCount(search, 0L);
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/30_version_range.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/30_version_range.yml
@@ -1,0 +1,67 @@
+# Integration tests for the version_range field
+#
+---
+setup:
+
+  - skip:
+      features: headers
+      version: " - 7.99.99"
+      reason: "version_range fields are added to 8.0 first"
+
+  - do:
+        indices.create:
+          index: test_index
+          body:
+              mappings:
+                properties:
+                  version:
+                    type: version_range
+
+  - do:
+        bulk:
+          refresh: true
+          body:
+            - '{ "index" : { "_index" : "test_index", "_id" : "1" } }'
+            - '{"version": { "gte" : "1.0.0", "lt" : "2.0.0" } }'
+            - '{ "index" : { "_index" : "test_index", "_id" : "2" } }'
+            - '{"version": { "gte" : "2.0.0", "lt" : "2.5.0" } }'
+            - '{ "index" : { "_index" : "test_index", "_id" : "3" } }'
+            - '{"version": { "gte" : "2.5.0", "lt" : "3.0.0" } }'
+
+---
+"Search":
+  - do:
+        search:
+          index: test_index
+          body:
+            query: { "range" : { "version" : { "gt" : "1.0.0", "lt" : "2.3.0", "relation" : "intersects" } } }
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+
+  - do:
+       search:
+         index: test_index
+         body:
+           query: { "range" : { "version" : { "gt" : "1.1.0", "lt" : "1.5.0", "relation" : "contains" } } }
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+  
+  - do:
+       search:
+         index: test_index
+         body:
+           query: { "range" : { "version" : { "gte" : "1.0.0", "lt" : "2.3.0", "relation" : "within" } } }
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+       search:
+         index: test_index
+         body:
+           query: { "range" : { "version" : { "gt" : "1.0.0", "lt" : "2.3.0", "relation" : "within" } } }
+
+  - match: { hits.total.value: 0 }


### PR DESCRIPTION
As a follow up to #59773, this PR adds a "version_range" field type to the existing range field types
that allows storing and querying version ranges. Currently still WIP since I expect the PR this is based
on to change over time, but opening this here to get CI coverage. 

Relates to #48878 