### PR TITLE
SQL: integer parameter validation in string functions (#58923)

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -70,6 +70,10 @@ public class InsertFunctionProcessor implements Processor {
         if (((Number) length).intValue() < 0) {
             throw new SqlIllegalArgumentException("A positive number is required for [length]; received [{}]", length);
         }
+        
+        if (((Number) start).longValue() - 1 > Integer.MAX_VALUE) {
+            return input;
+        }
 
         int startInt = ((Number) start).intValue() - 1;
         int realStart = startInt < 0 ? 0 : startInt;


### PR DESCRIPTION
In insert function, when argument start is larger than Integer.MAX_INT, it causes overflow and the number becomes negative. This commit fixed the bug and return origin input when start is larger than Integer.MAX_INT

According to original code logic about insert function insert(input, start, length, replaceString):

when the argument start is larger than length of input, it should return origin input;
when the argument start is less or equal than 0, it should work as insert(input, 1, length, replaceString).
In original code, when the start is larger than Integer.MAX_INT, it causes overflow and the start becomes negative. This triggers the second situation above, and the function works as insert(input, 1, length, replaceString). However, this expects to return origin input.