### PR TITLE
[7.x] [DOCS] Fix `requests_per_second` reindex param (#59871)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -761,7 +761,7 @@ end::request_cache[]
 tag::requests_per_second[]
 `requests_per_second`::
 (Optional, integer) The throttle for this request in sub-requests per second.
--1 means no throttle. Defaults to 0.
+Defaults to `-1` (no throttle).
 end::requests_per_second[]
 
 tag::routing[]


### PR DESCRIPTION
7.x backport of #59871