### PR TITLE
Reduce duplication in checks for expensive queries

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.JoinUtil;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.similarities.Similarity;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -53,8 +52,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * A query builder for {@code has_child} query.
@@ -298,10 +295,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[joining] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
 
         ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
         if (joinFieldMapper == null) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.join.query;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -45,8 +44,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * Builder for the 'has_parent' query.
@@ -161,10 +158,7 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[joining] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
 
         ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
         if (joinFieldMapper == null) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -38,8 +37,6 @@ import org.elasticsearch.join.mapper.ParentJoinFieldMapper;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQueryBuilder> {
     public static final String NAME = "parent_id";
@@ -156,10 +153,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[joining] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
 
         ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
         if (joinFieldMapper == null) {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -376,7 +376,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
                 hasChildQuery(CHILD_DOC, new TermQueryBuilder("custom_string", "value"), ScoreMode.None);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> queryBuilder.toQuery(queryShardContext));
-        assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
+        assertEquals("[has_child] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -277,7 +277,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
                 CHILD_DOC, new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()), false);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> queryBuilder.toQuery(queryShardContext));
-        assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
+        assertEquals("[has_parent] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -165,7 +165,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
         ParentIdQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> queryBuilder.toQuery(queryShardContext));
-        assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
+        assertEquals("[parent_id] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }
 }

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
@@ -69,8 +69,8 @@ teardown:
 ---
 "has_child is expensive":
   - skip:
-      version: " - 7.6.99"
-      reason: "implemented in 7.7.0"
+      version: " - 7.99.99"
+      reason: message changed in 8.0.0 (to be backported 7.10.0)
 
   ### Update setting to false
   - do:

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
@@ -67,7 +67,7 @@ teardown:
   - gte: { hits.hits.0.inner_hits.child.hits.hits.0._primary_term: 1 }
 
 ---
-"HasChild disallow expensive queries":
+"has_child is expensive":
   - skip:
       version: " - 7.6.99"
       reason: "implemented in 7.7.0"
@@ -83,6 +83,6 @@ teardown:
   - match: {transient: {search.allow_expensive_queries: "false"}}
 
   - do:
