### PR TITLE
Support spatial fields in field retrieval API.

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -22,6 +22,7 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<nested>>::    `nested` for arrays of JSON objects
 
 [float]
+[[_spatial_datatypes]]
 === Spatial data types
 
 <<geo-point>>::     `geo_point` for lat/lon points

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -22,7 +22,7 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<nested>>::    `nested` for arrays of JSON objects
 
 [float]
-[[_spatial_datatypes]]
+[[spatial_datatypes]]
 === Spatial data types
 
 <<geo-point>>::     `geo_point` for lat/lon points

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -87,9 +87,13 @@ POST twitter/_search
 
 <1> Both full field names and wildcard patterns are accepted.
 <2> Using object notation, you can pass a `format` parameter to apply a custom
-    format for the field's values. This is currently supported for
-    <<date,`date` fields>> and <<date_nanos, `date_nanos` fields>>, which
-    accept a <<mapping-date-format,date format>>.
+    format for the field's values. The date fields
+    <<date,`date`>> and <<date_nanos, `date_nanos`>> accept a
+    <<mapping-date-format,date format>>. <<_spatial_datatypes, Spatial fields>>
+    accept either `geojson` for http://www.geojson.org[GeoJSON] (the default)
+    or `wkt` for
+    https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry[Well Known Text].
+    Other field types do not support the `format` parameter.
 
 The values are returned as a flat list in the `fields` section in each hit:
 

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -89,7 +89,7 @@ POST twitter/_search
 <2> Using object notation, you can pass a `format` parameter to apply a custom
     format for the field's values. The date fields
     <<date,`date`>> and <<date_nanos, `date_nanos`>> accept a
-    <<mapping-date-format,date format>>. <<_spatial_datatypes, Spatial fields>>
+    <<mapping-date-format,date format>>. <<spatial_datatypes, Spatial fields>>
     accept either `geojson` for http://www.geojson.org[GeoJSON] (the default)
     or `wkt` for
     https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry[Well Known Text].

--- a/modules/geo/src/yamlRestTest/resources/rest-api-spec/test/geo_shape/10_basic.yml
+++ b/modules/geo/src/yamlRestTest/resources/rest-api-spec/test/geo_shape/10_basic.yml
@@ -57,3 +57,26 @@ setup:
               field: location
 
   - match: {hits.total: 1}
+
+---
+"Test retrieve geo_shape field":
+  - do:
+      search:
+        index: test
+        body:
+          fields: [location]
+          _source: false
+
+  - match: { hits.hits.0.fields.location.0.type: "Point" }
+  - match: { hits.hits.0.fields.location.0.coordinates: [1.0, 1.0] }
+
+  - do:
+      search:
+        index: test
+        body:
+          fields:
+            - field: location
+              format: wkt
+          _source: false
+
+  - match: { hits.hits.0.fields.location.0: "POINT (1.0 1.0)" }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -22,15 +22,21 @@ package org.elasticsearch.common.geo;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentSubParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
@@ -50,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -610,4 +617,14 @@ public final class GeoJson {
         }
     }
 
