### PR TITLE
Revert "Enforce fail on deprecated gradle usage"

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -133,9 +133,9 @@ dependencies {
   integTestImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude module:"groovy"
   }
-  minimumRuntimeImplementation "junit:junit:${props.getProperty('junit')}"
-  minimumRuntimeImplementation localGroovy()
-  minimumRuntimeImplementation gradleApi()
+  minimumRuntimeCompile "junit:junit:${props.getProperty('junit')}"
+  minimumRuntimeCompile localGroovy()
+  minimumRuntimeCompile gradleApi()
 }
 
 /*****************************************************************************

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -147,7 +147,7 @@ class PluginBuildPlugin implements Plugin<Project> {
             project.pluginManager.apply('nebula.maven-base-publish')
             // Only change Jar tasks, we don't want a -client zip so we can't change archivesBaseName
             project.tasks.withType(Jar) {
-                archiveBaseName = archiveBaseName.get() + "-client"
+                baseName = baseName + "-client"
             }
             // always configure publishing for client jars
             project.publishing.publications.nebula(MavenPublication).artifactId(extension.name + "-client")

--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/LoggedExec.java
@@ -25,6 +25,7 @@ import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.Internal;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
@@ -83,6 +84,7 @@ public class LoggedExec extends Exec {
         }
     }
 
+    @Internal
     public void setSpoolOutput(boolean spoolOutput) {
         final OutputStream out;
         if (spoolOutput) {

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -34,6 +34,12 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
+dependencyLicenses {
+  dependencies = project.configurations.runtime.fileCollection {
+    it.group.startsWith('org.elasticsearch') == false
+  }
+}
+
 forbiddenApisTest {
   // we don't use the core test-framework, no lucene classes present so we don't want the es-test-signatures to
   // be pulled in

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,3 @@ options.forkOptions.memoryMaximumSize=2g
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
 systemProp.org.gradle.dependency.duplicate.project.detection=false
-
-# Enforce the build to fail on deprecated gradle api usage
-systemProp.org.gradle.warning.mode=fail

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -39,7 +39,7 @@ if (!isEclipse) {
   }
 
   dependencies {
-    java11Implementation sourceSets.main.output
+    java11Compile sourceSets.main.output
   }
 
   compileJava11Java {
@@ -70,6 +70,10 @@ dependencies {
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+
+  if (!isEclipse) {
+    java11Compile sourceSets.main.output
+  }
 
   testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-core'

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -79,7 +79,6 @@ ext.expansions = [
 
 processTestResources {
   from(sourceSets.test.resources.srcDirs) {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     include '**/*.yml'
     inputs.properties(expansions)
     MavenFilteringHack.filter(it, expansions)

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -10,7 +10,6 @@ testFixtures.useFixture ":x-pack:test:smb-fixture"
 
 // add test resources from security, so tests can use example certs
 processTestResources {
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   from(project(xpackModule('core')).sourceSets.test.resources.srcDirs)
   from(project(xpackModule('security')).sourceSets.test.resources.srcDirs)
 }

--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -114,7 +114,7 @@ task buildTarArchive(dependsOn: copyRuntimeLibs, type: Tar) {
   compression Compression.GZIP
   archiveBaseName.set('snapshot-tool')
   destinationDirectory.set(project.buildDir)
-  into "snapshot-tool-${archiveVersion.get()}", {
+  into "snapshot-tool-${version}", {
     into "bin", {
       from file("${project.projectDir}/src/bin")
     }


### PR DESCRIPTION
In some unclear situations, deprecated features are used here in the 7.8
release branch. This commite reverts the enforcement of no deprecations for now.

This reverts commit 7aee0d0e453f71cd4d652e6d87260032939c0659.