### PR TITLE
[7.x] [DOCS] Correct the default value of `ignore_throttled` param (#60036)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -388,7 +388,7 @@ end::if_seq_no[]
 tag::ignore_throttled[]
 `ignore_throttled`::
 (Optional, boolean) If `true`, concrete, expanded or aliased indices are
-ignored when frozen.
+ignored when frozen. Defaults to `true`.
 end::ignore_throttled[]
 
 tag::index-ignore-unavailable[]

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -81,7 +81,7 @@ Defaults to `open`.
 `ignore_throttled`::
 (Optional, boolean)
 If `true`, concrete, expanded or aliased indices are ignored when frozen.
-Defaults to `false`.
+Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -68,7 +68,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 `ignore_throttled`::
   (Optional, boolean) If `true`, specified concrete, expanded or aliased indices 
-  are not included in the response when throttled. Defaults to `false`. 
+  are not included in the response when throttled. Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -107,7 +107,7 @@ As an alternative to deep paging, we recommend using
 
 `ignore_throttled`::
 (Optional, boolean) If `true`, concrete, expanded or aliased indices will be
-ignored when frozen. Defaults to `false`.
+ignored when frozen. Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 


### PR DESCRIPTION
7.x backport of #60036