### PR TITLE
[7.8] [DOCS] Fix typo in LDAP config docs (#59953)

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -19,7 +19,7 @@ However, multiple bind operations might be needed to find the correct user DN.
 
 . To configure an `ldap` realm with user search:
 
-.. Add a realm configuration of to `elasticsearch.yml` under the
+.. Add a realm configuration to `elasticsearch.yml` under the
 `xpack.security.authc.realms.ldap` namespace. At a minimum, you must specify
 the `url` of the LDAP server, and set `user_search.base_dn` to the container DN
 where the users are searched for.


### PR DESCRIPTION
7.8 backport of #59953