### PR TITLE
[DOCS] Reformat Plugin snippets to use two-space indents

### DIFF
--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -153,24 +153,24 @@ Then create an analyzer to use this rule file as follows:
 --------------------------------------------------
 PUT icu_sample
 {
-    "settings": {
-        "index":{
-            "analysis":{
-                "tokenizer" : {
-                    "icu_user_file" : {
-                       "type" : "icu_tokenizer",
-                       "rule_files" : "Latn:KeywordTokenizer.rbbi"
-                    }
-                },
-                "analyzer" : {
-                    "my_analyzer" : {
-                        "type" : "custom",
-                        "tokenizer" : "icu_user_file"
-                    }
-                }
-            }
+  "settings": {
+    "index": {
+      "analysis": {
+        "tokenizer": {
+          "icu_user_file": {
+            "type": "icu_tokenizer",
+            "rule_files": "Latn:KeywordTokenizer.rbbi"
+          }
+        },
+        "analyzer": {
+          "my_analyzer": {
+            "type": "custom",
+            "tokenizer": "icu_user_file"
+          }
         }
+      }
     }
+  }
 }
 
 GET icu_sample/_analyze

--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -354,32 +354,36 @@ katakana reading form:
 --------------------------------------------------
 PUT kuromoji_sample
 {
-    "settings": {
-        "index":{
-            "analysis":{
-                "analyzer" : {
-                    "romaji_analyzer" : {
-                        "tokenizer" : "kuromoji_tokenizer",
-                        "filter" : ["romaji_readingform"]
-                    },
-                    "katakana_analyzer" : {
-                        "tokenizer" : "kuromoji_tokenizer",
-                        "filter" : ["katakana_readingform"]
-                    }
-                },
-                "filter" : {
-                    "romaji_readingform" : {
-                        "type" : "kuromoji_readingform",
-                        "use_romaji" : true
-                    },
-                    "katakana_readingform" : {
-                        "type" : "kuromoji_readingform",
-                        "use_romaji" : false
-                    }
-                }
-            }
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "romaji_analyzer": {
+            "tokenizer": "kuromoji_tokenizer",
+            "filter": [
+              "romaji_readingform"
+            ]
+          },
+          "katakana_analyzer": {
+            "tokenizer": "kuromoji_tokenizer",
+            "filter": [
+              "katakana_readingform"
+            ]
+          }
+        },
+        "filter": {
+          "romaji_readingform": {
+            "type": "kuromoji_readingform",
+            "use_romaji": true
+          },
+          "katakana_readingform": {
+            "type": "kuromoji_readingform",
+            "use_romaji": false
+          }
         }
+      }
     }
+  }
 }
 
 GET kuromoji_sample/_analyze

--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -360,15 +360,11 @@ PUT kuromoji_sample
         "analyzer": {
           "romaji_analyzer": {
             "tokenizer": "kuromoji_tokenizer",
-            "filter": [
-              "romaji_readingform"
-            ]
+            "filter": [ "romaji_readingform" ]
           },
           "katakana_analyzer": {
             "tokenizer": "kuromoji_tokenizer",
-            "filter": [
-              "katakana_readingform"
-            ]
+            "filter": [ "katakana_readingform" ]
           }
         },
         "filter": {

--- a/docs/plugins/analysis-nori.asciidoc
+++ b/docs/plugins/analysis-nori.asciidoc
@@ -406,9 +406,7 @@ PUT nori_sample
         "analyzer": {
           "my_analyzer": {
             "tokenizer": "nori_tokenizer",
-            "filter": [
-              "nori_readingform"
-            ]
+            "filter": [ "nori_readingform" ]
           }
         }
       }

