### PR TITLE
[7.9] [DOCS] Reformat snippets to use two-space indents

### DIFF
--- a/docs/java-api/docs/update.asciidoc
+++ b/docs/java-api/docs/update.asciidoc
@@ -99,8 +99,8 @@ If the document `index/_doc/1` already exists, we will have after this operation
 [source,js]
 --------------------------------------------------
 {
-    "name"  : "Joe Dalton",        <1>
-    "gender": "male"
+  "name"  : "Joe Dalton",        <1>
+  "gender": "male"
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -111,8 +111,8 @@ If it does not exist, we will have a new document:
 [source,js]
 --------------------------------------------------
 {
-    "name" : "Joe Smith",
-    "gender": "male"
+  "name" : "Joe Smith",
+  "gender": "male"
 }
 --------------------------------------------------
 // NOTCONSOLE

--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -160,11 +160,11 @@ For example, if you have a file named `config/scripts/template_gender.mustache` 
 [source,js]
 --------------------------------------------------
 {
-    "query" : {
-        "match" : {
-            "gender" : "{{param_gender}}"
-        }
+  "query" : {
+    "match" : {
+      "gender" : "{{param_gender}}"
     }
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE

--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -23,15 +23,15 @@ A `moving_avg` aggregation looks like this in isolation:
 [source,js]
 --------------------------------------------------
 {
-    "moving_avg": {
-        "buckets_path": "the_sum",
-        "model": "holt",
-        "window": 5,
-        "gap_policy": "insert_zeros",
-        "settings": {
-            "alpha": 0.8
-        }
+  "moving_avg": {
+    "buckets_path": "the_sum",
+    "model": "holt",
+    "window": 5,
+    "gap_policy": "insert_zeros",
+    "settings": {
+      "alpha": 0.8
     }
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -55,23 +55,23 @@ embedded like any other metric aggregation:
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{                <1>
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" } <2>
-                },
-                "the_movavg":{
-                    "moving_avg":{ "buckets_path": "the_sum" } <3>
-                }
-            }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {                                <1>
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }                 <2>
+        },
+        "the_movavg": {
+          "moving_avg": { "buckets_path": "the_sum" } <3>
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -91,46 +91,46 @@ An example response from the above aggregation may look like:
 [source,js]
 --------------------------------------------------
 {
-   "took": 11,
-   "timed_out": false,
-   "_shards": ...,
-   "hits": ...,
-   "aggregations": {
-      "my_date_histo": {
-         "buckets": [
-             {
-                 "key_as_string": "2015/01/01 00:00:00",
-                 "key": 1420070400000,
-                 "doc_count": 3,
-                 "the_sum": {
-                    "value": 550.0
-                 }
-             },
-             {
-                 "key_as_string": "2015/02/01 00:00:00",
-                 "key": 1422748800000,
-                 "doc_count": 2,
-                 "the_sum": {
-                    "value": 60.0
-                 },
-                 "the_movavg": {
-                    "value": 550.0
-                 }
-             },
-             {
-                 "key_as_string": "2015/03/01 00:00:00",
-                 "key": 1425168000000,
-                 "doc_count": 2,
-                 "the_sum": {
-                    "value": 375.0
-                 },
-                 "the_movavg": {
-                    "value": 305.0
-                 }
-             }
-         ]
-      }
-   }
+  "took": 11,
+  "timed_out": false,
+  "_shards": ...,
+  "hits": ...,
+  "aggregations": {
+    "my_date_histo": {
+      "buckets": [
+        {
+          "key_as_string": "2015/01/01 00:00:00",
+          "key": 1420070400000,
+          "doc_count": 3,
+          "the_sum": {
+            "value": 550.0
+          }
+        },
+        {
+          "key_as_string": "2015/02/01 00:00:00",
+          "key": 1422748800000,
+          "doc_count": 2,
+          "the_sum": {
+            "value": 60.0
+          },
+          "the_movavg": {
+            "value": 550.0
+          }
+        },
+        {
+          "key_as_string": "2015/03/01 00:00:00",
+          "key": 1425168000000,
+          "doc_count": 2,
+          "the_sum": {
+            "value": 375.0
+          },
+          "the_movavg": {
+            "value": 305.0
+          }
+        }
+      ]
+    }
+  }
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"took": 11/"took": $body.took/]
@@ -157,27 +157,27 @@ the values from a `simple` moving average tend to "lag" behind the real data.
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg":{
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "simple"
-                    }
-                }
-            }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "simple"
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -210,27 +210,27 @@ the "lag" behind the data's mean, since older points have less influence.
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "linear"
-                    }
-                }
-            }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "linear"
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -269,30 +269,30 @@ The EWMA model can be <<movavg-minimizer, Minimized>>
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "ewma",
-                        "settings" : {
-                            "alpha" : 0.5
-                        }
-                    }
-                }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "ewma",
+            "settings": {
+              "alpha": 0.5
             }
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -327,31 +327,31 @@ The Holt-Linear model can be <<movavg-minimizer, Minimized>>
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "holt",
-                        "settings" : {
-                            "alpha" : 0.5,
-                            "beta" : 0.5
-                        }
-                    }
-                }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "holt",
+            "settings": {
+              "alpha": 0.5,
+              "beta": 0.5
             }
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -415,34 +415,34 @@ The additive Holt-Winters model can be <<movavg-minimizer, Minimized>>
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "holt_winters",
-                        "settings" : {
-                            "type" : "add",
-                            "alpha" : 0.5,
-                            "beta" : 0.5,
-                            "gamma" : 0.5,
-                            "period" : 7
-                        }
-                    }
-                }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "holt_winters",
+            "settings": {
+              "type": "add",
+              "alpha": 0.5,
+              "beta": 0.5,
+              "gamma": 0.5,
+              "period": 7
             }
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -475,35 +475,35 @@ you can disable this behavior with `pad: false`
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "holt_winters",
-                        "settings" : {
-                            "type" : "mult",
-                            "alpha" : 0.5,
-                            "beta" : 0.5,
-                            "gamma" : 0.5,
-                            "period" : 7,
-                            "pad" : true
-                        }
-                    }
-                }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "holt_winters",
+            "settings": {
+              "type": "mult",
+              "alpha": 0.5,
+              "beta": 0.5,
+              "gamma": 0.5,
+              "period": 7,
+              "pad": true
             }
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -524,28 +524,28 @@ as your buckets:
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "window" : 30,
-                        "model" : "simple",
-                        "predict" : 10
-                    }
-                }
-            }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "window": 30,
+            "model": "simple",
+            "predict": 10
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]
@@ -602,31 +602,31 @@ Minimization is enabled/disabled via the `minimize` parameter:
 --------------------------------------------------
 POST /_search
 {
-    "size": 0,
-    "aggs": {
-        "my_date_histo":{
-            "date_histogram":{
-                "field":"date",
-                "calendar_interval":"1M"
-            },
-            "aggs":{
-                "the_sum":{
-                    "sum":{ "field": "price" }
-                },
-                "the_movavg": {
-                    "moving_avg":{
-                        "buckets_path": "the_sum",
-                        "model" : "holt_winters",
-                        "window" : 30,
-                        "minimize" : true,  <1>
-                        "settings" : {
-                            "period" : 7
-                        }
-                    }
-                }
+  "size": 0,
+  "aggs": {
+    "my_date_histo": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "1M"
+      },
+      "aggs": {
+        "the_sum": {
+          "sum": { "field": "price" }
+        },
+        "the_movavg": {
+          "moving_avg": {
+            "buckets_path": "the_sum",
+            "model": "holt_winters",
+            "window": 30,
+            "minimize": true,  <1>
+            "settings": {
+              "period": 7
             }
+          }
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[setup:sales]

--- a/docs/reference/mapping/params/boost.asciidoc
+++ b/docs/reference/mapping/params/boost.asciidoc
@@ -33,13 +33,13 @@ You can achieve the same effect by using the boost parameter directly in the que
 --------------------------------------------------
 POST _search
 {
-    "query": {
-        "match" : {
-            "title": {
-                "query": "quick brown fox"
-            }
-        }
+  "query": {
+    "match": {
+      "title": {
+        "query": "quick brown fox"
+      }
     }
+  }
 }
 --------------------------------------------------
 
@@ -49,14 +49,14 @@ is equivalent to:
 --------------------------------------------------
 POST _search
 {
-    "query": {
-        "match" : {
-            "title": {
-                "query": "quick brown fox",
-                "boost": 2
-            }
-        }
+  "query": {
+    "match": {
+      "title": {
+        "query": "quick brown fox",
+        "boost": 2
+      }
     }
+  }
 }
 --------------------------------------------------
 

--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -564,9 +564,9 @@ in 7.0 the endpoint will immediately follow the index name:
 --------------------------------------------------
 POST index/_update/1
 {
-    "doc" : {
-        "foo" : "qux"
-    }
+  "doc" : {
+    "foo" : "qux"
+  }
 }
 
 GET /index/_source/1
@@ -620,16 +620,16 @@ GET index/_doc/1
 [source,console-result]
 --------------------------------------------------
 {
-    "_index" : "index",
-    "_type" : "_doc",
-    "_id" : "1",
-    "_version" : 1,
-    "_seq_no" : 0,
-    "_primary_term" : 1,
-    "found": true,
-    "_source" : {
-        "foo" : "baz"
-    }
+  "_index" : "index",
+  "_type" : "_doc",
+  "_id" : "1",
+  "_version" : 1,
+  "_seq_no" : 0,
+  "_primary_term" : 1,
+  "found": true,
+  "_source" : {
+    "foo" : "baz"
+  }
 }
 --------------------------------------------------
 

--- a/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
+++ b/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
@@ -240,14 +240,14 @@ The following `my_index_1` index contains a mapping for the `datetime` field, a
 --------------------------------------------------
 PUT my_index_1
 {
-    "mappings" : {
-      "properties" : {
-         "datetime": {
-           "type": "date",
-           "format": "yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis"
-         }
+  "mappings": {
+    "properties": {
+      "datetime": {
+        "type": "date",
+        "format": "yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis"
       }
     }
+  }
 }
 --------------------------------------------------
 ////
@@ -323,10 +323,10 @@ If you use index aliases, update them to point to the new index.
 --------------------------------------------------
 POST /_aliases
 {
-    "actions" : [
-        { "remove" : { "index" : "my_index_1", "alias" : "my_index" } },
-        { "add" : { "index" : "my_index_2", "alias" : "my_index" } }
-    ]
+  "actions" : [
+    { "remove" : { "index" : "my_index_1", "alias" : "my_index" } },
+    { "add" : { "index" : "my_index_2", "alias" : "my_index" } }
+  ]
 }
 --------------------------------------------------
 // TEST[continued]

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -69,9 +69,9 @@ the older round robin of search requests, you can use the
 --------------------------------------------------
 PUT /_cluster/settings
 {
-    "transient": {
-        "cluster.routing.use_adaptive_replica_selection": false
-    }
+  "transient": {
+    "cluster.routing.use_adaptive_replica_selection": false
+  }
 }
 --------------------------------------------------
 
@@ -232,13 +232,13 @@ match and `relation` indicates whether the value is accurate (`eq`) or a lower b
 [source,js]
 --------------------------------------------------
 {
-    "hits": {
-        "total": {  
-            "value": 1000,
-            "relation": "eq"
-        },
-        ...
-    }
+  "hits": {
+    "total": {
+      "value": 1000,
+      "relation": "eq"
+    },
+    ...
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -273,17 +273,17 @@ documents. If the total number of hits that match the query is greater than this
 [source,js]
 --------------------------------------------------
 {
-     "_shards": ...
-     "timed_out": false,
-     "took": 100,
-     "hits": {
-         "max_score": 1.0,
-         "total" : {
-             "value": 10000,    <1>
-             "relation": "gte"  <2>
-         },
-         "hits": ...
-     }
+  "_shards": ...
+  "timed_out": false,
+  "took": 100,
+  "hits": {
+    "max_score": 1.0,
+    "total": {
+      "value": 10000,    <1>
+      "relation": "gte"  <2>
+    },
+    "hits": ...
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE

--- a/docs/reference/query-dsl/common-terms-query.asciidoc
+++ b/docs/reference/query-dsl/common-terms-query.asciidoc
@@ -74,14 +74,14 @@ In this example, words that have a document frequency greater than 0.1%
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "common": {
-            "body": {
-                "query": "this is bonsai cool",
-                "cutoff_frequency": 0.001
-            }
-        }
+  "query": {
+    "common": {
+      "body": {
+        "query": "this is bonsai cool",
+        "cutoff_frequency": 0.001
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [common] used, replaced by [[match] query which can efficiently skip blocks of documents if the total number of hits is not tracked]]
@@ -98,15 +98,15 @@ all terms required:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "common": {
-            "body": {
-                "query": "nelly the elephant as a cartoon",
-                "cutoff_frequency": 0.001,
-                "low_freq_operator": "and"
-            }
-        }
+  "query": {
+    "common": {
+      "body": {
+        "query": "nelly the elephant as a cartoon",
+        "cutoff_frequency": 0.001,
+        "low_freq_operator": "and"
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [common] used, replaced by [[match] query which can efficiently skip blocks of documents if the total number of hits is not tracked]]
@@ -117,20 +117,20 @@ which is roughly equivalent to:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "bool": {
-            "must": [
-            { "term": { "body": "nelly"}},
-            { "term": { "body": "elephant"}},
-            { "term": { "body": "cartoon"}}
-            ],
-            "should": [
-            { "term": { "body": "the"}},
-            { "term": { "body": "as"}},
-            { "term": { "body": "a"}}
-            ]
-        }
+  "query": {
+    "bool": {
+      "must": [
+      { "term": { "body": "nelly"}},
+      { "term": { "body": "elephant"}},
+      { "term": { "body": "cartoon"}}
+      ],
+      "should": [
+      { "term": { "body": "the"}},
+      { "term": { "body": "as"}},
+      { "term": { "body": "a"}}
+      ]
     }
+  }
 }
 --------------------------------------------------
 
@@ -143,15 +143,15 @@ must be present, for instance:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "common": {
-            "body": {
-                "query": "nelly the elephant as a cartoon",
-                "cutoff_frequency": 0.001,
-                "minimum_should_match": 2
-            }
-        }
+  "query": {
+    "common": {
+      "body": {
+        "query": "nelly the elephant as a cartoon",
+        "cutoff_frequency": 0.001,
+        "minimum_should_match": 2
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [common] used, replaced by [[match] query which can efficiently skip blocks of documents if the total number of hits is not tracked]]
@@ -162,25 +162,25 @@ which is roughly equivalent to:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
+  "query": {
+    "bool": {
+      "must": {
         "bool": {
-            "must": {
-                "bool": {
-                    "should": [
-                    { "term": { "body": "nelly"}},
-                    { "term": { "body": "elephant"}},
-                    { "term": { "body": "cartoon"}}
-                    ],
-                    "minimum_should_match": 2
-                }
-            },
-            "should": [
-                { "term": { "body": "the"}},
-                { "term": { "body": "as"}},
-                { "term": { "body": "a"}}
-                ]
+          "should": [
+            { "term": { "body": "nelly"}},
+            { "term": { "body": "elephant"}},
+            { "term": { "body": "cartoon"}}
+          ],
+          "minimum_should_match": 2
         }
+      },
+      "should": [
+        { "term": { "body": "the"}},
+        { "term": { "body": "as"}},
+        { "term": { "body": "a"}}
+      ]
     }
+  }
 }
 --------------------------------------------------
 
@@ -194,18 +194,18 @@ additional parameters (note the change in structure):
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "common": {
-            "body": {
-                "query": "nelly the elephant not as a cartoon",
-                "cutoff_frequency": 0.001,
-                "minimum_should_match": {
-                    "low_freq" : 2,
-                    "high_freq" : 3
-                }
-            }
+  "query": {
+    "common": {
+      "body": {
+        "query": "nelly the elephant not as a cartoon",
+        "cutoff_frequency": 0.001,
+        "minimum_should_match": {
+          "low_freq": 2,
+          "high_freq": 3
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [common] used, replaced by [[match] query which can efficiently skip blocks of documents if the total number of hits is not tracked]]
@@ -216,31 +216,31 @@ which is roughly equivalent to:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
+  "query": {
+    "bool": {
+      "must": {
         "bool": {
-            "must": {
-                "bool": {
-                    "should": [
-                    { "term": { "body": "nelly"}},
-                    { "term": { "body": "elephant"}},
-                    { "term": { "body": "cartoon"}}
-                    ],
-                    "minimum_should_match": 2
-                }
-            },
-            "should": {
-                "bool": {
-                    "should": [
-                    { "term": { "body": "the"}},
-                    { "term": { "body": "not"}},
-                    { "term": { "body": "as"}},
-                    { "term": { "body": "a"}}
-                    ],
-                    "minimum_should_match": 3
-                }
-            }
+          "should": [
+            { "term": { "body": "nelly"}},
+            { "term": { "body": "elephant"}},
+            { "term": { "body": "cartoon"}}
+          ],
+          "minimum_should_match": 2
         }
+      },
+      "should": {
+        "bool": {
+          "should": [
+            { "term": { "body": "the"}},
+            { "term": { "body": "not"}},
+            { "term": { "body": "as"}},
+            { "term": { "body": "a"}}
+          ],
+          "minimum_should_match": 3
+        }
+      }
     }
+  }
 }
 --------------------------------------------------
 
@@ -254,18 +254,18 @@ for high frequency terms is when there are only high frequency terms:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "common": {
-            "body": {
-                "query": "how not to be",
-                "cutoff_frequency": 0.001,
-                "minimum_should_match": {
-                    "low_freq" : 2,
-                    "high_freq" : 3
-                }
-            }
+  "query": {
+    "common": {
+      "body": {
+        "query": "how not to be",
+        "cutoff_frequency": 0.001,
+        "minimum_should_match": {
+          "low_freq": 2,
+          "high_freq": 3
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [common] used, replaced by [[match] query which can efficiently skip blocks of documents if the total number of hits is not tracked]]
@@ -276,17 +276,17 @@ which is roughly equivalent to:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "bool": {
-            "should": [
-            { "term": { "body": "how"}},
-            { "term": { "body": "not"}},
-            { "term": { "body": "to"}},
-            { "term": { "body": "be"}}
-            ],
-            "minimum_should_match": "3<50%"
-        }
+  "query": {
+    "bool": {
+      "should": [
+        { "term": { "body": "how"}},
+        { "term": { "body": "not"}},
+        { "term": { "body": "to"}},
+        { "term": { "body": "be"}}
+      ],
+      "minimum_should_match": "3<50%"
     }
+  }
 }
 --------------------------------------------------
 

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -283,14 +283,14 @@ Here is an example showing a query composed of stopwords exclusively:
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "match" : {
-            "message" : {
-                "query" : "to be or not to be",
-                "cutoff_frequency" : 0.001
-            }
-        }
+  "query": {
+    "match": {
+      "message": {
+        "query": "to be or not to be",
+        "cutoff_frequency": 0.001
+      }
     }
+  }
 }
 --------------------------------------------------
 // TEST[warning:Deprecated field [cutoff_frequency] used, replaced by [you can omit this option, the [match] query can skip block of documents efficiently if the total number of hits is not tracked]]

--- a/docs/reference/query-dsl/type-query.asciidoc
+++ b/docs/reference/query-dsl/type-query.asciidoc
@@ -9,10 +9,10 @@ Filters documents matching the provided document / mapping type.
 --------------------------------------------------
 GET /_search
 {
-    "query": {
-        "type" : {
-            "value" : "_doc"
-        }
+  "query": {
+    "type": {
+      "value": "_doc"
     }
-}    
+  }
+}
 --------------------------------------------------


### PR DESCRIPTION
Reformats several snippets in the docs to use two-space indentation.

No substantive changes were made to the snippets.