### PR TITLE
[DOCS] Remove collapsible examples

### DIFF
--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -9,9 +9,6 @@ and `from` parameters. The `size` parameter is the number of matching documents
 to return. The `from` parameter is a zero-indexed offset from the beginning of
 the complete result set that indicates the document you want to start with.
 
-.*Example*
-[%collapsible]
-====
 The following search API request sets the `from` offset to `5`, meaning the
 request offsets, or skips, the first five matching documents.
 
@@ -31,7 +28,6 @@ GET /_search
   }
 }
 ----
-====
 
 By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the

--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -30,9 +30,6 @@ You can use the search API's <<search-api-query-params-q,`q` query string
 parameter>> to run a search in the request's URI. The `q` parameter only accepts
 queries written in Lucene's <<query-string-syntax,query string syntax>>.
 
-.*Example*
-[%collapsible]
-====
 To get started, ingest or add some data to an {es} index.
 
 The following <<docs-bulk,bulk API>> request adds some example user log data to
@@ -98,7 +95,6 @@ the document that matched the query.
 }
 ----
 // TESTRESPONSE[s/"took": 2/"took": "$body.took"/]
-====
 
 [discrete]
 [[run-request-body-search]]
@@ -108,9 +104,6 @@ You can use the search API's <<request-body-search-query,`query` request
 body parameter>> to provide a query as a JSON object, written in
 <<query-dsl,Query DSL>>.
 
-.*Example*
-[%collapsible]
-====
 The following request body search uses the <<query-dsl-match-query,`match`>>
 query to match documents with a `message` value of `login successful`. Note the
 `match` query is specified as a JSON object in the `query` parameter.
@@ -193,7 +186,6 @@ score>> that measures how well each document matches the query.
 }
 ----
 // TESTRESPONSE[s/"took": 1/"took": "$body.took"/]
-====
 
 [discrete]
 [[search-multiple-indices]]
@@ -202,9 +194,6 @@ score>> that measures how well each document matches the query.
 To search multiple data streams and indices, add them as comma-separated values
 in the search API request path.
 
-.*Example*
-[%collapsible]
-====
 The following request searches the `user_logs_000001` and `user_logs_000002`
 indices.
 
@@ -221,14 +210,10 @@ GET /user_logs_000001,user_logs_000002/_search
 ----
 // TEST[continued]
 // TEST[s/^/PUT user_logs_000002\n/]
-====
 
 You can also search multiple data streams and indices using a wildcard (`*`)
 pattern.
 
-.*Example*
-[%collapsible]
-====
 The following request targets the wildcard pattern `user_logs*`. The request
 searches any data streams or indices in the cluster that start with `user_logs`.
 
@@ -244,14 +229,10 @@ GET /user_logs*/_search
 }
 ----
 // TEST[continued]
-====
 
 To search all data streams and indices in a cluster, omit the target from the
 request path. Alternatively, you can use `_all` or `*`.
 
-.*Example*
-[%collapsible]
-====
 The following requests are equivalent and search all data streams and indices in the cluster.
 
 [source,console]
@@ -282,7 +263,6 @@ GET /*/_search
 }
 ----
 // TEST[continued]
-====
 
 include::request/from-size.asciidoc[]
 

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -39,9 +39,6 @@ following sections:
 You can use the `_source` parameter to select what fields of the source are
 returned. This is called _source filtering_.
 
-.*Example*
-[%collapsible]
-====
 The following search API request sets the `_source` request body parameter to
 `false`. The document source is not included in the response.
 
@@ -120,7 +117,6 @@ GET /_search
   }
 }
 ----
-====
 
 
 [discrete]
@@ -139,9 +135,6 @@ Doc values are stored for supported fields by default. However, doc values are
 not supported for <<text,`text`>> or
 {plugins}/mapper-annotated-text-usage.html[`text_annotated`] fields.
 
-.*Example*
-[%collapsible]
-====
 The following search request uses the `docvalue_fields` parameter to
 retrieve doc values for the following fields:
 
@@ -176,7 +169,6 @@ GET /_search
     <<mapping-date-format,date `format`>>. <<number,Numeric fields>> support a
     https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html[DecimalFormat
     pattern]. Other field data types do not support the `format` parameter.
-====
 
 TIP: You cannot use the `docvalue_fields` parameter to retrieve doc values for
 nested objects. If you specify a nested object, the search returns an empty


### PR DESCRIPTION
Removes collapsible sections. Snippets are now visible without additional clicks.