--- a/docs/plugins/analysis-nori.asciidoc
+++ b/docs/plugins/analysis-nori.asciidoc
@@ -214,88 +214,88 @@ Which responds with:
 [source,console-result]
 --------------------------------------------------
 {
-    "detail": {
-        "custom_analyzer": true,
-        "charfilters": [],
-        "tokenizer": {
-            "name": "nori_tokenizer",
-            "tokens": [
-                {
-                    "token": "뿌리",
-                    "start_offset": 0,
-                    "end_offset": 2,
-                    "type": "word",
-                    "position": 0,
-                    "leftPOS": "NNG(General Noun)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "NNG(General Noun)"
-                },
-                {
-                    "token": "가",
-                    "start_offset": 2,
-                    "end_offset": 3,
-                    "type": "word",
-                    "position": 1,
-                    "leftPOS": "J(Ending Particle)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "J(Ending Particle)"
-                },
-                {
-                    "token": "깊",
-                    "start_offset": 4,
-                    "end_offset": 5,
-                    "type": "word",
-                    "position": 2,
-                    "leftPOS": "VA(Adjective)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "VA(Adjective)"
-                },
-                {
-                    "token": "은",
-                    "start_offset": 5,
-                    "end_offset": 6,
-                    "type": "word",
-                    "position": 3,
-                    "leftPOS": "E(Verbal endings)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "E(Verbal endings)"
-                },
-                {
-                    "token": "나무",
-                    "start_offset": 7,
-                    "end_offset": 9,
-                    "type": "word",
-                    "position": 4,
-                    "leftPOS": "NNG(General Noun)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "NNG(General Noun)"
-                },
-                {
-                    "token": "는",
-                    "start_offset": 9,
-                    "end_offset": 10,
-                    "type": "word",
-                    "position": 5,
-                    "leftPOS": "J(Ending Particle)",
-                    "morphemes": null,
-                    "posType": "MORPHEME",
-                    "reading": null,
-                    "rightPOS": "J(Ending Particle)"
-                }
-            ]
+  "detail": {
+    "custom_analyzer": true,
+    "charfilters": [],
+    "tokenizer": {
+      "name": "nori_tokenizer",
+      "tokens": [
+        {
+          "token": "뿌리",
+          "start_offset": 0,
+          "end_offset": 2,
+          "type": "word",
+          "position": 0,
+          "leftPOS": "NNG(General Noun)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "NNG(General Noun)"
         },
-        "tokenfilters": []
-    }
+        {
+          "token": "가",
+          "start_offset": 2,
+          "end_offset": 3,
+          "type": "word",
+          "position": 1,
+          "leftPOS": "J(Ending Particle)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "J(Ending Particle)"
+        },
+        {
+          "token": "깊",
+          "start_offset": 4,
+          "end_offset": 5,
+          "type": "word",
+          "position": 2,
+          "leftPOS": "VA(Adjective)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "VA(Adjective)"
+        },
+        {
+          "token": "은",
+          "start_offset": 5,
+          "end_offset": 6,
+          "type": "word",
+          "position": 3,
+          "leftPOS": "E(Verbal endings)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "E(Verbal endings)"
+        },
+        {
+          "token": "나무",
+          "start_offset": 7,
+          "end_offset": 9,
+          "type": "word",
+          "position": 4,
+          "leftPOS": "NNG(General Noun)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "NNG(General Noun)"
+        },
+        {
+          "token": "는",
+          "start_offset": 9,
+          "end_offset": 10,
+          "type": "word",
+          "position": 5,
+          "leftPOS": "J(Ending Particle)",
+          "morphemes": null,
+          "posType": "MORPHEME",
+          "reading": null,
+          "rightPOS": "J(Ending Particle)"
+        }
+      ]
+    },
+    "tokenfilters": []
+  }
 }
 --------------------------------------------------
 
@@ -400,18 +400,20 @@ The `nori_readingform` token filter rewrites tokens written in Hanja to their Ha
 --------------------------------------------------
 PUT nori_sample
 {
-    "settings": {
-        "index":{
-            "analysis":{
-                "analyzer" : {
-                    "my_analyzer" : {
-                        "tokenizer" : "nori_tokenizer",
-                        "filter" : ["nori_readingform"]
-                    }
-                }
-            }
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "my_analyzer": {
+            "tokenizer": "nori_tokenizer",
+            "filter": [
+              "nori_readingform"
+            ]
+          }
         }
+      }
     }
+  }
 }
 
 GET nori_sample/_analyze

