### PR TITLE
[7.9] [DOCS] Mark data stream stats API as stable (#59978)

### DIFF
--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Data stream stats</titleabbrev>
 ++++
 
-experimental::[]
-
 Retrieves statistics for one or more <<data-streams,data streams>>.
 
 ////


### PR DESCRIPTION
7.9 backport of #59978