### PR TITLE
Small cleanup for IndexFieldData (backport of #59724)

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -518,11 +517,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         @Override
         public void clear() {
             scaledFieldData.clear();
-        }
-
-        @Override
-        public Index index() {
-            return scaledFieldData.index();
         }
 
         @Override

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.ContentPath;
@@ -95,7 +94,7 @@ public class QueryBuilderStoreTests extends ESTestCase {
             when(queryShardContext.getWriteableRegistry()).thenReturn(writableRegistry());
             when(queryShardContext.getXContentRegistry()).thenReturn(xContentRegistry());
             when(queryShardContext.getForField(fieldMapper.fieldType()))
-                .thenReturn(new BytesBinaryIndexFieldData(new Index("index", "uuid"), fieldMapper.name(), CoreValuesSourceType.BYTES));
+                .thenReturn(new BytesBinaryIndexFieldData(fieldMapper.name(), CoreValuesSourceType.BYTES));
             when(queryShardContext.fieldMapper(Mockito.anyString())).thenAnswer(invocation -> {
                 final String fieldName = (String) invocation.getArguments()[0];
                 return new KeywordFieldMapper.KeywordFieldType(fieldName);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -36,7 +36,6 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.IndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -55,7 +54,7 @@ import java.io.IOException;
  * Thread-safe utility class that allows to get per-segment values via the
  * {@link #load(LeafReaderContext)} method.
  */
-public interface IndexFieldData<FD extends LeafFieldData> extends IndexComponent {
+public interface IndexFieldData<FD extends LeafFieldData> {
 
     /**
      * The field name.

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexHistogramFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexHistogramFieldData.java
@@ -20,19 +20,16 @@
 package org.elasticsearch.index.fielddata;
 
 
-import org.elasticsearch.index.Index;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 /**
  * Specialization of {@link IndexFieldData} for histograms.
  */
 public abstract class IndexHistogramFieldData implements IndexFieldData<LeafHistogramFieldData> {
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public IndexHistogramFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    public IndexHistogramFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -50,10 +47,5 @@ public abstract class IndexHistogramFieldData implements IndexFieldData<LeafHist
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -28,9 +28,8 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.packed.PackedInts;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -51,7 +50,7 @@ public enum GlobalOrdinalsBuilder {
      * Build global ordinals for the provided {@link IndexReader}.
      */
     public static IndexOrdinalsFieldData build(final IndexReader indexReader, IndexOrdinalsFieldData indexFieldData,
-            IndexSettings indexSettings, CircuitBreakerService breakerService, Logger logger,
+            CircuitBreakerService breakerService, Logger logger,
             Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) throws IOException {
         assert indexReader.leaves().size() > 1;
         long startTimeNS = System.nanoTime();
@@ -74,13 +73,12 @@ public enum GlobalOrdinalsBuilder {
                     new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS)
             );
         }
-        return new GlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(), indexFieldData.getValuesSourceType(),
+        return new GlobalOrdinalsIndexFieldData(indexFieldData.getFieldName(), indexFieldData.getValuesSourceType(),
                 atomicFD, ordinalMap, memorySizeInBytes, scriptFunction
         );
     }
 
-    public static IndexOrdinalsFieldData buildEmpty(IndexSettings indexSettings, final IndexReader indexReader,
-            IndexOrdinalsFieldData indexFieldData) throws IOException {
+    public static IndexOrdinalsFieldData buildEmpty(IndexReader indexReader, IndexOrdinalsFieldData indexFieldData) throws IOException {
         assert indexReader.leaves().size() > 1;
 
         final LeafOrdinalsFieldData[] atomicFD = new LeafOrdinalsFieldData[indexReader.leaves().size()];
@@ -109,7 +107,7 @@ public enum GlobalOrdinalsBuilder {
             subs[i] = atomicFD[i].getOrdinalsValues();
         }
         final OrdinalMap ordinalMap = OrdinalMap.build(null, subs, PackedInts.DEFAULT);
-        return new GlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(), indexFieldData.getValuesSourceType(),
+        return new GlobalOrdinalsIndexFieldData(indexFieldData.getFieldName(), indexFieldData.getValuesSourceType(),
                 atomicFD, ordinalMap, 0, AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -27,11 +27,9 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.search.DocValueFormat;
@@ -55,7 +53,7 @@ import java.util.function.Function;
  * this is done to avoid creating all segment's {@link TermsEnum} each time we want to access the values of a single
  * segment.
  */
-public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent implements IndexOrdinalsFieldData, Accountable {
+public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldData, Accountable {
 
     private final String fieldName;
     private final ValuesSourceType valuesSourceType;
@@ -65,14 +63,12 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
     private final LeafOrdinalsFieldData[] segmentAfd;
     private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
 
-    protected GlobalOrdinalsIndexFieldData(IndexSettings indexSettings,
-                                           String fieldName,
+    protected GlobalOrdinalsIndexFieldData(String fieldName,
                                            ValuesSourceType valuesSourceType,
                                            LeafOrdinalsFieldData[] segmentAfd,
                                            OrdinalMap ordinalMap,
                                            long memorySizeInBytes,
                                            Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) {
-        super(indexSettings);
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.memorySizeInBytes = memorySizeInBytes;
@@ -82,7 +78,7 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
     }
 
     public IndexOrdinalsFieldData newConsumer(DirectoryReader source) {
-        return new Consumer(source, indexSettings);
+        return new Consumer(source);
     }
 
     @Override
@@ -154,12 +150,11 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
      * A non-thread safe {@link IndexOrdinalsFieldData} for global ordinals that creates the {@link TermsEnum} of each
      * segment once and use them to provide a single lookup per segment.
      */
-    public class Consumer extends AbstractIndexComponent implements IndexOrdinalsFieldData, Accountable {
+    public class Consumer implements IndexOrdinalsFieldData, Accountable {
         private final DirectoryReader source;
         private TermsEnum[] lookups;
 
-        Consumer(DirectoryReader source, IndexSettings settings) {
-            super(settings);
+        Consumer(DirectoryReader source) {
             this.source = source;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
@@ -24,8 +24,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.LeafFieldData;
@@ -34,19 +32,17 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 
-public abstract class AbstractIndexFieldData<FD extends LeafFieldData> extends AbstractIndexComponent implements IndexFieldData<FD> {
+public abstract class AbstractIndexFieldData<FD extends LeafFieldData> implements IndexFieldData<FD> {
 
     private final String fieldName;
     private ValuesSourceType valuesSourceType;
     protected final IndexFieldDataCache cache;
 
     public AbstractIndexFieldData(
-        IndexSettings indexSettings,
         String fieldName,
         ValuesSourceType valuesSourceType,
         IndexFieldDataCache cache
     ) {
-        super(indexSettings);
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.cache = cache;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
@@ -26,7 +26,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -44,12 +43,10 @@ import org.elasticsearch.search.sort.SortOrder;
 
 public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPointFieldData {
 
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    AbstractLatLonPointIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    AbstractLatLonPointIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -70,11 +67,6 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
     }
 
     @Override
-    public final Index index() {
-        return index;
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested,
             boolean reverse) {
         throw new IllegalArgumentException("can't sort on geo_point field without using specific sorting feature, like geo_distance");
@@ -87,8 +79,8 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
     }
 
     public static class LatLonPointIndexFieldData extends AbstractLatLonPointIndexFieldData {
-        public LatLonPointIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-            super(index, fieldName, valuesSourceType);
+        public LatLonPointIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+            super(fieldName, valuesSourceType);
         }
 
         @Override
@@ -128,7 +120,7 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
         public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // ignore breaker
-            return new LatLonPointIndexFieldData(indexSettings.getIndex(), fieldType.name(), valuesSourceType);
+            return new LatLonPointIndexFieldData(fieldType.name(), valuesSourceType);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryIndexFieldData.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -56,15 +55,13 @@ public class BinaryIndexFieldData implements IndexFieldData<BinaryDVLeafFieldDat
             MapperService mapperService
         ) {
             final String fieldName = fieldType.name();
-            return new BinaryIndexFieldData(indexSettings.getIndex(), fieldName, valuesSourceType);
+            return new BinaryIndexFieldData(fieldName, valuesSourceType);
         }
     }
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public BinaryIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    public BinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -82,11 +79,6 @@ public class BinaryIndexFieldData implements IndexFieldData<BinaryDVLeafFieldDat
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -42,12 +41,10 @@ import java.io.IOException;
 
 public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLeafFieldData> {
 
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public BytesBinaryIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    public BytesBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -65,11 +62,6 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 
     @Override
@@ -109,7 +101,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // Ignore breaker
             final String fieldName = fieldType.name();
-            return new BytesBinaryIndexFieldData(indexSettings.getIndex(), fieldName, valuesSourceType);
+            return new BytesBinaryIndexFieldData(fieldName, valuesSourceType);
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -67,7 +67,7 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
         @Override
         public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                 CircuitBreakerService breakerService, MapperService mapperService) {
-            return new ConstantIndexFieldData(indexSettings, fieldType.name(), valueFunction.apply(mapperService), valuesSourceType);
+            return new ConstantIndexFieldData(fieldType.name(), valueFunction.apply(mapperService), valuesSourceType);
         }
 
     }
@@ -139,8 +139,8 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
     private final ConstantLeafFieldData atomicFieldData;
 
-    private ConstantIndexFieldData(IndexSettings indexSettings, String name, String value, ValuesSourceType valuesSourceType) {
-        super(indexSettings, name, valuesSourceType, null, null,
+    private ConstantIndexFieldData(String name, String value, ValuesSourceType valuesSourceType) {
+        super(name, valuesSourceType, null, null,
                 TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.blocktree.FieldReader;
 import org.apache.lucene.codecs.blocktree.Stats;
 import org.apache.lucene.index.LeafReader;
@@ -56,7 +58,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import java.io.IOException;
 
 public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
-
+    private static final Logger logger = LogManager.getLogger(PagedBytesIndexFieldData.class);
 
     public static class Builder implements IndexFieldData.Builder {
 
@@ -74,13 +76,12 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
         @Override
         public IndexOrdinalsFieldData build(IndexSettings indexSettings, MappedFieldType fieldType,
                 IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new PagedBytesIndexFieldData(indexSettings, fieldType.name(), valuesSourceType, cache, breakerService,
+            return new PagedBytesIndexFieldData(fieldType.name(), valuesSourceType, cache, breakerService,
                     minFrequency, maxFrequency, minSegmentSize);
         }
     }
 
     public PagedBytesIndexFieldData(
-        IndexSettings indexSettings,
         String fieldName,
         ValuesSourceType valuesSourceType,
         IndexFieldDataCache cache,
@@ -89,7 +90,7 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
         double maxFrequency,
         int minSegmentSize
     ) {
-        super(indexSettings, fieldName, valuesSourceType, cache, breakerService, minFrequency, maxFrequency, minSegmentSize);
+        super(fieldName, valuesSourceType, cache, breakerService, minFrequency, maxFrequency, minSegmentSize);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -29,7 +29,6 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.time.DateUtils;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -73,17 +72,15 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
             MapperService mapperService
         ) {
             final String fieldName = fieldType.name();
-            return new SortedNumericIndexFieldData(indexSettings.getIndex(), fieldName, numericType);
+            return new SortedNumericIndexFieldData(fieldName, numericType);
         }
     }
 
     private final NumericType numericType;
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public SortedNumericIndexFieldData(Index index, String fieldName, NumericType numericType) {
-        this.index = index;
+    public SortedNumericIndexFieldData(String fieldName, NumericType numericType) {
         this.fieldName = fieldName;
         this.numericType = Objects.requireNonNull(numericType);
         this.valuesSourceType = numericType.getValuesSourceType();
@@ -102,11 +99,6 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
@@ -31,7 +31,6 @@ import org.apache.lucene.search.SortedSetSortField;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -78,13 +77,11 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
             MapperService mapperService
         ) {
             final String fieldName = fieldType.name();
-            return new SortedSetOrdinalsIndexFieldData(indexSettings, cache, fieldName, valuesSourceType, breakerService, scriptFunction);
+            return new SortedSetOrdinalsIndexFieldData(cache, fieldName, valuesSourceType, breakerService, scriptFunction);
         }
     }
 
-    protected final Index index;
     protected final String fieldName;
-    private final IndexSettings indexSettings;
     private final IndexFieldDataCache cache;
     private final CircuitBreakerService breakerService;
     private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
@@ -92,17 +89,14 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
     private static final Logger logger = LogManager.getLogger(SortedSetOrdinalsIndexFieldData.class);
 
     public SortedSetOrdinalsIndexFieldData(
-        IndexSettings indexSettings,
         IndexFieldDataCache cache,
         String fieldName,
         ValuesSourceType valuesSourceType,
         CircuitBreakerService breakerService,
         Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction
     ) {
-        this.index = indexSettings.getIndex();
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
-        this.indexSettings = indexSettings;
         this.cache = cache;
         this.breakerService = breakerService;
         this.scriptFunction = scriptFunction;
@@ -121,11 +115,6 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 
     @Override
@@ -193,7 +182,7 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
             // so if a field doesn't exist then we don't cache it and just return an empty field data instance.
             // The next time the field is found, we do cache.
             try {
-                return GlobalOrdinalsBuilder.buildEmpty(indexSettings, indexReader, this);
+                return GlobalOrdinalsBuilder.buildEmpty(indexReader, this);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -211,7 +200,7 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
 
     @Override
     public IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception {
-        return GlobalOrdinalsBuilder.build(indexReader, this, indexSettings, breakerService, logger, scriptFunction);
+        return GlobalOrdinalsBuilder.build(indexReader, this, breakerService, logger, scriptFunction);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
@@ -37,12 +36,10 @@ import java.io.IOException;
 
 public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDVLeafFieldData> {
 
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public StringBinaryIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    public StringBinaryIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -60,11 +57,6 @@ public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDV
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
     
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -176,12 +175,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
                     final IndexFieldData<?> fieldData = fieldDataBuilder.build(indexSettings, fieldType, cache,
                         breakerService, mapperService);
                     return new IndexFieldData<LeafFieldData>() {
-
-                        @Override
-                        public Index index() {
-                            return fieldData.index();
-                        }
-
                         @Override
                         public String getFieldName() {
                             return fieldData.getFieldName();

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
@@ -30,11 +30,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
@@ -89,13 +85,12 @@ public class FieldDataCacheTests extends ESTestCase {
     }
 
     private SortedSetOrdinalsIndexFieldData createSortedDV(String fieldName, IndexFieldDataCache indexFieldDataCache) {
-        return new SortedSetOrdinalsIndexFieldData(createIndexSettings(), indexFieldDataCache, fieldName, CoreValuesSourceType.BYTES,
+        return new SortedSetOrdinalsIndexFieldData(indexFieldDataCache, fieldName, CoreValuesSourceType.BYTES,
             new NoneCircuitBreakerService(), AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
     }
 
     private PagedBytesIndexFieldData createPagedBytes(String fieldName, IndexFieldDataCache indexFieldDataCache) {
         return new PagedBytesIndexFieldData(
-            createIndexSettings(),
             fieldName,
             CoreValuesSourceType.BYTES,
             indexFieldDataCache,
@@ -104,17 +99,6 @@ public class FieldDataCacheTests extends ESTestCase {
             TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
             TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE
         );
-    }
-
-    private IndexSettings createIndexSettings() {
-        Settings settings = Settings.EMPTY;
-        IndexMetadata indexMetadata = IndexMetadata.builder("_name")
-                .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(0)
-                .creationDate(System.currentTimeMillis())
-                .build();
-        return new IndexSettings(indexMetadata, settings);
     }
 
     private class DummyAccountingFieldDataCache implements IndexFieldDataCache {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.search.DocValueFormat;
@@ -38,12 +37,6 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
 
     public static IndexFieldData<LeafFieldData> hideOrdinals(final IndexFieldData<?> in) {
         return new IndexFieldData<LeafFieldData>() {
-
-            @Override
-            public Index index() {
-                return in.index();
-            }
-
             @Override
             public String getFieldName() {
                 return in.getFieldName();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -258,10 +258,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         docValuesField.setLongValue(1459641600000L);
         w.addDocument(doc);
         // Create the doc values reader
-        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        IndexSettings indexSettings =  new IndexSettings(IndexMetadata.builder("foo").settings(settings).build(), settings);
-        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData(indexSettings.getIndex(), "my_date",
+        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData("my_date",
             IndexNumericFieldData.NumericType.DATE_NANOSECONDS);
         // Read index and check the doc values
         DirectoryReader reader = DirectoryReader.open(w);

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -53,7 +53,6 @@ import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -165,11 +164,6 @@ public class FunctionScoreTests extends ESTestCase {
         public void clear() {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
-
-        @Override
-        public Index index() {
-            throw new UnsupportedOperationException(UNSUPPORTED);
-        }
     }
 
     /**
@@ -258,11 +252,6 @@ public class FunctionScoreTests extends ESTestCase {
 
         @Override
         public void clear() {
-            throw new UnsupportedOperationException(UNSUPPORTED);
-        }
-
-        @Override
-        public Index index() {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
@@ -34,7 +34,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -182,8 +181,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
                           Consumer<InternalSampler> verify, int shardSize, int maxDocsPerValue) throws IOException {
         MappedFieldType idFieldType = new KeywordFieldMapper.KeywordFieldType("id");
 
-        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData(new Index("index", "index"), "price",
-                IndexNumericFieldData.NumericType.DOUBLE);
+        SortedNumericIndexFieldData fieldData = new SortedNumericIndexFieldData("price", IndexNumericFieldData.NumericType.DOUBLE);
         FunctionScoreQuery query = new FunctionScoreQuery(new MatchAllDocsQuery(),
                 new FieldValueFactorFunction("price", 1, FieldValueFactorFunction.Modifier.RECIPROCAL, null, fieldData));
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -184,7 +184,7 @@ public class HistogramFieldMapper extends FieldMapper {
                 public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                                CircuitBreakerService breakerService, MapperService mapperService) {
 
-                    return new IndexHistogramFieldData(indexSettings.getIndex(), fieldType.name(), AnalyticsValuesSourceType.HISTOGRAM) {
+                    return new IndexHistogramFieldData(fieldType.name(), AnalyticsValuesSourceType.HISTOGRAM) {
 
                         @Override
                         public LeafHistogramFieldData load(LeafReaderContext context) {

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -416,11 +415,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             return false;
         }
 
-        @Override
-        public Index index() {
-            return delegate.index();
-        }
-
         public static class Builder implements IndexFieldData.Builder {
             private final String key;
             private final ValuesSourceType valuesSourceType;
@@ -437,7 +431,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                                            CircuitBreakerService breakerService,
                                            MapperService mapperService) {
                 String fieldName = fieldType.name();
-                IndexOrdinalsFieldData delegate = new SortedSetOrdinalsIndexFieldData(indexSettings,
+                IndexOrdinalsFieldData delegate = new SortedSetOrdinalsIndexFieldData(
                     cache, fieldName, valuesSourceType, breakerService, AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
                 return new KeyedFlatObjectFieldData(key, delegate);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/FieldDataCacheWithFieldSubsetReaderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/FieldDataCacheWithFieldSubsetReaderTests.java
@@ -18,16 +18,13 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.fielddata.LeafFieldData;
-import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.LeafFieldData;
+import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
@@ -57,13 +54,12 @@ public class FieldDataCacheWithFieldSubsetReaderTests extends ESTestCase {
 
     @Before
     public void setup() throws Exception {
-        IndexSettings indexSettings = createIndexSettings();
         CircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
         String name = "_field";
         indexFieldDataCache = new DummyAccountingFieldDataCache();
-        sortedSetOrdinalsIndexFieldData = new SortedSetOrdinalsIndexFieldData(indexSettings,indexFieldDataCache,  name,
+        sortedSetOrdinalsIndexFieldData = new SortedSetOrdinalsIndexFieldData(indexFieldDataCache,  name,
             CoreValuesSourceType.BYTES, circuitBreakerService, AbstractLeafOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION);
-        pagedBytesIndexFieldData = new PagedBytesIndexFieldData(indexSettings, name, CoreValuesSourceType.BYTES, indexFieldDataCache,
+        pagedBytesIndexFieldData = new PagedBytesIndexFieldData(name, CoreValuesSourceType.BYTES, indexFieldDataCache,
                 circuitBreakerService, TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
                 TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE);
@@ -84,7 +80,7 @@ public class FieldDataCacheWithFieldSubsetReaderTests extends ESTestCase {
             }
         }
         iw.close();
-        ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId(indexSettings.getIndex(), 0));
+        ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId(new Index("test", "test"), 0));
     }
 
     @After
@@ -150,17 +146,6 @@ public class FieldDataCacheWithFieldSubsetReaderTests extends ESTestCase {
             assertThat(atomic.getOrdinalsValues().getValueCount(), equalTo(0L));
         }
         assertThat(indexFieldDataCache.leafLevelBuilds, equalTo(ir.leaves().size()));
-    }
-
-    private IndexSettings createIndexSettings() {
-        Settings settings = Settings.EMPTY;
-        IndexMetadata indexMetadata = IndexMetadata.builder("_name")
-                .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(0)
-                .creationDate(System.currentTimeMillis())
-                .build();
-        return new IndexSettings(indexMetadata, settings);
     }
 
     private static class DummyAccountingFieldDataCache implements IndexFieldDataCache {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractLatLonShapeIndexFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractLatLonShapeIndexFieldData.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -27,12 +26,10 @@ import org.elasticsearch.search.sort.BucketedSort;
 import org.elasticsearch.search.sort.SortOrder;
 
 public abstract class AbstractLatLonShapeIndexFieldData implements IndexGeoShapeFieldData {
-    protected final Index index;
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    AbstractLatLonShapeIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-        this.index = index;
+    AbstractLatLonShapeIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }
@@ -53,19 +50,14 @@ public abstract class AbstractLatLonShapeIndexFieldData implements IndexGeoShape
     }
 
     @Override
-    public final Index index() {
-        return index;
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested,
             boolean reverse) {
         throw new IllegalArgumentException("can't sort on geo_shape field without using specific sorting feature, like geo_distance");
     }
 
     public static class LatLonShapeIndexFieldData extends AbstractLatLonShapeIndexFieldData {
-        public LatLonShapeIndexFieldData(Index index, String fieldName, ValuesSourceType valuesSourceType) {
-            super(index, fieldName, valuesSourceType);
+        public LatLonShapeIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+            super(fieldName, valuesSourceType);
         }
 
         @Override
@@ -112,7 +104,7 @@ public abstract class AbstractLatLonShapeIndexFieldData implements IndexGeoShape
         public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             // ignore breaker
-            return new LatLonShapeIndexFieldData(indexSettings.getIndex(), fieldType.name(), valuesSourceType);
+            return new LatLonShapeIndexFieldData(fieldType.name(), valuesSourceType);
         }
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorIndexFieldData.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorIndexFieldData.java
@@ -11,7 +11,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -28,16 +27,14 @@ import org.elasticsearch.search.sort.SortOrder;
 
 public class VectorIndexFieldData implements IndexFieldData<VectorDVLeafFieldData> {
 
-    protected final Index index;
     protected final String fieldName;
     private final boolean isDense;
     protected final ValuesSourceType valuesSourceType;
 
-    public VectorIndexFieldData(Index index, String fieldName, boolean isDense, ValuesSourceType valuesSourceType) {
+    public VectorIndexFieldData(String fieldName, boolean isDense, ValuesSourceType valuesSourceType) {
+        this.fieldName = fieldName;
         this.isDense = isDense;
         this.valuesSourceType = valuesSourceType;
-        this.index = index;
-        this.fieldName = fieldName;
     }
 
     @Override
@@ -53,11 +50,6 @@ public class VectorIndexFieldData implements IndexFieldData<VectorDVLeafFieldDat
     @Override
     public final void clear() {
         // can't do
-    }
-
-    @Override
-    public final Index index() {
-        return index;
     }
 
     @Override
@@ -93,7 +85,7 @@ public class VectorIndexFieldData implements IndexFieldData<VectorDVLeafFieldDat
         public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                                        CircuitBreakerService breakerService, MapperService mapperService) {
             final String fieldName = fieldType.name();
-            return new VectorIndexFieldData(indexSettings.getIndex(), fieldName, isDense, valuesSourceType);
+            return new VectorIndexFieldData(fieldName, isDense, valuesSourceType);
         }
 
     }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -878,7 +878,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 @Override
                 public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                         CircuitBreakerService breakerService, MapperService mapperService) {
-                    return new StringBinaryIndexFieldData(indexSettings.getIndex(), fieldType.name(), CoreValuesSourceType.BYTES);
+                    return new StringBinaryIndexFieldData(fieldType.name(), CoreValuesSourceType.BYTES);
                 }};
         }
 


### PR DESCRIPTION
This drops `IndexComponent` from `IndexFieldData` because it wasn't
doing anything other than forcing us to perform a bunch of ceremony to
build them.
