### PR TITLE
[DOCS] Fix security links in machine learning APIs

### DIFF
--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -20,7 +20,7 @@ Returns configuration and usage information about {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs}/setup.html[Set up {ml-features}].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[cat-anomaly-detectors-desc]]

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -20,7 +20,7 @@ Returns configuration and usage information about {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs}/setup.html[Set up {ml-features}].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[cat-datafeeds-desc]]

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -25,7 +25,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and {ml-docs}/setup.html[Set up {ml-features}].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 ////

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -23,8 +23,7 @@ privileges:
 
 * cluster: `monitor_ml`
 
-For more information, see <<security-privileges>> and 
-{ml-docs}/setup.html[Set up {ml-features}].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 ////

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -8,6 +8,7 @@
 :es-repo-dir:           {elasticsearch-root}/docs/reference
 
 include::../Versions.asciidoc[]
+include::links.asciidoc[]
 
 include::intro.asciidoc[]
 

--- a/docs/reference/links.asciidoc
+++ b/docs/reference/links.asciidoc
@@ -1,0 +1,4 @@
+// These attributes define common links in the Elasticsearch Reference
+
+:ml-docs-setup:            {ml-docs}/setup.html[Set up {ml-features}]
+:ml-docs-setup-privileges: {ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges]

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -26,7 +26,8 @@ operations, but you can still explore and navigate results.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 * Before you can close an {anomaly-job}, you must stop its {dfeed}. See
 <<ml-stop-datafeed>>.
 

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -26,8 +26,7 @@ operations, but you can still explore and navigate results.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 * Before you can close an {anomaly-job}, you must stop its {dfeed}. See
 <<ml-stop-datafeed>>.
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -18,8 +18,7 @@ Deletes scheduled events from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -18,7 +18,8 @@ Deletes scheduled events from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -18,8 +18,7 @@ Deletes {anomaly-jobs} from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -18,7 +18,8 @@ Deletes {anomaly-jobs} from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -18,8 +18,7 @@ Deletes a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -18,7 +18,8 @@ Deletes a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -22,8 +22,7 @@ Deletes an existing {dfeed}.
 can delete it.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-datafeed-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -22,7 +22,8 @@ Deletes an existing {dfeed}.
 can delete it.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-datafeed-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -20,7 +20,8 @@ Deletes expired and unused machine learning data.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-expired-data-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -20,8 +20,7 @@ Deletes expired and unused machine learning data.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-expired-data-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -18,8 +18,7 @@ Deletes a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -18,7 +18,8 @@ Deletes a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -22,7 +22,8 @@ Deletes forecasts from a {ml} job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-forecast-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -22,8 +22,7 @@ Deletes forecasts from a {ml} job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-forecast-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -17,7 +17,8 @@ Deletes an existing {anomaly-job}.
 == {api-prereq-title}
 
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See <<security-privileges>>.
+cluster privileges to use this API. See <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 * Before you can delete a job, you must delete the {dfeeds} that are associated
 with it. See <<ml-delete-datafeed>>.
 * Before you can delete a job, you must close it (unless you specify the `force` parameter). See <<ml-close-job>>.

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -18,7 +18,7 @@ Deletes an existing {anomaly-job}.
 
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 * Before you can delete a job, you must delete the {dfeeds} that are associated
 with it. See <<ml-delete-datafeed>>.
 * Before you can delete a job, you must close it (unless you specify the `force` parameter). See <<ml-close-job>>.

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -17,7 +17,8 @@ Deletes an existing model snapshot.
 == {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See <<security-privileges>>.
+`manage` cluster privileges to use this API. See <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-delete-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -18,7 +18,7 @@ Deletes an existing model snapshot.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-delete-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
@@ -19,12 +19,12 @@ fields it references.
 [[ml-estimate-model-memory-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-equivalent privileges:
+If the {es} {security-features} are enabled, you must have the following privileges:
 
 * `manage_ml` or cluster: `manage`
 
-For more information, see <<security-privileges>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-estimate-model-memory-request-body]]

--- a/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
@@ -24,7 +24,7 @@ If the {es} {security-features} are enabled, you must have the following privile
 * `manage_ml` or cluster: `manage`
 
 For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 
 [[ml-estimate-model-memory-request-body]]

--- a/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
@@ -23,7 +23,8 @@ suitable to be ingested into {es}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml` or
 `monitor` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-find-file-structure-desc]]

--- a/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
@@ -24,7 +24,7 @@ suitable to be ingested into {es}.
 * If the {es} {security-features} are enabled, you must have `monitor_ml` or
 `monitor` cluster privileges to use this API. See
 <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 
 [[ml-find-file-structure-desc]]

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -18,8 +18,7 @@ Forces any buffered data to be processed by the job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-flush-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -18,7 +18,8 @@ Forces any buffered data to be processed by the job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-flush-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -18,7 +18,8 @@ Predicts the future behavior of a time series by using its historical behavior.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-forecast-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -18,14 +18,13 @@ Predicts the future behavior of a time series by using its historical behavior.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-forecast-desc]]
 == {api-description-title}
 
 You can create a forecast job based on an {anomaly-job} to extrapolate future 
-behavior. Refer to 
+behavior. Refer to
 {ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future] and 
 {ml-docs}/ml-limitations.html#ml-forecast-limitations[forecast limitations] to 
 learn more.

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -22,9 +22,9 @@ Retrieves {anomaly-job} results for one or more buckets.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. For more information, see
-<<security-privileges>> and
-<<built-in-roles>>.
+privileges. For more information, see <<security-privileges>>,
+<<built-in-roles>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-bucket-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -23,8 +23,7 @@ Retrieves {anomaly-job} results for one or more buckets.
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. For more information, see <<security-privileges>>,
-<<built-in-roles>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<built-in-roles>>, and {ml-docs-setup-privileges}.
 
 [[ml-get-bucket-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -20,7 +20,8 @@ Retrieves information about the scheduled events in calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -20,8 +20,7 @@ Retrieves information about the scheduled events in calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -20,8 +20,7 @@ Retrieves configuration information for calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -20,7 +20,8 @@ Retrieves configuration information for calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -23,7 +23,7 @@ Retrieves {anomaly-job} results for one or more categories.
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-get-category-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -22,8 +22,8 @@ Retrieves {anomaly-job} results for one or more categories.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>> and
-<<built-in-roles>>.
+privileges. See <<security-privileges>>, <<built-in-roles>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-category-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -26,7 +26,8 @@ Retrieves usage information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-datafeed-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -26,8 +26,7 @@ Retrieves usage information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-datafeed-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -26,7 +26,8 @@ Retrieves configuration information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -26,8 +26,7 @@ Retrieves configuration information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -20,7 +20,8 @@ Retrieves filters.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -20,8 +20,7 @@ Retrieves filters.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -21,7 +21,7 @@ Retrieves {anomaly-job} results for one or more influencers.
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-get-influencer-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -20,8 +20,8 @@ Retrieves {anomaly-job} results for one or more influencers.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>> and
-<<built-in-roles>>.
+privileges. See <<security-privileges>>, <<built-in-roles>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-influencer-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -24,7 +24,8 @@ Retrieves usage information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-job-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -24,8 +24,7 @@ Retrieves usage information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-job-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -24,8 +24,7 @@ Retrieves configuration information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -24,7 +24,8 @@ Retrieves configuration information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -21,8 +21,8 @@ Returns defaults and limits used by machine learning.
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>> and
-<<built-in-roles>>.
+privileges. See <<security-privileges>>, <<built-in-roles>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[get-ml-info-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -22,7 +22,7 @@ Returns defaults and limits used by machine learning.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. See <<security-privileges>>, <<built-in-roles>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[get-ml-info-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -25,7 +25,8 @@ Retrieves overall bucket results that summarize the bucket results of multiple
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>> and <<built-in-roles>>.
+privileges. See <<security-privileges>>, <<built-in-roles>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-overall-buckets-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -26,7 +26,7 @@ Retrieves overall bucket results that summarize the bucket results of multiple
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-get-overall-buckets-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -21,7 +21,7 @@ Retrieves anomaly records for an {anomaly-job}.
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-get-record-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -20,7 +20,8 @@ Retrieves anomaly records for an {anomaly-job}.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>> and <<built-in-roles>>.
+privileges. See <<security-privileges>>, <<built-in-roles>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-record-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -20,8 +20,7 @@ Retrieves information about model snapshots.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-snapshot-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -20,7 +20,8 @@ Retrieves information about model snapshots.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-snapshot-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -18,8 +18,7 @@ Opens one or more {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-open-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -18,7 +18,8 @@ Opens one or more {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-open-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -18,8 +18,7 @@ Posts scheduled events in a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-post-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -18,7 +18,8 @@ Posts scheduled events in a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-post-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -18,7 +18,8 @@ Sends data to an anomaly detection job for analysis.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-post-data-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -18,8 +18,7 @@ Sends data to an anomaly detection job for analysis.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-post-data-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -20,8 +20,7 @@ Previews a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `monitor_ml`, `monitor`,
 `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-preview-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -20,7 +20,8 @@ Previews a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `monitor_ml`, `monitor`,
 `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-preview-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -18,7 +18,8 @@ Adds an {anomaly-job} to a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-put-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -18,8 +18,7 @@ Adds an {anomaly-job} to a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-put-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -18,8 +18,7 @@ Instantiates a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-put-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -18,7 +18,8 @@ Instantiates a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-put-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -21,7 +21,8 @@ Instantiates a {dfeed}.
 * You must create an {anomaly-job} before you create a {dfeed}.  
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-put-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -20,9 +20,8 @@ Instantiates a {dfeed}.
 
 * You must create an {anomaly-job} before you create a {dfeed}.  
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+cluster privileges to use this API. See <<security-privileges>> and
+{ml-docs-setup-privileges}.
 
 [[ml-put-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -18,7 +18,8 @@ Instantiates a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-put-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -18,8 +18,7 @@ Instantiates a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-put-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -18,7 +18,8 @@ Instantiates an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-put-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -18,8 +18,7 @@ Instantiates an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-put-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -19,7 +19,8 @@ Reverts to a specific snapshot.
 * Before you revert to a saved snapshot, you must close the job.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-revert-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -19,8 +19,7 @@ Reverts to a specific snapshot.
 * Before you revert to a saved snapshot, you must close the job.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-revert-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
@@ -29,7 +29,8 @@ POST /_ml/set_upgrade_mode?enabled=false&timeout=10m
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-set-upgrade-mode-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
@@ -29,8 +29,7 @@ POST /_ml/set_upgrade_mode?enabled=false&timeout=10m
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-set-upgrade-mode-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -22,7 +22,8 @@ Starts one or more {dfeeds}.
 error occurs.
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-start-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -22,8 +22,7 @@ Starts one or more {dfeeds}.
 error occurs.
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-start-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -24,7 +24,8 @@ Stops one or more {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-stop-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -24,8 +24,7 @@ Stops one or more {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-stop-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -22,8 +22,7 @@ Updates certain properties of a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `manage_ml`, or `manage`
 cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-update-datafeed-desc]]

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -22,7 +22,8 @@ Updates certain properties of a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `manage_ml`, or `manage`
 cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-update-datafeed-desc]]

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -18,8 +18,7 @@ Updates the description of a filter, adds items, or removes items.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-update-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -18,7 +18,8 @@ Updates the description of a filter, adds items, or removes items.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-update-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -18,8 +18,7 @@ Updates certain properties of an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-update-job-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -18,7 +18,8 @@ Updates certain properties of an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-update-job-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -18,7 +18,8 @@ Updates certain properties of a snapshot.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-update-snapshot-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -18,8 +18,7 @@ Updates certain properties of a snapshot.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-update-snapshot-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -18,8 +18,7 @@ Validates detector configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-valid-detector-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -18,7 +18,8 @@ Validates detector configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-valid-detector-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -18,8 +18,7 @@ Validates {anomaly-job} configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-valid-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -18,7 +18,8 @@ Validates {anomaly-job} configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-<<security-privileges>>.
+<<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-valid-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -25,9 +25,9 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
 
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -26,8 +26,7 @@ built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 
-For more information, see <<built-in-roles>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -27,8 +27,7 @@ built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 
-For more information, see <<built-in-roles>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 
 
 [[ml-delete-inference-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -26,9 +26,9 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
 
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-delete-inference-path-params]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -27,8 +27,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-evaluate-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -27,7 +27,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-evaluate-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -33,8 +33,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-explain-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -33,7 +33,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-explain-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -33,7 +33,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-dfanalytics-stats-path-params]]
 == {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -33,8 +33,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-dfanalytics-stats-path-params]]
 == {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -32,8 +32,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -32,7 +32,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -33,9 +33,9 @@ If the {es} {security-features} are enabled, you must have the following
 privileges:
 
 * cluster: `monitor_ml`
-  
-For more information, see <<security-privileges>> and <<built-in-roles>>.
 
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-get-inference-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -34,8 +34,7 @@ privileges:
 
 * cluster: `monitor_ml`
 
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-inference-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -34,8 +34,7 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-get-inference-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -34,7 +34,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<security-privileges>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-get-inference-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ built-in roles and privileges:
 * destination index: `read`, `create_index`, `manage` and `index`
   
 For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -24,14 +24,12 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
-
-
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
-* cluster: `monitor` (UI only)
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>>, <<security-privileges>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
 the time of creation. When you start the job, it performs the analysis using

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -28,11 +28,12 @@ experimental[]
 == {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following
-built-in roles and privileges:
+built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-put-inference-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -32,8 +32,7 @@ built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 
-For more information, see <<built-in-roles>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 
 
 [[ml-put-inference-desc]]

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -24,14 +24,11 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
-
-
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
-* cluster: `monitor` (UI only)
-  
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+
+For more information, see <<built-in-roles>>, <<security-privileges>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 [[ml-start-dfanalytics-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ built-in roles and privileges:
 * destination index: `read`, `create_index`, `manage` and `index`
 
 For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 [[ml-start-dfanalytics-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -29,8 +29,7 @@ built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
   
-For more information, see <<built-in-roles>> and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 
 
 [[ml-stop-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -28,9 +28,9 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>> and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[ml-stop-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -24,14 +24,11 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `machine_learning_admin`
-* `kibana_admin` (UI only)
-
-
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
-* cluster: `monitor` (UI only)
   
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>>, <<security-privileges>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
 the time of creation. When you start the job, it performs the analysis using

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ built-in roles and privileges:
 * destination index: `read`, `create_index`, `manage` and `index`
   
 For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
 the time of creation. When you start the job, it performs the analysis using

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -26,7 +26,7 @@ built-in roles and privileges:
 * destination index: `read`, `create_index`, `manage` and `index`
 
 For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+{ml-docs-setup-privileges}.
 
 
 [[put-transform-desc]]

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -22,13 +22,11 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `transform_admin`
-* `kibana_admin` (UI only)
-
 * source index: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
-* cluster: `monitor` (UI only)
 
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+For more information, see <<built-in-roles>>, <<security-privileges>>, and
+{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
 
 
 [[put-transform-desc]]

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -111,8 +111,7 @@ use of the {ml} APIs. Grants `manage_ml` cluster privileges, read access to
 `.ml-anomalies*`, `.ml-notifications*`, `.ml-state*`, `.ml-meta*` indices and
 write access to `.ml-annotations*` indices. {ml-cap} administrators also need
 index privileges for source and destination indices and roles that grant
-access to {kib}.
-See {ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+access to {kib}. See {ml-docs-setup-privileges}.
 
 [[built-in-roles-ml-user]] `machine_learning_user`::
 Grants the minimum privileges required to view {ml} configuration,
@@ -120,8 +119,7 @@ status, and work with results. This role grants `monitor_ml` cluster privileges,
 read access to the `.ml-notifications` and `.ml-anomalies*` indices
 (which store {ml} results), and write access to `.ml-annotations*` indices.
 {ml-cap} users also need index privileges for source and destination
-indices and roles that grant access to {kib}. See
-{ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges].
+indices and roles that grant access to {kib}. See {ml-docs-setup-privileges}.
 
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/1303

This PR removes the "UI only" items from the prerequisites in some data frame analytics API pages.
It also adds a link from each of the machine learning API pages to the list of machine learning security requirements (https://www.elastic.co/guide/en/machine-learning/current/setup.html#setup-privileges). Since it is a "cross document link" that is used many places and its URL might change during the documentation redesign, I've added an attribute for this link.