### PR TITLE
Render script params in script field xcontent

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -34,7 +34,7 @@ abstract class AbstractScriptMappedFieldType extends MappedFieldType {
 
     void mapperXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field("runtime_type", runtimeType());
-        builder.field("script", script.getIdOrCode()); // TODO For some reason this doesn't allow us to do the full xcontent of the script.
+        builder.field("script", script, params);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -20,7 +20,8 @@ setup:
               day_of_week:
                 type: script
                 runtime_type: keyword
-                script: value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))
+                script: |
+                  value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))
               days_starting_with_t:
                 type: script
                 runtime_type: keyword
@@ -30,6 +31,16 @@ setup:
                       value(dow);
                     }
                   }
+              prefixed_node:
+                type: script
+                runtime_type: keyword
+                script:
+                  source: |
+                    for (String node : doc['node']) {
+                      value(params.prefix + node);
+                    }
+                  params:
+                    prefix: node_
 
   - do:
       bulk:
@@ -50,15 +61,48 @@ setup:
           {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
 
 ---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.day_of_week.type: script }
+  - match: {sensor.mappings.properties.day_of_week.runtime_type: keyword }
+  - match:
+      sensor.mappings.properties.day_of_week.script.source: |
+        value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))
+  - match: {sensor.mappings.properties.day_of_week.script.lang: painless }
+  - match: {sensor.mappings.properties.days_starting_with_t.type: script }
+  - match: {sensor.mappings.properties.days_starting_with_t.runtime_type: keyword }
+  - match:
+      sensor.mappings.properties.days_starting_with_t.script.source: |
+        for (String dow: doc['day_of_week']) {
+          if (dow.startsWith('T')) {
+            value(dow);
+          }
+        }
+  - match: {sensor.mappings.properties.days_starting_with_t.script.lang: painless }
+  - match: {sensor.mappings.properties.prefixed_node.type: script }
+  - match: {sensor.mappings.properties.prefixed_node.runtime_type: keyword }
+  - match:
+      sensor.mappings.properties.prefixed_node.script.source: |
+        for (String node : doc['node']) {
+          value(params.prefix + node);
+        }
+  - match: {sensor.mappings.properties.prefixed_node.script.params: {prefix: node_} }
+  - match: {sensor.mappings.properties.prefixed_node.script.lang: painless }
+
+---
 "docvalue_fields":
   - do:
       search:
         index: sensor
         body:
           sort: timestamp
-          docvalue_fields: [day_of_week]
+          docvalue_fields: [day_of_week, days_starting_with_t, prefixed_node]
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.day_of_week: [Thursday] }
+  - match: {hits.hits.0.fields.days_starting_with_t: [Thursday] }
+  - match: {hits.hits.0.fields.prefixed_node: [node_c] }
 
 ---
 "terms agg":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -20,10 +20,13 @@ setup:
               voltage_times_ten:
                 type: script
                 runtime_type: long
-                script: |
-                  for (double v : doc['voltage']) {
-                    value((long)(v * 10));
-                  }
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      value((long)(v * params.multiplier));
+                    }
+                  params:
+                    multiplier: 10
               even_voltage_times_ten:
                 type: script
                 runtime_type: long
@@ -51,6 +54,31 @@ setup:
           {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
           {"index":{}}
           {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.voltage_times_ten.type: script }
+  - match: {sensor.mappings.properties.voltage_times_ten.runtime_type: long }
+  - match:
+      sensor.mappings.properties.voltage_times_ten.script.source: |
+        for (double v : doc['voltage']) {
+          value((long)(v * params.multiplier));
+        }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.params: {multiplier: 10} }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.lang: painless }
+  - match: {sensor.mappings.properties.even_voltage_times_ten.type: script }
+  - match: {sensor.mappings.properties.even_voltage_times_ten.runtime_type: long }
+  - match:
+      sensor.mappings.properties.even_voltage_times_ten.script.source: |
+        for (long tenV: doc['voltage_times_ten']) {
+          if (tenV % 2 == 0) {
+            value(tenV);
+          }
+        }
+  - match: {sensor.mappings.properties.even_voltage_times_ten.script.lang: painless }
 
 ---
 "docvalue_fields":


### PR DESCRIPTION
This fixes the rendering of the `script` field in the `script` field
type. Originally we weren't rendering the `params` and such because we
couldn't parse them. But we can parse them now so we should render them.

This updates the integration tests to include params and adds an
integration test that fetches the mapping.

Relates to #59332
