### PR TITLE
Remove typename validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -51,7 +51,6 @@ import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
-import org.elasticsearch.indices.InvalidTypeNameException;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
 
@@ -307,36 +306,11 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return internalMerge(documentMapper, reason);
     }
 
-    static void validateTypeName(String type) {
-        if (type.length() == 0) {
-            throw new InvalidTypeNameException("mapping type name is empty");
-        }
-        if (type.length() > 255) {
-            throw new InvalidTypeNameException("mapping type name [" + type + "] is too long; limit is length 255 but was ["
-                + type.length() + "]");
-        }
-        if (type.charAt(0) == '_' && SINGLE_MAPPING_NAME.equals(type) == false) {
-            throw new InvalidTypeNameException("mapping type name [" + type + "] can't start with '_' unless it is called ["
-                + SINGLE_MAPPING_NAME + "]");
-        }
-        if (type.contains("#")) {
-            throw new InvalidTypeNameException("mapping type name [" + type + "] should not include '#' in it");
-        }
-        if (type.contains(",")) {
-            throw new InvalidTypeNameException("mapping type name [" + type + "] should not include ',' in it");
-        }
-        if (type.charAt(0) == '.') {
-            throw new IllegalArgumentException("mapping type name [" + type + "] must not start with a '.'");
-        }
-    }
-
     private synchronized DocumentMapper internalMerge(DocumentMapper mapper, MergeReason reason) {
         boolean hasNested = this.hasNested;
         Map<String, ObjectMapper> fullPathObjectMappers = this.fullPathObjectMappers;
 
         assert mapper != null;
-        // check naming
-        validateTypeName(mapper.type());
 
         // compute the merged DocumentMapper
         DocumentMapper oldMapper = this.mapper;

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
-import org.elasticsearch.indices.InvalidTypeNameException;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -62,16 +61,6 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return List.of(InternalSettingsPlugin.class, ReloadableFilterPlugin.class);
-    }
-
-    public void testTypeValidation() {
-        InvalidTypeNameException e = expectThrows(InvalidTypeNameException.class, () -> MapperService.validateTypeName("_type"));
-        assertEquals("mapping type name [_type] can't start with '_' unless it is called [_doc]", e.getMessage());
-
-        e = expectThrows(InvalidTypeNameException.class, () -> MapperService.validateTypeName("_document"));
-        assertEquals("mapping type name [_document] can't start with '_' unless it is called [_doc]", e.getMessage());
-
-        MapperService.validateTypeName("_doc"); // no exception
     }
 
     public void testPreflightUpdateDoesNotChangeMapping() throws Throwable {


### PR DESCRIPTION
For new indexes in 8x, the type name of mappings is always `_doc`, so we can remove
the type name validation that MapperService does on all updates - either the typename
was generated in a 7x index, in which case it has already been validated; or it's new, in 
which case it is `_doc` and we already know it is valid.