### PR TITLE
Use deprecated object for accept_enterprise deprecation

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
@@ -22,8 +22,11 @@
       },
       "accept_enterprise":{
         "type":"boolean",
-        "description":"Supported for backwards compatibility with 7.x. If this param is used it must be set to true",
-        "deprecated":true
+        "description":"If this param is used it must be set to true",
+        "deprecated":{
+          "version":"8.0.0",
+          "description":"Supported for backwards compatibility with 7.x"
+        }
       }
     }
   }


### PR DESCRIPTION
This PR updates the deprecated property of accept_enterprise param on xpack.info REST API spec to indicate the version and description.

