### PR TITLE
[7.9] Include the resolve index action in the view_index_metadata privilege

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
 import org.elasticsearch.action.admin.indices.close.CloseIndexAction;
 import org.elasticsearch.action.admin.indices.create.AutoCreateAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.elasticsearch.xpack.core.action.CreateDataStreamAction;
 import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.elasticsearch.xpack.core.action.GetDataStreamAction;
@@ -69,7 +70,7 @@ public final class IndexPrivilege extends Privilege {
     private static final Automaton VIEW_METADATA_AUTOMATON = patterns(GetAliasesAction.NAME, AliasesExistAction.NAME,
         GetIndexAction.NAME, IndicesExistsAction.NAME, GetFieldMappingsAction.NAME + "*", GetMappingsAction.NAME,
         ClusterSearchShardsAction.NAME, TypesExistsAction.NAME, ValidateQueryAction.NAME + "*", GetSettingsAction.NAME,
-        ExplainLifecycleAction.NAME, GetDataStreamAction.NAME);
+        ExplainLifecycleAction.NAME, GetDataStreamAction.NAME, ResolveIndexAction.NAME);
     private static final Automaton MANAGE_FOLLOW_INDEX_AUTOMATON = patterns(PutFollowAction.NAME, UnfollowAction.NAME,
         CloseIndexAction.NAME + "*");
     private static final Automaton MANAGE_LEADER_INDEX_AUTOMATON = patterns(ForgetFollowerAction.NAME + "*");

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
@@ -1,0 +1,134 @@
+---
+setup:
+  - skip:
+      features: ["headers", "allowed_warnings"]
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      security.put_role:
+        name: "data_stream_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["simple*"], "privileges": ["read", "write", "create_index", "view_index_metadata", "monitor", "delete_index"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "data_stream_role2"
+        body:  >
+          {
+            "indices": [
+              { "names": ["matches_none"], "privileges": ["read"] }
+            ]
+          }
+
+  - do:
+      security.put_user:
+        username: "test_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "data_stream_role" ],
+            "full_name" : "user with privileges on some data streams"
+          }
+
+  - do:
+      security.put_user:
+        username: "no_authz_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "data_stream_role2" ],
+            "full_name" : "user with privileges on no data streams"
+          }
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [s*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [s*]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                'foo':
+                  type: keyword
+          data_stream: {}
+
+---
+teardown:
+  - do:
+      security.delete_user:
+        username: "test_user"
+        ignore: 404
+
+  - do:
+      security.delete_user:
+        username: "no_authz_user"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "data_stream_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "data_stream_role2"
+        ignore: 404
+
+---
+"resolve index respects view_index_metadata privilege":
+  - skip:
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
+      features: ["headers", "allowed_warnings"]
+
+  - do: # superuser
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do: # superuser
+      indices.create_data_stream:
+        name: s-data-stream1
+  - is_true: acknowledged
+
+  # should return a single data stream because test_user is authorized only for the simple* namespace
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      indices.resolve_index:
+        name: '*'
+
+  - length: { indices: 0 }
+  - length: { aliases: 0 }
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - match: { data_streams.0.backing_indices.0: .ds-simple-data-stream1-000001 }
+  - match: { data_streams.0.timestamp_field: "@timestamp" }
+
+  # should fail because no_authz_user is not authorized for view_index_metadata
+  - do:
+      catch: forbidden
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      indices.resolve_index:
+        name: '*'
+
+  - do: # superuser
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do: # superuser
+      indices.delete_data_stream:
+        name: s-data-stream1
+  - is_true: acknowledged


### PR DESCRIPTION
The resolve index action was never explicitly included in any existing index privileges, so because of its name (`indices:admin/resolve/index`) it was available only in relatively elevated privileges such as `manage`. The endpoint exposes no more information than is available in the get index, get alias, and get data stream endpoints which are already included in the lesser `view_index_metadata` privilege. As such, it makes sense to explicitly include resolve index in the `view_index_metadata` privilege.

Relates to https://github.com/elastic/kibana/issues/72219

Backport of #59785 
