### PR TITLE
[DOCS] Fix `requests_per_second` query param in reindex API docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -739,7 +739,7 @@ end::request_cache[]
 tag::requests_per_second[]
 `requests_per_second`::
 (Optional, integer) The throttle for this request in sub-requests per second.
--1 means no throttle. Defaults to 0.
+Defaults to `-1` (no throttle).
 end::requests_per_second[]
 
 tag::routing[]


### PR DESCRIPTION
Corrects the `requests_per_second` query parameter used in the reindex,
delete by query, and update by query API docs.

The parameter defaults to `-1` (no throttle). `0` is not an allowed value.