### PR TITLE
[7.8] [DOCS] Correct the default value of `ignore_throttled` param (#60036)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -383,7 +383,7 @@ end::if_seq_no[]
 tag::ignore_throttled[]
 `ignore_throttled`::
 (Optional, boolean) If `true`, concrete, expanded or aliased indices are
-ignored when frozen.
+ignored when frozen. Defaults to `true`.
 end::ignore_throttled[]
 
 tag::index-ignore-unavailable[]

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -72,7 +72,7 @@ Defaults to `open`.
 `ignore_throttled`::
 (Optional, boolean)
 If `true`, concrete, expanded or aliased indices are ignored when frozen.
-Defaults to `false`.
+Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -68,7 +68,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 `ignore_throttled`::
   (Optional, boolean) If `true`, specified concrete, expanded or aliased indices 
-  are not included in the response when throttled. Defaults to `false`. 
+  are not included in the response when throttled. Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -101,7 +101,7 @@ As an alternative to deep paging, we recommend using
 
 `ignore_throttled`::
 (Optional, boolean) If `true`, concrete, expanded or aliased indices will be
-ignored when frozen. Defaults to `false`.
+ignored when frozen. Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 


### PR DESCRIPTION
7.8 backport of #60036