### PR TITLE
[DOCS] Move search sort docs to separate page

### DIFF
--- a/docs/painless/painless-contexts.asciidoc
+++ b/docs/painless/painless-contexts.asciidoc
@@ -23,7 +23,7 @@ specialized code may define new ways to use a Painless script.
 | Reindex                           | <<painless-reindex-context, Painless Documentation>>
                                     | {ref}/docs-reindex.html[Elasticsearch Documentation]
 | Sort                              | <<painless-sort-context, Painless Documentation>>
-                                    | {ref}/search-request-body.html#request-body-search-sort[Elasticsearch Documentation]
+                                    | {ref}/sort-search-results.html[Elasticsearch Documentation]
 | Similarity                        | <<painless-similarity-context, Painless Documentation>>
                                     | {ref}/index-modules-similarity.html[Elasticsearch Documentation]
 | Weight                            | <<painless-weight-context, Painless Documentation>>

--- a/docs/painless/painless-contexts/painless-sort-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-sort-context.asciidoc
@@ -2,7 +2,7 @@
 === Sort context
 
 Use a Painless script to
-{ref}/search-request-body.html#request-body-search-sort[sort] the documents in a query.
+{ref}/sort-search-results.html[sort] the documents in a query.
 
 *Variables*
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -49,7 +49,7 @@ faster.
 ==== `sort`
 
 The `sort` field in the metric request functions exactly the same as the `sort` field in the
-<<request-body-search-sort, search>> request except:
+<<sort-search-results, search>> request except:
 * It can't be used on <<binary,binary>>, <<flattened,flattened>>, <<ip,ip>>,
 <<keyword,keyword>>, or <<text,text>> fields.
 * It only supports a single sort value so which document wins ties is not specified.

--- a/docs/reference/aggregations/pipeline/bucket-sort-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-sort-aggregation.asciidoc
@@ -38,7 +38,7 @@ is ascending.
 [options="header"]
 |===
 |Parameter Name |Description |Required |Default Value
-|`sort` |The list of fields to sort on. See <<request-body-search-sort,`sort`>> for more details. |Optional |
+|`sort` |The list of fields to sort on. See <<sort-search-results,`sort`>> for more details. |Optional |
 |`from` |Buckets in positions prior to the set value will be truncated. |Optional | `0`
 |`size` |The number of buckets to return. Defaults to all buckets of the parent aggregation. |Optional |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -131,7 +131,7 @@ Add together the relevance scores of all matching child documents.
 [[has-child-query-performance]]
 ===== Sorting
 You cannot sort the results of a `has_child` query using standard
-<<request-body-search-sort,sort options>>.
+<<sort-search-results,sort options>>.
 
 If you need to sort returned documents by a field in their child documents, use
 a `function_score` query and sort by `_score`. For example, the following query

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -112,7 +112,7 @@ You can use this parameter to query multiple indices that may not contain the
 [[has-parent-query-performance]]
 ===== Sorting
 You cannot sort the results of a `has_parent` query using standard
-<<request-body-search-sort,sort options>>.
+<<sort-search-results,sort options>>.
 
 If you need to sort returned documents by a field in their parent documents, use
 a `function_score` query and sort by `_score`. For example, the following query

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -132,7 +132,7 @@ See <<request-body-search-search-type>>.
 
 [role="exclude",id="search-request-sort"]
 === Sort parameter for request body search API
-See <<request-body-search-sort>>.
+See <<sort-search-results>>.
 
 [role="exclude",id="search-request-source-filtering"]
 === Source filtering parameter for request body search API

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -946,4 +946,8 @@ See <<highlighting>>.
 [role="exclude",id="highlighter-internal-work"]
 ==== How highlighters work internally
 See <<how-highlighters-work-internally>>.
+
+[role="exclude",id="request-body-search-sort"]
+==== Sort
+See <<sort-search-results>>.
 ////

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -36,7 +36,7 @@ each of which is explained below.
 === Accessing the score of a document within a script
 
 Scripts used in the <<query-dsl-function-score-query,`function_score` query>>,
-in <<request-body-search-sort,script-based sorting>>, or in
+in <<sort-search-results,script-based sorting>>, or in
 <<search-aggregations,aggregations>> have access to the `_score` variable which
 represents the current relevance score of a document.
 

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -139,7 +139,10 @@ include::request/search-after.asciidoc[]
 
 include::request/search-type.asciidoc[]
 
-include::request/sort.asciidoc[]
+[[request-body-search-sort]]
+==== Sort
+
+See <<sort-search-results>>.
 
 include::request/source-filtering.asciidoc[]
 

--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -15,7 +15,7 @@ Currently the rescore API has only one implementation: the query
 rescorer, which uses a query to tweak the scoring. In the future,
 alternative rescorers may be made available, for example, a pair-wise rescorer.
 
-NOTE: An error will be thrown if an explicit <<request-body-search-sort,`sort`>> 
+NOTE: An error will be thrown if an explicit <<sort-search-results,`sort`>>
 (other than `_score` in descending order) is provided with a `rescore` query.
 
 NOTE: when exposing pagination to your users, you should not change

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -1,5 +1,5 @@
-[[request-body-search-sort]]
-==== Sort
+[[sort-search-results]]
+=== Sort search results
 
 Allows you to add one or more sorts on specific fields. Each sort can be
 reversed as well. The sort is defined on a per field level, with special
