### PR TITLE
Support transfer leader feature in elasticsearch

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -45,6 +45,8 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.TransportListTasksAction;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageAction;
 import org.elasticsearch.action.admin.cluster.node.usage.TransportNodesUsageAction;
+import org.elasticsearch.action.admin.cluster.reelect.ClusterReelectAction;
+import org.elasticsearch.action.admin.cluster.reelect.TransportClusterReelectAction;
 import org.elasticsearch.action.admin.cluster.remote.RemoteInfoAction;
 import org.elasticsearch.action.admin.cluster.remote.TransportRemoteInfoAction;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryAction;
@@ -269,6 +271,7 @@ import org.elasticsearch.rest.action.admin.cluster.RestClearVotingConfigExclusio
 import org.elasticsearch.rest.action.admin.cluster.RestClusterAllocationExplainAction;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterGetSettingsAction;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterHealthAction;
+import org.elasticsearch.rest.action.admin.cluster.RestClusterReelectAction;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterRerouteAction;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterSearchShardsAction;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterStateAction;
@@ -500,6 +503,7 @@ public class ActionModule extends AbstractModule {
         actions.register(ClusterHealthAction.INSTANCE, TransportClusterHealthAction.class);
         actions.register(ClusterUpdateSettingsAction.INSTANCE, TransportClusterUpdateSettingsAction.class);
         actions.register(ClusterRerouteAction.INSTANCE, TransportClusterRerouteAction.class);
+        actions.register(ClusterReelectAction.INSTANCE, TransportClusterReelectAction.class);
         actions.register(ClusterSearchShardsAction.INSTANCE, TransportClusterSearchShardsAction.class);
         actions.register(PendingClusterTasksAction.INSTANCE, TransportPendingClusterTasksAction.class);
         actions.register(PutRepositoryAction.INSTANCE, TransportPutRepositoryAction.class);
@@ -650,6 +654,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestClusterHealthAction());
         registerHandler.accept(new RestClusterUpdateSettingsAction());
         registerHandler.accept(new RestClusterGetSettingsAction(settings, clusterSettings, settingsFilter));
+        registerHandler.accept(new RestClusterReelectAction());
         registerHandler.accept(new RestClusterRerouteAction(settingsFilter));
         registerHandler.accept(new RestClusterSearchShardsAction());
         registerHandler.accept(new RestPendingClusterTasksAction());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectAction.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.reelect;
