### PR TITLE
Complete backport of #59755

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/59755" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.monitor.fs;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -435,10 +433,6 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             paths[i] = new Path(in);
         }
         this.total = total();
-        if (in.getVersion().before(Version.V_8_0_0)) {
-            in.readOptionalWriteable(DiskUsage::new); // previously leastDiskEstimate
-            in.readOptionalWriteable(DiskUsage::new); // previously mostDiskEstimate
-        }
     }
 
     @Override
@@ -448,10 +442,6 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         out.writeVInt(paths.length);
         for (Path path : paths) {
             path.writeTo(out);
-        }
-        if (out.getVersion().before(Version.V_8_0_0)) {
-            out.writeOptionalWriteable(null); // previously leastDiskEstimate
-            out.writeOptionalWriteable(null); // previously mostDiskEstimate
         }
     }
 


### PR DESCRIPTION
Adjusts the version logic used for BWC and reinstates the BWC tests