### PR TITLE
Remaining queries for long script field

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -67,6 +67,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /** A {@link FieldMapper} for numeric types: byte, short, int, long, float and double. */
@@ -881,10 +882,6 @@ public class NumberFieldMapper extends FieldMapper {
             return Numbers.toLong(stringValue, coerce);
         }
 
-        @FunctionalInterface
-        public interface RangeQueryBuilder {
-            Query build(long lower, long upper);
-        }
         /**
          * Processes query bounds into {@code long}s and delegates the
          * provided {@code builder} to build a range query.
@@ -894,7 +891,7 @@ public class NumberFieldMapper extends FieldMapper {
             Object upperTerm,
             boolean includeLower,
             boolean includeUpper,
-            RangeQueryBuilder builder
+            BiFunction<Long, Long, Query> builder
         ) {
             long l = Long.MIN_VALUE;
             long u = Long.MAX_VALUE;
@@ -923,7 +920,7 @@ public class NumberFieldMapper extends FieldMapper {
                     --u;
                 }
             }
-            return builder.build(l, u);
+            return builder.apply(l, u);
         }
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+
+import java.util.Objects;
+
+public class LongScriptFieldRangeQuery extends AbstractLongScriptFieldQuery {
+    private final long lowerValue;
+    private final long upperValue;
+
+    public LongScriptFieldRangeQuery(
+        Script script,
+        LongScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        long lowerValue,
+        long upperValue
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lowerValue = lowerValue;
+        this.upperValue = upperValue;
+        assert lowerValue <= upperValue;
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (lowerValue <= values[i] && values[i] <= upperValue) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append('[').append(lowerValue).append(" TO ").append(upperValue).append(']');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lowerValue, upperValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldRangeQuery other = (LongScriptFieldRangeQuery) obj;
+        return lowerValue == other.lowerValue && upperValue == other.upperValue;
+    }
+
+    long lowerValue() {
+        return lowerValue;
+    }
+
+    long upperValue() {
+        return upperValue;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongSet;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+
+import java.util.Objects;
+
+public class LongScriptFieldTermsQuery extends AbstractLongScriptFieldQuery {
+    private final LongSet terms;
+
+    public LongScriptFieldTermsQuery(Script script, LongScriptFieldScript.LeafFactory leafFactory, String fieldName, LongSet terms) {
+        super(script, leafFactory, fieldName);
+        this.terms = terms;
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (terms.contains(values[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return terms.toString();
+        }
+        return fieldName() + ":" + terms;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), terms);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldTermsQuery other = (LongScriptFieldTermsQuery) obj;
+        return terms.equals(other.terms);
+    }
+
+    LongSet terms() {
+        return terms;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
@@ -32,6 +32,7 @@ public abstract class AbstractScriptFieldQueryTestCase<T extends AbstractScriptF
     public final void testToString() {
         T query = createTestInstance();
         assertThat(query.toString(), equalTo(query.fieldName() + ":" + query.toString(query.fieldName())));
+        assertToString(query);
     }
 
     protected abstract void assertToString(T query);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
@@ -36,6 +36,6 @@ public class LongScriptFieldExistsQueryTests extends AbstractLongScriptFieldQuer
 
     @Override
     protected void assertToString(LongScriptFieldExistsQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo("ScriptFieldExists"));
+        assertThat(query.toString(query.fieldName()), equalTo("LongScriptFieldExistsQuery"));
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldRangeQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldRangeQuery> {
+    @Override
+    protected LongScriptFieldRangeQuery createTestInstance() {
+        long lower = randomLong();
+        long upper = randomValueOtherThan(lower, ESTestCase::randomLong);
+        if (lower > upper) {
+            long tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new LongScriptFieldRangeQuery(randomScript(), leafFactory, randomAlphaOfLength(5), lower, upper);
+    }
+
+    @Override
+    protected LongScriptFieldRangeQuery copy(LongScriptFieldRangeQuery orig) {
+        return new LongScriptFieldRangeQuery(orig.script(), leafFactory, orig.fieldName(), orig.lowerValue(), orig.upperValue());
+    }
+
+    @Override
+    protected LongScriptFieldRangeQuery mutate(LongScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        long lower = orig.lowerValue();
+        long upper = orig.upperValue();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                if (lower == Long.MIN_VALUE) {
+                    fieldName += "modified_instead_of_lower";
+                } else {
+                    lower -= 1;
+                }
+                break;
+            case 3:
+                if (upper == Long.MAX_VALUE) {
+                    fieldName += "modified_instead_of_upper";
+                } else {
+                    upper += 1;
+                }
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldRangeQuery(script, leafFactory, fieldName, lower, upper);
+    }
+
+    @Override
+    public void testMatches() {
+        LongScriptFieldRangeQuery query = new LongScriptFieldRangeQuery(randomScript(), leafFactory, "test", 1, 3);
+        assertTrue(query.matches(new long[] { 1 }, 1));
+        assertTrue(query.matches(new long[] { 2 }, 1));
+        assertTrue(query.matches(new long[] { 3 }, 1));
+        assertFalse(query.matches(new long[] { 1 }, 0));
+        assertFalse(query.matches(new long[] { 5 }, 1));
+        assertTrue(query.matches(new long[] { 1, 5 }, 2));
+        assertTrue(query.matches(new long[] { 5, 1 }, 2));
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldRangeQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("[" + query.lowerValue() + " TO " + query.upperValue() + "]"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldTermsQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldTermsQuery> {
+    @Override
+    protected LongScriptFieldTermsQuery createTestInstance() {
+        LongSet terms = new LongHashSet();
+        int count = between(1, 100);
+        while (terms.size() < count) {
+            terms.add(randomLong());
+        }
+        return new LongScriptFieldTermsQuery(randomScript(), leafFactory, randomAlphaOfLength(5), terms);
+    }
+
+    @Override
+    protected LongScriptFieldTermsQuery copy(LongScriptFieldTermsQuery orig) {
+        return new LongScriptFieldTermsQuery(orig.script(), leafFactory, orig.fieldName(), orig.terms());
+    }
+
+    @Override
+    protected LongScriptFieldTermsQuery mutate(LongScriptFieldTermsQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        LongSet terms = orig.terms();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                terms = new LongHashSet(terms);
+                while (false == terms.add(randomLong())) {
+                    // Random long was already in the set
+                }
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldTermsQuery(script, leafFactory, fieldName, terms);
+    }
+
+    @Override
+    public void testMatches() {
+        LongScriptFieldTermsQuery query = new LongScriptFieldTermsQuery(randomScript(), leafFactory, "test", LongHashSet.from(1, 2, 3));
+        assertTrue(query.matches(new long[] { 1 }, 1));
+        assertTrue(query.matches(new long[] { 2 }, 1));
+        assertTrue(query.matches(new long[] { 3 }, 1));
+        assertTrue(query.matches(new long[] { 1, 0 }, 2));
+        assertTrue(query.matches(new long[] { 0, 1 }, 2));
+        assertFalse(query.matches(new long[] { 0 }, 1));
+        assertFalse(query.matches(new long[] { 0, 1 }, 1));
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldTermsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.terms().toString()));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
@@ -43,7 +43,7 @@ public class StringScriptFieldExistsQueryTests extends AbstractStringScriptField
 
     @Override
     protected void assertToString(StringScriptFieldExistsQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo("ScriptFieldExists"));
+        assertThat(query.toString(query.fieldName()), equalTo("StringScriptFieldExistsQuery"));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
@@ -95,7 +95,10 @@ public class StringScriptFieldFuzzyQueryTests extends AbstractStringScriptFieldQ
 
     @Override
     protected void assertToString(StringScriptFieldFuzzyQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo(query.delegate().getTerm().bytes().utf8ToString()));
+        assertThat(
+            query.toString(query.fieldName()),
+            equalTo(query.delegate().getTerm().bytes().utf8ToString() + "~" + query.delegate().getMaxEdits())
+        );
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
@@ -58,7 +58,7 @@ public class StringScriptFieldPrefixQueryTests extends AbstractStringScriptField
 
     @Override
     protected void assertToString(StringScriptFieldPrefixQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo(query.prefix()));
+        assertThat(query.toString(query.fieldName()), equalTo(query.prefix() + "*"));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
@@ -60,7 +60,7 @@ public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFie
 
     @Override
     protected void assertToString(StringScriptFieldWildcardQuery query) {
-        assertThat(query.toString(query.fieldName()), equalTo("/" + query.pattern() + "/"));
+        assertThat(query.toString(query.fieldName()), equalTo(query.pattern()));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -174,4 +174,4 @@ setup:
           sort: timestamp
   - match: {hits.total.value: 2}
   - match: {hits.hits.0._source.voltage: 4.0}
-  - match: {hits.hits.0._source.voltage: 5.8}
+  - match: {hits.hits.1._source.voltage: 5.8}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -101,3 +101,78 @@ setup:
   - match: {hits.hits.2._source.voltage: 5.6}
   - match: {hits.hits.3._source.voltage: 5.8}
   - match: {hits.hits.4._source.voltage: 5.2}
+
+---
+"range query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_times_ten:
+                gt: 57
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_times_ten:
+                gt: 58
+  - match: {hits.total.value: 0}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_times_ten:
+                gte: 58
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_times_ten:
+                gte: 51
+                lte: 52
+          sort: timestamp
+  - match: {hits.total.value: 2}
+  - match: {hits.hits.0._source.voltage: 5.1}
+  - match: {hits.hits.1._source.voltage: 5.2}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              voltage_times_ten: 58
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"terms query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            terms:
+              voltage_times_ten: [58, 59, 40]
+          sort: timestamp
+  - match: {hits.total.value: 2}
+  - match: {hits.hits.0._source.voltage: 4.0}
+  - match: {hits.hits.1._source.voltage: 5.8}
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -174,5 +174,4 @@ setup:
           sort: timestamp
   - match: {hits.total.value: 2}
   - match: {hits.hits.0._source.voltage: 4.0}
-  - match: {hits.hits.1._source.voltage: 5.8}
-
+  - match: {hits.hits.0._source.voltage: 5.8}


### PR DESCRIPTION
Adds the `terms` and `range` queries for `long` typed `script` fields.
It also fixes a bug in a few of `toString` tests for `keyword` typed
`script` fields.

Relates to #59332