### PR TITLE
[ML] Include same fields during test inference as in training

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.BoostedTreeParams;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
-import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.junit.After;
 
 import java.io.IOException;
@@ -41,7 +40,6 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -17,12 +17,16 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.BoostedTreeParams;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
+import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.junit.After;
 
 import java.io.IOException;
@@ -33,9 +37,11 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -459,6 +465,104 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertModelStatePersisted(stateDocId());
         assertInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
+        assertThatAuditMessagesMatch(jobId,
+            "Created analytics with analysis type [regression]",
+            "Estimated memory usage for this analytics to be",
+            "Starting analytics on node",
+            "Started analytics",
+            "Creating destination index [" + destIndex + "]",
+            "Started reindexing to destination index [" + destIndex + "]",
+            "Finished reindexing to destination index [" + destIndex + "]",
+            "Started loading data",
+            "Started analyzing",
+            "Started writing results",
+            "Finished analysis");
+    }
+
+    public void testAliasFields() throws Exception {
+        // The goal of this test is to assert alias fields are included in the analytics job.
+        // We have a simple dataset with two integer fields: field_1 and field_2.
+        // field_2 is double the value of field_1.
+        // We also add an alias to field_1 and we exclude field_1 from the analysis forcing
+        // field_1_alias to be the feature and field_2 to be the dependent variable.
+        // Then we proceed to check the predictions are roughly double the feature value.
+        // If alias fields are not being extracted properly the predictions will be wrong.
+
+        initialize("regression_alias_fields");
+        String predictionField = "field_2_prediction";
+
+        String mapping = "{\n" +
+            "      \"properties\": {\n" +
+            "        \"field_1\": {\n" +
+            "          \"type\": \"integer\"\n" +
+            "        }," +
+            "        \"field_2\": {\n" +
+            "          \"type\": \"integer\"\n" +
+            "        }," +
+            "        \"field_1_alias\": {\n" +
+            "          \"type\": \"alias\",\n" +
+            "          \"path\": \"field_1\"\n" +
+            "        }" +
+            "      }\n" +
+            "    }";
+        client().admin().indices().prepareCreate(sourceIndex)
+            .setMapping(mapping)
+            .get();
+
+        int totalDocCount = 300;
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk()
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 0; i < totalDocCount; i++) {
+            List<Object> source = List.of("field_1", i, "field_2", 2 * i);
+            IndexRequest indexRequest = new IndexRequest(sourceIndex).source(source.toArray()).opType(DocWriteRequest.OpType.CREATE);
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+
+        Regression regression = new Regression(
+            "field_2",
+            BoostedTreeParams.builder().setNumTopFeatureImportanceValues(1).build(),
+            null,
+            90.0,
+            null,
+            null,
+            null);
+        DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder()
+            .setId(jobId)
+            .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null))
+            .setDest(new DataFrameAnalyticsDest(destIndex, null))
+            .setAnalysis(regression)
+            .setAnalyzedFields(new FetchSourceContext(true, null, new String[] {"field_1"}))
+            .build();
+        putAnalytics(config);
+
+        assertIsStopped(jobId);
+        assertProgressIsZero(jobId);
+
+        startAnalytics(jobId);
+        waitUntilAnalyticsIsStopped(jobId);
+
+        SearchResponse sourceData = client().prepareSearch(sourceIndex).setSize(totalDocCount).get();
+        for (SearchHit hit : sourceData.getHits()) {
+            Map<String, Object> destDoc = getDestDoc(config, hit);
+            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
+
+            int featureValue = (int) destDoc.get("field_1");
+            double predictionValue = (double) resultsObject.get(predictionField);
+            assertThat(predictionValue, closeTo(2 * featureValue, 10.0));
+
+            assertThat(resultsObject.containsKey(predictionField), is(true));
+            assertThat(resultsObject.containsKey("is_training"), is(true));
+        }
+
+        assertProgressComplete(jobId);
+        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertModelStatePersisted(stateDocId());
+        assertInferenceModelPersisted(jobId);
+        assertMlResultsFieldMappings(destIndex, predictionField, "double");
         assertThatAuditMessagesMatch(jobId,
             "Created analytics with analysis type [regression]",
             "Estimated memory usage for this analytics to be",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
@@ -22,9 +22,9 @@ import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 import org.elasticsearch.xpack.ml.utils.persistence.SearchAfterDocumentsIterator;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
 
@@ -35,15 +35,8 @@ public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
     TestDocsIterator(OriginSettingClient client, DataFrameAnalyticsConfig config, ExtractedFields extractedFields) {
         super(client, config.getDest().getIndex(), true);
         this.config = Objects.requireNonNull(config);
-        this.docValueFieldAndFormatPairs = buildDocValueFieldAndFormatPairs(extractedFields);
-    }
-
-    private static Map<String, String> buildDocValueFieldAndFormatPairs(ExtractedFields extractedFields) {
-        Map<String, String> docValueFieldAndFormatPairs = new HashMap<>();
-        for (ExtractedField docValueField : extractedFields.getDocValueFields()) {
-            docValueFieldAndFormatPairs.put(docValueField.getSearchField(), docValueField.getDocValueFormat());
-        }
-        return docValueFieldAndFormatPairs;
+        this.docValueFieldAndFormatPairs = extractedFields.getDocValueFields().stream()
+            .collect(Collectors.toMap(ExtractedField::getSearchField, ExtractedField::getDocValueFormat));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
@@ -22,9 +22,9 @@ import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 import org.elasticsearch.xpack.ml.utils.persistence.SearchAfterDocumentsIterator;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
 
@@ -35,8 +35,15 @@ public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
     TestDocsIterator(OriginSettingClient client, DataFrameAnalyticsConfig config, ExtractedFields extractedFields) {
         super(client, config.getDest().getIndex(), true);
         this.config = Objects.requireNonNull(config);
-        this.docValueFieldAndFormatPairs = extractedFields.getDocValueFields().stream()
-            .collect(Collectors.toMap(ExtractedField::getSearchField, ExtractedField::getDocValueFormat));
+        this.docValueFieldAndFormatPairs = buildDocValueFieldAndFormatPairs(extractedFields);
+    }
+
+    private static Map<String, String> buildDocValueFieldAndFormatPairs(ExtractedFields extractedFields) {
+        Map<String, String> docValueFieldAndFormatPairs = new HashMap<>();
+        for (ExtractedField docValueField : extractedFields.getDocValueFields()) {
+            docValueFieldAndFormatPairs.put(docValueField.getSearchField(), docValueField.getDocValueFormat());
+        }
+        return docValueFieldAndFormatPairs;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
@@ -17,7 +17,9 @@ import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -128,8 +130,16 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
             sourceBuilder.searchAfter(searchAfterValues);
         }
 
+        for (Map.Entry<String, String> docValueFieldAndFormat : docValueFieldAndFormatPairs().entrySet()) {
+            sourceBuilder.docValueField(docValueFieldAndFormat.getKey(), docValueFieldAndFormat.getValue());
+        }
+
         searchRequest.source(sourceBuilder);
         return executeSearchRequest(searchRequest);
+    }
+
+    protected Map<String, String> docValueFieldAndFormatPairs() {
+        return Collections.emptyMap();
     }
 
     protected SearchResponse executeSearchRequest(SearchRequest searchRequest) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
@@ -27,6 +27,8 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConf
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.ml.dataframe.stats.DataCountsTracker;
 import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
+import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceField;
 import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
@@ -75,6 +77,10 @@ public class InferenceRunnerTests extends ESTestCase {
     }
 
     public void testInferTestDocs() {
+        ExtractedFields extractedFields = new ExtractedFields(
+            Collections.singletonList(new SourceField("key", Collections.singleton("integer"))),
+            Collections.emptyMap());
+
         Map<String, Object> doc1 = new HashMap<>();
         doc1.put("key", 1);
         Map<String, Object> doc2 = new HashMap<>();
@@ -94,7 +100,7 @@ public class InferenceRunnerTests extends ESTestCase {
                 Collections.emptyList(),
                 config));
 
-        InferenceRunner inferenceRunner = createInferenceRunner();
+        InferenceRunner inferenceRunner = createInferenceRunner(extractedFields);
 
         inferenceRunner.inferTestDocs(localModel, testDocsIterator);
 
@@ -121,13 +127,13 @@ public class InferenceRunnerTests extends ESTestCase {
     }
 
     public void testInferTestDocs_GivenCancelWasCalled() {
-
+        ExtractedFields extractedFields = mock(ExtractedFields.class);
         LocalModel localModel = mock(LocalModel.class);
 
         TestDocsIterator infiniteDocsIterator = mock(TestDocsIterator.class);
         when(infiniteDocsIterator.hasNext()).thenReturn(true);
 
-        InferenceRunner inferenceRunner = createInferenceRunner();
+        InferenceRunner inferenceRunner = createInferenceRunner(extractedFields);
         inferenceRunner.cancel();
 
         inferenceRunner.inferTestDocs(localModel, infiniteDocsIterator);
@@ -157,8 +163,8 @@ public class InferenceRunnerTests extends ESTestCase {
         return localModel;
     }
 
-    private InferenceRunner createInferenceRunner() {
-        return new InferenceRunner(client, modelLoadingService,  resultsPersisterService, parentTaskId, config, progressTracker,
-            new DataCountsTracker());
+    private InferenceRunner createInferenceRunner(ExtractedFields extractedFields) {
+        return new InferenceRunner(client, modelLoadingService,  resultsPersisterService, parentTaskId, config, extractedFields,
+            progressTracker, new DataCountsTracker());
     }
 }


### PR DESCRIPTION
In #58877, when we switched test inference on java, we just
use the doc's `_source` as features. However, this could be
missing out on features that were used during training,
e.g. alias fields, etc.

This commit addresses this by extracting fields to use as
features during inference the same way they are extracted
in `DataFrameDataExtractor` when they are used for training.
