### PR TITLE
[ML] Remove unused Request constructors

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteCalendarAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteCalendarAction.java
@@ -36,9 +36,6 @@ public class DeleteCalendarAction extends ActionType<AcknowledgedResponse> {
             calendarId = in.readString();
         }
 
-        public Request() {
-        }
-
         public Request(String calendarId) {
             this.calendarId = ExceptionsHelper.requireNonNull(calendarId, Calendar.ID.getPreferredName());
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteCalendarEventAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteCalendarEventAction.java
@@ -37,9 +37,6 @@ public class DeleteCalendarEventAction extends ActionType<AcknowledgedResponse> 
             eventId = in.readString();
         }
 
-        public Request() {
-        }
-
         public Request(String calendarId, String eventId) {
             this.calendarId = ExceptionsHelper.requireNonNull(calendarId, Calendar.ID.getPreferredName());
             this.eventId = ExceptionsHelper.requireNonNull(eventId, ScheduledEvent.EVENT_ID.getPreferredName());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedAction.java
@@ -40,9 +40,6 @@ public class DeleteDatafeedAction extends ActionType<AcknowledgedResponse> {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteFilterAction.java
@@ -38,10 +38,6 @@ public class DeleteFilterAction extends ActionType<AcknowledgedResponse> {
             filterId = in.readString();
         }
 
-        public Request() {
-
-        }
-
         public Request(String filterId) {
             this.filterId = ExceptionsHelper.requireNonNull(filterId, FILTER_ID.getPreferredName());
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteForecastAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteForecastAction.java
@@ -39,9 +39,6 @@ public class DeleteForecastAction extends ActionType<AcknowledgedResponse> {
             allowNoForecasts = in.readBoolean();
         }
 
-        public Request() {
-        }
-
         public Request(String jobId, String forecastId) {
             this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
             this.forecastId = ExceptionsHelper.requireNonNull(forecastId, ForecastRequestStats.FORECAST_ID.getPreferredName());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteJobAction.java
@@ -44,8 +44,6 @@ public class DeleteJobAction extends ActionType<AcknowledgedResponse> {
             this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
         }
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteModelSnapshotAction.java
@@ -31,9 +31,6 @@ public class DeleteModelSnapshotAction extends ActionType<AcknowledgedResponse> 
         private String jobId;
         private String snapshotId;
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteTrainedModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteTrainedModelAction.java
@@ -37,8 +37,6 @@ public class DeleteTrainedModelAction extends ActionType<AcknowledgedResponse> {
             id = in.readString();
         }
 
-        public Request() {}
-
         public Request(String id) {
             this.id = ExceptionsHelper.requireNonNull(id, TrainedModelConfig.MODEL_ID);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FinalizeJobExecutionAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FinalizeJobExecutionAction.java
@@ -31,9 +31,6 @@ public class FinalizeJobExecutionAction extends ActionType<AcknowledgedResponse>
             this.jobIds = jobIds;
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobIds = in.readStringArray();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -57,8 +57,6 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
         }
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
@@ -73,8 +73,6 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
             this.expandedJobsIds = Collections.singletonList(jobId);
         }
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/KillProcessAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/KillProcessAction.java
@@ -29,10 +29,6 @@ public class KillProcessAction extends ActionType<KillProcessAction.Response> {
             super(jobId);
         }
 
-        public Request() {
-            super();
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -68,9 +68,6 @@ public class OpenJobAction extends ActionType<NodeAcknowledgedResponse> {
             jobParams = new JobParams(in);
         }
 
-        public Request() {
-        }
-
         public JobParams getJobParams() {
             return jobParams;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PersistJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PersistJobAction.java
@@ -25,9 +25,6 @@ public class PersistJobAction extends ActionType<PersistJobAction.Response> {
 
     public static class Request extends JobTaskRequest<PersistJobAction.Request> {
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             // isBackground for fwc

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
@@ -63,9 +63,6 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
         private String calendarId;
         private List<ScheduledEvent> scheduledEvents;
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             calendarId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostDataAction.java
@@ -104,9 +104,6 @@ public class PostDataAction extends ActionType<PostDataAction.Response> {
         private XContentType xContentType;
         private BytesReference content;
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             resetStart = in.readOptionalString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -36,9 +36,6 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
 
         private String datafeedId;
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
@@ -49,10 +49,6 @@ public class PutCalendarAction extends ActionType<PutCalendarAction.Response> {
 
         private Calendar calendar;
 
-        public Request() {
-
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             calendar = new Calendar(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
@@ -66,8 +66,6 @@ public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalytic
 
         private DataFrameAnalyticsConfig config;
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             config = new DataFrameAnalyticsConfig(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedAction.java
@@ -46,9 +46,6 @@ public class PutDatafeedAction extends ActionType<PutDatafeedAction.Response> {
             this.datafeed = datafeed;
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeed = new DatafeedConfig(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
@@ -48,10 +48,6 @@ public class PutFilterAction extends ActionType<PutFilterAction.Response> {
 
         private MlFilter filter;
 
-        public Request() {
-
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             filter = new MlFilter(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
@@ -66,9 +66,6 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
             this.jobBuilder = jobBuilder;
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobBuilder = new Job.Builder(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SetUpgradeModeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SetUpgradeModeAction.java
@@ -49,9 +49,6 @@ public class SetUpgradeModeAction extends ActionType<AcknowledgedResponse> {
             this.enabled = in.readBoolean();
         }
 
-        public Request() {
-        }
-
         public boolean isEnabled() {
             return enabled;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -83,9 +83,6 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
             params = new DatafeedParams(in);
         }
 
-        public Request() {
-        }
-
         public DatafeedParams getParams() {
             return params;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
@@ -30,9 +30,6 @@ public class UpdateCalendarJobAction extends ActionType<PutCalendarAction.Respon
         private String jobIdsToAddExpression;
         private String jobIdsToRemoveExpression;
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             calendarId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDataFrameAnalyticsAction.java
@@ -50,8 +50,6 @@ public class UpdateDataFrameAnalyticsAction extends ActionType<PutDataFrameAnaly
 
         private DataFrameAnalyticsConfigUpdate update;
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             update = new DataFrameAnalyticsConfigUpdate(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedAction.java
@@ -46,9 +46,6 @@ public class UpdateDatafeedAction extends ActionType<PutDatafeedAction.Response>
             this.update = update;
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             update = new DatafeedUpdate(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -54,9 +54,6 @@ public class UpdateJobAction extends ActionType<PutJobAction.Response> {
             }
         }
 
-        public Request() {
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
@@ -95,8 +95,6 @@ public class UpdateProcessAction extends ActionType<UpdateProcessAction.Response
         private MlFilter filter;
         private boolean updateScheduledEvents = false;
 
-        public Request() {}
-
         public Request(StreamInput in) throws IOException {
             super(in);
             modelPlotConfig = in.readOptionalWriteable(ModelPlotConfig::new);


### PR DESCRIPTION
Remove unused, empty Request constructors from ml actions in core
plugin. 

Relates #59989 
