### PR TITLE
[DOCS] Mark data stream stats API as stable

### DIFF
--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Data stream stats</titleabbrev>
 ++++
 
-experimental::[]
-
 Retrieves statistics for one or more <<data-streams,data streams>>.
 
 ////


### PR DESCRIPTION
Removes experimental admon from data stream stats API.
Relates to #59860.