+    public static Map<?, ?> toXContentMap(Geometry geometry) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        GeoJson.toXContent(geometry, builder, ToXContent.EMPTY_PARAMS);
+        StreamInput input = BytesReference.bytes(builder).streamInput();
+
+        try (XContentParser parser = XContentType.JSON.xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, input)) {
+            return parser.map();
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -22,21 +22,15 @@ package org.elasticsearch.common.geo;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentSubParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
@@ -56,7 +50,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -614,17 +607,6 @@ public final class GeoJson {
                 builder.endArray();
             }
             return builder;
-        }
-    }
-
-    public static Map<?, ?> toXContentMap(Geometry geometry) throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        GeoJson.toXContent(geometry, builder, ToXContent.EMPTY_PARAMS);
-        StreamInput input = BytesReference.bytes(builder).streamInput();
-
-        try (XContentParser parser = XContentType.JSON.xContent()
-            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, input)) {
-            return parser.map();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.geometry.Geometry;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
+    public static final String NAME = "geojson";
+
+    private final GeoJson geoJsonParser;
+
+    public GeoJsonGeometryFormat(GeoJson geoJsonParser) {
+        this.geoJsonParser = geoJsonParser;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Geometry fromXContent(XContentParser parser) throws IOException {
+        if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+            return null;
+        }
+        return geoJsonParser.fromXContent(parser);
+    }
+
+    @Override
+    public XContentBuilder toXContent(Geometry geometry, XContentBuilder builder, ToXContent.Params params) throws IOException {
+        if (geometry != null) {
+            return GeoJson.toXContent(geometry, builder, params);
+        } else {
+            return builder.nullValue();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
@@ -32,7 +32,6 @@ import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Map;
 
 public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
     public static final String NAME = "geojson";
@@ -66,7 +65,7 @@ public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
     }
 
     @Override
-    public Map<?, ?> toXContentAsObject(Geometry geometry) {
+    public Object toXContentAsObject(Geometry geometry) {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             GeoJson.toXContent(geometry, builder, ToXContent.EMPTY_PARAMS);

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
@@ -66,7 +66,7 @@ public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
     }
 
     @Override
-    public Map<?, ?> toObject(Geometry geometry) {
+    public Map<?, ?> toXContentAsObject(Geometry geometry) {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             GeoJson.toXContent(geometry, builder, ToXContent.EMPTY_PARAMS);

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
@@ -32,6 +32,11 @@ import java.text.ParseException;
 public interface GeometryFormat<ParsedFormat> {
 
     /**
+     * The name of the format, for example 'wkt'.
+     */
+    String name();
+
+    /**
      * Parser JSON representation of a geometry
      */
     ParsedFormat fromXContent(XContentParser parser) throws IOException, ParseException;
@@ -40,5 +45,4 @@ public interface GeometryFormat<ParsedFormat> {
      * Serializes the geometry into its JSON representation
      */
     XContentBuilder toXContent(ParsedFormat geometry, XContentBuilder builder, ToXContent.Params params) throws IOException;
-
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
@@ -45,4 +45,11 @@ public interface GeometryFormat<ParsedFormat> {
      * Serializes the geometry into its JSON representation
      */
     XContentBuilder toXContent(ParsedFormat geometry, XContentBuilder builder, ToXContent.Params params) throws IOException;
+
+    /**
+     * Serializes the geometry into a standard Java object.
+     *
+     * For example, the GeoJson format returns the geometry as a map, while WKT returns a string.
+     */
+    Object toObject(ParsedFormat geometry);
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
@@ -51,5 +51,5 @@ public interface GeometryFormat<ParsedFormat> {
      *
      * For example, the GeoJson format returns the geometry as a map, while WKT returns a string.
      */
-    Object toObject(ParsedFormat geometry);
+    Object toXContentAsObject(ParsedFormat geometry);
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
@@ -22,15 +22,13 @@ package org.elasticsearch.common.geo;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.MapXContentParser;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
 import org.elasticsearch.geometry.Point;
-import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.WellKnownText;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+public class WKTGeometryFormat implements GeometryFormat<Geometry> {
+    public static final String NAME = "wkt";
+
+    private final WellKnownText wellKnownTextParser;
+
+    public WKTGeometryFormat(WellKnownText wellKnownTextParser) {
+        this.wellKnownTextParser = wellKnownTextParser;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Geometry fromXContent(XContentParser parser) throws IOException, ParseException {
+        if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+            return null;
+        }
+        return wellKnownTextParser.fromWKT(parser.text());
+    }
+
+    @Override
+    public XContentBuilder toXContent(Geometry geometry, XContentBuilder builder, ToXContent.Params params) throws IOException {
+        if (geometry != null) {
+            return builder.value(wellKnownTextParser.toWKT(geometry));
+        } else {
+            return builder.nullValue();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
@@ -58,4 +58,9 @@ public class WKTGeometryFormat implements GeometryFormat<Geometry> {
             return builder.nullValue();
         }
     }
+
+    @Override
+    public String toObject(Geometry geometry) {
+        return wellKnownTextParser.toWKT(geometry);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
@@ -60,7 +60,7 @@ public class WKTGeometryFormat implements GeometryFormat<Geometry> {
     }
 
     @Override
-    public String toObject(Geometry geometry) {
+    public String toXContentAsObject(Geometry geometry) {
         return wellKnownTextParser.toWKT(geometry);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -84,7 +84,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
     /**
      * Interface representing parser in geometry indexing pipeline.
      */
-    public static abstract class Parser<Parsed> {
+    public abstract static class Parser<Parsed> {
         /**
          * Parse the given xContent value to an object of type {@link Parsed}. The value can be
          * in any supported format.

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -183,7 +183,7 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
     }
 
     /** A parser implementation that can parse the various point formats */
-    public static class PointParser<P extends ParsedPoint> implements Parser<List<P>> {
+    public static class PointParser<P extends ParsedPoint> extends Parser<List<P>> {
         /**
          * Note that this parser is only used for formatting values.
          */

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -258,7 +258,7 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
             GeometryFormat<Geometry> geometryFormat = geometryParser.geometryFormat(format);
             for (ParsedPoint point : points) {
                 Geometry geometry = point.asGeometry();
-                result.add(geometryFormat.toObject(geometry));
+                result.add(geometryFormat.toXContentAsObject(geometry));
             }
             return result;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -29,10 +29,11 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLatLonPointIndexFieldData;
-import org.elasticsearch.index.query.VectorGeoPointShapeQueryProcessor;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper.ParsedGeoPoint;
+import org.elasticsearch.index.query.VectorGeoPointShapeQueryProcessor;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
 import java.io.IOException;
@@ -49,6 +50,7 @@ import java.util.Map;
 public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<ParsedGeoPoint>, List<? extends GeoPoint>> {
     public static final String CONTENT_TYPE = "geo_point";
     public static final FieldType FIELD_TYPE = new FieldType();
+
     static {
         FIELD_TYPE.setStored(false);
         FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
@@ -70,6 +72,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
             GeoPointFieldType ft = new GeoPointFieldType(buildFullName(context), indexed, hasDocValues, meta);
             ft.setGeometryParser(new PointParser<>());
             ft.setGeometryIndexer(new GeoPointIndexer(ft));
+            ft.setGeometryFormatter(new PointFormatter<>());
             ft.setGeometryQueryBuilder(new VectorGeoPointShapeQueryProcessor());
             return new GeoPointFieldMapper(name, fieldType, ft, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
         }
@@ -216,6 +219,10 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         @Override
         public void resetCoords(double x, double y) {
             this.reset(y, x);
+        }
+
+        public Point asGeometry() {
+            return new Point(lon(), lat());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -72,7 +72,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
             GeoPointFieldType ft = new GeoPointFieldType(buildFullName(context), indexed, hasDocValues, meta);
             ft.setGeometryParser(new PointParser<>());
             ft.setGeometryIndexer(new GeoPointIndexer(ft));
-            ft.setGeometryFormatter(new PointFormatter<>());
             ft.setGeometryQueryBuilder(new VectorGeoPointShapeQueryProcessor());
             return new GeoPointFieldMapper(name, fieldType, ft, multiFields, ignoreMalformed, ignoreZValue, nullValue, copyTo);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -73,6 +73,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
                 ignoreZValue().value());
             ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
             ft.setGeometryIndexer(new GeoShapeIndexer(orientation().value().getAsBoolean(), buildFullName(context)));
+            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new VectorGeoShapeQueryProcessor());
             ft.setOrientation(orientation == null ? Defaults.ORIENTATION.value() : orientation);
             return ft;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -71,9 +71,8 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
             GeoShapeFieldType ft = new GeoShapeFieldType(buildFullName(context), indexed, hasDocValues, meta);
             GeometryParser geometryParser = new GeometryParser(ft.orientation.getAsBoolean(), coerce().value(),
                 ignoreZValue().value());
-            ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
+            ft.setGeometryParser(new GeoShapeParser(geometryParser));
             ft.setGeometryIndexer(new GeoShapeIndexer(orientation().value().getAsBoolean(), buildFullName(context)));
-            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new VectorGeoShapeQueryProcessor());
             ft.setOrientation(orientation == null ? Defaults.ORIENTATION.value() : orientation);
             return ft;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFormatter.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFormatter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.geo.GeoJson;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.WellKnownText;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class GeoShapeFormatter implements AbstractGeometryFieldMapper.Formatter<Geometry> {
+    @Override
+    public Object formatGeoJson(Geometry value) {
+        try {
+            return GeoJson.toXContentMap(value);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public Object formatWKT(Geometry value) {
+        return WellKnownText.INSTANCE.toWKT(value);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
@@ -19,25 +19,27 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.geo.GeoJson;
+import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.text.ParseException;
 
-public class GeoShapeFormatter implements AbstractGeometryFieldMapper.Formatter<Geometry> {
-    @Override
-    public Object formatGeoJson(Geometry value) {
-        try {
-            return GeoJson.toXContentMap(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+public class GeoShapeParser implements AbstractGeometryFieldMapper.Parser<Geometry> {
+    private final GeometryParser geometryParser;
+
+    public GeoShapeParser(GeometryParser geometryParser) {
+        this.geometryParser = geometryParser;
     }
 
     @Override
-    public Object formatWKT(Geometry value) {
-        return WellKnownText.INSTANCE.toWKT(value);
+    public Geometry parse(XContentParser parser, AbstractGeometryFieldMapper mapper) throws IOException, ParseException {
+        return geometryParser.parse(parser);
+    }
+
+    @Override
+    public Object format(Geometry value, String format) {
+        return geometryParser.geometryFormat(format).toObject(value);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
@@ -47,7 +47,7 @@ public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry>
 
     @Override
     public Object format(Geometry value, String format) {
-        return geometryParser.geometryFormat(format).toObject(value);
+        return geometryParser.geometryFormat(format).toXContentAsObject(value);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -31,8 +31,8 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
@@ -43,14 +43,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.query.LegacyGeoShapeQueryProcessor;
 import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -259,8 +259,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
             setupFieldTypeDeprecatedParameters(ft);
             setupPrefixTrees(ft);
             ft.setGeometryIndexer(new LegacyGeoShapeIndexer(ft));
-            ft.setGeometryParser(ShapeParser::parse);
-            ft.setGeometryFormatter(new LegacyGeoShapeFormatter());
+            ft.setGeometryParser(new LegacyGeoShapeParser());
             ft.setGeometryQueryBuilder(new LegacyGeoShapeQueryProcessor(ft));
             ft.setOrientation(orientation == null ? Defaults.ORIENTATION.value() : orientation);
             return ft;
@@ -282,20 +281,25 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
     }
 
-    private static class LegacyGeoShapeFormatter implements Formatter<ShapeBuilder<?, ?, ?>> {
-        @Override
-        public Object formatGeoJson(ShapeBuilder<?, ?, ?> value) {
-            try {
-                Geometry geometry = value.buildGeometry();
-                return GeoJson.toXContentMap(geometry);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+    private static class LegacyGeoShapeParser implements Parser<ShapeBuilder<?, ?, ?>> {
+        /**
+         * Note that this parser is only used for formatting values.
+         */
+        private final GeometryParser geometryParser;
+
+        private LegacyGeoShapeParser() {
+            this.geometryParser = new GeometryParser(true, true, true);
         }
 
         @Override
-        public String formatWKT(ShapeBuilder<?, ?, ?> value) {
-            return WellKnownText.INSTANCE.toWKT(value.buildGeometry());
+        public ShapeBuilder<?, ?, ?> parse(XContentParser parser, AbstractGeometryFieldMapper mapper) throws IOException, ParseException {
+            return ShapeParser.parse(parser);
+        }
+
+        @Override
+        public Object format(ShapeBuilder<?, ?, ?> value, String format) {
+            Geometry geometry = value.buildGeometry();
+            return geometryParser.geometryFormat(format).toObject(geometry);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -281,7 +281,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
     }
 
-    private static class LegacyGeoShapeParser implements Parser<ShapeBuilder<?, ?, ?>> {
+    private static class LegacyGeoShapeParser extends Parser<ShapeBuilder<?, ?, ?>> {
         /**
          * Note that this parser is only used for formatting values.
          */

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -299,7 +299,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         @Override
         public Object format(ShapeBuilder<?, ?, ?> value, String format) {
             Geometry geometry = value.buildGeometry();
-            return geometryParser.geometryFormat(format).toObject(geometry);
+            return geometryParser.geometryFormat(format).toXContentAsObject(geometry);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -25,6 +25,8 @@ import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -33,6 +35,7 @@ import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -40,6 +43,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.junit.Before;
@@ -47,6 +51,8 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_Z_VALUE;
@@ -838,5 +844,39 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase<LegacyGe
 
     public String toXContentString(LegacyGeoShapeFieldMapper mapper) throws IOException {
         return toXContentString(mapper, true);
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        LegacyGeoShapeFieldMapper mapper = new LegacyGeoShapeFieldMapper.Builder("field").build(context);
+        SourceLookup sourceLookup = new SourceLookup();
+
+        Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates",
+            List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
+        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(14.0, 15.0));
+        String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
+        String wktPoint = "POINT (14.0 15.0)";
+
+        // Test a single shape in geojson format.
+        sourceLookup.setSource(Collections.singletonMap("field", jsonLineString));
+        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a list of shapes in geojson format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(jsonLineString, jsonPoint)));
+        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a single shape in wkt format.
+        sourceLookup.setSource(Collections.singletonMap("field", wktLineString));
+        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a list of shapes in wkt format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(wktLineString, wktPoint)));
+        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
@@ -120,35 +120,30 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         MapperService mapperService = createMapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
-            .array("completion", "first", "second")
+            .array("geo_point", 27.1, 42.0)
         .endObject();
 
-        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "completion");
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "geo_point");
         assertThat(fields.size(), equalTo(1));
 
-        DocumentField field = fields.get("completion");
-        assertNotNull(field);
-        assertThat(field.getValues().size(), equalTo(2));
-        assertThat(field.getValues(), hasItems("first", "second"));
-
-        // Test a field with multiple geo-points.
-        source = XContentFactory.jsonBuilder().startObject()
-            .startObject("completion")
-                .array("input", "first", "second")
-                .field("weight", "2.718")
-            .endObject()
-        .endObject();
-
-        fields = retrieveFields(mapperService, source, "completion");
-        assertThat(fields.size(), equalTo(1));
-
-        field = fields.get("completion");
+        DocumentField field = fields.get("geo_point");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(1));
 
-        Map<String, Object> expected = Map.of("input", List.of("first", "second"),
-            "weight", "2.718");
-        assertThat(field.getValues().get(0), equalTo(expected));
+        // Test a field with multiple geo-points.
+        source = XContentFactory.jsonBuilder().startObject()
+            .startArray("geo_point")
+                .startArray().value(27.1).value(42.0).endArray()
+                .startArray().value(31.4).value(42.0).endArray()
+            .endArray()
+        .endObject();
+
+        fields = retrieveFields(mapperService, source, "geo_point");
+        assertThat(fields.size(), equalTo(1));
+
+        field = fields.get("geo_point");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(2));
     }
 
     public void testFieldNamesWithWildcard() throws IOException {
@@ -355,7 +350,7 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
                 .startObject("field").field("type", "keyword").endObject()
                 .startObject("integer_field").field("type", "integer").endObject()
                 .startObject("date_field").field("type", "date").endObject()
-                .startObject("completion").field("type", "completion").endObject()
+                .startObject("geo_point").field("type", "geo_point").endObject()
                 .startObject("float_range").field("type", "float_range").endObject()
                 .startObject("object")
                     .startObject("properties")

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Objects;
 
 import static org.elasticsearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_Z_VALUE;
 
@@ -141,13 +142,7 @@ public class CartesianPoint implements ToXContentFragment {
 
     @Override
     public int hashCode() {
-        int result;
-        int temp;
-        temp = x != +0.0f ? Float.floatToIntBits(x) : 0;
-        result = Integer.hashCode(temp);
-        temp = y != +0.0f ? Float.floatToIntBits(y) : 0;
-        result = 31 * result + Integer.hashCode(temp);
-        return result;
+        return Objects.hash(x, y);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
@@ -37,18 +37,18 @@ public class CartesianPoint implements ToXContentFragment {
     private static final ParseField Y_FIELD = new ParseField("y");
     private static final ParseField Z_FIELD = new ParseField("z");
 
-    protected float x;
-    protected float y;
+    protected double x;
+    protected double y;
 
     public CartesianPoint() {
     }
 
-    public CartesianPoint(float x, float y) {
+    public CartesianPoint(double x, double y) {
         this.x = x;
         this.y = y;
     }
 
-    public CartesianPoint reset(float x, float y) {
+    public CartesianPoint reset(double x, double y) {
         this.x = x;
         this.y = y;
         return this;
@@ -69,11 +69,11 @@ public class CartesianPoint implements ToXContentFragment {
             throw new ElasticsearchParseException("failed to parse [{}], expected 2 or 3 coordinates "
                 + "but found: [{}]", vals, vals.length);
         }
-        final float x;
-        final float y;
+        final double x;
+        final double y;
         try {
-            x = Float.parseFloat(vals[0].trim());
-            if (Float.isFinite(x) == false) {
+            x = Double.parseDouble(vals[0].trim());
+            if (Double.isFinite(x) == false) {
                 throw new ElasticsearchParseException("invalid [{}] value [{}]; " +
                     "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
                     X_FIELD.getPreferredName(),
@@ -83,8 +83,8 @@ public class CartesianPoint implements ToXContentFragment {
             throw new ElasticsearchParseException("[{}]] must be a number", X_FIELD.getPreferredName());
         }
         try {
-            y = Float.parseFloat(vals[1].trim());
-            if (Float.isFinite(y) == false) {
+            y = Double.parseDouble(vals[1].trim());
+            if (Double.isFinite(y) == false) {
                 throw new ElasticsearchParseException("invalid [{}] value [{}]; " +
                     "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
                     Y_FIELD.getPreferredName(),
@@ -95,7 +95,7 @@ public class CartesianPoint implements ToXContentFragment {
         }
         if (vals.length > 2) {
             try {
-                CartesianPoint.assertZValue(ignoreZValue, Float.parseFloat(vals[2].trim()));
+                CartesianPoint.assertZValue(ignoreZValue, Double.parseDouble(vals[2].trim()));
             } catch (NumberFormatException ex) {
                 throw new ElasticsearchParseException("[{}]] must be a number", Y_FIELD.getPreferredName());
             }
@@ -116,14 +116,14 @@ public class CartesianPoint implements ToXContentFragment {
                 "but found {}", PointFieldMapper.CONTENT_TYPE, geometry.type());
         }
         org.elasticsearch.geometry.Point point = (org.elasticsearch.geometry.Point) geometry;
-        return reset((float) point.getX(), (float) point.getY());
+        return reset(point.getX(), point.getY());
     }
 
-    public float getX() {
+    public double getX() {
         return this.x;
     }
 
-    public float getY() {
+    public double getY() {
         return this.y;
     }
 
@@ -134,8 +134,8 @@ public class CartesianPoint implements ToXContentFragment {
 
         CartesianPoint point = (CartesianPoint) o;
 
-        if (Float.compare(point.x, x) != 0) return false;
-        if (Float.compare(point.y, y) != 0) return false;
+        if (Double.compare(point.x, x) != 0) return false;
+        if (Double.compare(point.y, y) != 0) return false;
 
         return true;
     }
@@ -157,8 +157,8 @@ public class CartesianPoint implements ToXContentFragment {
 
     public static CartesianPoint parsePoint(XContentParser parser, CartesianPoint point, boolean ignoreZvalue)
         throws IOException, ElasticsearchParseException {
-        float x = Float.NaN;
-        float y = Float.NaN;
+        double x = Double.NaN;
+        double y = Double.NaN;
         NumberFormatException numberFormatException = null;
 
         if(parser.currentToken() == XContentParser.Token.START_OBJECT) {
@@ -172,7 +172,7 @@ public class CartesianPoint implements ToXContentFragment {
                                 case VALUE_NUMBER:
                                 case VALUE_STRING:
                                     try {
-                                        x = subParser.floatValue(true);
+                                        x = subParser.doubleValue(true);
                                     } catch (NumberFormatException e) {
                                         numberFormatException = e;
                                     }
@@ -187,7 +187,7 @@ public class CartesianPoint implements ToXContentFragment {
                                 case VALUE_NUMBER:
                                 case VALUE_STRING:
                                     try {
-                                        y = subParser.floatValue(true);
+                                        y = subParser.doubleValue(true);
                                     } catch (NumberFormatException e) {
                                         numberFormatException = e;
                                     }
@@ -202,7 +202,7 @@ public class CartesianPoint implements ToXContentFragment {
                                 case VALUE_NUMBER:
                                 case VALUE_STRING:
                                     try {
-                                         CartesianPoint.assertZValue(ignoreZvalue, subParser.floatValue(true));
+                                         CartesianPoint.assertZValue(ignoreZvalue, subParser.doubleValue(true));
                                     } catch (NumberFormatException e) {
                                         numberFormatException = e;
                                     }
@@ -222,12 +222,12 @@ public class CartesianPoint implements ToXContentFragment {
                 }
             }
            if (numberFormatException != null) {
-                throw new ElasticsearchParseException("[{}] and [{}] must be valid float values", numberFormatException,
+                throw new ElasticsearchParseException("[{}] and [{}] must be valid double values", numberFormatException,
                     X_FIELD.getPreferredName(),
                     Y_FIELD.getPreferredName());
-            } else if (Float.isNaN(x)) {
+            } else if (Double.isNaN(x)) {
                 throw new ElasticsearchParseException("field [{}] missing", X_FIELD.getPreferredName());
-            } else if (Float.isNaN(y)) {
+            } else if (Double.isNaN(y)) {
                 throw new ElasticsearchParseException("field [{}] missing", Y_FIELD.getPreferredName());
             } else {
                 return point.reset(x, y);
@@ -240,9 +240,9 @@ public class CartesianPoint implements ToXContentFragment {
                     if (subParser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
                         element++;
                         if (element == 1) {
-                            x = subParser.floatValue();
+                            x = subParser.doubleValue();
                         } else if (element == 2) {
-                            y = subParser.floatValue();
+                            y = subParser.doubleValue();
                         } else {
                             throw new ElasticsearchParseException("[{}}] field type does not accept > 2 dimensions",
                                 PointFieldMapper.CONTENT_TYPE);
@@ -277,12 +277,12 @@ public class CartesianPoint implements ToXContentFragment {
         }
     }
 
-    public static double assertZValue(final boolean ignoreZValue, float zValue) {
+    public static double assertZValue(final boolean ignoreZValue, double zValue) {
         if (ignoreZValue == false) {
             throw new ElasticsearchParseException("Exception parsing coordinates: found Z value [{}] but [{}] "
                 + "parameter is [{}]", zValue, IGNORE_Z_VALUE, ignoreZValue);
         }
-        if (Float.isFinite(zValue) == false) {
+        if (Double.isFinite(zValue) == false) {
             throw new ElasticsearchParseException("invalid [{}] value [{}]; " +
                 "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
                 Z_FIELD.getPreferredName(),

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -21,6 +21,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.GeoShapeFormatter;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -92,6 +93,7 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
                 ignoreZValue().value());
             ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
             ft.setGeometryIndexer(new GeoShapeIndexer(orientation().value().getAsBoolean(), ft.name()));
+            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new VectorGeoShapeQueryProcessor());
             ft.setOrientation(orientation().value());
             return new GeoShapeWithDocValuesFieldMapper(name, fieldType, ft, ignoreMalformed(context), coerce(context),

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -21,8 +21,8 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeFormatter;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
+import org.elasticsearch.index.mapper.GeoShapeParser;
 import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -91,9 +91,8 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
             // @todo check coerce
             GeometryParser geometryParser = new GeometryParser(ft.orientation().getAsBoolean(), coerce().value(),
                 ignoreZValue().value());
-            ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
+            ft.setGeometryParser(new GeoShapeParser(geometryParser));
             ft.setGeometryIndexer(new GeoShapeIndexer(orientation().value().getAsBoolean(), ft.name()));
-            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new VectorGeoShapeQueryProcessor());
             ft.setOrientation(orientation().value());
             return new GeoShapeWithDocValuesFieldMapper(name, fieldType, ft, ignoreMalformed(context), coerce(context),

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -137,7 +137,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
             return CONTENT_TYPE;
         }
     }
-    
+
     // Eclipse requires the AbstractPointGeometryFieldMapper prefix or it can't find ParsedPoint
     // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=565255
     protected static class ParsedCartesianPoint extends CartesianPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -71,10 +71,10 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
             ParsedCartesianPoint point = new ParsedCartesianPoint();
             CartesianPoint.parsePoint(nullValue, point, ignoreZValue);
             if (ignoreMalformed == false) {
-                if (Float.isFinite(point.getX()) == false) {
+                if (Double.isFinite(point.getX()) == false) {
                     throw new IllegalArgumentException("illegal x value [" + point.getX() + "]");
                 }
-                if (Float.isFinite(point.getY()) == false) {
+                if (Double.isFinite(point.getY()) == false) {
                     throw new IllegalArgumentException("illegal y value [" + point.getY() + "]");
                 }
             }
@@ -108,7 +108,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
     protected void addDocValuesFields(String name, List<? extends CartesianPoint> points, List<IndexableField> fields,
                                       ParseContext context) {
         for (CartesianPoint point : points) {
-            context.doc().add(new XYDocValuesField(fieldType().name(), point.getX(), point.getY()));
+            context.doc().add(new XYDocValuesField(fieldType().name(), (float) point.getX(), (float) point.getY()));
         }
     }
 
@@ -143,10 +143,10 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
     protected static class ParsedCartesianPoint extends CartesianPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
         @Override
         public void validate(String fieldName) {
-            if (Float.isFinite(getX()) == false) {
+            if (Double.isFinite(getX()) == false) {
                 throw new IllegalArgumentException("illegal x value [" + getX() + "] for " + fieldName);
             }
-            if (Float.isFinite(getY()) == false) {
+            if (Double.isFinite(getY()) == false) {
                 throw new IllegalArgumentException("illegal y value [" + getY() + "] for " + fieldName);
             }
         }
@@ -163,7 +163,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
 
         @Override
         public void resetCoords(double x, double y) {
-            this.reset((float)x, (float)y);
+            this.reset(x, y);
         }
 
         @Override
@@ -223,7 +223,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
         public List<IndexableField> indexShape(ParseContext context, List<? extends CartesianPoint> points) {
             ArrayList<IndexableField> fields = new ArrayList<>(1);
             for (CartesianPoint point : points) {
-                fields.add(new XYPointField(fieldType.name(), point.getX(), point.getY()));
+                fields.add(new XYPointField(fieldType.name(), (float) point.getX(), (float) point.getY()));
             }
             return fields;
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
@@ -46,6 +47,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
             PointFieldType ft = new PointFieldType(buildFullName(context), indexed, hasDocValues, meta);
             ft.setGeometryParser(new PointParser<>());
             ft.setGeometryIndexer(new PointIndexer(ft));
+            ft.setGeometryFormatter(new PointFormatter<>());
             ft.setGeometryQueryBuilder(new ShapeQueryPointProcessor());
             return new PointFieldMapper(simpleName, fieldType, ft, multiFields,
                 ignoreMalformed, ignoreZValue(context), nullValue, copyTo);
@@ -135,7 +137,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
             return CONTENT_TYPE;
         }
     }
-
+    
     // Eclipse requires the AbstractPointGeometryFieldMapper prefix or it can't find ParsedPoint
     // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=565255
     protected static class ParsedCartesianPoint extends CartesianPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
@@ -162,6 +164,11 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
         @Override
         public void resetCoords(double x, double y) {
             this.reset((float)x, (float)y);
+        }
+
+        @Override
+        public Point asGeometry() {
+            return new Point(getX(), getY());
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -17,8 +17,8 @@ import org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.xpack.spatial.common.CartesianPoint;
-import org.elasticsearch.xpack.spatial.index.query.ShapeQueryPointProcessor;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper.ParsedCartesianPoint;
+import org.elasticsearch.xpack.spatial.index.query.ShapeQueryPointProcessor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,7 +47,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
             PointFieldType ft = new PointFieldType(buildFullName(context), indexed, hasDocValues, meta);
             ft.setGeometryParser(new PointParser<>());
             ft.setGeometryIndexer(new PointIndexer(ft));
-            ft.setGeometryFormatter(new PointFormatter<>());
             ft.setGeometryQueryBuilder(new ShapeQueryPointProcessor());
             return new PointFieldMapper(simpleName, fieldType, ft, multiFields,
                 ignoreMalformed, ignoreZValue(context), nullValue, copyTo);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
+import org.elasticsearch.index.mapper.GeoShapeFormatter;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
@@ -55,6 +56,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry,
                 = new GeometryParser(orientation().value().getAsBoolean(), coerce().value(), ignoreZValue().value());
             ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
             ft.setGeometryIndexer(new ShapeIndexer(ft.name()));
+            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new ShapeQueryProcessor());
             ft.setOrientation(orientation().value());
             return new ShapeFieldMapper(name, fieldType, ft, ignoreMalformed(context), coerce(context),

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeFormatter;
+import org.elasticsearch.index.mapper.GeoShapeParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
@@ -54,9 +54,8 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry,
             ShapeFieldType ft = new ShapeFieldType(buildFullName(context), indexed, hasDocValues, meta);
             GeometryParser geometryParser
                 = new GeometryParser(orientation().value().getAsBoolean(), coerce().value(), ignoreZValue().value());
-            ft.setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
+            ft.setGeometryParser(new GeoShapeParser(geometryParser));
             ft.setGeometryIndexer(new ShapeIndexer(ft.name()));
-            ft.setGeometryFormatter(new GeoShapeFormatter());
             ft.setGeometryQueryBuilder(new ShapeQueryProcessor());
             ft.setOrientation(orientation().value());
             return new ShapeFieldMapper(name, fieldType, ft, ignoreMalformed(context), coerce(context),

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
@@ -6,20 +6,29 @@
 package org.elasticsearch.xpack.spatial.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.spatial.common.CartesianPoint;
 import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE;
 import static org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper.Names.NULL_VALUE;
@@ -294,5 +303,38 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
 
         ignoreZValue = ((PointFieldMapper)fieldMapper).ignoreZValue().value();
         assertThat(ignoreZValue, equalTo(false));
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        AbstractGeometryFieldMapper<?, ?> mapper = new PointFieldMapper.Builder("field").build(context);
+        SourceLookup sourceLookup = new SourceLookup();
+
+        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.100000381469727));
+        String wktPoint = "POINT (42.0 27.100000381469727)";
+        Map<String, Object> otherJsonPoint = Map.of("type", "Point", "coordinates", List.of(30.0, 50.0));
+        String otherWktPoint = "POINT (30.0 50.0)";
+
+        // Test a single point in [x, y] array format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(42.0, 27.1)));
+        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a single point in "x, y" string format.
+        sourceLookup.setSource(Collections.singletonMap("field", "42.0,27.1"));
+        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a list of points in [x, y] array format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0))));
+        assertEquals(List.of(jsonPoint, otherJsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktPoint, otherWktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a single point in well-known text format.
+        sourceLookup.setSource(Collections.singletonMap("field", "POINT (42.0 27.1)"));
+        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
@@ -312,8 +312,8 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
         AbstractGeometryFieldMapper<?, ?> mapper = new PointFieldMapper.Builder("field").build(context);
         SourceLookup sourceLookup = new SourceLookup();
 
-        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.100000381469727));
-        String wktPoint = "POINT (42.0 27.100000381469727)";
+        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.1));
+        String wktPoint = "POINT (42.0 27.1)";
         Map<String, Object> otherJsonPoint = Map.of("type", "Point", "coordinates", List.of(30.0, 50.0));
         String otherWktPoint = "POINT (30.0 50.0)";
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -6,25 +6,32 @@
 package org.elasticsearch.xpack.spatial.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper.Names.IGNORE_Z_VALUE;
 import static org.hamcrest.Matchers.equalTo;
@@ -323,5 +330,39 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
 
     public String toXContentString(ShapeFieldMapper mapper) throws IOException {
         return toXContentString(mapper, true);
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        ShapeFieldMapper mapper = new ShapeFieldMapper.Builder("field").build(context);
+        SourceLookup sourceLookup = new SourceLookup();
+
+        Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates",
+            List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
+        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(14.3, 15.0));
+        String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
+        String wktPoint = "POINT (14.3 15.0)";
+
+        // Test a single shape in geojson format.
+        sourceLookup.setSource(Collections.singletonMap("field", jsonLineString));
+        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a list of shapes in geojson format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(jsonLineString, jsonPoint)));
+        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a single shape in wkt format.
+        sourceLookup.setSource(Collections.singletonMap("field", wktLineString));
+        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+
+        // Test a list of shapes in wkt format.
+        sourceLookup.setSource(Collections.singletonMap("field", List.of(wktLineString, wktPoint)));
+        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
     }
 }


### PR DESCRIPTION
Although we accept a variety of formats during indexing, spatial data is
returned in a single consistent format. This is GeoJSON by default, but
well-known text is also supported by passing the option `format: wkt`.

Note that points (in addition to shapes) are returned in GeoJSON by default. The
reasoning is that this gives better consistency, and is the most convenient
format for most REST API users.