### PR TITLE
Fix retrieving data stream stats for a DS with multiple backing indices

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
@@ -38,4 +38,4 @@
   - match: { docs.1._index:     test_two_and_three      }
   - match: { docs.1._id:        "2"                     }
   - match: { docs.1.error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.indices.associated.with.it.\\[\\[test_[23]{1},.test_[23]{1}\\]\\],.can't.execute.a.single.index.op/" }
+  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.index.associated.with.it.\\[test_[23]{1},.test_[23]{1}\\],.can't.execute.a.single.index.op/" }

--- a/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -95,7 +95,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
 
         assertThat(mgetResponse.getResponses()[1].getIndex(), is("multiIndexAlias"));
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), containsString("more than one indices"));
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), containsString("more than one index"));
 
         mgetResponse = client().prepareMultiGet()
             .add(new MultiGetRequest.Item("multiIndexAlias", "1"))
@@ -103,7 +103,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("multiIndexAlias"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), containsString("more than one indices"));
+        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), containsString("more than one index"));
     }
 
     public void testThatMgetShouldWorkWithAliasRouting() throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -257,8 +257,8 @@ public class IndexNameExpressionResolver {
                         indexNames[i++] = indexMetadata.getIndex().getName();
                     }
                     throw new IllegalArgumentException(indexAbstraction.getType().getDisplayName() + " [" + expression +
-                        "] has more than one indices associated with it [" + Arrays.toString(indexNames) +
-                        "], can't execute a single index op");
+                        "] has more than one index associated with it " + Arrays.toString(indexNames) +
+                        ", can't execute a single index op");
                 }
 
                 for (IndexMetadata index : indexAbstraction.getIndices()) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -604,7 +604,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(context, "foofoobar"));
-            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one indices associated with it"));
+            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one index associated with it"));
         }
 
         {
@@ -612,7 +612,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "foofoobar"));
-            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one indices associated with it"));
+            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one index associated with it"));
         }
 
         {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
@@ -37,7 +37,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         public Request() {
             // this doesn't really matter since data stream name resolution isn't affected by IndicesOptions and
             // a data stream's backing indices are retrieved from its metadata
-            super(null, IndicesOptions.fromOptions(false, true, true, true, false, false, true, false));
+            super(null, IndicesOptions.fromOptions(false, true, true, true, true, false, true, false));
         }
 
         public Request(StreamInput in) throws IOException {

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/120_data_streams_stats.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/120_data_streams_stats.yml
@@ -48,12 +48,16 @@ setup:
   - is_true: acknowledged
 
   - do:
+      indices.rollover:
+        alias: "simple-data-stream1"
+
+  - do:
       indices.data_streams_stats: {}
   - match: { data_stream_count: 1 }
-  - match: { backing_indices: 1 }
+  - match: { backing_indices: 2 }
   - length: { data_streams: 1 }
   - match: { data_streams.0.data_stream: 'simple-data-stream1' }
-  - match: { data_streams.0.backing_indices: 1 }
+  - match: { data_streams.0.backing_indices: 2 }
   - match: { data_streams.0.maximum_timestamp: 0 }
 
   - do:


### PR DESCRIPTION
This API incorrectly had `allowAliasesToMultipleIndices` set to false in the default options for the
request. This changes it from `false` to `true` and enhances a test to exercise the functionality.

Resolves #59802