--- a/docs/plugins/analysis-smartcn.asciidoc
+++ b/docs/plugins/analysis-smartcn.asciidoc
@@ -100,329 +100,329 @@ The above request returns:
 [source,console-result]
 --------------------------------------------------
 {
-    "tokens": [
-        {
-            "token": "哈",
-            "start_offset": 0,
-            "end_offset": 1,
-            "type": "word",
-            "position": 0
-        },
-        {
-            "token": "喽",
-            "start_offset": 1,
-            "end_offset": 2,
-            "type": "word",
-            "position": 1
-        },
-        {
-            "token": "我们",
-            "start_offset": 3,
-            "end_offset": 5,
-            "type": "word",
-            "position": 3
-        },
-        {
-            "token": "是",
-            "start_offset": 5,
-            "end_offset": 6,
-            "type": "word",
-            "position": 4
-        },
-        {
-            "token": "elast",
-            "start_offset": 7,
-            "end_offset": 14,
-            "type": "word",
-            "position": 5
-        },
-        {
-            "token": "我们",
-            "start_offset": 17,
-            "end_offset": 19,
-            "type": "word",
-            "position": 6
-        },
-        {
-            "token": "是",
-            "start_offset": 19,
-            "end_offset": 20,
-            "type": "word",
-            "position": 7
-        },
-        {
-            "token": "elast",
-            "start_offset": 21,
-            "end_offset": 28,
-            "type": "word",
-            "position": 8
-        },
-        {
-            "token": "elasticsearch",
-            "start_offset": 35,
-            "end_offset": 48,
-            "type": "word",
-            "position": 11
-        },
-        {
-            "token": "kibana",
-            "start_offset": 49,
-            "end_offset": 55,
-            "type": "word",
-            "position": 13
-        },
-        {
-            "token": "beat",
-            "start_offset": 56,
-            "end_offset": 61,
-            "type": "word",
-            "position": 15
-        },
-        {
-            "token": "和",
-            "start_offset": 62,
-            "end_offset": 63,
-            "type": "word",
-            "position": 16
-        },
-        {
-            "token": "logstash",
-            "start_offset": 64,
-            "end_offset": 72,
-            "type": "word",
-            "position": 17
-        },
-        {
-            "token": "开发",
-            "start_offset": 74,
-            "end_offset": 76,
-            "type": "word",
-            "position": 20
-        },
-        {
-            "token": "公司",
-            "start_offset": 76,
-            "end_offset": 78,
-            "type": "word",
-            "position": 21
-        },
-        {
-            "token": "从",
-            "start_offset": 79,
-            "end_offset": 80,
-            "type": "word",
-            "position": 23
-        },
-        {
-            "token": "股票",
-            "start_offset": 80,
-            "end_offset": 82,
-            "type": "word",
-            "position": 24
-        },
-        {
-            "token": "行情",
-            "start_offset": 82,
-            "end_offset": 84,
-            "type": "word",
-            "position": 25
-        },
-        {
-            "token": "到",
-            "start_offset": 84,
-            "end_offset": 85,
-            "type": "word",
-            "position": 26
-        },
-        {
-            "token": "twitter",
-            "start_offset": 86,
-            "end_offset": 93,
-            "type": "word",
-            "position": 27
-        },
-        {
-            "token": "消息",
-            "start_offset": 94,
-            "end_offset": 96,
-            "type": "word",
-            "position": 28
-        },
-        {
-            "token": "流",
-            "start_offset": 96,
-            "end_offset": 97,
-            "type": "word",
-            "position": 29
-        },
-        {
-            "token": "从",
-            "start_offset": 98,
-            "end_offset": 99,
-            "type": "word",
-            "position": 31
-        },
-        {
-            "token": "apach",
-            "start_offset": 100,
-            "end_offset": 106,
-            "type": "word",
-            "position": 32
-        },
-        {
-            "token": "日志",
-            "start_offset": 107,
-            "end_offset": 109,
-            "type": "word",
-            "position": 33
-        },
-        {
-            "token": "到",
-            "start_offset": 109,
-            "end_offset": 110,
-            "type": "word",
-            "position": 34
-        },
-        {
-            "token": "wordpress",
-            "start_offset": 111,
-            "end_offset": 120,
-            "type": "word",
-            "position": 35
-        },
-        {
-            "token": "博",
-            "start_offset": 121,
-            "end_offset": 122,
-            "type": "word",
-            "position": 36
-        },
-        {
-            "token": "文",
-            "start_offset": 122,
-            "end_offset": 123,
-            "type": "word",
-            "position": 37
-        },
-        {
-            "token": "我们",
-            "start_offset": 124,
-            "end_offset": 126,
-            "type": "word",
-            "position": 39
-        },
-        {
-            "token": "可以",
-            "start_offset": 126,
-            "end_offset": 128,
-            "type": "word",
-            "position": 40
-        },
-        {
-            "token": "帮助",
-            "start_offset": 128,
-            "end_offset": 130,
-            "type": "word",
-            "position": 41
-        },
-        {
-            "token": "人们",
-            "start_offset": 130,
-            "end_offset": 132,
-            "type": "word",
-            "position": 42
-        },
-        {
-            "token": "体验",
-            "start_offset": 132,
-            "end_offset": 134,
-            "type": "word",
-            "position": 43
-        },
-        {
-            "token": "搜索",
-            "start_offset": 134,
-            "end_offset": 136,
-            "type": "word",
-            "position": 44
-        },
-        {
-            "token": "强大",
-            "start_offset": 137,
-            "end_offset": 139,
-            "type": "word",
-            "position": 46
-        },
-        {
-            "token": "力量",
-            "start_offset": 139,
-            "end_offset": 141,
-            "type": "word",
-            "position": 47
-        },
-        {
-            "token": "帮助",
-            "start_offset": 142,
-            "end_offset": 144,
-            "type": "word",
-            "position": 49
-        },
-        {
-            "token": "他们",
-            "start_offset": 144,
-            "end_offset": 146,
-            "type": "word",
-            "position": 50
-        },
-        {
-            "token": "以",
-            "start_offset": 146,
-            "end_offset": 147,
-            "type": "word",
-            "position": 51
-        },
-        {
-            "token": "截然不同",
-            "start_offset": 147,
-            "end_offset": 151,
-            "type": "word",
-            "position": 52
-        },
-        {
-            "token": "方式",
-            "start_offset": 152,
-            "end_offset": 154,
-            "type": "word",
-            "position": 54
-        },
-        {
-            "token": "探索",
-            "start_offset": 154,
-            "end_offset": 156,
-            "type": "word",
-            "position": 55
-        },
-        {
-            "token": "和",
-            "start_offset": 156,
-            "end_offset": 157,
-            "type": "word",
-            "position": 56
-        },
-        {
-            "token": "分析",
-            "start_offset": 157,
-            "end_offset": 159,
-            "type": "word",
-            "position": 57
-        },
-        {
-            "token": "数据",
-            "start_offset": 159,
-            "end_offset": 161,
-            "type": "word",
-            "position": 58
-        }
-    ]
+  "tokens": [
+    {
+      "token": "哈",
+      "start_offset": 0,
+      "end_offset": 1,
+      "type": "word",
+      "position": 0
+    },
+    {
+      "token": "喽",
+      "start_offset": 1,
+      "end_offset": 2,
+      "type": "word",
+      "position": 1
+    },
+    {
+      "token": "我们",
+      "start_offset": 3,
+      "end_offset": 5,
+      "type": "word",
+      "position": 3
+    },
+    {
+      "token": "是",
+      "start_offset": 5,
+      "end_offset": 6,
+      "type": "word",
+      "position": 4
+    },
+    {
+      "token": "elast",
+      "start_offset": 7,
+      "end_offset": 14,
+      "type": "word",
+      "position": 5
+    },
+    {
+      "token": "我们",
+      "start_offset": 17,
+      "end_offset": 19,
+      "type": "word",
+      "position": 6
+    },
+    {
+      "token": "是",
+      "start_offset": 19,
+      "end_offset": 20,
+      "type": "word",
+      "position": 7
+    },
+    {
+      "token": "elast",
+      "start_offset": 21,
+      "end_offset": 28,
+      "type": "word",
+      "position": 8
+    },
+    {
+      "token": "elasticsearch",
+      "start_offset": 35,
+      "end_offset": 48,
+      "type": "word",
+      "position": 11
+    },
+    {
+      "token": "kibana",
+      "start_offset": 49,
+      "end_offset": 55,
+      "type": "word",
+      "position": 13
+    },
+    {
+      "token": "beat",
+      "start_offset": 56,
+      "end_offset": 61,
+      "type": "word",
+      "position": 15
+    },
+    {
+      "token": "和",
+      "start_offset": 62,
+      "end_offset": 63,
+      "type": "word",
+      "position": 16
+    },
+    {
+      "token": "logstash",
+      "start_offset": 64,
+      "end_offset": 72,
+      "type": "word",
+      "position": 17
+    },
+    {
+      "token": "开发",
+      "start_offset": 74,
+      "end_offset": 76,
+      "type": "word",
+      "position": 20
+    },
+    {
+      "token": "公司",
+      "start_offset": 76,
+      "end_offset": 78,
+      "type": "word",
+      "position": 21
+    },
+    {
+      "token": "从",
+      "start_offset": 79,
+      "end_offset": 80,
+      "type": "word",
+      "position": 23
+    },
+    {
+      "token": "股票",
+      "start_offset": 80,
+      "end_offset": 82,
+      "type": "word",
+      "position": 24
+    },
+    {
+      "token": "行情",
+      "start_offset": 82,
+      "end_offset": 84,
+      "type": "word",
+      "position": 25
+    },
+    {
+      "token": "到",
+      "start_offset": 84,
+      "end_offset": 85,
+      "type": "word",
+      "position": 26
+    },
+    {
+      "token": "twitter",
+      "start_offset": 86,
+      "end_offset": 93,
+      "type": "word",
+      "position": 27
+    },
+    {
+      "token": "消息",
+      "start_offset": 94,
+      "end_offset": 96,
+      "type": "word",
+      "position": 28
+    },
+    {
+      "token": "流",
+      "start_offset": 96,
+      "end_offset": 97,
+      "type": "word",
+      "position": 29
+    },
+    {
+      "token": "从",
+      "start_offset": 98,
+      "end_offset": 99,
+      "type": "word",
+      "position": 31
+    },
+    {
+      "token": "apach",
+      "start_offset": 100,
+      "end_offset": 106,
+      "type": "word",
+      "position": 32
+    },
+    {
+      "token": "日志",
+      "start_offset": 107,
+      "end_offset": 109,
+      "type": "word",
+      "position": 33
+    },
+    {
+      "token": "到",
+      "start_offset": 109,
+      "end_offset": 110,
+      "type": "word",
+      "position": 34
+    },
+    {
+      "token": "wordpress",
+      "start_offset": 111,
+      "end_offset": 120,
+      "type": "word",
+      "position": 35
+    },
+    {
+      "token": "博",
+      "start_offset": 121,
+      "end_offset": 122,
+      "type": "word",
+      "position": 36
+    },
+    {
+      "token": "文",
+      "start_offset": 122,
+      "end_offset": 123,
+      "type": "word",
+      "position": 37
+    },
+    {
+      "token": "我们",
+      "start_offset": 124,
+      "end_offset": 126,
+      "type": "word",
+      "position": 39
+    },
+    {
+      "token": "可以",
+      "start_offset": 126,
+      "end_offset": 128,
+      "type": "word",
+      "position": 40
+    },
+    {
+      "token": "帮助",
+      "start_offset": 128,
+      "end_offset": 130,
+      "type": "word",
+      "position": 41
+    },
+    {
+      "token": "人们",
+      "start_offset": 130,
+      "end_offset": 132,
+      "type": "word",
+      "position": 42
+    },
+    {
+      "token": "体验",
+      "start_offset": 132,
+      "end_offset": 134,
+      "type": "word",
+      "position": 43
+    },
+    {
+      "token": "搜索",
+      "start_offset": 134,
+      "end_offset": 136,
+      "type": "word",
+      "position": 44
+    },
+    {
+      "token": "强大",
+      "start_offset": 137,
+      "end_offset": 139,
+      "type": "word",
+      "position": 46
+    },
+    {
+      "token": "力量",
+      "start_offset": 139,
+      "end_offset": 141,
+      "type": "word",
+      "position": 47
+    },
+    {
+      "token": "帮助",
+      "start_offset": 142,
+      "end_offset": 144,
+      "type": "word",
+      "position": 49
+    },
+    {
+      "token": "他们",
+      "start_offset": 144,
+      "end_offset": 146,
+      "type": "word",
+      "position": 50
+    },
+    {
+      "token": "以",
+      "start_offset": 146,
+      "end_offset": 147,
+      "type": "word",
+      "position": 51
+    },
+    {
+      "token": "截然不同",
+      "start_offset": 147,
+      "end_offset": 151,
+      "type": "word",
+      "position": 52
+    },
+    {
+      "token": "方式",
+      "start_offset": 152,
+      "end_offset": 154,
+      "type": "word",
+      "position": 54
+    },
+    {
+      "token": "探索",
+      "start_offset": 154,
+      "end_offset": 156,
+      "type": "word",
+      "position": 55
+    },
+    {
+      "token": "和",
+      "start_offset": 156,
+      "end_offset": 157,
+      "type": "word",
+      "position": 56
+    },
+    {
+      "token": "分析",
+      "start_offset": 157,
+      "end_offset": 159,
+      "type": "word",
+      "position": 57
+    },
+    {
+      "token": "数据",
+      "start_offset": 159,
+      "end_offset": 161,
+      "type": "word",
+      "position": 58
+    }
+  ]
 }
 --------------------------------------------------

