### PR TITLE
[7.x][ML] Skip test inference if DFA task has been stopped (#60116)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -323,8 +323,8 @@ public class AnalyticsProcessManager {
 
     private void runInference(ParentTaskAssigningClient parentTaskClient, DataFrameAnalyticsTask task, ProcessContext processContext,
                               ExtractedFields extractedFields) {
-        if (processContext.failureReason.get() != null) {
-            // If there has been an error thus far let's not run inference at all
+        if (task.isStopping() || processContext.failureReason.get() != null) {
+            // If the task is stopping or there has been an error thus far let's not run inference at all
             return;
         }
 


### PR DESCRIPTION
If the job is stopped before starting inference on test data, we
should skip inference entirely.

Backport of #60116