-      catch: /\[joining\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
+      catch: /\[has_child\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
       search:
         body: { "query": { "has_child": { "type": "child", "query": { "match_all": {} }, "inner_hits": {} } } }

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -122,7 +122,7 @@ teardown:
     - match: { hits.hits.1._source.join_field.parent: "1" }
 
 ---
-"HasChild disallow expensive queries":
+"parent_id is expensive":
   - skip:
       version: " - 7.6.99"
       reason: "implemented in 7.7.0"
@@ -138,7 +138,7 @@ teardown:
   - match: {transient: {search.allow_expensive_queries: "false"}}
 
   - do:
-      catch: /\[joining\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
+      catch: /\[parent_id\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
       search:
         body:
           sort: [ "id" ]

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -124,8 +124,8 @@ teardown:
 ---
 "parent_id is expensive":
   - skip:
-      version: " - 7.6.99"
-      reason: "implemented in 7.7.0"
+      version: " - 7.99.99"
+      reason: message changed in 8.0.0 (to be backported 7.10.0)
 
   ### Update setting to false
   - do:

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
@@ -88,8 +88,8 @@ teardown:
 ---
 "has_parent is expensive":
   - skip:
-      version: " - 7.6.99"
-      reason: "implemented in 7.7.0"
+      version: " - 7.99.99"
+      reason: message changed in 8.0.0 (to be backported 7.10.0)
 
   ### Update setting to false
   - do:

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
@@ -86,7 +86,7 @@ teardown:
   - match: { hits.hits.1.inner_hits.question.hits.hits.0._id: "1"}
 
 ---
-"HasParent disallow expensive queries":
+"has_parent is expensive":
   - skip:
       version: " - 7.6.99"
       reason: "implemented in 7.7.0"
@@ -102,7 +102,7 @@ teardown:
   - match: {transient: {search.allow_expensive_queries: "false"}}
 
   - do:
-      catch: /\[joining\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
+      catch: /\[has_parent\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
       search:
         index: test
         body:

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -92,7 +92,6 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBuilder> {
     public static final String NAME = "percolate";
@@ -437,10 +436,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[percolate] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
 
         // Call nowInMillis() so that this query becomes un-cacheable since we
         // can't be sure that it doesn't use now or scripts

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries.yml
@@ -135,7 +135,7 @@ teardown:
 
   ### Nested
   - do:
-      catch: /\[joining\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
+      catch: /\[nested\] queries cannot be executed when \'search.allow_expensive_queries\' is set to false./
       search:
         index: test
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries.yml
@@ -47,8 +47,8 @@ teardown:
 ---
 "Test disallow expensive queries":
   - skip:
-      version: " - 7.6.99"
-      reason: "implemented in 7.7.0"
+      version: " - 7.99.99"
+      reason: message changed in 8.0.0 (to be backported 7.10.0)
 
   ### Check for initial setting = null -> false
   - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -54,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * This defines the core properties and functions to operate on a field.
@@ -358,5 +361,30 @@ public abstract class MappedFieldType {
      */
     public TextSearchInfo getTextSearchInfo() {
         return textSearchInfo;
+    }
+
+    /**
+     * Throw an exception if expensive queries aren't allowed. Called by the
+     * code that builds expensive queries to fail the search if they
+     * aren't allowed.
+     */
+    public static void checkAllowExpensiveQueries(QueryShardContext context, String format, Object... args) {
+        if (context.allowExpensiveQueries() == false) {
+            throw new ElasticsearchException(format, args);
+        }
+    }
+
+    /**
+     * Throw an exception if expensive queries aren't allowed. Called by the
+     * code that builds expensive queries to fail the search if they
+     * aren't allowed.
+     */
+    public static void checkAllowExpensiveQueries(QueryShardContext context, String query) {
+        checkAllowExpensiveQueries(
+            context,
+            "[{}] queries cannot be executed when '{}' is set to false.",
+            query,
+            ALLOW_EXPENSIVE_QUERIES.getKey()
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -366,5 +367,14 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     @Override
     public final String toString() {
         return Strings.toString(this, true, true);
+    }
+
+    /**
+     * Throw an exception if expensive queries aren't allowed. Called by the
+     * code that builds expensive queries to fail the search if they
+     * aren't allowed.
+     */
+    protected final void checkAllowExpensiveQueries(QueryShardContext context) {
+        MappedFieldType.checkAllowExpensiveQueries(context, getName());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -52,8 +52,8 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
 import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper.AbstractGeometryFieldType.QueryProcessor;
+import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
 import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.spatial4j.shape.Shape;
@@ -79,8 +79,13 @@ public class LegacyGeoShapeQueryProcessor implements QueryProcessor {
     @Override
     public Query process(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation, QueryShardContext context) {
         if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[geo-shape] queries on [PrefixTree geo shapes] cannot be executed when '"
-                    + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
+            throw new ElasticsearchException(
+                "["
+                    + GeoShapeQueryBuilder.NAME
+                    + "] queries on [PrefixTree geo shapes] cannot be executed when '"
+                    + ALLOW_EXPENSIVE_QUERIES.getKey()
+                    + "' is set to false."
+            );
         }
 
         LegacyGeoShapeFieldMapper.GeoShapeFieldType shapeFieldType = (LegacyGeoShapeFieldMapper.GeoShapeFieldType) ft;

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -34,7 +34,6 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.ParentChildrenBlockJoinQuery;
 import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.MaxScoreCollector;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
@@ -58,7 +57,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 import static org.elasticsearch.search.fetch.subphase.InnerHitsContext.intersect;
 
 public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder> {
@@ -268,10 +266,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[joining] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
 
         ObjectMapper nestedObjectMapper = context.getObjectMapper(path);
         if (nestedObjectMapper == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,8 +39,6 @@ import org.elasticsearch.script.Script;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder> {
     public static final String NAME = "script";
@@ -133,10 +130,7 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[script] queries cannot be executed when '" +
-                    ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
         FilterScript.Factory factory = context.compile(script, FilterScript.CONTEXT);
         FilterScript.LeafFactory filterScript = factory.newFactory(script.getParams(), context.lookup());
         return new ScriptQuery(script, filterScript);

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -44,7 +43,6 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * A query that computes a document score based on the provided script
@@ -173,10 +171,7 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException("[script score] queries cannot be executed when '"
-                    + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-        }
+        checkAllowExpensiveQueries(context);
         ScoreScript.Factory factory = context.compile(script, ScoreScript.CONTEXT);
         ScoreScript.LeafFactory scoreScriptFactory = factory.newFactory(script.getParams(), context.lookup());
         Query query = this.query.toQuery(context);

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -58,6 +58,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("deprecation") // It tests deprecated code
 public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase<LegacyGeoShapeFieldMapper.Builder> {
 
     @Override
@@ -771,7 +772,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase<LegacyGe
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> geoShapeFieldMapper.fieldType().geometryQueryBuilder().process(
                         new Point(-10, 10), "location", SpatialStrategy.TERM, ShapeRelation.INTERSECTS, queryShardContext));
-        assertEquals("[geo-shape] queries on [PrefixTree geo shapes] cannot be executed when " +
+        assertEquals("[geo_shape] queries on [PrefixTree geo shapes] cannot be executed when " +
                         "'search.allow_expensive_queries' is set to false.", e.getMessage());
         assertFieldWarnings("tree");
     }

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -360,7 +360,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         NestedQueryBuilder queryBuilder = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> queryBuilder.toQuery(queryShardContext));
-        assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
+        assertEquals("[nested] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
@@ -135,7 +135,7 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
         ScriptScoreQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> queryBuilder.toQuery(queryShardContext));
-        assertEquals("[script score] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
+        assertEquals("[script_score] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -300,11 +300,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 return new MatchNoDocsQuery();
             }
 
-            if (context.allowExpensiveQueries() == false) {
-                throw new ElasticsearchException(
-                    "[regexp] queries cannot be executed when '" + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false."
-                );
-            }
+            checkAllowExpensiveQueries(context, "regexp");
 
             RegExp ngramRegex = new RegExp(addLineEndChars(toLowerCase(value)), flags);
 


### PR DESCRIPTION
This moves all of the checks to prevent expensive queries to a few
shared methods. It also standardizes the error message to include the
name of the query.