--- a/docs/plugins/repository-azure.asciidoc
+++ b/docs/plugins/repository-azure.asciidoc
@@ -58,10 +58,10 @@ For example:
 ----
 PUT _snapshot/my_backup
 {
-    "type": "azure",
-    "settings": {
-        "client": "secondary"
-    }
+  "type": "azure",
+  "settings": {
+    "client": "secondary"
+  }
 }
 ----
 // TEST[skip:we don't have azure setup while testing this]
@@ -192,37 +192,37 @@ Some examples, using scripts:
 # The simplest one
 PUT _snapshot/my_backup1
 {
-    "type": "azure"
+  "type": "azure"
 }
 
 # With some settings
 PUT _snapshot/my_backup2
 {
-    "type": "azure",
-    "settings": {
-        "container": "backup-container",
-        "base_path": "backups",
-        "chunk_size": "32MB",
-        "compress": true
-    }
+  "type": "azure",
+  "settings": {
+    "container": "backup-container",
+    "base_path": "backups",
+    "chunk_size": "32MB",
+    "compress": true
+  }
 }
 
 
 # With two accounts defined in elasticsearch.yml (my_account1 and my_account2)
 PUT _snapshot/my_backup3
 {
-    "type": "azure",
-    "settings": {
-        "client": "secondary"
-    }
+  "type": "azure",
+  "settings": {
+    "client": "secondary"
+  }
 }
 PUT _snapshot/my_backup4
 {
-    "type": "azure",
-    "settings": {
-        "client": "secondary",
-        "location_mode": "primary_only"
-    }
+  "type": "azure",
+  "settings": {
+    "client": "secondary",
+    "location_mode": "primary_only"
+  }
 }
 ----
 // TEST[skip:we don't have azure setup while testing this]


### PR DESCRIPTION
Reformats snippets in the Plugin docs to use two-space indentation.

No substantive changes were made to the snippets.

Relates to #50606.