### PR TITLE
Update Gradle configurations section in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ dependencies. Fix them:
 Next you'll want to import our auto-formatter:
 
  - Select **Window > Preferences**
- - Select **Java > Code Style > Formater**
+ - Select **Java > Code Style > Formatter**
  - Click **Import**
  - Import the file at **buildSrc/formatterConfig.xml**
  - Make sure it is the **Active profile**
@@ -575,10 +575,14 @@ allows you to use these configurations arbitrarily. Here are some of the most
 common configurations in our build and how we use them:
 
 <dl>
-<dt>`compile`</dt><dd>Code that is on the classpath at both compile and
-runtime.</dd>
-<dt>`runtime`</dt><dd>Code that is not on the classpath at compile time but is
-on the classpath at runtime. We mostly use this configuration to make sure that
+<dt>`implementation`</dt><dd>Dependencies that are used by the project 
+at compile and runtime but are not exposed as a compile dependency to other dependent projects.
+Dependencies added to the `implementation` configuration are considered an implementation detail 
+that can be changed at a later date without affecting any dependent projects.</dd>
+<dt>`api`</dt><dd>Dependencies that are used as compile and runtime depdendencies of a project
+ and are considered part of the external api of the project.
+<dt>`runtimeOnly`</dt><dd>Dependencies that not on the classpath at compile time but 
+are on the classpath at runtime. We mostly use this configuration to make sure that
 we do not accidentally compile against dependencies of our dependencies also
 known as "transitive" dependencies".</dd>
 <dt>`compileOnly`</dt><dd>Code that is on the classpath at compile time but that


### PR DESCRIPTION
After we've updated the configurations we use for our dependencies to not use deprecated gradle configurations, we also need to update the according section in our contribution doc 