### PR TITLE
Make full text queries work against keyword scripted fields

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -26,7 +26,7 @@ abstract class AbstractScriptMappedFieldType extends MappedFieldType {
     protected final Script script;
 
     AbstractScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
-        super(name, false, false, TextSearchInfo.NONE, meta);
+        super(name, false, false, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
         this.script = script;
     }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
@@ -11,6 +11,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,12 +21,20 @@ abstract class AbstractScriptMappedFieldTypeTestCase extends ESTestCase {
         return mockContext(true);
     }
 
-    protected QueryShardContext mockContext(boolean allowExpensiveQueries) {
+    protected static QueryShardContext mockContext(boolean allowExpensiveQueries) {
+        return mockContext(allowExpensiveQueries, null);
+    }
+
+    protected static QueryShardContext mockContext(boolean allowExpensiveQueries, AbstractScriptMappedFieldType mappedFieldType) {
         MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType(anyString())).thenReturn(mappedFieldType);
         QueryShardContext context = mock(QueryShardContext.class);
+        if (mappedFieldType != null) {
+            when(context.fieldMapper(anyString())).thenReturn(mappedFieldType);
+            when(context.getSearchAnalyzer(any())).thenReturn(mappedFieldType.getTextSearchInfo().getSearchAnalyzer());
+        }
         when(context.allowExpensiveQueries()).thenReturn(allowExpensiveQueries);
         when(context.lookup()).thenReturn(new SearchLookup(mapperService, mft -> null));
         return context;
     }
-
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.store.Directory;
@@ -26,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.painless.PainlessPlugin;
 import org.elasticsearch.painless.PainlessScriptEngine;
@@ -256,15 +258,29 @@ public class ScriptKeywordMappedFieldTypeTests extends AbstractScriptMappedField
         checkExpensiveQuery((ft, ctx) -> ft.wildcardQuery(randomAlphaOfLengthBetween(1, 1000), null, ctx));
     }
 
-    private ScriptKeywordMappedFieldType build(String code) throws IOException {
+    public void testMatchQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": 1}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": 2}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptKeywordMappedFieldType fieldType = build("value(source.foo.toString() + params.param)", Map.of("param", "-Suffix"));
+                QueryShardContext queryShardContext = mockContext(true, fieldType);
+                Query query = new MatchQueryBuilder("test", "1-Suffix").toQuery(queryShardContext);
+                assertThat(searcher.count(query), equalTo(1));
+            }
+        }
+    }
+
+    private static ScriptKeywordMappedFieldType build(String code) throws IOException {
         return build(new Script(code));
     }
 
-    private ScriptKeywordMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static ScriptKeywordMappedFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, PainlessScriptEngine.NAME, code, params));
     }
 
-    private ScriptKeywordMappedFieldType build(Script script) throws IOException {
+    private static ScriptKeywordMappedFieldType build(Script script) throws IOException {
         PainlessPlugin painlessPlugin = new PainlessPlugin();
         painlessPlugin.loadExtensions(new ExtensionLoader() {
             @Override
@@ -280,7 +296,7 @@ public class ScriptKeywordMappedFieldTypeTests extends AbstractScriptMappedField
         }
     }
 
-    private void checkExpensiveQuery(BiConsumer<ScriptKeywordMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+    private static void checkExpensiveQuery(BiConsumer<ScriptKeywordMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
         ScriptKeywordMappedFieldType ft = build("value('cat')");
         Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
         assertThat(

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -199,6 +199,29 @@ setup:
   - match: {hits.hits.0._source.voltage: 5.8}
 
 ---
+"match query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              day_of_week: Monday
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              day_of_week:
+                query: Monday
+                analyzer: standard
+  - match: {hits.total.value: 0}
+
+---
 "terms query":
   - do:
       search:


### PR DESCRIPTION
The keyword scripted field should apply the keyword analyzer at all times, by providing it as part of `TextSearchInfo` to the base mapped field type class. That is because the field does not support normalization, and if we don't force the keyword analyzer the default search analyzer will get picked up which will lowercase the query etc.

Relates to #59332