### PR TITLE
[7.x] Fix retrieving data stream stats for a DS with multiple backing indices (#59806)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
@@ -1,8 +1,8 @@
 ---
 "Multi Get with alias that resolves to multiple indices":
   - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
+      version: " - 7.8.99"
+      reason: "message was changed to fix grammar in 7.9"
 
   - do:
       bulk:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/14_alias_to_multiple_indices.yml
@@ -42,4 +42,4 @@
   - match: { docs.1._type:      null                    }
   - match: { docs.1._id:        "2"                     }
   - match: { docs.1.error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.indices.associated.with.it.\\[\\[test_[23]{1},.test_[23]{1}\\]\\],.can't.execute.a.single.index.op/" }
+  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.index.associated.with.it.\\[test_[23]{1},.test_[23]{1}\\],.can't.execute.a.single.index.op/" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/21_alias_to_multiple_indices_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/21_alias_to_multiple_indices_with_types.yml
@@ -39,4 +39,4 @@
   - match: { docs.1._type:      test                    }
   - match: { docs.1._id:        "2"                     }
   - match: { docs.1.error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.indices.associated.with.it.\\[\\[test_[23]{1},.test_[23]{1}\\]\\],.can't.execute.a.single.index.op/" }
+  - match: { docs.1.error.root_cause.0.reason: "/[aA]lias.\\[test_two_and_three\\].has.more.than.one.index.associated.with.it.\\[test_[23]{1},.test_[23]{1}\\],.can't.execute.a.single.index.op/" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/21_alias_to_multiple_indices_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/21_alias_to_multiple_indices_with_types.yml
@@ -1,5 +1,8 @@
 ---
 "Multi Get with alias that resolves to multiple indices":
+  - skip:
+      version: " - 7.8.99"
+      reason: "message was changed to fix grammar in 7.9"
 
   - do:
       bulk:

--- a/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -95,7 +95,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
 
         assertThat(mgetResponse.getResponses()[1].getIndex(), is("multiIndexAlias"));
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), containsString("more than one indices"));
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), containsString("more than one index"));
 
         mgetResponse = client().prepareMultiGet()
             .add(new MultiGetRequest.Item("multiIndexAlias", "test", "1"))
@@ -103,7 +103,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("multiIndexAlias"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), containsString("more than one indices"));
+        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), containsString("more than one index"));
     }
 
     public void testThatMgetShouldWorkWithAliasRouting() throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -258,8 +258,8 @@ public class IndexNameExpressionResolver {
                         indexNames[i++] = indexMetadata.getIndex().getName();
                     }
                     throw new IllegalArgumentException(indexAbstraction.getType().getDisplayName() + " [" + expression +
-                        "] has more than one indices associated with it [" + Arrays.toString(indexNames) +
-                        "], can't execute a single index op");
+                        "] has more than one index associated with it " + Arrays.toString(indexNames) +
+                        ", can't execute a single index op");
                 }
 
                 for (IndexMetadata index : indexAbstraction.getIndices()) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -604,7 +604,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(context, "foofoobar"));
-            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one indices associated with it"));
+            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one index associated with it"));
         }
 
         {
@@ -612,7 +612,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "foofoobar"));
-            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one indices associated with it"));
+            assertThat(e.getMessage(), containsString("alias [foofoobar] has more than one index associated with it"));
         }
 
         {

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/120_data_streams_stats.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/120_data_streams_stats.yml
@@ -48,12 +48,16 @@ setup:
   - is_true: acknowledged
 
   - do:
+      indices.rollover:
+        alias: "simple-data-stream1"
+
+  - do:
       indices.data_streams_stats: {}
   - match: { data_stream_count: 1 }
-  - match: { backing_indices: 1 }
+  - match: { backing_indices: 2 }
   - length: { data_streams: 1 }
   - match: { data_streams.0.data_stream: 'simple-data-stream1' }
-  - match: { data_streams.0.backing_indices: 1 }
+  - match: { data_streams.0.backing_indices: 2 }
   - match: { data_streams.0.maximum_timestamp: 0 }
 
   - do:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix retrieving data stream stats for a DS with multiple backing indices (#59806)