### PR TITLE
[DOCS] Fix keyword marker docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc
@@ -317,7 +317,7 @@ You cannot specify this parameter and `keywords_pattern`.
 `keywords_path`::
 +
 --
-(Required*, array of strings)
+(Required*, string)
 Path to a file that contains a list of keywords. Tokens that match these
 keywords are not stemmed.
 
@@ -380,7 +380,7 @@ PUT /my_index
       "filter": {
         "my_custom_keyword_marker_filter": {
           "type": "keyword_marker",
-          "keywords": "analysis/example_word_list.txt"
+          "keywords_path": "analysis/example_word_list.txt"
         }
       }
     }


### PR DESCRIPTION
Two documentation fixes:

- **keywords_path** requires a string, not an array of strings
- the last code example should use **keywords_path** instead of **keywords**