### PR TITLE
Fix race in testSendSnapshotSendsOps

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -246,7 +246,9 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             public void indexTranslogOperations(List<Translog.Operation> operations, int totalTranslogOps, long timestamp, long msu,
                                                 RetentionLeases retentionLeases, long mappingVersion, ActionListener<Long> listener) {
                 shippedOps.addAll(operations);
-                checkpointOnTarget.set(randomLongBetween(checkpointOnTarget.get(), Long.MAX_VALUE));
+                if (randomBoolean()) {
+                    checkpointOnTarget.addAndGet(between(1, 20));
+                }
                 listener.onResponse(checkpointOnTarget.get());
             }
         };


### PR DESCRIPTION
There is a race between increase and get the global checkpoint in the test as indexTranslogOperations can be executed concurrently.

Closes #59492