### PR TITLE
Introduce CopyOnReadInputStream with CachedBlobContainer

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlobContainer.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlobContainer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.blobstore.cache;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.support.FilterBlobContainer;
+import org.elasticsearch.common.bytes.PagedBytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.util.ByteArray;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CachedBlobContainer extends FilterBlobContainer {
+
+    protected static final int DEFAULT_BYTE_ARRAY_SIZE = 1 << 14;
+
+    public CachedBlobContainer(BlobContainer delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected BlobContainer wrapChild(BlobContainer child) {
+        return new CachedBlobContainer(child);
+    }
+
+    /**
+     * A {@link FilterInputStream} that copies over all the bytes read from the original input stream to a given {@link ByteArray}. The
+     * number of bytes copied cannot exceed the size of the {@link ByteArray}.
+     */
+    static class CopyOnReadInputStream extends FilterInputStream {
+
+        private final AtomicBoolean closed;
+        private final ByteArray bytes;
+
+        private long count;
+        private long mark;
+
+        protected CopyOnReadInputStream(InputStream in, ByteArray byteArray) {
+            super(in);
+            this.bytes = Objects.requireNonNull(byteArray);
+            this.closed = new AtomicBoolean(false);
+        }
+
+        long getCount() {
+            return count;
+        }
+
+        public int read() throws IOException {
+            final int result = super.read();
+            if (result != -1) {
+                if (count < bytes.size()) {
+                    bytes.set(count, (byte) result);
+                }
+                count++;
+            }
+            return result;
+        }
+
+        public int read(byte[] b, int off, int len) throws IOException {
+            final int result = super.read(b, off, len);
+            if (result != -1) {
+                if (count < bytes.size()) {
+                    bytes.set(count, b, off, Math.toIntExact(Math.min(bytes.size() - count, result)));
+                }
+                count += result;
+            }
+            return result;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            final long skip = super.skip(n);
+            if (skip > 0L) {
+                count += skip;
+            }
+            return skip;
+        }
+
+        @Override
+        public synchronized void mark(int readlimit) {
+            super.mark(readlimit);
+            mark = count;
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            super.reset();
+            count = mark;
+        }
+
+        protected void closeInternal(final ReleasableBytesReference releasable) {
+            releasable.close();
+        }
+
+        @Override
+        public final void close() throws IOException {
+            if (closed.compareAndSet(false, true)) {
+                boolean success = false;
+                try {
+                    super.close();
+                    final PagedBytesReference reference = new PagedBytesReference(bytes, Math.toIntExact(Math.min(count, bytes.size())));
+                    closeInternal(new ReleasableBytesReference(reference, bytes));
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        bytes.close();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/blobstore/cache/CachedBlobContainerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/blobstore/cache/CachedBlobContainerTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.blobstore.cache;
+
+import org.elasticsearch.blobstore.cache.CachedBlobContainer.CopyOnReadInputStream;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.elasticsearch.blobstore.cache.CachedBlobContainer.DEFAULT_BYTE_ARRAY_SIZE;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CachedBlobContainerTests extends ESTestCase {
+
+    private final MockBigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+
+    public void testCopyOnReadInputStreamDoesNotCopyMoreThanByteArraySize() throws Exception {
+        final byte[] expected = randomByteArray();
+
+        final ByteArray byteArray = bigArrays.newByteArray(randomIntBetween(0, DEFAULT_BYTE_ARRAY_SIZE));
+        final InputStream stream = new CopyOnReadInputStream(new ByteArrayInputStream(expected), byteArray) {
+            @Override
+            protected void closeInternal(ReleasableBytesReference releasable) {
+                assertThat(getCount(), equalTo((long) expected.length));
+                assertArrayEquals(
+                    Arrays.copyOfRange(expected, 0, Math.toIntExact(Math.min(expected.length, byteArray.size()))),
+                    BytesReference.toBytes(releasable)
+                );
+                super.closeInternal(releasable);
+            }
+        };
+        randomReads(stream, expected.length);
+        stream.close();
+    }
+
+    public void testCopyOnReadInputStream() throws Exception {
+        final byte[] expected = randomByteArray();
+        final ByteArray byteArray = bigArrays.newByteArray(DEFAULT_BYTE_ARRAY_SIZE);
+
+        final int maxBytesToRead = randomIntBetween(0, Math.toIntExact(Math.min(expected.length, byteArray.size())));
+        final InputStream stream = new CopyOnReadInputStream(new ByteArrayInputStream(expected), byteArray) {
+            @Override
+            protected void closeInternal(ReleasableBytesReference releasable) {
+                assertThat(getCount(), equalTo((long) maxBytesToRead));
+                assertArrayEquals(Arrays.copyOfRange(expected, 0, maxBytesToRead), BytesReference.toBytes(releasable));
+                super.closeInternal(releasable);
+            }
+        };
+        randomReads(stream, maxBytesToRead);
+        stream.close();
+    }
+
+    private static byte[] randomByteArray() {
+        return randomByteArrayOfLength(randomIntBetween(0, frequently() ? 512 : 1 << 20)); // rarely up to 1mb;
+    }
+
+    private void randomReads(final InputStream stream, final int maxBytesToRead) throws IOException {
+        int remaining = maxBytesToRead;
+        while (remaining > 0) {
+            int read;
+            switch (randomInt(3)) {
+                case 0: // single byte read
+                    read = stream.read();
+                    if (read != -1) {
+                        remaining--;
+                    }
+                    break;
+                case 1: // buffered read with fixed buffer offset/length
+                    read = stream.read(new byte[randomIntBetween(1, remaining)]);
+                    if (read != -1) {
+                        remaining -= read;
+                    }
+                    break;
+                case 2: // buffered read with random buffer offset/length
+                    final byte[] tmp = new byte[randomIntBetween(1, remaining)];
+                    final int off = randomIntBetween(0, tmp.length - 1);
+                    read = stream.read(tmp, off, randomIntBetween(1, Math.min(1, tmp.length - off)));
+                    if (read != -1) {
+                        remaining -= read;
+                    }
+                    break;
+
+                case 3: // mark & reset with intermediate skip()
+                    final int toSkip = randomIntBetween(1, remaining);
+                    stream.mark(toSkip);
+                    assertThat(stream.skip(toSkip), equalTo((long) toSkip));
+                    stream.reset();
+                    break;
+                default:
+                    fail("Unsupported test condition in " + getTestName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `CachedBlobContainer` along with a `CopyOnReadInputStream` inner class. 

The `CachedBlobContainer` is aimed to become a new cache layer on top of `SearchableSnapshotDirectory`'s blob containers. In the future, its `readBlob()` method should be able to poll a cache in order to retrieve cached blobs to read. In the case a blob is not in cache `CachedBlobContainer` should read the blob from the remote blob store repository and then adds the blob to the cache. 

This is where `CopyOnReadInputStream` plays a role: while reading the `InputStream` from the remote repository this class copies the first N bytes to an internal byte array (recycled through BigArrays). The copied bytes are then provided back to a `closeInternal()` method when the original `InputStream` is closed. In the future, this is where the copied bytes should be added to the blob store cache (as newly indexed documents).