+
+import org.elasticsearch.action.ActionType;
+
+public class ClusterReelectAction extends ActionType<ClusterReelectResponse> {
+
+    public static final ClusterReelectAction INSTANCE = new ClusterReelectAction();
+    public static final String NAME = "cluster:admin/reelect";
+
+    private ClusterReelectAction() {
+        super(NAME, ClusterReelectResponse::new);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.reelect;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+public class ClusterReelectRequest extends AcknowledgedRequest<ClusterReelectRequest> {
+
+    public ClusterReelectRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public ClusterReelectRequest() { }
+
+    @Override
+    public ActionRequestValidationException validate() { return null; }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectRequestBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.reelect;
+
+import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class ClusterReelectRequestBuilder extends AcknowledgedRequestBuilder<ClusterReelectRequest,
+    ClusterReelectResponse, ClusterReelectRequestBuilder> {
+
+    public ClusterReelectRequestBuilder(ElasticsearchClient client, ClusterReelectAction action) {
+        super(client, action, new ClusterReelectRequest());
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/ClusterReelectResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.reelect;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Response returned after a cluster reelect request
+ */
+public class ClusterReelectResponse extends AcknowledgedResponse implements ToXContentObject {
+
+    private String message;
+
+    ClusterReelectResponse(StreamInput in) throws IOException {
+        super(in);
+        message = in.readOptionalString();
+    }
+
+    ClusterReelectResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    ClusterReelectResponse(boolean acknowledged, String message) {
+        super(acknowledged);
+        this.message = message;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(message);
+    }
+
+    @Override
+    protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
+        if (message != null && !message.isEmpty()) {
+            builder.field("message", message);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/TransportClusterReelectAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reelect/TransportClusterReelectAction.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.reelect;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.coordination.Coordinator;
+import org.elasticsearch.cluster.coordination.PreVoteRequest;
+import org.elasticsearch.cluster.coordination.PreVoteResponse;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.cluster.coordination.PreVoteCollector.REQUEST_PRE_VOTE_ACTION_NAME;
+
+public class TransportClusterReelectAction extends TransportMasterNodeAction<ClusterReelectRequest, ClusterReelectResponse> {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+    private final Discovery discovery;
+
+    @Inject
+    public TransportClusterReelectAction(TransportService transportService, ClusterService clusterService,
+                                         ThreadPool threadPool, ActionFilters actionFilters,
+                                         IndexNameExpressionResolver indexNameExpressionResolver,
+                                         Discovery discovery) throws UnsupportedOperationException {
+        super(ClusterReelectAction.NAME, transportService, clusterService, threadPool, actionFilters,
+            ClusterReelectRequest::new, indexNameExpressionResolver);
+
+        this.discovery = discovery;
+    }
+
+    @Override
+    protected String executor() {
+        // we go async right away
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected ClusterReelectResponse read(StreamInput in) throws IOException {
+        return new ClusterReelectResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(ClusterReelectRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+    @Override
+    protected void masterOperation(Task task, final ClusterReelectRequest request, final ClusterState state,
+                                   final ActionListener<ClusterReelectResponse> listener) {
+        assert discovery instanceof Coordinator;
+        final Coordinator coordinator = ((Coordinator) discovery);
+        final String[] preferredMasters = coordinator.getPreferredMasters();
+        final ClusterState lastAcceptedState = coordinator.getLastAcceptedState();
+        if (String.join(",", preferredMasters).equals("")) {
+            // preferred master has not been set, reelect randomly
+            final List<DiscoveryNode> masterCandidates = coordinator.getMasterCandidates(lastAcceptedState,
+                Arrays.asList(lastAcceptedState.getNodes().getMasterNodes().values().toArray(DiscoveryNode.class)));
+            coordinator.atomicAbdicateTo(masterCandidates.get(new Random(Randomness.get().nextLong()).nextInt(masterCandidates.size())));
+            listener.onResponse(new ClusterReelectResponse(true));
+            return;
+        }
+
+        ArrayList<DiscoveryNode> preferredNodes = new ArrayList<>();
+        for (String preferredMaster : preferredMasters) {
+            if (preferredMaster.equals(lastAcceptedState.nodes().getMasterNode().getName())) {
+                listener.onResponse(new ClusterReelectResponse(true, "preferred master node has already been elected"));
+                return;
+            }
+
+            Iterator<DiscoveryNode> iterator = lastAcceptedState.getNodes().getMasterNodes().valuesIt();
+            while (iterator.hasNext()) {
+                DiscoveryNode node = iterator.next();
+                if (node.getName().equals(preferredMaster) && Coordinator.nodeMayWinElection(lastAcceptedState, node)) {
+                    preferredNodes.add(node);
+                }
+            }
+        }
+
+        if (preferredNodes.size() == 0) {
+            listener.onResponse(new ClusterReelectResponse(false, "none of preferred master node can be elected"));
+            return;
+        }
+
+        // check prefer master's cluster state
+        AtomicInteger lagPreferredNodesCount = new AtomicInteger(0);
+        for (DiscoveryNode node : preferredNodes) {
+            // leader send preVote request to preferred master nodes and compare last accepted state version to avoid useless waiting
+            PreVoteRequest preVoteRequest = new PreVoteRequest(transportService.getLocalNode(), lastAcceptedState.term());
+            transportService.sendRequest(node, REQUEST_PRE_VOTE_ACTION_NAME, preVoteRequest,
+                new TransportResponseHandler<PreVoteResponse>() {
+                    @Override
+                    public PreVoteResponse read(StreamInput in) throws IOException {
+                        return new PreVoteResponse(in);
+                    }
+
+                    @Override
+                    public void handleResponse(PreVoteResponse response) {
+                        if (response.getLastAcceptedVersion() < lastAcceptedState.version()) {
+                            logger.info("ignoring {} from {} as cluster version is older than leader", response, node);
+                            if (lagPreferredNodesCount.incrementAndGet() == preferredNodes.size()) {
+                                listener.onResponse(new ClusterReelectResponse(false,
+                                    "none of prefer master's state is catching up with leader"));
+                            }
+                            return;
+                        }
+
+                        logger.info("the preferred master {} has the newest state", node);
+                        coordinator.atomicAbdicateTo(node);
+                        listener.onResponse(new ClusterReelectResponse(true));
+                    }
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        listener.onResponse(new ClusterReelectResponse(false, "check cluster state failed: " + exp));
+                    }
+
+                    @Override
+                    public String executor() {
+                        return ThreadPool.Names.GENERIC;
+                    }
+                });
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -469,6 +469,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             ElectionSchedulerFactory.ELECTION_DURATION_SETTING,
             Coordinator.PUBLISH_TIMEOUT_SETTING,
             Coordinator.PUBLISH_INFO_TIMEOUT_SETTING,
+            Coordinator.PREFERRED_MASTER_NAME_SETTING,
             JoinHelper.JOIN_TIMEOUT_SETTING,
             FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING,
             FollowersChecker.FOLLOWER_CHECK_INTERVAL_SETTING,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterReelectAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterReelectAction.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.action.admin.cluster.reelect.ClusterReelectAction;
+import org.elasticsearch.action.admin.cluster.reelect.ClusterReelectRequest;
+import org.elasticsearch.action.admin.cluster.reelect.ClusterReelectResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+
+public class RestClusterReelectAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() { return List.of(new Route(POST, "/_cluster/reelect")); }
+
+    @Override
+    public String getName() { return "cluster_reelect_action"; }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final ClusterReelectRequest clusterReelectRequest = new ClusterReelectRequest();
+        clusterReelectRequest.timeout(request.paramAsTime("timeout", clusterReelectRequest.timeout()));
+        clusterReelectRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterReelectRequest.masterNodeTimeout()));
+        return channel -> client.execute(ClusterReelectAction.INSTANCE, clusterReelectRequest,
+            new RestToXContentListener<ClusterReelectResponse>(channel));
+    }
+}


### PR DESCRIPTION
## Issue
Leadership transfer extension is an important feature in raft protocol. It is similar to leader abdication but it aims at switching to a pre-set node as fast as possible.  It can improve the availability of elasticsearch in the below situations:

1. In the case of a rolling restart, we shut down one node at a time. When we shut down the leader node, it takes at least 3 seconds or more downtime for the cluster to detect leader failure and elect a new leader. We can transfer the leader to a node that has been restarted before shut down the origin leader within a hundred milliseconds,  to avoid restarting the leader node. 

2. When the leader node is under heavy load but still connected with other nodes, this affects the health of the cluster. We need to switch the leader node to the new one as soon as possible instead of shutting it down and waiting for slow leader fault detection and re-election.

3. 2 master/data nodes plus one dedicated master node is a cheap and reasonable setup for many users.  The master/data nodes are only elected as leader temporarily when the dedicated master node fails down. In general situations, the low-spec dedicated master node is always elected as leader by leadership transfer extension.

## Solution
 The process of Leadership transfer extension is as follows.
1. Update cluster setting `preferred_master_name` to designate a follower as the future leader.
2. POST `_cluster/reelect` to the cluster.
3. The assigned node has the priority to become leader in the next round election. It begins to send votes to others to elect itself.
4. if the assigned node is elected as leader, the process ends. if the assigned node fails, it loses its priority, an equal election will be launched.


## Testing
Using Leadership transfer extension to avoid shutting down the active leader. Here is the test result.

|          | before optimization  | after optimization     | after optimization but the first election failed | 
|----------|----------|----------|----------| 
| downtime | 3.0-3.1s | 0.5-0.6s |1.0-1.1s    | 