@@ -48,12 +48,12 @@ NOTE: `_doc` has no real use-case besides being the most efficient sort order.
 So if you don't care about the order in which documents are returned, then you
 should sort by `_doc`. This especially helps when <<request-body-search-scroll,scrolling>>.
 
-===== Sort Values
+==== Sort Values
 
 The sort values for each document returned are also returned as part of
 the response.
 
-===== Sort Order
+==== Sort Order
 
 The `order` option can have the following values:
 
@@ -64,7 +64,7 @@ The `order` option can have the following values:
 The order defaults to `desc` when sorting on the `_score`, and defaults
 to `asc` when sorting on anything else.
 
-===== Sort mode option
+==== Sort mode option
 
 Elasticsearch supports sorting by array or multi-valued fields. The `mode` option
 controls what array value is picked for sorting the document it belongs
@@ -84,7 +84,7 @@ The default sort mode in the ascending sort order is `min` -- the lowest value
 is picked. The default sort mode in the descending order is `max` --
 the highest value is picked.
 
-====== Sort mode example usage
+===== Sort mode example usage
 
 In the example below the field price has multiple prices per document.
 In this case the result hits will be sorted by price ascending based on
@@ -109,7 +109,7 @@ POST /_search
 }
 --------------------------------------------------
 
-===== Sorting numeric fields
+==== Sorting numeric fields
 
 For numeric fields it is also possible to cast the values from one type
 to another using the `numeric_type` option.
@@ -227,7 +227,7 @@ To avoid overflow, the conversion to `date_nanos` cannot be applied on dates bef
 1970 and after 2262 as nanoseconds are represented as longs.
 
 [[nested-sorting]]
-===== Sorting within nested objects.
+==== Sorting within nested objects.
 
 Elasticsearch also supports sorting by
 fields that are inside one or more nested objects. The sorting by nested
@@ -253,7 +253,7 @@ field support has a `nested` sort option with the following properties:
 NOTE: Elasticsearch will throw an error if a nested field is defined in a sort without
 a `nested` context.
 
-====== Nested sorting examples
+===== Nested sorting examples
 
 In the below example `offer` is a field of type `nested`.
 The nested `path` needs to be specified; otherwise, Elasticsearch doesn't know on what nested level sort values need to be captured.
@@ -331,7 +331,7 @@ POST /_search
 Nested sorting is also supported when sorting by
 scripts and sorting by geo distance.
 
-===== Missing Values
+==== Missing Values
 
 The `missing` parameter specifies how docs which are missing
 the sort field should be treated: The `missing` value can be
@@ -357,7 +357,7 @@ GET /_search
 NOTE: If a nested inner object doesn't match with
 the `nested.filter` then a missing value is used.
 
-===== Ignoring Unmapped Fields
+==== Ignoring Unmapped Fields
 
 By default, the search request will fail if there is no mapping
 associated with a field. The `unmapped_type` option allows you to ignore
@@ -383,7 +383,7 @@ then Elasticsearch will handle it as if there was a mapping of type
 `long`, with all documents in this index having no value for this field.
 
 [[geo-sorting]]
-===== Geo Distance Sorting
+==== Geo Distance Sorting
 
 Allow to sort by `_geo_distance`. Here is an example, assuming `pin.location` is a field of type `geo_point`:
 
@@ -438,7 +438,7 @@ have values for the field that is used for distance computation.
 
 The following formats are supported in providing the coordinates:
 
-====== Lat Lon as Properties
+===== Lat Lon as Properties
 
 [source,console]
 --------------------------------------------------
@@ -462,7 +462,7 @@ GET /_search
 }
 --------------------------------------------------
 
-====== Lat Lon as String
+===== Lat Lon as String
 
 Format in `lat,lon`.
 
@@ -485,7 +485,7 @@ GET /_search
 }
 --------------------------------------------------
 
-====== Geohash
+===== Geohash
 
 [source,console]
 --------------------------------------------------
@@ -506,7 +506,7 @@ GET /_search
 }
 --------------------------------------------------
 
-====== Lat Lon as Array
+===== Lat Lon as Array
 
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
 conform with http://geojson.org/[GeoJSON].
@@ -531,7 +531,7 @@ GET /_search
 --------------------------------------------------
 
 
-===== Multiple reference points
+==== Multiple reference points
 
 Multiple geo points can be passed as an array containing any `geo_point` format, for example
 
@@ -560,7 +560,7 @@ The final distance for a document will then be `min`/`max`/`avg` (defined via `m
 
 
 
-===== Script Based Sorting
+==== Script Based Sorting
 
 Allow to sort based on custom scripts, here is an example:
 
@@ -588,7 +588,7 @@ GET /_search
 --------------------------------------------------
 
 
-===== Track Scores
+==== Track Scores
 
 When sorting on a field, scores are not computed. By setting
 `track_scores` to true, scores will still be computed and tracked.
@@ -609,7 +609,7 @@ GET /_search
 }
 --------------------------------------------------
 
-===== Memory Considerations
+==== Memory Considerations
 
 When sorting, the relevant sorted field values are loaded into memory.
 This means that per shard, there should be enough memory to contain

--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -271,3 +271,5 @@ include::request/from-size.asciidoc[]
 include::search-fields.asciidoc[]
 
 include::request/highlighting.asciidoc[]
+
+include::request/sort.asciidoc[]


### PR DESCRIPTION
Moves the search sort docs from the deprecated 'Request Body Search'
page to a new subpage of 'Run a search'.

No substantive changes were made to the content.