### PR TITLE
[DOCS] Fix typo in thread pools docs

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -15,7 +15,7 @@ There are several thread pools, but the important ones include:
 `search`::
     For count/search/suggest operations. Thread pool type is
     `fixed_auto_queue_size` with a size of `int((`<<node.processors,
-    `# of available_processors`>>`pass:[ * ]3) / 2) + 1`, and initial queue_size of
+    `# of allocated processors`>>`pass:[ * ]3) / 2) + 1`, and initial queue_size of
     `1000`.
 
 [[search-throttled]]`search_throttled`::
@@ -72,7 +72,7 @@ There are several thread pools, but the important ones include:
     For <<indices-flush,flush>>, <<indices-synced-flush-api,synced flush>>, and
     <<index-modules-translog, translog>> `fsync` operations. Thread pool type is
     `scaling` with a keep-alive of `5m` and a default maximum size of `min(5, (`
-    <<node.processors, `# of available processors`>>`) / 2)`.
+    <<node.processors, `# of allocated processors`>>`) / 2)`.
 
 `force_merge`::
     For <<indices-forcemerge,force merge>> operations.


### PR DESCRIPTION
Fix typo where available processors should be allocated processors.

This was fixed in https://github.com/elastic/elasticsearch/pull/54907/files as can be seen in 
https://github.com/jasontedor/elasticsearch/blob/3b4c567bf5a7e46142f8ab9cdff2371848df70db/docs/reference/modules/threadpool.asciidoc

But for some reason, they were showing as `available processors` in the 7.8 branch. 