### PR TITLE
[DOCS] Changes level offset in data frame analytics APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[delete-dfanalytics]]
-=== Delete {dfanalytics-jobs} API
+= Delete {dfanalytics-jobs} API
 [subs="attributes"]
 ++++
 <titleabbrev>Delete {dfanalytics-jobs}</titleabbrev>
@@ -13,13 +13,13 @@ experimental[]
 
 
 [[ml-delete-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `DELETE _ml/data_frame/analytics/<data_frame_analytics_id>`
 
 
 [[ml-delete-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles or equivalent privileges:
@@ -31,14 +31,14 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-delete-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 [[ml-delete-dfanalytics-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `force`::
   (Optional, boolean) If `true`, it deletes a job that is not stopped; this method is
@@ -51,7 +51,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 
 [[ml-delete-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example deletes the `loganalytics` {dfanalytics-job}:
 

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[delete-inference]]
-=== Delete {infer} trained model API
+= Delete {infer} trained model API
 [subs="attributes"]
 ++++
 <titleabbrev>Delete {infer} trained model</titleabbrev>
@@ -14,13 +14,13 @@ experimental[]
 
 
 [[ml-delete-inference-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `DELETE _ml/inference/<model_id>`
 
 
 [[ml-delete-inference-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles or equivalent privileges:
@@ -32,7 +32,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-delete-inference-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<model_id>`::
 (Optional, string) 
@@ -40,7 +40,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-delete-inference-response-codes]]
-==== {api-response-codes-title}
+== {api-response-codes-title}
 
 `409`::
   The code indicates that the trained {infer} model is referenced by an ingest 
@@ -48,7 +48,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-delete-inference-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example deletes the `regression-job-one-1574775307356` trained 
 model:

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[evaluate-dfanalytics]]
-=== Evaluate {dfanalytics} API
+= Evaluate {dfanalytics} API
 
 [subs="attributes"]
 ++++
@@ -14,13 +14,13 @@ experimental[]
 
 
 [[ml-evaluate-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `POST _ml/data_frame/_evaluate`
 
 
 [[ml-evaluate-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -31,7 +31,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-evaluate-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 The API packages together commonly used evaluation metrics for various types of 
 machine learning features. This has been designed for use on indexes created by 
@@ -40,7 +40,7 @@ result field to be present.
 
 
 [[ml-evaluate-dfanalytics-request-body]]
-==== {api-request-body-title}
+== {api-request-body-title}
 
 `evaluation`::
 (Required, object) Defines the type of evaluation you want to perform.
@@ -64,10 +64,10 @@ performed.
 source index. See <<query-dsl>>.
 
 [[ml-evaluate-dfanalytics-resources]]
-==== {dfanalytics-cap} evaluation resources
+== {dfanalytics-cap} evaluation resources
 
 [[binary-sc-resources]]
-===== Binary soft classification evaluation objects
+=== Binary soft classification evaluation objects
 
 Binary soft classification evaluates the results of an analysis which outputs 
 the probability that each document belongs to a certain class. For example, in 
@@ -109,7 +109,7 @@ document is an outlier.
 
     
 [[regression-evaluation-resources]]
-===== {regression-cap} evaluation objects
+=== {regression-cap} evaluation objects
 
 {regression-cap} evaluation evaluates the results of a {regression} analysis 
 which outputs a prediction of values.
@@ -145,7 +145,7 @@ which outputs a prediction of values.
 
   
 [[classification-evaluation-resources]]
-==== {classification-cap} evaluation objects
+== {classification-cap} evaluation objects
 
 {classification-cap} evaluation evaluates the results of a {classanalysis} which 
 outputs a prediction that identifies to which of the classes each document 
@@ -178,7 +178,7 @@ belongs.
 
 ////
 [[ml-evaluate-dfanalytics-results]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `binary_soft_classification`::
   (object) If you chose to do binary soft classification, the API returns the
@@ -195,11 +195,11 @@ belongs.
 
 
 [[ml-evaluate-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 
 [[ml-evaluate-binary-soft-class-example]]
-===== Binary soft classification
+=== Binary soft classification
 
 [source,console]
 --------------------------------------------------
@@ -261,7 +261,7 @@ The API returns the following results:
 
 
 [[ml-evaluate-regression-example]]
-===== {regression-cap}
+=== {regression-cap}
 
 [source,console]
 --------------------------------------------------
@@ -375,7 +375,7 @@ calculated by the {reganalysis}.
 
 
 [[ml-evaluate-classification-example]]
-===== {classification-cap}
+=== {classification-cap}
 
 
 [source,console]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[explain-dfanalytics]]
-=== Explain {dfanalytics} API
+= Explain {dfanalytics} API
 
 [subs="attributes"]
 ++++
@@ -14,7 +14,7 @@ experimental[]
 
 
 [[ml-explain-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `GET _ml/data_frame/analytics/_explain` +
 
@@ -26,7 +26,7 @@ experimental[]
 
 
 [[ml-explain-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -37,7 +37,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-explain-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 This API provides explanations for a {dataframe-analytics-config} that either 
 exists already or one that has not been created yet.
@@ -52,21 +52,21 @@ they are not included in the explanation.
 
 
 [[ml-explain-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 [[ml-explain-dfanalytics-request-body]]
-==== {api-request-body-title}
+== {api-request-body-title}
 
 A {dataframe-analytics-config} as described in <<put-dfanalytics>>.
 Note that `id` and `dest` don't need to be provided in the context of this API.
 
 [role="child_attributes"]
 [[ml-explain-dfanalytics-results]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 The API returns a response that contains the following:
 
@@ -118,7 +118,7 @@ memory needed to perform {dfanalytics}.
 
 
 [[ml-explain-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[get-dfanalytics-stats]]
-=== Get {dfanalytics-jobs} statistics API
+= Get {dfanalytics-jobs} statistics API
 [subs="attributes"]
 ++++
 <titleabbrev>Get {dfanalytics-jobs} stats</titleabbrev>
@@ -12,7 +12,7 @@ Retrieves usage information for {dfanalytics-jobs}.
 experimental[]
 
 [[ml-get-dfanalytics-stats-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `GET _ml/data_frame/analytics/<data_frame_analytics_id>/_stats` +
 
@@ -26,7 +26,7 @@ experimental[]
 
 
 [[ml-get-dfanalytics-stats-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -36,7 +36,7 @@ privileges:
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-get-dfanalytics-stats-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Optional, string)
@@ -44,7 +44,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-def
 
 
 [[ml-get-dfanalytics-stats-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean)
@@ -64,7 +64,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=verbose]
 
 [role="child_attributes"]
 [[ml-get-dfanalytics-stats-response-body]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `data_frame_analytics`::
 (array)
@@ -521,7 +521,7 @@ values: `analyzing`, `failed`, `reindexing`, `started`, `starting`,`stopping`,
 
 
 [[ml-get-dfanalytics-stats-response-codes]]
-==== {api-response-codes-title}
+== {api-response-codes-title}
 
 `404` (Missing resources)::
   If `allow_no_match` is `false`, this code indicates that there are no
@@ -529,7 +529,7 @@ values: `analyzing`, `failed`, `reindexing`, `started`, `starting`,`stopping`,
 
 
 [[ml-get-dfanalytics-stats-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following API retrieves usage information for the
 {ml-docs}/ecommerce-outliers.html[{oldetection} {dfanalytics-job} example]:

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[get-dfanalytics]]
-=== Get {dfanalytics-jobs} API
+= Get {dfanalytics-jobs} API
 [subs="attributes"]
 ++++
 <titleabbrev>Get {dfanalytics-jobs}</titleabbrev>
@@ -13,7 +13,7 @@ experimental[]
 
 
 [[ml-get-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `GET _ml/data_frame/analytics/<data_frame_analytics_id>` +
 
@@ -25,7 +25,7 @@ experimental[]
 
 
 [[ml-get-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -36,14 +36,14 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 You can get information for multiple {dfanalytics-jobs} in a single API request 
 by using a comma-separated list of {dfanalytics-jobs} or a wildcard expression.
 
 
 [[ml-get-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Optional, string) 
@@ -57,7 +57,7 @@ You can get information for all {dfanalytics-jobs} by using _all, by specifying
 
 
 [[ml-get-dfanalytics-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean) 
@@ -73,7 +73,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 [role="child_attributes"]
 [[ml-get-dfanalytics-results]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `data_frame_analytics`::
 (array)
@@ -166,7 +166,7 @@ destination.
 
 
 [[ml-get-dfanalytics-response-codes]]
-==== {api-response-codes-title}
+== {api-response-codes-title}
 
 `404` (Missing resources)::
   If `allow_no_match` is `false`, this code indicates that there are no
@@ -174,7 +174,7 @@ destination.
 
 
 [[ml-get-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example gets configuration information for the `loganalytics` 
 {dfanalytics-job}:

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-inference-stats]]
-=== Get {infer} trained model statistics API
+= Get {infer} trained model statistics API
 [subs="attributes"]
 ++++
 <titleabbrev>Get {infer} trained model stats</titleabbrev>
@@ -13,7 +13,7 @@ experimental[]
 
 
 [[ml-get-inference-stats-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `GET _ml/inference/_stats` +
 
@@ -27,7 +27,7 @@ experimental[]
 
 
 [[ml-get-inference-stats-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -38,14 +38,14 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-inference-stats-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 You can get usage information for multiple trained models in a single API 
 request by using a comma-separated list of model IDs or a wildcard expression.
 
 
 [[ml-get-inference-stats-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<model_id>`::
 (Optional, string) 
@@ -53,7 +53,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-get-inference-stats-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean) 
@@ -69,7 +69,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 [role="child_attributes"]
 [[ml-get-inference-stats-results]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `count`::
 (integer)
@@ -137,14 +137,14 @@ section in <<cluster-nodes-stats>>.
 ====
 
 [[ml-get-inference-stats-response-codes]]
-==== {api-response-codes-title}
+== {api-response-codes-title}
 
 `404` (Missing resources)::
   If `allow_no_match` is `false`, this code indicates that there are no
   resources that match the request or only partial matches for the request.
 
 [[ml-get-inference-stats-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example gets usage information for all the trained models:
 

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-inference]]
-=== Get {infer} trained model API
+= Get {infer} trained model API
 [subs="attributes"]
 ++++
 <titleabbrev>Get {infer} trained model</titleabbrev>
@@ -13,7 +13,7 @@ experimental[]
 
 
 [[ml-get-inference-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `GET _ml/inference/` +
 
@@ -27,7 +27,7 @@ experimental[]
 
 
 [[ml-get-inference-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
@@ -38,14 +38,14 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-inference-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 You can get information for multiple trained models in a single API request by 
 using a comma-separated list of model IDs or a wildcard expression.
 
 
 [[ml-get-inference-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<model_id>`::
 (Optional, string) 
@@ -53,7 +53,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-get-inference-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean) 
@@ -90,7 +90,7 @@ and then added to another cluster. Default is false.
 
 [role="child_attributes"]
 [[ml-get-inference-results]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `trained_model_configs`::
 (array)
@@ -150,7 +150,7 @@ The {es} version number in which the trained model was created.
 
 
 [[ml-get-inference-response-codes]]
-==== {api-response-codes-title}
+== {api-response-codes-title}
 
 `400`::
   If `include_model_definition` is `true`, this code indicates that more than 
@@ -162,7 +162,7 @@ The {es} version number in which the trained model was created.
   
 
 [[ml-get-inference-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example gets configuration information for all the trained models:
 

--- a/docs/reference/ml/df-analytics/apis/index.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/index.asciidoc
@@ -1,48 +1,21 @@
-[role="xpack"]
-[testenv="platinum"]
-[[ml-df-analytics-apis]]
-== {ml-cap} {dfanalytics} APIs
-
-You can use the following APIs to perform {ml} {dfanalytics} activities.
-
-* <<put-dfanalytics,Create {dfanalytics-jobs}>>
-* <<update-dfanalytics,Update {dfanalytics-jobs}>>
-* <<delete-dfanalytics,Delete {dfanalytics-jobs}>>
-* <<get-dfanalytics,Get {dfanalytics-jobs} info>>
-* <<get-dfanalytics-stats,Get {dfanalytics-jobs} statistics>>
-* <<start-dfanalytics,Start {dfanalytics-jobs}>>
-* <<stop-dfanalytics,Stop {dfanalytics-jobs}>>
-* <<evaluate-dfanalytics,Evaluate {dfanalytics}>>
-* <<explain-dfanalytics,Explain {dfanalytics}>>
-
-
-You can use the following APIs to perform {infer} operations.
-
-* <<put-inference>>
-* <<get-inference>>
-* <<get-inference-stats>>
-* <<delete-inference>>
-
-
-See also <<ml-apis>>.
-
+include::ml-df-analytics-apis.asciidoc[leveloffset=+1]
 //CREATE
-include::put-dfanalytics.asciidoc[]
-include::put-inference.asciidoc[]
+include::put-dfanalytics.asciidoc[leveloffset=+2]
+include::put-inference.asciidoc[leveloffset=+2]
 //UPDATE
-include::update-dfanalytics.asciidoc[]
+include::update-dfanalytics.asciidoc[leveloffset=+2]
 //DELETE
-include::delete-dfanalytics.asciidoc[]
-include::delete-inference-trained-model.asciidoc[]
+include::delete-dfanalytics.asciidoc[leveloffset=+2]
+include::delete-inference-trained-model.asciidoc[leveloffset=+2]
 //EVALUATE
-include::evaluate-dfanalytics.asciidoc[]
+include::evaluate-dfanalytics.asciidoc[leveloffset=+2]
 //ESTIMATE_MEMORY_USAGE
-include::explain-dfanalytics.asciidoc[]
+include::explain-dfanalytics.asciidoc[leveloffset=+2]
 //GET
-include::get-dfanalytics.asciidoc[]
-include::get-dfanalytics-stats.asciidoc[]
-include::get-inference-trained-model.asciidoc[]
-include::get-inference-trained-model-stats.asciidoc[]
+include::get-dfanalytics.asciidoc[leveloffset=+2]
+include::get-dfanalytics-stats.asciidoc[leveloffset=+2]
+include::get-inference-trained-model.asciidoc[leveloffset=+2]
+include::get-inference-trained-model-stats.asciidoc[leveloffset=+2]
 //SET/START/STOP
-include::start-dfanalytics.asciidoc[]
-include::stop-dfanalytics.asciidoc[]
+include::start-dfanalytics.asciidoc[leveloffset=+2]
+include::stop-dfanalytics.asciidoc[leveloffset=+2]

--- a/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
@@ -1,0 +1,27 @@
+[role="xpack"]
+[testenv="platinum"]
+[[ml-df-analytics-apis]]
+= {ml-cap} {dfanalytics} APIs
+
+You can use the following APIs to perform {ml} {dfanalytics} activities.
+
+* <<put-dfanalytics,Create {dfanalytics-jobs}>>
+* <<update-dfanalytics,Update {dfanalytics-jobs}>>
+* <<delete-dfanalytics,Delete {dfanalytics-jobs}>>
+* <<get-dfanalytics,Get {dfanalytics-jobs} info>>
+* <<get-dfanalytics-stats,Get {dfanalytics-jobs} statistics>>
+* <<start-dfanalytics,Start {dfanalytics-jobs}>>
+* <<stop-dfanalytics,Stop {dfanalytics-jobs}>>
+* <<evaluate-dfanalytics,Evaluate {dfanalytics}>>
+* <<explain-dfanalytics,Explain {dfanalytics}>>
+
+
+You can use the following APIs to perform {infer} operations.
+
+* <<put-inference>>
+* <<get-inference>>
+* <<get-inference-stats>>
+* <<delete-inference>>
+
+
+See also <<ml-apis>>.

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[put-dfanalytics]]
-=== Create {dfanalytics-jobs} API
+= Create {dfanalytics-jobs} API
 [subs="attributes"]
 ++++
 <titleabbrev>Create {dfanalytics-jobs}</titleabbrev>
@@ -12,13 +12,13 @@ Instantiates a {dfanalytics-job}.
 experimental[]
 
 [[ml-put-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `PUT _ml/data_frame/analytics/<data_frame_analytics_id>`
 
 
 [[ml-put-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles and privileges:
@@ -40,7 +40,7 @@ those same roles. If you provide
 those credentials are used instead.
 
 [[ml-put-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 This API creates a {dfanalytics-job} that performs an analysis on the source 
 indices and stores the outcome in a destination index.
@@ -54,7 +54,7 @@ determines a value for each of the undefined parameters.
 
 
 [[ml-put-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Required, string)
@@ -62,7 +62,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-def
 
 [role="child_attributes"]
 [[ml-put-dfanalytics-request-body]]
-==== {api-request-body-title}
+== {api-request-body-title}
 
 `allow_lazy_start`::
 (Optional, boolean) 
@@ -386,10 +386,10 @@ the destination.
 ====
 
 [[ml-put-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 [[ml-put-dfanalytics-example-preprocess]]
-===== Preprocessing actions example
+=== Preprocessing actions example
 
 The following example shows how to limit the scope of the analysis to certain 
 fields, specify excluded fields in the destination index, and use a query to 
@@ -460,7 +460,7 @@ excluded field by the `excludes` parameter of the `analyzed_fields` object.
 
 
 [[ml-put-dfanalytics-example-od]]
-===== {oldetection-cap} example
+=== {oldetection-cap} example
 
 The following example creates the `loganalytics` {dfanalytics-job}, the analysis 
 type is `outlier_detection`:
@@ -524,7 +524,7 @@ The API returns the following result:
 
 
 [[ml-put-dfanalytics-example-r]]
-===== {regression-cap} examples
+=== {regression-cap} examples
 
 The following example creates the `house_price_regression_analysis` 
 {dfanalytics-job}, the analysis type is `regression`:
@@ -613,7 +613,7 @@ PUT _ml/data_frame/analytics/student_performance_mathematics_0.3
 
 
 [[ml-put-dfanalytics-example-c]]
-===== {classification-cap} example
+=== {classification-cap} example
 
 The following example creates the `loan_classification` {dfanalytics-job}, the 
 analysis type is `classification`:

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-inference]]
-=== Create {infer} trained model API
+= Create {infer} trained model API
 [subs="attributes"]
 ++++
 <titleabbrev>Create {infer} trained model</titleabbrev>
@@ -19,13 +19,13 @@ experimental[]
 
 
 [[ml-put-inference-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `PUT _ml/inference/<model_id>`
 
 
 [[ml-put-inference-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
@@ -36,14 +36,14 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-put-inference-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 The create {infer} trained model API enables you to supply a trained model that
 is not created by {dfanalytics}.
 
 
 [[ml-put-inference-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<model_id>`::
 (Required, string)
@@ -51,7 +51,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 [role="child_attributes"]
 [[ml-put-inference-request-body]]
-==== {api-request-body-title}
+== {api-request-body-title}
 
 `compressed_definition`::
 (Required, string)
@@ -449,10 +449,10 @@ An array of tags to organize the model.
 
 
 [[ml-put-inference-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 [[ml-put-inference-preprocessor-example]]
-===== Preprocessor examples
+=== Preprocessor examples
 
 The example below shows a `frequency_encoding` preprocessor object:
 
@@ -519,7 +519,7 @@ This example shows a `target_mean_encoding` preprocessor object:
 
 
 [[ml-put-inference-model-example]]
-===== Model examples
+=== Model examples
 
 The first example shows a `trained_model` object:
 
@@ -603,7 +603,7 @@ The following example shows an `ensemble` model object:
 
 
 [[ml-put-inference-aggregated-output-example]]
-===== Aggregated output example
+=== Aggregated output example
 
 Example of a `logistic_regression` object:
 
@@ -658,7 +658,7 @@ Example of an `exponent` object:
 
 
 [[ml-put-inference-json-schema]]
-===== {infer-cap} JSON schema
+=== {infer-cap} JSON schema
 
 For the full JSON schema of model {infer},
 https://github.com/elastic/ml-json-schemas[click here].

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[start-dfanalytics]]
-=== Start {dfanalytics-jobs} API
+= Start {dfanalytics-jobs} API
 
 [subs="attributes"]
 ++++
@@ -13,12 +13,12 @@ Starts a {dfanalytics-job}.
 experimental[]
 
 [[ml-start-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `POST _ml/data_frame/analytics/<data_frame_analytics_id>/_start`
 
 [[ml-start-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles and privileges:
@@ -34,7 +34,7 @@ built-in roles and privileges:
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-start-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 A {dfanalytics-job} can be started and stopped multiple times throughout its 
 lifecycle.
@@ -56,21 +56,21 @@ provided <<http-clients-secondary-authorization,secondary authorization headers>
 when you created the job, those credentials are used.
 
 [[ml-start-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
 
 [[ml-start-dfanalytics-query-params]]
-==== {api-query-parms-title}
+== {api-query-parms-title}
 
 `timeout`::
 (Optional, <<time-units,time units>>) 
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timeout-start]
 
 [[ml-start-dfanalytics-response-body]]
-==== {api-response-body-title}
+== {api-response-body-title}
 
 `acknowledged`::
   (boolean) For a successful response, this value is always `true`. On failure, an
@@ -81,7 +81,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timeout-start]
   If the job is allowed to open lazily and has not yet been assigned to a node, this value is an empty string.
 
 [[ml-start-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example starts the `loganalytics` {dfanalytics-job}:
 

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[stop-dfanalytics]]
-=== Stop {dfanalytics-jobs} API
+= Stop {dfanalytics-jobs} API
 
 [subs="attributes"]
 ++++
@@ -13,7 +13,7 @@ Stops one or more {dfanalytics-jobs}.
 experimental[]
 
 [[ml-stop-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `POST _ml/data_frame/analytics/<data_frame_analytics_id>/_stop` +
 
@@ -22,7 +22,7 @@ experimental[]
 `POST _ml/data_frame/analytics/_all/_stop`
 
 [[ml-stop-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles or equivalent privileges:
@@ -34,7 +34,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-stop-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 A {dfanalytics-job} can be started and stopped multiple times throughout its 
 lifecycle.
@@ -45,14 +45,14 @@ stop all {dfanalytics-job} by using _all or by specifying * as the
 <data_frame_analytics_id>.
 
 [[ml-stop-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
   
 [[ml-stop-dfanalytics-query-params]]
-==== {api-query-parms-title}  
+== {api-query-parms-title}  
   
 `allow_no_match`::
 (Optional, boolean) 
@@ -68,7 +68,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timeout-stop]
 
 
 [[ml-stop-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 The following example stops the `loganalytics` {dfanalytics-job}:
 

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[update-dfanalytics]]
-=== Update {dfanalytics-jobs} API
+= Update {dfanalytics-jobs} API
 [subs="attributes"]
 ++++
 <titleabbrev>Update {dfanalytics-jobs}</titleabbrev>
@@ -12,13 +12,13 @@ Updates an existing {dfanalytics-job}.
 experimental[]
 
 [[ml-update-dfanalytics-request]]
-==== {api-request-title}
+== {api-request-title}
 
 `POST _ml/data_frame/analytics/<data_frame_analytics_id>/_update`
 
 
 [[ml-update-dfanalytics-prereq]]
-==== {api-prereq-title}
+== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles and privileges:
@@ -40,14 +40,14 @@ those same roles. If you provide
 those credentials are used instead.
 
 [[ml-update-dfanalytics-desc]]
-==== {api-description-title}
+== {api-description-title}
 
 This API updates an existing {dfanalytics-job} that performs an analysis on the source
 indices and stores the outcome in a destination index.
 
 
 [[ml-update-dfanalytics-path-params]]
-==== {api-path-parms-title}
+== {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
 (Required, string)
@@ -55,7 +55,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-def
 
 [role="child_attributes"]
 [[ml-update-dfanalytics-request-body]]
-==== {api-request-body-title}
+== {api-request-body-title}
 
 `allow_lazy_start`::
 (Optional, boolean) 
@@ -89,10 +89,10 @@ setting, an error occurs when you try to create {dfanalytics-jobs} that have
 <<ml-settings>>.
 
 [[ml-update-dfanalytics-example]]
-==== {api-examples-title}
+== {api-examples-title}
 
 [[ml-update-dfanalytics-example-preprocess]]
-===== Updating model memory limit example
+=== Updating model memory limit example
 
 The following example shows how to update the model memory limit for the existing {dfanalytics} configuration.
 


### PR DESCRIPTION
This PR improves the consistency of machine learning data frame analytics API pages such that:
 
- There is a one-to-one mapping between source files and output files (unless it is a subset of content that gets re-used in multiple places).
- All of the source files begin with the same section title level (=).
- All of the navigation and nesting of pages is handled in the index.asciidoc file.


### Preview

https://elasticsearch_59919.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-df-analytics-apis.html