### PR TITLE
Add source_content_type to _common.json rest spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
@@ -23,6 +23,10 @@
       "type": "string",
       "description": "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."
     },
+    "source_content_type": {
+      "type": "string",
+      "description": "The URL-encoded media type that indicates the format of the URL-encoded request definition passed with the source parameter. For example, application/json, encoded as application%2fjson. Useful for libraries that do not accept a request body for non-POST requests."
+    },
     "filter_path": {
       "type": "list",
       "description": "A comma-separated list of filters used to reduce the response."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
@@ -21,11 +21,11 @@
     },
     "source": {
       "type": "string",
-      "description": "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."
+      "description": "The URL-encoded request definition."
     },
     "source_content_type": {
       "type": "string",
-      "description": "The URL-encoded media type that indicates the format of the URL-encoded request definition passed with the source parameter. For example, application/json, encoded as application%2fjson. Useful for libraries that do not accept a request body for non-POST requests."
+      "description": "The URL-encoded media type that indicates the format of the URL-encoded request definition passed with the source parameter. For example, application/json, encoded as application%2fjson."
     },
     "filter_path": {
       "type": "list",


### PR DESCRIPTION
This commit adds the `source_content_type` parameter to the `_common.json` parameters. `source_content_type` is required when passing a URL-encoded request definition using the source parameter.

