### PR TITLE
Increase Timeout in testSLMRetentionAfterRestore

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -429,14 +429,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
                 // This is what we want to happen
             }
             logger.info("--> snapshot [{}] has been deleted", snapshotName);
-        });
-
-        // Cancel/delete the snapshot
-        try {
-            client().admin().cluster().prepareDeleteSnapshot(REPO, snapshotName).get();
-        } catch (SnapshotMissingException e) {
-            // ignore
-        }
+        }, 30L, TimeUnit.SECONDS);
     }
 
     private SnapshotsStatusResponse getSnapshotStatus(String snapshotName) {


### PR DESCRIPTION
This test failed by hitting the 10s default busy assert timeout.
Given how involved the retention run is (multiple disk reads, CS updates etc.)
we should have a higher timeout here.

Also, removed the pointless delete call for the snapshot that we just asserted is gone,
 at the end of the test.

Closes #59956
