### PR TITLE
Remove unused deprecate method in FormatNames

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.common.time;
 
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.util.LazyInitializable;
-
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -117,13 +114,6 @@ public enum FormatNames {
     private final String camelCaseName;
     private final String snakeCaseName;
 
-    // DateFormatters and FormatNames are being used even before the logging is initialized.
-    // If LogManager.getLogger is called before logging config is loaded
-    // it results in errors sent to status logger and startup to fail.
-    // Hence a lazy initialization.
-    private static final LazyInitializable<DeprecationLogger, RuntimeException> deprecationLogger
-        = new LazyInitializable(() -> DeprecationLogger.getLogger(FormatNames.class));
-
     FormatNames(String camelCaseName, String snakeCaseName) {
         this.camelCaseName = camelCaseName;
         this.snakeCaseName = snakeCaseName;
@@ -148,13 +138,6 @@ public enum FormatNames {
 
     public  boolean isCamelCase(String format) {
         return format.equals(camelCaseName);
-    }
-
-    private void deprecate() {
-        String msg = "Camel case format name {} is deprecated and will be removed in a future version. " +
-            "Use snake case name {} instead.";
-        deprecationLogger.getOrCompute()
-            .deprecate("camelCaseDateFormat", msg, camelCaseName, snakeCaseName);
     }
 
     public String getSnakeCaseName() {


### PR DESCRIPTION
The method was accidentally added in https://github.com/elastic/elasticsearch/pull/59555
Deprecation is being done in DateFormatters and Joda classes in `guard pattern` style. 
