### PR TITLE
[7.x] [DOCS] Swap `[float]` for `[discrete]` (#60124)

### DIFF
--- a/docs/java-api/admin/indices/create-index.asciidoc
+++ b/docs/java-api/admin/indices/create-index.asciidoc
@@ -8,7 +8,7 @@ Using an <<java-admin-indices,`IndicesAdminClient`>>, you can create an index wi
 client.admin().indices().prepareCreate("twitter").get();
 --------------------------------------------------
 
-[float]
+[discrete]
 [[java-admin-indices-create-index-settings]]
 ===== Index Settings
 

--- a/docs/java-api/docs/update-by-query.asciidoc
+++ b/docs/java-api/docs/update-by-query.asciidoc
@@ -111,7 +111,7 @@ specifying a `pipeline` like this:
 include-tagged::{client-reindex-tests}/ReindexDocumentationIT.java[update-by-query-pipeline]
 --------------------------------------------------
 
-[float]
+[discrete]
 [[java-docs-update-by-query-task-api]]
 === Works with the Task API
 
@@ -130,7 +130,7 @@ With the `TaskId` shown above you can look up the task directly:
 include-tagged::{client-reindex-tests}/ReindexDocumentationIT.java[update-by-query-get-task]
 --------------------------------------------------
 
-[float]
+[discrete]
 [[java-docs-update-by-query-cancel-task-api]]
 === Works with the Cancel Task API
 
@@ -146,7 +146,7 @@ Use the `list tasks` API to find the value of `taskId`.
 Cancelling a request is typically a very fast process but can take up to a few seconds.
 The task status API continues to list the task until the cancellation is complete.
 
-[float]
+[discrete]
 [[java-docs-update-by-query-rethrottle]]
 === Rethrottling
 

--- a/docs/painless/painless-guide/painless-walkthrough.asciidoc
+++ b/docs/painless/painless-guide/painless-walkthrough.asciidoc
@@ -31,7 +31,7 @@ PUT hockey/_bulk?refresh
 ----------------------------------------------------------------
 // TESTSETUP
 
-[float]
+[discrete]
 ==== Accessing Doc Values from Painless
 
 Document values can be accessed from a `Map` named `doc`.
@@ -111,7 +111,7 @@ GET hockey/_search
 ----------------------------------------------------------------
 
 
-[float]
+[discrete]
 ==== Missing values
 
 `doc['field'].value` throws an exception if
@@ -121,7 +121,7 @@ To check if a document is missing a value, you can call
 `doc['field'].size() == 0`.
 
 
-[float]
+[discrete]
 ==== Updating Fields with Painless
 
 You can also easily update fields. You access the original source for a field as `ctx._source.<field-name>`.
@@ -177,7 +177,7 @@ POST hockey/_update/1
 }
 ----------------------------------------------------------------
 
-[float]
+[discrete]
 [[modules-scripting-painless-dates]]
 ==== Dates
 
@@ -202,7 +202,7 @@ GET hockey/_search
 }
 ----------------------------------------------------------------
 
-[float]
+[discrete]
 [[modules-scripting-painless-regex]]
 ==== Regular expressions
 

--- a/docs/plugins/alerting.asciidoc
+++ b/docs/plugins/alerting.asciidoc
@@ -3,7 +3,7 @@
 
 Alerting plugins allow Elasticsearch to monitor indices and to trigger alerts when thresholds are breached.
 
-[float]
+[discrete]
 === Core alerting plugins
 
 The core alerting plugins are:

--- a/docs/plugins/analysis-phonetic.asciidoc
+++ b/docs/plugins/analysis-phonetic.asciidoc
@@ -73,7 +73,7 @@ is often beneficial to use separate fields for analysis with and without phoneti
 That way searches can be run against both fields with differing boosts and trade-offs (e.g.
 only run a fuzzy `match` query on the original text field, but not on the phonetic version).
 
-[float]
+[discrete]
 ===== Double metaphone settings
 
 If the `double_metaphone` encoder is used, then this additional setting is
@@ -83,7 +83,7 @@ supported:
 
     The maximum length of the emitted metaphone token.  Defaults to `4`.
 
-[float]
+[discrete]
 ===== Beider Morse settings
 
 If the `beider_morse` encoder is used, then these additional settings are

--- a/docs/plugins/analysis-smartcn.asciidoc
+++ b/docs/plugins/analysis-smartcn.asciidoc
@@ -14,7 +14,7 @@ include::install_remove.asciidoc[]
 
 
 [[analysis-smartcn-tokenizer]]
-[float]
+[discrete]
 ==== `smartcn` tokenizer and token filter
 
 The plugin provides the `smartcn` analyzer, `smartcn_tokenizer` tokenizer, and

--- a/docs/plugins/analysis-stempel.asciidoc
+++ b/docs/plugins/analysis-stempel.asciidoc
@@ -11,7 +11,7 @@ http://www.egothor.org/[Egothor project].
 include::install_remove.asciidoc[]
 
 [[analysis-stempel-tokenizer]]
-[float]
+[discrete]
 ==== `stempel` tokenizer and token filters
 
 The plugin provides the `polish` analyzer and the `polish_stem` and `polish_stop` token filters,

--- a/docs/plugins/analysis-ukrainian.asciidoc
+++ b/docs/plugins/analysis-ukrainian.asciidoc
@@ -9,7 +9,7 @@ It provides stemming for Ukrainian using the http://github.com/morfologik/morfol
 include::install_remove.asciidoc[]
 
 [[analysis-ukrainian-analyzer]]
-[float]
+[discrete]
 ==== `ukrainian` analyzer
 
 The plugin provides the `ukrainian` analyzer.

--- a/docs/plugins/analysis.asciidoc
+++ b/docs/plugins/analysis.asciidoc
@@ -4,7 +4,7 @@
 Analysis plugins extend Elasticsearch by adding new analyzers, tokenizers,
 token filters, or character filters to Elasticsearch.
 
-[float]
+[discrete]
 ==== Core analysis plugins
 
 The core analysis plugins are:
@@ -44,7 +44,7 @@ Provides high quality stemming for Polish.
 
 Provides stemming for Ukrainian.
 
-[float]
+[discrete]
 ==== Community contributed analysis plugins
 
 A number of analysis plugins have been contributed by our community:

--- a/docs/plugins/api.asciidoc
+++ b/docs/plugins/api.asciidoc
@@ -3,7 +3,7 @@
 
 API extension plugins add new functionality to Elasticsearch by adding new APIs or features, usually to do with search or mapping.
 
-[float]
+[discrete]
 === Community contributed API extension plugins
 
 A number of plugins have been contributed by our community:

--- a/docs/plugins/authors.asciidoc
+++ b/docs/plugins/authors.asciidoc
@@ -18,7 +18,7 @@ These examples provide the bare bones needed to get started.  For more
 information about how to write a plugin, we recommend looking at the plugins
 listed in this documentation for inspiration.
 
-[float]
+[discrete]
 === Plugin descriptor file
 
 All plugins must contain a file called `plugin-descriptor.properties`.
@@ -32,7 +32,7 @@ include::{plugin-properties-files}/plugin-descriptor.properties[]
 Either fill in this template yourself or, if you are using Elasticsearch's Gradle build system, you
 can fill in the necessary values in the `build.gradle` file for your plugin.
 
-[float]
+[discrete]
 ==== Mandatory elements for plugins
 
 
@@ -70,7 +70,7 @@ in the presence of plugins with the incorrect `elasticsearch.version`.
 ==============================================
 
 
-[float]
+[discrete]
 === Testing your plugin
 
 When testing a Java plugin, it will only be auto-loaded if it is in the
@@ -81,7 +81,7 @@ You may also load your plugin within the test framework for integration tests.
 Read more in {ref}/integration-tests.html#changing-node-configuration[Changing Node Configuration].
 
 
-[float]
+[discrete]
 [[plugin-authors-jsm]]
 === Java Security permissions
 

--- a/docs/plugins/discovery.asciidoc
+++ b/docs/plugins/discovery.asciidoc
@@ -5,7 +5,7 @@ Discovery plugins extend Elasticsearch by adding new seed hosts providers that
 can be used to extend the {ref}/modules-discovery.html[cluster formation
 module].
 
-[float]
+[discrete]
 ==== Core discovery plugins
 
 The core discovery plugins are:
@@ -25,7 +25,7 @@ addresses of seed hosts.
 The Google Compute Engine discovery plugin uses the GCE API to identify the
 addresses of seed hosts.
 
-[float]
+[discrete]
 ==== Community contributed discovery plugins
 
 The following discovery plugins have been contributed by our community:

--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -3,7 +3,7 @@
 
 The ingest plugins extend Elasticsearch by providing additional ingest node capabilities.
 
-[float]
+[discrete]
 === Core Ingest Plugins
 
 The core ingest plugins are:
@@ -29,7 +29,7 @@ A processor that extracts details from the User-Agent header value. The
 distributed by default with Elasticsearch. See
 {ref}/user-agent-processor.html[User Agent processor] for more details.
 
-[float]
+[discrete]
 === Community contributed ingest plugins
 
 The following plugin has been contributed by our community:

--- a/docs/plugins/install_remove.asciidoc
+++ b/docs/plugins/install_remove.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [id="{plugin_name}-install"]
 ==== Installation
 
@@ -25,7 +25,7 @@ This plugin can be downloaded for <<plugin-management-custom-url,offline install
 
 endif::[]
 
-[float]
+[discrete]
 [id="{plugin_name}-remove"]
 ==== Removal
 

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -4,11 +4,11 @@
 
 Integrations are not plugins, but are external tools or modules that make it easier to work with Elasticsearch.
 
-[float]
+[discrete]
 [[cms-integrations]]
 === CMS integrations
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * http://drupal.org/project/search_api_elasticsearch[Drupal]:
@@ -31,14 +31,14 @@ Integrations are not plugins, but are external tools or modules that make it eas
 * http://extensions.xwiki.org/xwiki/bin/view/Extension/Elastic+Search+Macro/[XWiki Next Generation Wiki]:
   XWiki has an Elasticsearch and Kibana macro allowing to run Elasticsearch queries and display the results in XWiki pages using XWiki's scripting language as well as include Kibana Widgets in XWiki pages
 
-[float]
+[discrete]
 [[data-integrations]]
 === Data import/export and validation
 
 NOTE: Rivers were used to import data from external systems into Elasticsearch prior to the 2.0 release. Elasticsearch
 releases 2.0 and later do not support rivers.
 
-[float]
+[discrete]
 ==== Supported by Elasticsearch:
 
 * {logstash-ref}/plugins-outputs-elasticsearch.html[Logstash output to Elasticsearch]:
@@ -50,7 +50,7 @@ releases 2.0 and later do not support rivers.
 * {logstash-ref}/plugins-codecs-es_bulk.html[Elasticsearch bulk codec]
   The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * https://github.com/jprante/elasticsearch-jdbc[JDBC importer]:
@@ -75,11 +75,11 @@ releases 2.0 and later do not support rivers.
 * https://github.com/senacor/elasticsearch-evolution[Elasticsearch Evolution]:
   A library to migrate elasticsearch mappings.
 
-[float]
+[discrete]
 [[deployment]]
 === Deployment
 
-[float]
+[discrete]
 ==== Supported by Elasticsearch:
 
 * https://github.com/elastic/ansible-elasticsearch[Ansible playbook for Elasticsearch]:
@@ -88,17 +88,17 @@ releases 2.0 and later do not support rivers.
 * https://github.com/elastic/puppet-elasticsearch[Puppet]:
   Elasticsearch puppet module.
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * https://github.com/elastic/cookbook-elasticsearch[Chef]:
   Chef cookbook for Elasticsearch
 
-[float]
+[discrete]
 [[framework-integrations]]
 === Framework integrations
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * http://www.searchtechnologies.com/aspire-for-elasticsearch[Aspire for Elasticsearch]:
@@ -157,29 +157,29 @@ releases 2.0 and later do not support rivers.
 * https://micrometer.io[Micrometer]:
   Vendor-neutral application metrics facade. Think SLF4j, but for metrics.
 
-[float]
+[discrete]
 [[hadoop-integrations]]
 === Hadoop integrations
 
-[float]
+[discrete]
 ==== Supported by Elasticsearch:
 
 * link:/guide/en/elasticsearch/hadoop/current/[es-hadoop]: Elasticsearch real-time
   search and analytics natively integrated with Hadoop. Supports Map/Reduce,
   Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * https://github.com/criteo/garmadon[Garmadon]:
   Garmadon is a solution for Hadoop Cluster realtime introspection.
 
 
-[float]
+[discrete]
 [[monitoring-integrations]]
 === Health and Performance Monitoring
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * https://github.com/radu-gheorghe/check-es[check-es]:
@@ -193,10 +193,10 @@ releases 2.0 and later do not support rivers.
   and receive events information.
 
 [[other-integrations]]
-[float]
+[discrete]
 === Other integrations
 
-[float]
+[discrete]
 ==== Supported by the community:
 
 * https://www.wireshark.org/[Wireshark]:

--- a/docs/plugins/management.asciidoc
+++ b/docs/plugins/management.asciidoc
@@ -3,7 +3,7 @@
 
 Management plugins offer UIs for managing and interacting with Elasticsearch.
 
-[float]
+[discrete]
 === Core management plugins
 
 The core management plugins are:

--- a/docs/plugins/mapper.asciidoc
+++ b/docs/plugins/mapper.asciidoc
@@ -3,7 +3,7 @@
 
 Mapper plugins allow new field data types to be added to Elasticsearch.
 
-[float]
+[discrete]
 === Core mapper plugins
 
 The core mapper plugins are:

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -33,7 +33,7 @@ The documentation for each plugin usually includes specific installation
 instructions for that plugin, but below we document the various available
 options:
 
-[float]
+[discrete]
 === Core Elasticsearch plugins
 
 Core Elasticsearch plugins can be installed as follows:
@@ -149,7 +149,7 @@ For safety reasons, a node will not start if it is missing a mandatory plugin.
 [[listing-removing-updating]]
 === Listing, Removing and Updating Installed Plugins
 
-[float]
+[discrete]
 === Listing plugins
 
 A list of the currently loaded plugins can be retrieved with the `list` option:
@@ -162,7 +162,7 @@ sudo bin/elasticsearch-plugin list
 Alternatively, use the {ref}/cluster-nodes-info.html[node-info API] to find
 out which plugins are installed on each node in the cluster
 
-[float]
+[discrete]
 === Removing plugins
 
 Plugins can be removed manually, by deleting the appropriate directory under
@@ -182,7 +182,7 @@ purge the configuration files while removing a plugin, use `-p` or `--purge`.
 This can option can be used after a plugin is removed to remove any lingering
 configuration files.
 
-[float]
+[discrete]
 === Updating plugins
 
 Plugins are built for a specific version of Elasticsearch, and therefore must be reinstalled
@@ -198,7 +198,7 @@ sudo bin/elasticsearch-plugin install [pluginname]
 
 The `plugin` scripts supports a number of other command line parameters:
 
-[float]
+[discrete]
 === Silent/Verbose mode
 
 The `--verbose` parameter outputs more debug information, while the `--silent`
@@ -211,7 +211,7 @@ return the following exit codes:
 `74`:: IO error
 `70`:: any other error
 
-[float]
+[discrete]
 === Batch mode
 
 Certain plugins require more privileges than those provided by default in core
@@ -229,7 +229,7 @@ mode can be forced by specifying `-b` or `--batch` as follows:
 sudo bin/elasticsearch-plugin install --batch [pluginname]
 -----------------------------------
 
-[float]
+[discrete]
 === Custom config directory
 
 If your `elasticsearch.yml` config file is in a custom location, you will need
@@ -241,7 +241,7 @@ can do this as follows:
 sudo ES_PATH_CONF=/path/to/conf/dir bin/elasticsearch-plugin install <plugin name>
 ---------------------
 
-[float]
+[discrete]
 === Proxy settings
 
 To install a plugin via a proxy, you can add the proxy details to the

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -78,7 +78,7 @@ include::repository-shared-settings.asciidoc[]
     link:repository-hdfs-security-runtime[Creating the Secure Repository]).
 
 [[repository-hdfs-availability]]
-[float]
+[discrete]
 ===== A Note on HDFS Availability
 When you initialize a repository, its settings are persisted in the cluster state. When a node comes online, it will
 attempt to initialize all repositories for which it has settings. If your cluster has an HDFS repository configured, then
@@ -106,7 +106,7 @@ methods are supported by the plugin:
     <<repository-hdfs-security-runtime>> for more info)
 
 [[repository-hdfs-security-keytabs]]
-[float]
+[discrete]
 ===== Principals and Keytabs
 Before attempting to connect to a secured HDFS cluster, provision the Kerberos principals and keytabs that the
 Elasticsearch nodes will use for authenticating to Kerberos. For maximum security and to avoid tripping up the Kerberos
@@ -137,7 +137,7 @@ host!
 
 // Setup at runtime (principal name)
 [[repository-hdfs-security-runtime]]
-[float]
+[discrete]
 ===== Creating the Secure Repository
 Once your keytab files are in place and your cluster is started, creating a secured HDFS repository is simple. Just
 add the name of the principal that you will be authenticating as in the repository settings under the
@@ -175,7 +175,7 @@ PUT _snapshot/my_hdfs_repository
 // TEST[skip:we don't have hdfs set up while testing this]
 
 [[repository-hdfs-security-authorization]]
-[float]
+[discrete]
 ===== Authorization
 Once Elasticsearch is connected and authenticated to HDFS, HDFS will infer a username to use for
 authorizing file access for the client. By default, it picks this username from the primary part of

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -200,7 +200,7 @@ pattern then you should set this setting to `true` when upgrading.
     https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setSignerOverride-java.lang.String-[AWS
     Java SDK documentation] for details. Defaults to empty string which means that no signing algorithm override will be used.
 
-[float]
+[discrete]
 [[repository-s3-compatible-services]]
 ===== S3-compatible services
 
@@ -435,7 +435,7 @@ The bucket needs to exist to register a repository for snapshots. If you did not
 create the bucket then the repository registration will fail.
 
 [[repository-s3-aws-vpc]]
-[float]
+[discrete]
 ==== AWS VPC Bandwidth Settings
 
 AWS instances resolve S3 endpoints to a public IP. If the Elasticsearch

--- a/docs/plugins/repository.asciidoc
+++ b/docs/plugins/repository.asciidoc
@@ -5,7 +5,7 @@ Repository plugins extend the {ref}/modules-snapshots.html[Snapshot/Restore]
 functionality in Elasticsearch by adding repositories backed by the cloud or
 by distributed file systems:
 
-[float]
+[discrete]
 ==== Core repository plugins
 
 The core repository plugins are:
@@ -27,7 +27,7 @@ The Hadoop HDFS Repository plugin adds support for using HDFS as a repository.
 The GCS repository plugin adds support for using Google Cloud Storage service as a repository.
 
 
-[float]
+[discrete]
 === Community contributed repository plugins
 
 The following plugin has been contributed by our community:

--- a/docs/plugins/security.asciidoc
+++ b/docs/plugins/security.asciidoc
@@ -3,7 +3,7 @@
 
 Security plugins add a security layer to  Elasticsearch.
 
-[float]
+[discrete]
 === Core security plugins
 
 The core security plugins are:
@@ -15,7 +15,7 @@ enterprise-grade security to their Elastic Stack. Designed to address the
 growing security needs of thousands of enterprises using the Elastic Stack
 today, X-Pack provides peace of mind when it comes to protecting your data.
 
-[float]
+[discrete]
 === Community contributed security plugins
 
 The following plugins have been contributed by our community:

--- a/docs/plugins/store.asciidoc
+++ b/docs/plugins/store.asciidoc
@@ -3,7 +3,7 @@
 
 Store plugins offer alternatives to default Lucene stores.
 
-[float]
+[discrete]
 === Core store plugins
 
 The core store plugins are:

--- a/docs/reference/aggregations.asciidoc
+++ b/docs/reference/aggregations.asciidoc
@@ -44,7 +44,7 @@ NOTE:   Aggregations operate on the `double` representation of
         the data. As a consequence, the result may be approximate when running on longs
         whose absolute value is greater than `2^53`.
 
-[float]
+[discrete]
 == Structuring Aggregations
 
 The following snippet captures the basic structure of aggregations:
@@ -76,7 +76,7 @@ sub-aggregations you define on the bucketing aggregation level will be computed 
 bucketing aggregation. For example, if you define a set of aggregations under the `range` aggregation, the
 sub-aggregations will be computed for the range buckets that are defined.
 
-[float]
+[discrete]
 === Values Source
 
 Some aggregations work on values extracted from the aggregated documents. Typically, the values will be extracted from

--- a/docs/reference/aggregations/pipeline.asciidoc
+++ b/docs/reference/aggregations/pipeline.asciidoc
@@ -26,7 +26,7 @@ NOTE: Because pipeline aggregations only add to the output, when chaining pipeli
 will be included in the final output.
 
 [[buckets-path-syntax]]
-[float]
+[discrete]
 === `buckets_path` Syntax
 
 Most pipeline aggregations require another aggregation as their input.  The input aggregation is defined via the `buckets_path`
@@ -158,7 +158,7 @@ POST /_search
 <1> `buckets_path` selects the hats and bags buckets (via `['hat']`/`['bag']``) to use in the script specifically,
 instead of fetching all the buckets from `sale_type` aggregation
 
-[float]
+[discrete]
 === Special Paths
 
 Instead of pathing to a metric, `buckets_path` can use a special `"_count"` path.  This instructs
@@ -229,7 +229,7 @@ POST /sales/_search
 for the `categories` aggregation
 
 [[dots-in-agg-names]]
-[float]
+[discrete]
 === Dealing with dots in agg names
 
 An alternate syntax is supported to cope with aggregations or metrics which
@@ -244,7 +244,7 @@ may be referred to as:
 // NOTCONSOLE
 
 [[gap-policy]]
-[float]
+[discrete]
 === Dealing with gaps in the data
 
 Data in the real world is often noisy and sometimes contains *gaps* -- places where data simply doesn't exist.  This can

--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -11,7 +11,7 @@ _Text analysis_ is the process of converting unstructured text, like
 the body of an email or a product description, into a structured format that's
 optimized for search.
 
-[float]
+[discrete]
 [[when-to-configure-analysis]]
 === When to configure text analysis
 
@@ -29,7 +29,7 @@ analysis configuration if you're using {es} to:
 * Fine-tune search for a specific language
 * Perform lexicographic or linguistic research
 
-[float]
+[discrete]
 [[analysis-toc]]
 === In this section
 

--- a/docs/reference/analysis/analyzers.asciidoc
+++ b/docs/reference/analysis/analyzers.asciidoc
@@ -45,7 +45,7 @@ Elasticsearch provides many language-specific analyzers like `english` or
 The `fingerprint` analyzer is a specialist analyzer which creates a
 fingerprint which can be used for duplicate detection.
 
-[float]
+[discrete]
 === Custom analyzers
 
 If you do not find an analyzer suitable for your needs, you can create a

--- a/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
@@ -8,7 +8,7 @@ When the built-in analyzers do not fulfill your needs, you can create a
 * a <<analysis-tokenizers,tokenizer>>
 * zero or more <<analysis-tokenfilters,token filters>>.
 
-[float]
+[discrete]
 === Configuration
 
 The `custom` analyzer accepts the following parameters:
@@ -36,7 +36,7 @@ The `custom` analyzer accepts the following parameters:
     ensure that a phrase query doesn't match two terms from different array
     elements.  Defaults to `100`. See <<position-increment-gap>> for more.
 
-[float]
+[discrete]
 === Example configuration
 
 Here is an example that combines the following:

--- a/docs/reference/analysis/analyzers/fingerprint-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/fingerprint-analyzer.asciidoc
@@ -12,7 +12,7 @@ Input text is lowercased, normalized to remove extended characters, sorted,
 deduplicated and concatenated into a single token.  If a stopword list is
 configured, stop words will also be removed.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -51,7 +51,7 @@ The above sentence would produce the following single term:
 [ and consistent godel is said sentence this yes ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `fingerprint` analyzer accepts the following parameters:
@@ -79,7 +79,7 @@ See the <<analysis-stop-tokenfilter,Stop Token Filter>> for more information
 about stop word configuration.
 
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `fingerprint` analyzer to use the
@@ -135,7 +135,7 @@ The above example produces the following term:
 [ consistent godel said sentence yes ]
 ---------------------------
 
-[float]
+[discrete]
 === Definition
 
 The `fingerprint` tokenizer consists of:

--- a/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc
@@ -7,7 +7,7 @@
 The `keyword` analyzer is a ``noop'' analyzer which returns the entire input
 string as a single token.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -46,12 +46,12 @@ The above sentence would produce the following single term:
 [ The 2 QUICK Brown-Foxes jumped over the lazy dog's bone. ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `keyword` analyzer is not configurable.
 
-[float]
+[discrete]
 === Definition
 
 The `keyword` analyzer consists of:

--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -22,7 +22,7 @@ Read more about http://www.regular-expressions.info/catastrophic.html[pathologic
 
 ========================================
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -138,7 +138,7 @@ The above sentence would produce the following terms:
 [ the, 2, quick, brown, foxes, jumped, over, the, lazy, dog, s, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `pattern` analyzer accepts the following parameters:
@@ -170,7 +170,7 @@ See the <<analysis-stop-tokenfilter,Stop Token Filter>> for more information
 about stop word configuration.
 
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `pattern` analyzer to split email addresses
@@ -258,7 +258,7 @@ The above example produces the following terms:
 [ john, smith, foo, bar, com ]
 ---------------------------
 
-[float]
+[discrete]
 ==== CamelCase tokenizer
 
 The following more complicated example splits CamelCase text into tokens:
@@ -363,7 +363,7 @@ The regex above is easier to understand as:
   )
 --------------------------------------------------
 
-[float]
+[discrete]
 === Definition
 
 The `pattern` anlayzer consists of:

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -10,7 +10,7 @@ Segmentation algorithm, as specified in
 http://unicode.org/reports/tr29/[Unicode Standard Annex #29]) and works well
 for most languages.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -119,7 +119,7 @@ The above sentence would produce the following terms:
 [ the, 2, quick, brown, foxes, jumped, over, the, lazy, dog's, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `standard` analyzer accepts the following parameters:
@@ -143,7 +143,7 @@ See the <<analysis-stop-tokenfilter,Stop Token Filter>> for more information
 about stop word configuration.
 
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `standard` analyzer to have a
@@ -263,7 +263,7 @@ The above example produces the following terms:
 [ 2, quick, brown, foxes, jumpe, d, over, lazy, dog's, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Definition
 
 The `standard` analyzer consists of:

--- a/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
@@ -8,7 +8,7 @@ The `stop` analyzer is the same as the <<analysis-simple-analyzer,`simple` analy
 but adds support for removing stop words.  It defaults to using the
 `_english_` stop words.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -103,7 +103,7 @@ The above sentence would produce the following terms:
 [ quick, brown, foxes, jumped, over, lazy, dog, s, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `stop` analyzer accepts the following parameters:
@@ -123,7 +123,7 @@ The `stop` analyzer accepts the following parameters:
 See the <<analysis-stop-tokenfilter,Stop Token Filter>> for more information
 about stop word configuration.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `stop` analyzer to use a specified list of
@@ -228,7 +228,7 @@ The above example produces the following terms:
 [ quick, brown, foxes, jumped, lazy, dog, s, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Definition
 
 It consists of:

--- a/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
@@ -7,7 +7,7 @@
 The `whitespace` analyzer breaks text into terms whenever it encounters a
 whitespace character.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -109,12 +109,12 @@ The above sentence would produce the following terms:
 [ The, 2, QUICK, Brown-Foxes, jumped, over, the, lazy, dog's, bone. ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `whitespace` analyzer is not configurable.
 
-[float]
+[discrete]
 === Definition
 
 It consists of:

--- a/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
+++ b/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
@@ -22,7 +22,7 @@ Read more about http://www.regular-expressions.info/catastrophic.html[pathologic
 
 ========================================
 
-[float]
+[discrete]
 === Configuration
 
 The `pattern_replace` character filter accepts the following parameters:
@@ -43,7 +43,7 @@ The `pattern_replace` character filter accepts the following parameters:
     Java regular expression http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#field.summary[flags].
     Flags should be pipe-separated, eg `"CASE_INSENSITIVE|COMMENTS"`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `pattern_replace` character filter to

--- a/docs/reference/analysis/normalizers.asciidoc
+++ b/docs/reference/analysis/normalizers.asciidoc
@@ -16,7 +16,7 @@ following: `arabic_normalization`, `asciifolding`, `bengali_normalization`,
 Elasticsearch ships with a `lowercase` built-in normalizer. For other forms of
 normalization a custom configuration is required.
 
-[float]
+[discrete]
 === Custom normalizers
 
 Custom normalizers take a list of

--- a/docs/reference/analysis/tokenfilters/multiplexer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/multiplexer-tokenfilter.asciidoc
@@ -11,7 +11,7 @@ output tokens at the same position will be removed.
 WARNING: If the incoming token stream has duplicate tokens, then these will also be
 removed by the multiplexer
 
-[float]
+[discrete]
 === Options
 [horizontal]
 filters:: a list of token filters to apply to incoming tokens.  These can be any
@@ -27,7 +27,7 @@ preserve_original:: if `true` (the default) then emit the original token in
   addition to the filtered tokens
 
 
-[float]
+[discrete]
 === Settings example
 
 You can set it up like:

--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -94,7 +94,7 @@ set to `false` no mapping would get added as when `expand=false` the target mapp
 `expand=true` then the mappings added would be equivalent to `foo, baz => foo, baz` i.e, all mappings other than the
 stop word.
 
-[float]
+[discrete]
 [[synonym-graph-tokenizer-ignore_case-deprecated]]
 ==== `tokenizer` and `ignore_case` are deprecated
 
@@ -104,7 +104,7 @@ The `ignore_case` parameter works with `tokenizer` parameter only.
 
 Two synonym formats are supported: Solr, WordNet.
 
-[float]
+[discrete]
 ==== Solr synonyms
 
 The following is a sample format of the file:
@@ -142,7 +142,7 @@ PUT /test_index
 However, it is recommended to define large synonyms set in a file using
 `synonyms_path`, because specifying them inline increases cluster size unnecessarily.
 
-[float]
+[discrete]
 ==== WordNet synonyms
 
 Synonyms based on http://wordnet.princeton.edu/[WordNet] format can be
@@ -175,7 +175,7 @@ PUT /test_index
 Using `synonyms_path` to define WordNet synonyms in a file is supported
 as well.
 
-[float]
+[discrete]
 ==== Parsing synonym files
 
 Elasticsearch will use the token filters preceding the synonym filter

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -85,7 +85,7 @@ set to `false` no mapping would get added as when `expand=false` the target mapp
 stop word.
 
 
-[float]
+[discrete]
 [[synonym-tokenizer-ignore_case-deprecated]]
 ==== `tokenizer` and `ignore_case` are deprecated
 
@@ -95,7 +95,7 @@ The `ignore_case` parameter works with `tokenizer` parameter only.
 
 Two synonym formats are supported: Solr, WordNet.
 
-[float]
+[discrete]
 ==== Solr synonyms
 
 The following is a sample format of the file:
@@ -133,7 +133,7 @@ PUT /test_index
 However, it is recommended to define large synonyms set in a file using
 `synonyms_path`, because specifying them inline increases cluster size unnecessarily.
 
-[float]
+[discrete]
 ==== WordNet synonyms
 
 Synonyms based on http://wordnet.princeton.edu/[WordNet] format can be

--- a/docs/reference/analysis/tokenizers.asciidoc
+++ b/docs/reference/analysis/tokenizers.asciidoc
@@ -18,7 +18,7 @@ represents (used for highlighting search snippets).
 Elasticsearch has a number of built in tokenizers which can be used to build
 <<analysis-custom-analyzer,custom analyzers>>.
 
-[float]
+[discrete]
 === Word Oriented Tokenizers
 
 The following tokenizers are usually used for tokenizing full text into
@@ -59,7 +59,7 @@ The `classic` tokenizer is a grammar based tokenizer for the English Language.
 
 The `thai` tokenizer segments Thai text into words.
 
-[float]
+[discrete]
 === Partial Word Tokenizers
 
 These tokenizers break up text or words into small fragments, for partial word
@@ -80,7 +80,7 @@ n-grams of each word which are anchored to the start of the word, e.g. `quick` -
 `[q, qu, qui, quic, quick]`.
 
 
-[float]
+[discrete]
 === Structured Text Tokenizers
 
 The following tokenizers are usually used with structured text like

--- a/docs/reference/analysis/tokenizers/chargroup-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/chargroup-tokenizer.asciidoc
@@ -9,7 +9,7 @@ character which is in a defined set. It is mostly useful for cases where a simpl
 custom tokenization is desired, and the overhead of use of the <<analysis-pattern-tokenizer, `pattern` tokenizer>>
 is not acceptable.
 
-[float]
+[discrete]
 === Configuration
 
 The `char_group` tokenizer accepts one parameter:
@@ -26,7 +26,7 @@ The `char_group` tokenizer accepts one parameter:
     it is split at `max_token_length` intervals. Defaults to `255`.
 
 
-[float]
+[discrete]
 === Example output
 
 [source,console]

--- a/docs/reference/analysis/tokenizers/classic-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/classic-tokenizer.asciidoc
@@ -18,7 +18,7 @@ languages other than English:
 
 * It recognizes email addresses and internet hostnames as one token.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -127,7 +127,7 @@ The above sentence would produce the following terms:
 [ The, 2, QUICK, Brown, Foxes, jumped, over, the, lazy, dog's, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `classic` tokenizer accepts the following parameters:
@@ -138,7 +138,7 @@ The `classic` tokenizer accepts the following parameters:
     The maximum token length. If a token is seen that exceeds this length then
     it is split at `max_token_length` intervals. Defaults to `255`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `classic` tokenizer to have a

--- a/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
@@ -17,7 +17,7 @@ order, such as movie or song titles, the
 choice than edge N-grams.  Edge N-grams have the advantage when trying to
 autocomplete words that can appear in any order.
 
-[float]
+[discrete]
 === Example output
 
 With the default settings, the `edge_ngram` tokenizer treats the initial text as a
@@ -70,7 +70,7 @@ The above sentence would produce the following terms:
 NOTE: These default gram lengths are almost entirely useless.  You need to
 configure the `edge_ngram` before using it.
 
-[float]
+[discrete]
 === Configuration
 
 The `edge_ngram` tokenizer accepts the following parameters:
@@ -108,7 +108,7 @@ Character classes may be any of the following:
     setting this to `+-_` will make the tokenizer treat the plus, minus and
     underscore sign  as part of a token.
 
-[float]
+[discrete]
 [[max-gram-limits]]
 === Limitations of the `max_gram` parameter
 
@@ -133,7 +133,7 @@ and `apple`.
 We recommend testing both approaches to see which best fits your
 use case and desired search experience.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `edge_ngram` tokenizer to treat letters and

--- a/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
@@ -8,7 +8,7 @@ The `keyword` tokenizer  is a ``noop'' tokenizer that accepts whatever text it
 is given and outputs the exact same text as a single term.  It can be combined
 with token filters to normalise output, e.g. lower-casing email addresses.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -95,7 +95,7 @@ The request produces the following token:
 ---------------------------
 
 
-[float]
+[discrete]
 === Configuration
 
 The `keyword` tokenizer accepts the following parameters:

--- a/docs/reference/analysis/tokenizers/letter-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/letter-tokenizer.asciidoc
@@ -9,7 +9,7 @@ character which is not a letter. It does a reasonable job for most European
 languages, but does a terrible job for some Asian languages, where words are
 not separated by spaces.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -118,7 +118,7 @@ The above sentence would produce the following terms:
 [ The, QUICK, Brown, Foxes, jumped, over, the, lazy, dog, s, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `letter` tokenizer is not configurable.

--- a/docs/reference/analysis/tokenizers/lowercase-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/lowercase-tokenizer.asciidoc
@@ -13,7 +13,7 @@ lowercases all terms.  It is functionally equivalent to the
 efficient as it performs both steps in a single pass.
 
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -122,7 +122,7 @@ The above sentence would produce the following terms:
 [ the, quick, brown, foxes, jumped, over, the, lazy, dog, s, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `lowercase` tokenizer is not configurable.

--- a/docs/reference/analysis/tokenizers/ngram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/ngram-tokenizer.asciidoc
@@ -13,7 +13,7 @@ N-grams are like a sliding window that moves across the word - a continuous
 sequence of characters of the specified length. They are useful for querying
 languages that don't use spaces or that have long compound words, like German.
 
-[float]
+[discrete]
 === Example output
 
 With the default settings, the `ngram` tokenizer treats the initial text as a
@@ -168,7 +168,7 @@ The above sentence would produce the following terms:
 [ Q, Qu, u, ui, i, ic, c, ck, k, "k ", " ", " F", F, Fo, o, ox, x ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `ngram` tokenizer accepts the following parameters:
@@ -210,7 +210,7 @@ matches.  A tri-gram (length `3`) is a good place to start.
 The index level setting `index.max_ngram_diff` controls the maximum allowed
 difference between `max_gram` and `min_gram`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `ngram` tokenizer to treat letters and

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
@@ -8,7 +8,7 @@ The `path_hierarchy` tokenizer takes a hierarchical value like a filesystem
 path, splits on the path separator, and emits a term for each component in the
 tree.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -62,7 +62,7 @@ The above text would produce the following terms:
 [ /one, /one/two, /one/two/three ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `path_hierarchy` tokenizer accepts the following parameters:
@@ -86,7 +86,7 @@ The `path_hierarchy` tokenizer accepts the following parameters:
 `skip`::
     The number of initial tokens to skip.  Defaults to `0`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `path_hierarchy` tokenizer to split on `-`

--- a/docs/reference/analysis/tokenizers/pattern-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pattern-tokenizer.asciidoc
@@ -25,7 +25,7 @@ Read more about http://www.regular-expressions.info/catastrophic.html[pathologic
 
 ========================================
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -99,7 +99,7 @@ The above sentence would produce the following terms:
 [ The, foo_bar_size, s, default, is, 5 ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `pattern` tokenizer accepts the following parameters:
@@ -118,7 +118,7 @@ The `pattern` tokenizer accepts the following parameters:
 
     Which capture group to extract as tokens.  Defaults to `-1` (split).
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `pattern` tokenizer to break text into

--- a/docs/reference/analysis/tokenizers/simplepattern-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/simplepattern-tokenizer.asciidoc
@@ -20,7 +20,7 @@ For an explanation of the supported features and syntax, see <<regexp-syntax,Reg
 The default pattern is the empty string, which produces no terms. This
 tokenizer should always be configured with a non-default pattern.
 
-[float]
+[discrete]
 === Configuration
 
 The `simple_pattern` tokenizer accepts the following parameters:
@@ -29,7 +29,7 @@ The `simple_pattern` tokenizer accepts the following parameters:
 `pattern`::
     {lucene-core-javadoc}/org/apache/lucene/util/automaton/RegExp.html[Lucene regular expression], defaults to the empty string.
 
-[float]
+[discrete]
 === Example configuration
 
 This example configures the `simple_pattern` tokenizer to produce terms that are

--- a/docs/reference/analysis/tokenizers/simplepatternsplit-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/simplepatternsplit-tokenizer.asciidoc
@@ -21,7 +21,7 @@ The default pattern is the empty string, which produces one term containing the
 full input. This tokenizer should always be configured with a non-default
 pattern.
 
-[float]
+[discrete]
 === Configuration
 
 The `simple_pattern_split` tokenizer accepts the following parameters:
@@ -30,7 +30,7 @@ The `simple_pattern_split` tokenizer accepts the following parameters:
 `pattern`::
     A {lucene-core-javadoc}/org/apache/lucene/util/automaton/RegExp.html[Lucene regular expression], defaults to the empty string.
 
-[float]
+[discrete]
 === Example configuration
 
 This example configures the `simple_pattern_split` tokenizer to split the input

--- a/docs/reference/analysis/tokenizers/standard-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/standard-tokenizer.asciidoc
@@ -9,7 +9,7 @@ Unicode Text Segmentation algorithm, as specified in
 http://unicode.org/reports/tr29/[Unicode Standard Annex #29]) and works well
 for most languages.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -118,7 +118,7 @@ The above sentence would produce the following terms:
 [ The, 2, QUICK, Brown, Foxes, jumped, over, the, lazy, dog's, bone ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `standard` tokenizer accepts the following parameters:
@@ -129,7 +129,7 @@ The `standard` tokenizer accepts the following parameters:
     The maximum token length. If a token is seen that exceeds this length then
     it is split at `max_token_length` intervals. Defaults to `255`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `standard` tokenizer to have a

--- a/docs/reference/analysis/tokenizers/thai-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/thai-tokenizer.asciidoc
@@ -13,7 +13,7 @@ WARNING: This tokenizer may not be supported by all JREs. It is known to work
 with Sun/Oracle and OpenJDK. If your application needs to be fully portable,
 consider using the {plugins}/analysis-icu-tokenizer.html[ICU Tokenizer] instead.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -101,7 +101,7 @@ The above sentence would produce the following terms:
 [ การ, ที่, ได้, ต้อง, แสดง, ว่า, งาน, ดี ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `thai` tokenizer is not configurable.

--- a/docs/reference/analysis/tokenizers/uaxurlemail-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/uaxurlemail-tokenizer.asciidoc
@@ -7,7 +7,7 @@
 The `uax_url_email` tokenizer is like the <<analysis-standard-tokenizer,`standard` tokenizer>> except that it
 recognises URLs and email addresses as single tokens.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -74,7 +74,7 @@ while the `standard` tokenizer would produce:
 [ Email, me, at, john.smith, global, international.com ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `uax_url_email` tokenizer accepts the following parameters:
@@ -85,7 +85,7 @@ The `uax_url_email` tokenizer accepts the following parameters:
     The maximum token length. If a token is seen that exceeds this length then
     it is split at `max_token_length` intervals. Defaults to `255`.
 
-[float]
+[discrete]
 === Example configuration
 
 In this example, we configure the `uax_url_email` tokenizer to have a

--- a/docs/reference/analysis/tokenizers/whitespace-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/whitespace-tokenizer.asciidoc
@@ -7,7 +7,7 @@
 The `whitespace` tokenizer breaks text into terms whenever it encounters a
 whitespace character.
 
-[float]
+[discrete]
 === Example output
 
 [source,console]
@@ -109,7 +109,7 @@ The above sentence would produce the following terms:
 [ The, 2, QUICK, Brown-Foxes, jumped, over, the, lazy, dog's, bone. ]
 ---------------------------
 
-[float]
+[discrete]
 === Configuration
 
 The `whitespace` tokenizer accepts the following parameters:

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -160,7 +160,7 @@ include::rest-api/cron-expressions.asciidoc[]
 
 The following options can be applied to all of the REST APIs.
 
-[float]
+[discrete]
 ==== Pretty Results
 
 When appending `?pretty=true` to any request made, the JSON returned
@@ -169,7 +169,7 @@ to set `?format=yaml` which will cause the result to be returned in the
 (sometimes) more readable yaml format.
 
 
-[float]
+[discrete]
 ==== Human readable output
 
 Statistics are returned in a format suitable for humans
@@ -182,7 +182,7 @@ consumption.  The default for the `human` flag is
 `false`.
 
 [[date-math]]
-[float]
+[discrete]
 ==== Date Math
 
 Most parameters which accept a formatted date value -- such as `gt` and `lt`
@@ -219,7 +219,7 @@ Assuming `now` is `2001-01-01 12:00:00`, some examples are:
 `now-1h/d`:: `now` in milliseconds minus one hour, rounded down to UTC 00:00. Resolves to: `2001-01-01 00:00:00`
  `2001.02.01\|\|+1M/d`:: `2001-02-01` in milliseconds plus one month. Resolves to: `2001-03-01 00:00:00`
 
-[float]
+[discrete]
 [[common-options-response-filtering]]
 ==== Response Filtering
 
@@ -376,7 +376,7 @@ GET /_search?filter_path=hits.hits._source&_source=title&sort=rating:desc
 --------------------------------------------------
 
 
-[float]
+[discrete]
 ==== Flat Settings
 
 The `flat_settings` flag affects rendering of the lists of settings. When the
@@ -445,27 +445,27 @@ Returns:
 
 By default `flat_settings` is set to `false`.
 
-[float]
+[discrete]
 ==== Parameters
 
 Rest parameters (when using HTTP, map to HTTP URL parameters) follow the
 convention of using underscore casing.
 
-[float]
+[discrete]
 ==== Boolean Values
 
 All REST API parameters (both request parameters and JSON body) support
 providing boolean "false" as the value `false` and boolean "true" as the
 value `true`. All other values will raise an error.
 
-[float]
+[discrete]
 ==== Number Values
 
 All REST APIs support providing numbered parameters as `string` on top
 of supporting the native JSON number types.
 
 [[time-units]]
-[float]
+[discrete]
 ==== Time units
 
 Whenever durations need to be specified, e.g. for a `timeout` parameter, the duration must specify
@@ -481,7 +481,7 @@ the unit, like `2d` for 2 days.  The supported units are:
 `nanos`::   Nanoseconds
 
 [[byte-units]]
-[float]
+[discrete]
 ==== Byte size units
 
 Whenever the byte size of data needs to be specified, e.g. when setting a buffer size
@@ -497,7 +497,7 @@ these units use powers of 1024, so `1kb` means 1024 bytes. The supported units a
 `pb`::  Petabytes
 
 [[size-units]]
-[float]
+[discrete]
 ==== Unit-less quantities
 
 Unit-less quantities means that they don't have a "unit" like "bytes" or "Hertz" or "meter" or "long tonne".
@@ -513,7 +513,7 @@ when we mean 87 though. These are the supported multipliers:
 `p`::  Peta
 
 [[distance-units]]
-[float]
+[discrete]
 ==== Distance Units
 
 Wherever distances need to be specified, such as the `distance` parameter in
@@ -535,7 +535,7 @@ Millimeter::    `mm` or `millimeters`
 Nautical mile:: `NM`, `nmi`, or `nauticalmiles`
 
 [[fuzziness]]
-[float]
+[discrete]
 ==== Fuzziness
 
 Some queries and APIs support parameters to allow inexact _fuzzy_ matching,
@@ -567,7 +567,7 @@ the default values are 3 and 6, equivalent to `AUTO:3,6` that make for lengths:
 `AUTO` should generally be the preferred value for `fuzziness`.
 --
 
-[float]
+[discrete]
 [[common-options-error-options]]
 ==== Enabling stack traces
 
@@ -643,7 +643,7 @@ The response looks like:
 // TESTRESPONSE[s/"stack_trace": "java.lang.IllegalArgum.+\.\.\."/"stack_trace": $body.error.stack_trace/]
 // TESTRESPONSE[s/"stack_trace": "java.lang.Number.+\.\.\."/"stack_trace": $body.error.caused_by.stack_trace/]
 
-[float]
+[discrete]
 ==== Request body in query string
 
 For libraries that don't accept a request body for non-POST requests,
@@ -652,7 +652,7 @@ instead. When using this method, the `source_content_type` parameter
 should also be passed with a media type value that indicates the format
 of the source, such as `application/json`.
 
-[float]
+[discrete]
 ==== Content-Type Requirements
 
 The type of the content sent in a request body must be specified using

--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -5,7 +5,7 @@
 
 You can use the following APIs to perform autoscaling operations.
 
-[float]
+[discrete]
 [[autoscaling-api-top-level]]
 === Top-Level
 

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -21,11 +21,11 @@ All the cat commands accept a query string parameter `help` to see all
 the headers and info they provide, and the `/_cat` command alone lists all
 the available commands.
 
-[float]
+[discrete]
 [[common-parameters]]
 === Common parameters
 
-[float]
+[discrete]
 [[verbose]]
 ==== Verbose
 
@@ -46,7 +46,7 @@ u_n93zwxThWHi1PDBJAGAg 127.0.0.1 127.0.0.1 u_n93zw
 --------------------------------------------------
 // TESTRESPONSE[s/u_n93zw(xThWHi1PDBJAGAg)?/.+/ non_json]
 
-[float]
+[discrete]
 [[help]]
 ==== Help
 
@@ -74,7 +74,7 @@ For example `GET _cat/shards/twitter?help` or `GET _cat/indices/twi*?help`
 results in an error. Use `GET _cat/shards?help` or `GET _cat/indices?help`
 instead.
 
-[float]
+[discrete]
 [[headers]]
 ==== Headers
 
@@ -98,7 +98,7 @@ You can also request multiple columns using simple wildcards like
 `/_cat/thread_pool?h=ip,queue*` to get all headers (or aliases) starting
 with `queue`.
 
-[float]
+[discrete]
 [[numeric-formats]]
 ==== Numeric formats
 
@@ -141,7 +141,7 @@ If you want to change the <<size-units,size units>>, use `size` parameter.
 
 If you want to change the <<byte-units,byte units>>, use `bytes` parameter.
 
-[float]
+[discrete]
 ==== Response as text, json, smile, yaml or cbor
 
 [source,sh]
@@ -193,7 +193,7 @@ For example:
 --------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[sort]]
 ==== Sort
 

--- a/docs/reference/ccr/apis/ccr-apis.asciidoc
+++ b/docs/reference/ccr/apis/ccr-apis.asciidoc
@@ -5,13 +5,13 @@
 
 You can use the following APIs to perform {ccr} operations.
 
-[float]
+[discrete]
 [[ccr-api-top-level]]
 === Top-Level
 
 * <<ccr-get-stats,Get {ccr} stats>>
 
-[float]
+[discrete]
 [[ccr-api-follow]]
 === Follow
 
@@ -23,7 +23,7 @@ You can use the following APIs to perform {ccr} operations.
 * <<ccr-get-follow-stats,Get stats about follower indices>>
 * <<ccr-get-follow-info,Get info about follower indices>>
 
-[float]
+[discrete]
 [[ccr-api-auto-follow]]
 === Auto-follow
 

--- a/docs/reference/commands/certgen.asciidoc
+++ b/docs/reference/commands/certgen.asciidoc
@@ -10,7 +10,7 @@ authorities (CA), certificate signing requests (CSR), and signed certificates
 for use with the Elastic Stack. Though this command is deprecated, you do not
 need to replace CAs, CSRs, or certificates that it created.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -23,7 +23,7 @@ bin/elasticsearch-certgen
 ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 By default, the command runs in interactive mode and you are prompted for
@@ -54,7 +54,7 @@ organization-specific certificate authority to obtain signed certificates. The
 signed certificates must be in PEM format to work with the {stack}
 {security-features}.
 
-[float]
+[discrete]
 === Parameters
 
 `--cert <cert_file>`:: Specifies to generate new instance certificates and keys
@@ -103,10 +103,10 @@ which can be blank. This parameter cannot be used with the `-csr` parameter.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
-[float]
+[discrete]
 [[certgen-silent]]
 ==== Using `elasticsearch-certgen` in Silent Mode
 

--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -6,7 +6,7 @@
 The `elasticsearch-certutil` command simplifies the creation of certificates for
 use with Transport Layer Security (TLS) in the {stack}.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -32,14 +32,14 @@ bin/elasticsearch-certutil
 [-h, --help] ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 You can specify one of the following modes: `ca`, `cert`, `csr`, `http`. The
 `elasticsearch-certutil` command also supports a silent mode of operation to
 enable easier batch operations.
 
-[float]
+[discrete]
 [[certutil-ca]]
 ==== CA mode
 
@@ -51,7 +51,7 @@ format.
 
 You can subsequently use these files as input for the `cert` mode of the command.
 
-[float]
+[discrete]
 [[certutil-cert]]
 ==== CERT mode
 
@@ -90,7 +90,7 @@ certificates and keys and packages them into a zip file.
 If you specify the `--keep-ca-key`, `--multiple` or `--in` parameters,
 the command produces a zip file containing the generated certificates and keys.
 
-[float]
+[discrete]
 [[certutil-csr]]
 ==== CSR mode
 
@@ -111,7 +111,7 @@ private keys for each instance. Each CSR is provided as a standard PEM
 encoding of a PKCS#10 CSR. Each key is provided as a PEM encoding of an RSA
 private key.
 
-[float]
+[discrete]
 [[certutil-http]]
 ==== HTTP mode
 
@@ -123,7 +123,7 @@ authority (CA), a certificate signing request (CSR), or certificates and keys
 for use in {es} and {kib}. Each folder in the zip file contains a readme that
 explains how to use the files.
 
-[float]
+[discrete]
 === Parameters
 
 `ca`:: Specifies to generate a new local certificate authority (CA). This
@@ -214,7 +214,7 @@ parameter cannot be used with the `csr` parameter.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
 The following command generates a CA certificate and private key in PKCS#12
@@ -244,7 +244,7 @@ which you can copy to the relevant configuration directory for each Elastic
 product that you want to configure. For more information, see
 <<ssl-tls>>.
 
-[float]
+[discrete]
 [[certutil-silent]]
 ==== Using `elasticsearch-certutil` in Silent Mode
 

--- a/docs/reference/commands/migrate-tool.asciidoc
+++ b/docs/reference/commands/migrate-tool.asciidoc
@@ -10,7 +10,7 @@ to the native realm. From 5.0 onward, you should use the `native` realm to
 manage roles and local users.
 
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -23,7 +23,7 @@ bin/elasticsearch-migrate
 [-s, --silent] [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 NOTE: When migrating from Shield 2.x, the `elasticsearch-migrate` tool should be
@@ -38,7 +38,7 @@ roles that already exist in the `native` realm are not replaced or
 overridden. If the names you specify with the `--users` and `--roles` options
 don't exist in the `file` realm, they are skipped.
 
-[float]
+[discrete]
 [[migrate-tool-options]]
 === Parameters
 The `native` subcommand supports the following options:
@@ -73,7 +73,7 @@ Username to use for authentication with {es}.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
 Run the `elasticsearch-migrate` tool when {xpack} is installed. For example:

--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -7,7 +7,7 @@ allows you to adjust the <<modules-node,role>> of a node, unsafely edit cluster
 settings and may be able to recover some data after a disaster or start a node
 even if it is incompatible with the data on disk.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -17,7 +17,7 @@ bin/elasticsearch-node repurpose|unsafe-bootstrap|detach-cluster|override-versio
   [-h, --help] ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 This tool has a number of modes:
@@ -51,7 +51,7 @@ This tool has a number of modes:
   {es}.
 
 [[node-tool-repurpose]]
-[float]
+[discrete]
 ==== Changing the role of a node
 
 There may be situations where you want to repurpose a node without following
@@ -83,7 +83,7 @@ The tool provides a summary of the data to be deleted and asks for confirmation
 before making any changes. You can get detailed information about the affected
 indices and shards by passing the verbose (`-v`) option.
 
-[float]
+[discrete]
 ==== Removing persistent cluster settings
 
 There may be situations where a node contains persistent cluster
@@ -103,7 +103,7 @@ The intended use is:
 * Repeat for all other master-eligible nodes
 * Start the nodes
 
-[float]
+[discrete]
 ==== Removing custom metadata from the cluster state
 
 There may be situations where a node contains custom metadata, typically
@@ -121,7 +121,7 @@ The intended use is:
 * Repeat for all other master-eligible nodes
 * Start the nodes
 
-[float]
+[discrete]
 ==== Recovering data after a disaster
 
 Sometimes {es} nodes are temporarily stopped, perhaps because of the need to
@@ -161,7 +161,7 @@ way forward that does not risk data loss, but it may be possible to use the
 data from the failed cluster.
 
 [[node-tool-override-version]]
-[float]
+[discrete]
 ==== Bypassing version checks
 
 The data that {es} writes to disk is designed to be read by the current version
@@ -181,7 +181,7 @@ tool to overwrite the version number stored in the data path with the current
 version, causing {es} to believe that it is compatible with the on-disk data.
 
 [[node-tool-unsafe-bootstrap]]
-[float]
+[discrete]
 ===== Unsafe cluster bootstrapping
 
 If there is at least one remaining master-eligible node, but it is not possible
@@ -256,7 +256,7 @@ there has been no data loss, it just means that tool was able to complete its
 job.
 
 [[node-tool-detach-cluster]]
-[float]
+[discrete]
 ===== Detaching nodes from their cluster
 
 It is unsafe for nodes to move between clusters, because different clusters
@@ -321,7 +321,7 @@ that there has been no data loss, it just means that tool was able to complete
 its job.
 
 
-[float]
+[discrete]
 === Parameters
 
 `repurpose`:: Delete excess data when a node's roles are changed.
@@ -350,10 +350,10 @@ to `0`, meaning to use the first node in the data path.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
-[float]
+[discrete]
 ==== Repurposing a node as a dedicated master node
 
 In this example, a former data node is repurposed as a dedicated master node.
@@ -375,7 +375,7 @@ Confirm [y/N] y
 Node successfully repurposed to master and no-data.
 ----
 
-[float]
+[discrete]
 ==== Repurposing a node as a coordinating-only node
 
 In this example, a node that previously held data is repurposed as a
@@ -398,7 +398,7 @@ Confirm [y/N] y
 Node successfully repurposed to no-master and no-data.
 ----
 
-[float]
+[discrete]
 ==== Removing persistent cluster settings
 
 If your nodes contain persistent cluster settings that prevent the cluster
@@ -432,7 +432,7 @@ You can also use wildcards to remove multiple settings, for example using
 node$ ./bin/elasticsearch-node remove-settings xpack.monitoring.*
 ----
 
-[float]
+[discrete]
 ==== Removing custom metadata from the cluster state
 
 If the on-disk cluster state contains custom metadata that prevents the node
@@ -459,7 +459,7 @@ Confirm [y/N] y
 Customs were successfully removed from the cluster state
 ----
 
-[float]
+[discrete]
 ==== Unsafe cluster bootstrapping
 
 Suppose your cluster had five master-eligible nodes and you have permanently
@@ -535,7 +535,7 @@ Confirm [y/N] y
 Master node was successfully bootstrapped
 ----
 
-[float]
+[discrete]
 ==== Detaching nodes from their cluster
 
 After unsafely bootstrapping a new cluster, run the `elasticsearch-node
@@ -561,7 +561,7 @@ Confirm [y/N] y
 Node was successfully detached from the cluster
 ----
 
-[float]
+[discrete]
 ==== Bypassing version checks
 
 Run the `elasticsearch-node override-version` command to overwrite the version

--- a/docs/reference/commands/saml-metadata.asciidoc
+++ b/docs/reference/commands/saml-metadata.asciidoc
@@ -6,7 +6,7 @@
 The `elasticsearch-saml-metadata` command can be used to generate a SAML 2.0 Service
 Provider Metadata file.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -23,7 +23,7 @@ bin/elasticsearch-saml-metadata
 [-h, --help] ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 The SAML 2.0 specification provides a mechanism for Service Providers to
@@ -44,7 +44,7 @@ If your {es} keystore is password protected, you
 are prompted to enter the password when you run the
 `elasticsearch-saml-metadata` command.
 
-[float]
+[discrete]
 === Parameters
 
 `--attribute <name>`:: Specifies a SAML attribute that should be
@@ -107,7 +107,7 @@ realm in your {es} configuration.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
 The following command generates a default metadata file for the `saml1` realm:

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -6,7 +6,7 @@
 The `elasticsearch-setup-passwords` command sets the passwords for the
 <<built-in-users,built-in users>>.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -16,7 +16,7 @@ bin/elasticsearch-setup-passwords auto|interactive
 [-s, --silent] [-u, --url "<URL>"] [-v, --verbose]
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 This command is intended for use only during the initial configuration of the
@@ -40,7 +40,7 @@ override settings in your `elasticsearch.yml` file by using the `-E` command
 option. For more information about debugging connection failures, see
 <<trb-security-setup>>.
 
-[float]
+[discrete]
 === Parameters
 
 `auto`::  Outputs randomly-generated passwords to the console.
@@ -63,7 +63,7 @@ you must specify an HTTPS URL.
 
 `-v, --verbose`:: Shows verbose output.
 
-[float]
+[discrete]
 === Examples
 
 The following example uses the `-u` parameter to tell the tool where to submit

--- a/docs/reference/commands/shard-tool.asciidoc
+++ b/docs/reference/commands/shard-tool.asciidoc
@@ -11,7 +11,7 @@ You will lose the corrupted data when you run `elasticsearch-shard`.  This tool
 should only be used as a last resort if there is no way to recover from another
 copy of the shard or restore a snapshot.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -23,7 +23,7 @@ bin/elasticsearch-shard remove-corrupted-data
   [-h, --help] ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 When {es} detects that a shard's data is corrupted, it fails that shard copy and
@@ -44,7 +44,7 @@ There are two ways to specify the path:
 * Use the `--dir` option to specify the full path to the corrupted index or
   translog files.
 
-[float]
+[discrete]
 ==== Removing corrupted data
 
 `elasticsearch-shard` analyses the shard copy and provides an overview of the

--- a/docs/reference/commands/syskeygen.asciidoc
+++ b/docs/reference/commands/syskeygen.asciidoc
@@ -6,7 +6,7 @@
 The `elasticsearch-syskeygen` command creates a system key file in the
 elasticsearch config directory.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -16,7 +16,7 @@ bin/elasticsearch-syskeygen
 ([-s, --silent] | [-v, --verbose])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 The command generates a `system_key` file, which you can use to symmetrically
@@ -27,7 +27,7 @@ from returning and storing information that contains clear text credentials. See
 IMPORTANT: The system key is a symmetric key, so the same key must be used on
 every node in the cluster.
 
-[float]
+[discrete]
 === Parameters
 
 `-E <KeyValuePair>`:: Configures a setting. For example, if you have a custom
@@ -41,7 +41,7 @@ environment variable.
 `-v, --verbose`:: Shows verbose output.
 
 
-[float]
+[discrete]
 === Examples
 
 The following command generates a `system_key` file in the

--- a/docs/reference/commands/users-command.asciidoc
+++ b/docs/reference/commands/users-command.asciidoc
@@ -6,7 +6,7 @@
 If you use file-based user authentication, the `elasticsearch-users` command
 enables you to add and remove users, assign user roles, and manage passwords.
 
-[float]
+[discrete]
 === Synopsis
 
 [source,shell]
@@ -19,7 +19,7 @@ bin/elasticsearch-users
 ([userdel <username>])
 --------------------------------------------------
 
-[float]
+[discrete]
 === Description
 
 If you use the built-in `file` internal realm, users are defined in local files
@@ -40,7 +40,7 @@ TIP: To ensure that {es} can read the user and role information at startup, run
 command as root or some other user updates the permissions for the `users` and
 `users_roles` files and prevents {es} from accessing them.
 
-[float]
+[discrete]
 === Parameters
 
 `-a <roles>`:: If used with the `roles` parameter, adds a comma-separated list
@@ -81,10 +81,10 @@ removing roles within the same command to change a user's roles.
 
 //`-v, --verbose`:: Shows verbose output.
 
-//[float]
+//[discrete]
 //=== Authorization
 
-[float]
+[discrete]
 === Examples
 
 The following example adds a new user named `jacknich` to the `file` realm. The

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -89,7 +89,7 @@ Experiment with different settings to find the optimal size for your particular 
 When using the HTTP API, make sure that the client does not send HTTP chunks, 
 as this will slow things down.
 
-[float]
+[discrete]
 [[bulk-clients]]
 ===== Client support for bulk requests
 
@@ -116,7 +116,7 @@ JavaScript::
 .NET::
     See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
 
-[float]
+[discrete]
 [[bulk-curl]]
 ===== Submitting bulk requests with cURL
 
@@ -135,7 +135,7 @@ $ curl -s -H "Content-Type: application/x-ndjson" -XPOST localhost:9200/_bulk --
 // NOTCONSOLE
 // Not converting to console because this shows how curl works
 
-[float]
+[discrete]
 [[bulk-optimistic-concurrency-control]]
 ===== Optimistic Concurrency Control
 
@@ -146,7 +146,7 @@ how operations are executed, based on the last modification to existing
 documents. See <<optimistic-concurrency-control>> for more details.
 
 
-[float]
+[discrete]
 [[bulk-versioning]]
 ===== Versioning
 
@@ -155,7 +155,7 @@ Each bulk item can include the version value using the
 index / delete operation based on the `_version` mapping. It also
 support the `version_type` (see <<index-versioning, versioning>>).
 
-[float]
+[discrete]
 [[bulk-routing]]
 ===== Routing
 
@@ -166,7 +166,7 @@ index / delete operation based on the `_routing` mapping.
 NOTE: Data streams do not support custom routing. Instead, target the
 appropriate backing index for the stream.
 
-[float]
+[discrete]
 [[bulk-wait-for-active-shards]]
 ===== Wait For Active Shards
 
@@ -176,7 +176,7 @@ before starting to process the bulk request. See
 <<index-wait-for-active-shards,here>> for further details and a usage
 example.
 
-[float]
+[discrete]
 [[bulk-refresh]]
 ===== Refresh
 
@@ -190,7 +190,7 @@ with five shards. The request will only wait for those three shards to
 refresh. The other two shards that make up the index do not
 participate in the `_bulk` request at all.
 
-[float]
+[discrete]
 [[bulk-security]]
 ===== Security
 
@@ -537,7 +537,7 @@ The API returns the following result:
 // TESTRESPONSE[s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
 // TESTRESPONSE[s/"_primary_term" : 4/"_primary_term" : $body.items.3.update._primary_term/]
 
-[float]
+[discrete]
 [[bulk-update]]
 ===== Bulk update example
 

--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -2,7 +2,7 @@
 [[docs-replication]]
 === Reading and Writing documents
 
-[float]
+[discrete]
 ==== Introduction
 
 Each index in Elasticsearch is <<scalability,divided into shards>>
@@ -53,7 +53,7 @@ encompasses the lifetime of each subsequent stage. For example, the coordinating
 stage, which may be spread out across different primary shards, has completed. Each primary stage will not complete until the
 in-sync replicas have finished indexing the docs locally and responded to the replica requests.
 
-[float]
+[discrete]
 ===== Failure handling
 
 Many things can go wrong during indexing -- disks can get corrupted, nodes can be disconnected from each other, or some
@@ -94,7 +94,7 @@ into the primary will not be lost. Of course, since at that point we are running
 issues can cause data loss. See <<index-wait-for-active-shards>> for some mitigation options.
 ************
 
-[float]
+[discrete]
 ==== Basic read model
 
 Reads in Elasticsearch can be very lightweight lookups by ID or a heavy search request with complex aggregations that
@@ -112,7 +112,7 @@ is as follows:
 . Send shard level read requests to the selected copies.
 . Combine the results and respond. Note that in the case of get by ID look up, only one shard is relevant and this step can be skipped.
 
-[float]
+[discrete]
 [[shard-failures]]
 ===== Shard failures
 
@@ -132,7 +132,7 @@ Responses containing partial results still provide a `200 OK` HTTP status code.
 Shard failures are indicated by the `timed_out` and `_shards` fields of
 the response header.
 
-[float]
+[discrete]
 ==== A few simple implications
 
 Each of these basic flows determines how Elasticsearch behaves as a system for both reads and writes. Furthermore, since read
@@ -147,7 +147,7 @@ Read unacknowledged:: Since the primary first indexes locally and then replicate
 Two copies by default:: This model can be fault tolerant while maintaining only two copies of the data. This is in contrast to
   quorum-based system where the minimum number of copies for fault tolerance is 3.
 
-[float]
+[discrete]
 ==== Failures
 
 Under failures, the following is possible:
@@ -161,7 +161,7 @@ Dirty reads:: An isolated primary can expose writes that will not be acknowledge
   At that point the operation is already indexed into the primary and can be read by a concurrent read. Elasticsearch mitigates
   this risk by pinging the master every second (by default) and rejecting indexing operations if no master is known.
 
-[float]
+[discrete]
 ==== The Tip of the Iceberg
 
 This document provides a high level overview of how Elasticsearch deals with data. Of course, there is much much more

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -410,7 +410,7 @@ POST twitter/_delete_by_query?scroll_size=5000
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[docs-delete-by-query-manual-slice]]
 ===== Slice manually
 
@@ -482,7 +482,7 @@ Which results in a sensible `total` like this one:
 }
 ----------------------------------------------------------------
 
-[float]
+[discrete]
 [[docs-delete-by-query-automatic-slice]]
 ===== Use automatic slicing
 
@@ -565,7 +565,7 @@ being deleted.
 * Each sub-request gets a slightly different snapshot of the source data stream or index
 though these are all taken at approximately the same time.
 
-[float]
+[discrete]
 [[docs-delete-by-query-rethrottle]]
 ===== Change throttling for a request
 
@@ -657,7 +657,7 @@ and `wait_for_completion=false` was set on it then it'll come back with
 you to delete that document.
 
 
-[float]
+[discrete]
 [[docs-delete-by-query-cancel-task-api]]
 ===== Cancel a delete by query operation
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -21,7 +21,7 @@ NOTE: You cannot send deletion requests directly to a data stream. To delete a
 document in a data stream, you must target the backing index containing the
 document. See <<update-delete-docs-in-a-backing-index>>.
 
-[float]
+[discrete]
 [[optimistic-concurrency-control-delete]]
 ===== Optimistic concurrency control
 
@@ -31,7 +31,7 @@ term specified by the `if_seq_no` and `if_primary_term` parameters. If a
 mismatch is detected, the operation will result in a `VersionConflictException`
 and a status code of 409. See <<optimistic-concurrency-control>> for more details.
 
-[float]
+[discrete]
 [[delete-versioning]]
 ===== Versioning
 
@@ -44,7 +44,7 @@ short time after deletion to allow for control of concurrent operations. The
 length of time for which a deleted document's version remains available is
 determined by the `index.gc_deletes` index setting and defaults to 60 seconds.
 
-[float]
+[discrete]
 [[delete-routing]]
 ===== Routing
 
@@ -80,7 +80,7 @@ DELETE /twitter/_doc/1?routing=kimchy
 This request deletes the tweet with id `1`, but it is routed based on the
 user. The document is not deleted if the correct routing is not specified.
 
-[float]
+[discrete]
 [[delete-index-creation]]
 ===== Automatic index creation
 
@@ -89,7 +89,7 @@ the delete operation automatically creates the specified index if it does not
 exist. For information about manually creating indices, see
 <<indices-create-index,create index API>>.
 
-[float]
+[discrete]
 [[delete-distributed]]
 ===== Distributed
 
@@ -97,7 +97,7 @@ The delete operation gets hashed into a specific shard id. It then gets
 redirected into the primary shard within that id group, and replicated
 (if needed) to shard replicas within that id group.
 
-[float]
+[discrete]
 [[delete-wait-for-active-shards]]
 ===== Wait for active shards
 
@@ -107,14 +107,14 @@ before starting to process the delete request. See
 <<index-wait-for-active-shards,here>> for further details and a usage
 example.
 
-[float]
+[discrete]
 [[delete-refresh]]
 ===== Refresh
 
 Control when the changes made by this request are visible to search. See
 <<docs-refresh>>.
 
-[float]
+[discrete]
 [[delete-timeout]]
 ===== Timeout
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -30,7 +30,7 @@ particular index. Use HEAD to verify that a document exists. You can
 use the `_source` resource retrieve just the document source or verify
 that it exists.
 
-[float]
+[discrete]
 [[realtime]]
 ===== Realtime
 
@@ -41,7 +41,7 @@ has been updated but is not yet refreshed, the get API will have to parse
 and analyze the source to extract the stored fields. In order to disable
 realtime GET, the `realtime` parameter can be set to `false`.
 
-[float]
+[discrete]
 [[get-source-filtering]]
 ===== Source filtering
 
@@ -75,7 +75,7 @@ GET twitter/_doc/0?_source=*.id,retweeted
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[get-routing]]
 ===== Routing
 
@@ -91,7 +91,7 @@ GET twitter/_doc/2?routing=user1
 This request gets the tweet with id `2`, but it is routed based on the
 user. The document is not fetched if the correct routing is not specified.
 
-[float]
+[discrete]
 [[preference]]
 ===== Preference
 
@@ -112,7 +112,7 @@ Custom (string) value::
 	states. A sample value can be something like the web session id, or the
 	user name.
 
-[float]
+[discrete]
 [[get-refresh]]
 ===== Refresh
 
@@ -122,7 +122,7 @@ it to `true` should be done after careful thought and verification that
 this does not cause a heavy load on the system (and slows down
 indexing).
 
-[float]
+[discrete]
 [[get-distributed]]
 ===== Distributed
 
@@ -132,7 +132,7 @@ result. The replicas are the primary shard and its replicas within that
 shard id group. This means that the more replicas we have, the
 better GET scaling we will have.
 
-[float]
+[discrete]
 [[get-versioning]]
 ===== Versioning support
 
@@ -262,7 +262,7 @@ HEAD twitter/_doc/0
 {es} returns a status code of `200 - OK` if the document exists, or
 `404 - Not Found` if it doesn't.
 
-[float]
+[discrete]
 [[_source]]
 ===== Get the source field only
 
@@ -294,7 +294,7 @@ HEAD twitter/_source/1
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[get-stored-fields]]
 ===== Get stored fields
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -219,7 +219,7 @@ the order specified.
 
 <3> Allow automatic creation of any index. This is the default.
 
-[float]
+[discrete]
 [[operation-type]]
 ===== Put if absent
 
@@ -228,7 +228,7 @@ setting the `op_type` parameter to _create_. In this case,
 the index operation fails if a document with the specified ID
 already exists in the index.
 
-[float]
+[discrete]
 ===== Create document IDs automatically
 
 When using the `POST /<target>/_doc/` request format, the `op_type` is
@@ -266,7 +266,7 @@ The API returns the following result:
 --------------------------------------------------
 // TESTRESPONSE[s/W0tpsmIBdwcYyG50zbta/$body._id/ s/"successful": 2/"successful": 1/]
 
-[float]
+[discrete]
 [[optimistic-concurrency-control-index]]
 ===== Optimistic concurrency control
 
@@ -276,7 +276,7 @@ term specified by the `if_seq_no` and `if_primary_term` parameters. If a
 mismatch is detected, the operation will result in a `VersionConflictException`
 and a status code of 409. See <<optimistic-concurrency-control>> for more details.
 
-[float]
+[discrete]
 [[index-routing]]
 ===== Routing
 
@@ -308,7 +308,7 @@ value is provided or extracted.
 NOTE: Data streams do not support custom routing. Instead, target the
 appropriate backing index for the stream.
 
-[float]
+[discrete]
 [[index-distributed]]
 ===== Distributed
 
@@ -317,7 +317,7 @@ The index operation is directed to the primary shard based on its route
 containing this shard. After the primary shard completes the operation,
 if needed, the update is distributed to applicable replicas.
 
-[float]
+[discrete]
 [[index-wait-for-active-shards]]
 ===== Active shards
 
@@ -375,14 +375,14 @@ replication succeeded/failed.
 --------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[index-refresh]]
 ===== Refresh
 
 Control when the changes made by this request are visible to search. See
 <<docs-refresh,refresh>>.
 
-[float]
+[discrete]
 [[index-noop]]
 ===== Noop updates
 
@@ -397,7 +397,7 @@ It's a combination of lots of factors like how frequently your data source
 sends updates that are actually noops and how many queries per second
 Elasticsearch runs on the shard receiving the updates.
 
-[float]
+[discrete]
 [[timeout]]
 ===== Timeout
 
@@ -420,7 +420,7 @@ PUT twitter/_doc/1?timeout=5m
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[index-versioning]]
 ===== Versioning
 
@@ -466,7 +466,7 @@ a database is simplified if external versioning is used, as only the
 latest version will be used if the index operations arrive out of order for
 whatever reason.
 
-[float]
+[discrete]
 [[index-version-types]]
 ===== Version types
 

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -80,7 +80,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
-[float]
+[discrete]
 [[docs-multi-termvectors-api-example]]
 ==== {api-examples-title}
 

--- a/docs/reference/docs/refresh.asciidoc
+++ b/docs/reference/docs/refresh.asciidoc
@@ -29,7 +29,7 @@ to return.
 Take no refresh related actions. The changes made by this request will be made
 visible at some point after the request returns.
 
-[float]
+[discrete]
 ==== Choosing which setting to use
 // tag::refresh-default[]
 Unless you have a good reason to wait for the change to become visible, always
@@ -62,7 +62,7 @@ refresh immediately, `refresh=true` will affect other ongoing request. In
 general, if you have a running system you don't wish to disturb then
 `refresh=wait_for` is a smaller modification.
 
-[float]
+[discrete]
 [[refresh_wait_for-force-refresh]]
 ==== `refresh=wait_for` Can Force a Refresh
 
@@ -78,7 +78,7 @@ contain `"forced_refresh": true`.
 Bulk requests only take up one slot on each shard that they touch no matter how
 many times they modify the shard.
 
-[float]
+[discrete]
 ==== Examples
 
 These will create a document and immediately refresh the index so it is visible:

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -409,7 +409,7 @@ POST twitter/_update_by_query?pipeline=set-foo
 // TEST[setup:twitter]
 
 
-[float]
+[discrete]
 [[docs-update-by-query-fetch-tasks]]
 ===== Get the status of update by query operations
 
@@ -488,7 +488,7 @@ and `wait_for_completion=false` was set on it, then it'll come back with a
 you to delete that document.
 
 
-[float]
+[discrete]
 [[docs-update-by-query-cancel-task-api]]
 ===== Cancel an update by query operation
 
@@ -506,7 +506,7 @@ API above will continue to list the update by query task until this task checks
 that it has been cancelled and terminates itself.
 
 
-[float]
+[discrete]
 [[docs-update-by-query-rethrottle]]
 ===== Change throttling for a request
 
@@ -527,7 +527,7 @@ query takes effect immediately, but rethrotting that slows down the query will
 take effect after completing the current batch. This prevents scroll
 timeouts.
 
-[float]
+[discrete]
 [[docs-update-by-query-manual-slice]]
 ===== Slice manually
 Slice an update by query manually by providing a slice id and total number of
@@ -581,7 +581,7 @@ Which results in a sensible `total` like this one:
 }
 ----------------------------------------------------------------
 
-[float]
+[discrete]
 [[docs-update-by-query-automatic-slice]]
 ===== Use automatic slicing
 
@@ -651,7 +651,7 @@ being updated.
 * Each sub-request gets a slightly different snapshot of the source data stream or index
 though these are all taken at approximately the same time.
 
-[float]
+[discrete]
 [[picking-up-a-new-property]]
 ===== Pick up a new property
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -190,7 +190,7 @@ POST test/_update/1
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 ===== Update part of a document
 
 The following partial update adds a new field to the
@@ -210,7 +210,7 @@ POST test/_update/1
 If both `doc` and `script` are specified, then `doc` is ignored. If you
 specify a scripted update, include the fields you want to update in the script.
 
-[float]
+[discrete]
 ===== Detect noop updates
 
 By default updates that don't change anything detect that they don't change
@@ -263,7 +263,7 @@ POST test/_update/1
 // TEST[continued]
 
 [[upserts]]
-[float]
+[discrete]
 ===== Upsert
 
 If the document does not already exist, the contents of the `upsert` element
@@ -288,7 +288,7 @@ POST test/_update/1
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[scripted_upsert]]
 ===== Scripted upsert
 
@@ -316,7 +316,7 @@ POST sessions/_update/dh3sgudg8gsrgl
 // TEST[s/"id": "my_web_session_summariser"/"source": "ctx._source.page_view_event = params.pageViewEvent"/]
 // TEST[continued]
 
-[float]
+[discrete]
 [[doc_as_upsert]]
 ===== Doc as upsert
 

--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -15,7 +15,7 @@ You can use EQL in {es} to easily express relationships between events and
 quickly match events with shared properties. You can use EQL and query
 DSL together to better filter your searches.
 
-[float]
+[discrete]
 [[eql-advantages]]
 === Advantages of EQL
 
@@ -32,7 +32,7 @@ While you can use EQL for any event-based data, we created EQL for threat
 hunting. EQL not only supports indicator of compromise (IOC) searching but
 makes it easy to describe activity that goes beyond IOCs.
 
-[float]
+[discrete]
 [[when-to-use-eql]]
 === When to use EQL
 
@@ -42,7 +42,7 @@ Consider using EQL if you:
 * Search time-series data or logs, such as network or system logs
 * Want an easy way to explore relationships between events
 
-[float]
+[discrete]
 [[eql-toc]]
 === In this section
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -37,7 +37,7 @@ To take {es} for a test drive, you can create a
 the {ess} or set up a multi-node {es} cluster on your own
 Linux, macOS, or Windows machine.
 
-[float]
+[discrete]
 [[run-elasticsearch-hosted]]
 === Run {es} on Elastic Cloud
 
@@ -53,7 +53,7 @@ and verify your email address.
 
 Once you've created a deployment, you're ready to <<getting-started-index>>.
 
-[float]
+[discrete]
 [[run-elasticsearch-local]]
 === Run {es} locally on Linux, macOS, or Windows
 
@@ -226,7 +226,7 @@ privileges are required to run each API, see <<rest-apis>>.
 {es} responds to each API request with an HTTP status code like `200 OK`. With
 the exception of `HEAD` requests, it also returns a JSON-encoded response body. 
 
-[float]
+[discrete]
 [[gs-other-install]]
 === Other installation options
 
@@ -314,7 +314,7 @@ and shows the original source fields that were indexed.
 // TESTRESPONSE[s/"_seq_no" : \d+/"_seq_no" : $body._seq_no/ ]
 // TESTRESPONSE[s/"_primary_term" : \d+/"_primary_term" : $body._primary_term/]
 
-[float]
+[discrete]
 [[getting-started-batch-processing]]
 === Indexing documents in bulk
 

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -15,12 +15,12 @@ For additional information about working with the explore API, see the Graph
 {kibana-ref}/graph-troubleshooting.html[Troubleshooting] and
 {kibana-ref}/graph-limitations.html[Limitations] topics.
 
-[float]
+[discrete]
 === Request
 
 `POST <index>/_graph/explore`
 
-[float]
+[discrete]
 === Description
 
 An initial request to the `_explore` API contains a seed query that identifies
@@ -29,7 +29,7 @@ and connections you want to include in the graph. Subsequent `_explore` requests
 enable you to _spider out_ from one more vertices of interest. You can exclude
 vertices that have already been returned.
 
-[float]
+[discrete]
 === Request Body
 
 [role="child_attributes"]
@@ -185,13 +185,13 @@ a maximum number of documents per value for that field. For example:
 ======
 ====
 
-// [float]
+// [discrete]
 // === Authorization
 
-[float]
+[discrete]
 === Examples
 
-[float]
+[discrete]
 [[basic-search]]
 ==== Basic exploration
 
@@ -289,7 +289,7 @@ to the other as part of exploration. The `doc_count` value indicates how many
 documents in the sample set contain this pairing of terms (this is
 not a global count for all documents in the index).
 
-[float]
+[discrete]
 [[optional-controls]]
 ==== Optional controls
 
@@ -369,7 +369,7 @@ the connection is returned for global consideration.
 <8> Restrict which document are considered as you explore connected terms.
 
 
-[float]
+[discrete]
 [[spider-search]]
 ==== Spidering operations
 

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -1,7 +1,7 @@
 [[tune-for-disk-usage]]
 == Tune for disk usage
 
-[float]
+[discrete]
 === Disable the features you do not need
 
 By default Elasticsearch indexes and adds doc values to most fields so that they
@@ -86,7 +86,7 @@ PUT index
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[default-dynamic-string-mapping]]
 === Don't use default dynamic string mappings
 
@@ -121,20 +121,20 @@ PUT index
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 === Watch your shard size
 
 Larger shards are going to be more efficient at storing data. To increase the size of your shards, you can decrease the number of primary shards in an index by <<indices-create-index,creating indices>> with fewer primary shards, creating fewer indices (e.g. by leveraging the <<indices-rollover-index,Rollover API>>), or modifying an existing index using the <<indices-shrink-index,Shrink API>>.
 
 Keep in mind that large shard sizes come with drawbacks, such as long full recovery times.
 
-[float]
+[discrete]
 [[disable-source]]
 === Disable `_source`
 
 The <<mapping-source-field,`_source`>> field stores the original JSON body of the document. If you don’t need access to it you can disable it. However, APIs that needs access to `_source` such as update and reindex won’t work.
 
-[float]
+[discrete]
 [[best-compression]]
 === Use `best_compression`
 
@@ -142,19 +142,19 @@ The `_source` and stored fields can easily take a non negligible amount of disk
 space. They can be compressed more aggressively by using the `best_compression`
 <<index-codec,codec>>.
 
-[float]
+[discrete]
 === Force Merge
 
 Indices in Elasticsearch are stored in one or more shards. Each shard is a Lucene index and made up of one or more segments - the actual files on disk. Larger segments are more efficient for storing data.
 
 The <<indices-forcemerge,`_forcemerge` API>> can be used to reduce the number of segments per shard. In many cases, the number of segments can be reduced to one per shard by setting `max_num_segments=1`.
 
-[float]
+[discrete]
 === Shrink Index
 
 The <<indices-shrink-index,Shrink API>> allows you to reduce the number of shards in an index. Together with the Force Merge API above, this can significantly reduce the number of shards and segments of an index.
 
-[float]
+[discrete]
 === Use the smallest numeric type that is sufficient
 
 The type that you pick for <<number,numeric data>> can have a significant impact
@@ -164,7 +164,7 @@ stored in a `scaled_float` if appropriate or in the smallest type that fits the
 use-case: using `float` over `double`, or `half_float` over `float` will help
 save storage.
 
-[float]
+[discrete]
 === Use index sorting to colocate similar documents
 
 When Elasticsearch stores `_source`, it compresses multiple documents at once
@@ -178,7 +178,7 @@ to the index. If you enabled <<index-modules-index-sorting,index sorting>>
 then instead they are compressed in sorted order. Sorting documents with similar
 structure, fields, and values together should improve the compression ratio.
 
-[float]
+[discrete]
 === Put fields in the same order in documents
 
 Due to the fact that multiple documents are compressed together into blocks,

--- a/docs/reference/how-to/general.asciidoc
+++ b/docs/reference/how-to/general.asciidoc
@@ -1,7 +1,7 @@
 [[general-recommendations]]
 == General recommendations
 
-[float]
+[discrete]
 [[large-size]]
 === Don't return large result sets
 
@@ -11,7 +11,7 @@ for workloads that fall into the database domain, such as retrieving all
 documents that match a particular query. If you need to do this, make sure to
 use the <<request-body-search-scroll,Scroll>> API.
 
-[float]
+[discrete]
 [[maximum-document-size]]
 === Avoid large documents
 

--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -1,7 +1,7 @@
 [[tune-for-indexing-speed]]
 == Tune for indexing speed
 
-[float]
+[discrete]
 === Use bulk requests
 
 Bulk requests will yield much better performance than single-document index
@@ -16,7 +16,7 @@ cluster under memory pressure when many of them are sent concurrently, so
 it is advisable to avoid going beyond a couple tens of megabytes per request
 even if larger requests seem to perform better.
 
-[float]
+[discrete]
 [[multiple-workers-threads]]
 === Use multiple workers/threads to send data to Elasticsearch
 
@@ -36,7 +36,7 @@ Similarly to sizing bulk requests, only testing can tell what the optimal
 number of workers is. This can be tested by progressively increasing the
 number of workers until either I/O or CPU is saturated on the cluster.
 
-[float]
+[discrete]
 === Unset or increase the refresh interval
 
 The operation that consists of making changes visible to search - called a
@@ -57,7 +57,7 @@ gets indexed and when it becomes visible, increasing the
 <<index-refresh-interval-setting,`index.refresh_interval`>> to a larger value, e.g.
 `30s`, might help improve indexing speed.
 
-[float]
+[discrete]
 === Disable replicas for initial loads
 
 If you have a large amount of data that you want to load all at once into
@@ -71,20 +71,20 @@ If `index.refresh_interval` is configured in the index settings, it may further
 help to unset it during this initial load and setting it back to its original
 value once the initial load is finished.
 
-[float]
+[discrete]
 === Disable swapping
 
 You should make sure that the operating system is not swapping out the java
 process by <<setup-configuration-memory,disabling swapping>>.
 
-[float]
+[discrete]
 === Give memory to the filesystem cache
 
 The filesystem cache will be used in order to buffer I/O operations. You should
 make sure to give at least half the memory of the machine running Elasticsearch
 to the filesystem cache.
 
-[float]
+[discrete]
 === Use auto-generated ids
 
 When indexing a document that has an explicit id, Elasticsearch needs to check
@@ -93,7 +93,7 @@ is a costly operation and gets even more costly as the index grows. By using
 auto-generated ids, Elasticsearch can skip this check, which makes indexing
 faster.
 
-[float]
+[discrete]
 === Use faster hardware
 
 If indexing is I/O bound, you should investigate giving more memory to the
@@ -115,7 +115,7 @@ different nodes so there's redundancy for any node failures. You can also use
 <<modules-snapshots,snapshot and restore>> to backup the index for further
 insurance.
 
-[float]
+[discrete]
 === Indexing buffer size
 
 If your node is doing only heavy indexing, be sure
@@ -131,7 +131,7 @@ The default is `10%` which is often plenty: for example, if you give the JVM
 10GB of memory, it will give 1GB to the index buffer, which is enough to host
 two shards that are heavily indexing.
 
-[float]
+[discrete]
 === Use {ccr} to prevent searching from stealing resources from indexing
 
 Within a single cluster, indexing and searching can compete for resources. By
@@ -140,7 +140,7 @@ one cluster to the other one, and routing all searches to the cluster that has
 the follower indices, search activity will no longer steal resources from
 indexing on the cluster that hosts the leader indices.
 
-[float]
+[discrete]
 === Additional optimizations
 
 Many of the strategies outlined in <<tune-for-disk-usage>> also

--- a/docs/reference/how-to/recipes/scoring.asciidoc
+++ b/docs/reference/how-to/recipes/scoring.asciidoc
@@ -4,7 +4,7 @@
 The fact that Elasticsearch operates with shards and replicas adds challenges
 when it comes to having good scoring.
 
-[float]
+[discrete]
 ==== Scores are not reproducible
 
 Say the same user runs the same request twice in a row and documents do not come
@@ -39,7 +39,7 @@ they will be sorted by their internal Lucene doc id (which is unrelated to the
 the same shard. So by always hitting the same shard, we would get more
 consistent ordering of documents that have the same scores.
 
-[float]
+[discrete]
 ==== Relevancy looks wrong
 
 If you notice that two documents with the same content get different scores or

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -1,7 +1,7 @@
 [[tune-for-search-speed]]
 == Tune for search speed
 
-[float]
+[discrete]
 === Give memory to the filesystem cache
 
 Elasticsearch heavily relies on the filesystem cache in order to make search
@@ -9,7 +9,7 @@ fast. In general, you should make sure that at least half the available memory
 goes to the filesystem cache so that Elasticsearch can keep hot regions of the
 index in physical memory.
 
-[float]
+[discrete]
 === Use faster hardware
 
 If your search is I/O bound, you should investigate giving more memory to the
@@ -25,7 +25,7 @@ throttled.
 
 If your search is CPU-bound, you should investigate buying faster CPUs.
 
-[float]
+[discrete]
 === Document modeling
 
 Documents should be modeled so that search-time operations are as cheap as possible.
@@ -35,7 +35,7 @@ several times slower and <<parent-join,parent-child>> relations can make
 queries hundreds of times slower. So if the same questions can be answered without
 joins by denormalizing documents, significant speedups can be expected.
 
-[float]
+[discrete]
 === Search as few fields as possible
 
 The more fields a <<query-dsl-query-string-query,`query_string`>> or
@@ -70,7 +70,7 @@ PUT movies
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 === Pre-index data
 
 You should leverage patterns in your queries to optimize the way data is indexed.
@@ -155,13 +155,13 @@ GET index/_search
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[map-ids-as-keyword]]
 === Consider mapping identifiers as `keyword`
 
 include::../mapping/types/numeric.asciidoc[tag=map-ids-as-keyword]
 
-[float]
+[discrete]
 === Avoid scripts
 
 If possible, avoid using <<modules-scripting,scripts>> or
@@ -169,7 +169,7 @@ If possible, avoid using <<modules-scripting,scripts>> or
 <<scripts-and-search-speed>>.
 
 
-[float]
+[discrete]
 === Search rounded dates
 
 Queries on date fields that use `now` are typically not cacheable since the
@@ -284,7 +284,7 @@ However such practice might make the query run slower in some cases since the
 overhead introduced by the `bool` query may defeat the savings from better
 leveraging the query cache.
 
-[float]
+[discrete]
 === Force-merge read-only indices
 
 Indices that are read-only may benefit from being <<indices-forcemerge,merged
@@ -299,7 +299,7 @@ background merge process to perform merges as needed to keep the index running
 smoothly. If you continue to write to a force-merged index then its performance
 may become much worse.
 
-[float]
+[discrete]
 === Warm up global ordinals
 
 Global ordinals are a data-structure that is used in order to run
@@ -325,7 +325,7 @@ PUT index
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 === Warm up the filesystem cache
 
 If the machine running Elasticsearch is restarted, the filesystem cache will be
@@ -339,14 +339,14 @@ WARNING: Loading data into the filesystem cache eagerly on too many indices or
 too many files will make search _slower_ if the filesystem cache is not large
 enough to hold all the data. Use with caution.
 
-[float]
+[discrete]
 === Use index sorting to speed up conjunctions
 
 <<index-modules-index-sorting,Index sorting>> can be useful in order to make
 conjunctions faster at the cost of slightly slower indexing. Read more about it
 in the <<index-modules-index-sorting-conjunctions,index sorting documentation>>.
 
-[float]
+[discrete]
 [[preference-cache-optimization]]
 === Use `preference` to optimize cache utilization
 
@@ -364,7 +364,7 @@ one after another, for instance in order to analyze a narrower subset of the
 index, using a preference value that identifies the current user or session
 could help optimize usage of the caches.
 
-[float]
+[discrete]
 === Replicas might help with throughput, but not always
 
 In addition to improving resiliency, replicas can help improve throughput. For

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -8,7 +8,7 @@
 Index Modules are modules created per index and control all aspects related to
 an index.
 
-[float]
+[discrete]
 [[index-modules-settings]]
 == Index Settings
 
@@ -31,7 +31,7 @@ WARNING: Changing static or dynamic index settings on a closed index could
 result in incorrect settings that are impossible to rectify without deleting
 and recreating the index.
 
-[float]
+[discrete]
 === Static index settings
 
 Below is a list of all _static_ index settings that are not associated with any
@@ -88,7 +88,7 @@ indices.
     per request through the use of the `expand_wildcards` parameter. Possible values are
     `true` and `false` (default).
 
-[float]
+[discrete]
 [[dynamic-index-settings]]
 === Dynamic index settings
 
@@ -238,7 +238,7 @@ specific index module:
     the default pipeline (if it exists). The special pipeline name `_none`
     indicates no ingest pipeline will run.
 
-[float]
+[discrete]
 === Settings in other index modules
 
 Other index settings are available in index modules:
@@ -285,7 +285,7 @@ Other index settings are available in index modules:
 
     Configure indexing back pressure limits.
 
-[float]
+[discrete]
 [[x-pack-index-settings]]
 === [xpack]#{xpack} index settings#
 

--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -21,7 +21,7 @@ For example, you could use a custom node attribute to indicate a node's
 performance characteristics and use shard allocation filtering to route shards
 for a particular index to the most appropriate class of hardware.
 
-[float]
+[discrete]
 [[index-allocation-filters]]
 ==== Enabling index-level shard allocation filtering
 
@@ -74,7 +74,7 @@ PUT test/_settings
 // TEST[s/^/PUT test\n/]
 --
 
-[float]
+[discrete]
 [[index-allocation-settings]]
 ==== Index allocation filter settings
 

--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -56,7 +56,7 @@ copying just the missing operations from the translog
 <<index-modules-translog-retention,as long as those operations are retained
 there>>. {ccr-cap} will not function if soft deletes are disabled.
 
-[float]
+[discrete]
 === History retention settings
 
 `index.soft_deletes.enabled`::

--- a/docs/reference/index-modules/index-sorting.asciidoc
+++ b/docs/reference/index-modules/index-sorting.asciidoc
@@ -100,7 +100,7 @@ a sort on an existing index. Index sorting also has a cost in terms of indexing 
 documents must be sorted at flush and merge time. You should test the impact on your application
 before activating this feature.
 
-[float]
+[discrete]
 [[early-terminate]]
 === Early termination of search request
 

--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -10,7 +10,7 @@ deletes.
 The merge process uses auto-throttling to balance the use of hardware
 resources between merging and other activities like search.
 
-[float]
+[discrete]
 [[merge-scheduling]]
 === Merge scheduling
 

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -9,7 +9,7 @@ Configuring a custom similarity is considered an expert feature and the
 builtin similarities are most likely sufficient as is described in
 <<similarity>>.
 
-[float]
+[discrete]
 [[configuration]]
 === Configuring a similarity
 
@@ -52,10 +52,10 @@ PUT /index/_mapping
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 === Available similarities
 
-[float]
+[discrete]
 [[bm25]]
 ==== BM25 similarity (*default*)
 
@@ -80,7 +80,7 @@ This similarity has the following options:
 
 Type name: `BM25`
 
-[float]
+[discrete]
 [[dfr]]
 ==== DFR similarity
 
@@ -110,7 +110,7 @@ All options but the first option need a normalization value.
 
 Type name: `DFR`
 
-[float]
+[discrete]
 [[dfi]]
 ==== DFI similarity
 
@@ -130,7 +130,7 @@ frequency will get a score equal to 0.
 
 Type name: `DFI`
 
-[float]
+[discrete]
 [[ib]]
 ==== IB similarity.
 
@@ -151,7 +151,7 @@ This similarity has the following options:
 
 Type name: `IB`
 
-[float]
+[discrete]
 [[lm_dirichlet]]
 ==== LM Dirichlet similarity.
 
@@ -167,7 +167,7 @@ Lucene, so such terms get a score of 0.
 
 Type name: `LMDirichlet`
 
-[float]
+[discrete]
 [[lm_jelinek_mercer]]
 ==== LM Jelinek Mercer similarity.
 
@@ -180,7 +180,7 @@ for title queries and `0.7` for long queries. Default to `0.1`. When value appro
 
 Type name: `LMJelinekMercer`
 
-[float]
+[discrete]
 [[scripted_similarity]]
 ==== Scripted similarity
 
@@ -508,7 +508,7 @@ GET /index/_search?explain=true
 
 Type name: `scripted`
 
-[float]
+[discrete]
 [[default-base]]
 ==== Default Similarity
 

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -1,7 +1,7 @@
 [[index-modules-slowlog]]
 == Slow Log
 
-[float]
+[discrete]
 [[search-slow-log]]
 === Search Slow Log
 
@@ -82,7 +82,7 @@ logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref
 logger.index_search_slowlog_rolling.additivity = false
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Identifying search slow log origin
 
 It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then the user ID
@@ -117,7 +117,7 @@ The user ID is also included in JSON logs.
 ---------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[index-slow-log]]
 === Index Slow log
 

--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -7,7 +7,7 @@ NOTE: This is a low-level setting. Some store implementations have poor
 concurrency or disable optimizations for heap memory usage. We recommend
 sticking to the defaults.
 
-[float]
+[discrete]
 [[file-system]]
 === File system storage types
 

--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -22,7 +22,7 @@ would make replaying its operations take a considerable amount of time during
 recovery. The ability to perform a flush manually is also exposed through an
 API, although this is rarely needed.
 
-[float]
+[discrete]
 === Translog settings
 
 The data in the translog is only persisted to disk when the translog is
@@ -76,7 +76,7 @@ update, or bulk request. This setting accepts the following parameters:
   has been reached a flush will happen, generating a new Lucene commit point.
   Defaults to `512mb`.
 
-[float]
+[discrete]
 [[index-modules-translog-retention]]
 ==== Translog retention
 

--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -4,7 +4,7 @@
 Index APIs are used to manage individual indices,
 index settings, aliases, mappings, and index templates.
 
-[float]
+[discrete]
 [[index-management]]
 === Index management:
 
@@ -23,7 +23,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-resolve-index-api>>
 
 
-[float]
+[discrete]
 [[mapping-management]]
 === Mapping management:
 
@@ -32,7 +32,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-get-field-mapping>>
 * <<indices-types-exists>>
 
-[float]
+[discrete]
 [[alias-management]]
 === Alias management:
 * <<indices-add-alias>>
@@ -41,14 +41,14 @@ index settings, aliases, mappings, and index templates.
 * <<indices-alias-exists>>
 * <<indices-aliases>>
 
-[float]
+[discrete]
 [[index-settings]]
 === Index settings:
 * <<indices-update-settings>>
 * <<indices-get-settings>>
 * <<indices-analyze>>
 
-[float]
+[discrete]
 [[index-templates]]
 === Index templates:
 * <<indices-templates>>
@@ -61,7 +61,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-simulate-index>>
 * <<indices-simulate-template>>
 
-[float]
+[discrete]
 [[monitoring]]
 === Monitoring:
 * <<indices-stats>>
@@ -69,7 +69,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-recovery>>
 * <<indices-shards-stores>>
 
-[float]
+[discrete]
 [[status-management]]
 === Status management:
 * <<indices-clearcache>>
@@ -78,7 +78,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-synced-flush-api>>
 * <<indices-forcemerge>>
 
-[float]
+[discrete]
 [[dangling-indices-api]]
 === Dangling indices:
 * <<dangling-indices-list>>

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -118,7 +118,7 @@ The enrich processor works best with reference data
 that doesn't change frequently.
 ====
 
-[float]
+[discrete]
 [[enrich-prereqs]]
 ==== Prerequisites
 

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -26,7 +26,7 @@ order.
 The processors in a pipeline have read and write access to documents that pass through the pipeline.
 The processors can access fields in the source of a document and the document's metadata fields.
 
-[float]
+[discrete]
 [[accessing-source-fields]]
 === Accessing Fields in the Source
 Accessing a field in the source is straightforward. You simply refer to fields by
@@ -56,7 +56,7 @@ On top of this, fields from the source are always accessible via the `_source` p
 --------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[accessing-metadata-fields]]
 === Accessing Metadata Fields
 You can access metadata fields in the same way that you access fields in the source. This
@@ -78,7 +78,7 @@ The following example sets the `_id` metadata field of a document to `1`:
 
 The following metadata fields are accessible by a processor: `_index`, `_type`, `_id`, `_routing`.
 
-[float]
+[discrete]
 [[accessing-ingest-metadata]]
 === Accessing Ingest Metadata Fields
 Beyond metadata fields and source fields, ingest also adds ingest metadata to the documents that it processes.
@@ -106,7 +106,7 @@ Unlike Elasticsearch metadata fields, the ingest metadata field name `_ingest` c
 in the source of a document. Use `_source._ingest` to refer to the field in the source document. Otherwise, `_ingest`
 will be interpreted as an ingest metadata field.
 
-[float]
+[discrete]
 [[accessing-template-fields]]
 === Accessing Fields and Metafields in Templates
 A number of processor settings also support templating. Settings that support templating can have zero or more
@@ -751,7 +751,7 @@ continues to execute, which in this case means that the pipeline does nothing.
 
 The `ignore_failure` can be set on any processor and defaults to `false`.
 
-[float]
+[discrete]
 [[accessing-error-metadata]]
 === Accessing Error Metadata From Processors Handling Exceptions
 
@@ -853,7 +853,7 @@ A node will not start if this plugin is not available.
 The <<cluster-nodes-stats,node stats API>> can be used to fetch ingest usage statistics, globally and on a per
 pipeline basis. Useful to find out which pipelines are used the most or spent the most time on preprocessing.
 
-[float]
+[discrete]
 === Ingest Processor Plugins
 
 Additional ingest processors can be implemented and installed as Elasticsearch {plugins}/intro.html[plugins].

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -102,7 +102,7 @@ https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} client]
 for your language of choice: Java, JavaScript, Go, .NET, PHP, Perl, Python
 or Ruby.
 
-[float]
+[discrete]
 [[search-data]]
 ==== Searching your data
 
@@ -127,7 +127,7 @@ construct <<sql-overview, SQL-style queries>> to search and aggregate data
 natively inside {es}, and JDBC and ODBC drivers enable a broad range of
 third-party applications to interact with {es} via SQL.
 
-[float]
+[discrete]
 [[analyze-data]]
 ==== Analyzing your data
 
@@ -159,7 +159,7 @@ size 70 needles, you’re displaying a count of the size 70 needles
 that match your users' search criteria--for example, all size 70 _non-stick
 embroidery_ needles.
 
-[float]
+[discrete]
 [[more-features]]
 ===== But wait, there’s more
 
@@ -206,7 +206,7 @@ The number of primary shards in an index is fixed at the time that an index is
 created, but the number of replica shards can be changed at any time, without
 interrupting indexing or query operations.
 
-[float]
+[discrete]
 [[it-depends]]
 ==== It depends...
 
@@ -234,7 +234,7 @@ The best way to determine the optimal configuration for your use case is
 through https://www.elastic.co/elasticon/conf/2016/sf/quantitative-cluster-sizing[
 testing with your own data and queries].
 
-[float]
+[discrete]
 [[disaster-ccr]]
 ==== In case of disaster
 
@@ -254,7 +254,7 @@ create secondary clusters to serve read requests in geo-proximity to your users.
 the active leader index and handles all write requests. Indices replicated to
 secondary clusters are read-only followers.
 
-[float]
+[discrete]
 [[admin]]
 ==== Care and feeding
 

--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -8,26 +8,26 @@
 
 This API enables you to delete licensing information.
 
-[float]
+[discrete]
 ==== Request
 
 `DELETE /_license`
 
-[float]
+[discrete]
 ==== Description
 
 When your license expires, {xpack} operates in a degraded mode.  For more
 information, see
 {kibana-ref}/managing-licenses.html#license-expiration[License expiration].
 
-[float]
+[discrete]
 ==== Authorization
 
 You must have `manage` cluster privileges to use this API.
 For more information, see
 <<security-privileges>>.
 
-[float]
+[discrete]
 ==== Examples
 
 The following example queries the info API:

--- a/docs/reference/licensing/get-basic-status.asciidoc
+++ b/docs/reference/licensing/get-basic-status.asciidoc
@@ -8,12 +8,12 @@
 
 This API enables you to check the status of your basic license.
 
-[float]
+[discrete]
 ==== Request
 
 `GET /_license/basic_status`
 
-[float]
+[discrete]
 ==== Description
 
 In order to initiate a basic license, you must not currently have a basic
@@ -27,7 +27,7 @@ https://www.elastic.co/subscriptions.
 You must have `monitor` cluster privileges to use this API.
 For more information, see <<security-privileges>>.
 
-[float]
+[discrete]
 ==== Examples
 
 The following example checks whether you are eligible to start a basic:

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -8,12 +8,12 @@
 
 This API enables you to retrieve licensing information.
 
-[float]
+[discrete]
 ==== Request
 
 `GET /_license`
 
-[float]
+[discrete]
 ==== Description
 
 This API returns information about the type of license, when it was issued, and
@@ -23,7 +23,7 @@ For more information about the different types of licenses, see
 https://www.elastic.co/subscriptions.
 
 
-[float]
+[discrete]
 ==== Query Parameters
 
 `local`::
@@ -31,14 +31,14 @@ https://www.elastic.co/subscriptions.
   is `false`, which means the information is retrieved from the master node.
 
 
-[float]
+[discrete]
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
 For more information, see <<security-privileges>>.
 
 
-[float]
+[discrete]
 ==== Examples
 
 The following example provides information about a trial license:

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -8,12 +8,12 @@
 
 Enables you to check the status of your trial.
 
-[float]
+[discrete]
 ==== Request
 
 `GET /_license/trial_status`
 
-[float]
+[discrete]
 ==== Description
 
 If you want to try all the subscription features, you can start a 30-day trial. 
@@ -32,7 +32,7 @@ You must have `monitor` cluster privileges to use this API.
 For more information, see
 <<security-privileges>>.
 
-[float]
+[discrete]
 ==== Examples
 
 The following example checks whether you are eligible to start a trial:

--- a/docs/reference/licensing/start-basic.asciidoc
+++ b/docs/reference/licensing/start-basic.asciidoc
@@ -8,12 +8,12 @@
 
 This API starts an indefinite basic license.
 
-[float]
+[discrete]
 ==== Request
 
 `POST /_license/start_basic`
 
-[float]
+[discrete]
 ==== Description
 
 The `start basic` API enables you to initiate an indefinite basic license, which
@@ -34,7 +34,7 @@ You must have `manage` cluster privileges to use this API.
 For more information, see
 <<security-privileges>>.
 
-[float]
+[discrete]
 ==== Examples
 
 The following example starts a basic license if you do not currently have a license:

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -8,12 +8,12 @@
 
 Starts a 30-day trial.
 
-[float]
+[discrete]
 ==== Request
 
 `POST /_license/start_trial`
 
-[float]
+[discrete]
 ==== Description
 
 The `start trial` API enables you to start a 30-day trial, which gives access to
@@ -35,7 +35,7 @@ You must have `manage` cluster privileges to use this API.
 For more information, see
 <<security-privileges>>.
 
-[float]
+[discrete]
 ==== Examples
 
 The following example starts a 30-day trial. The acknowledge parameter is

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -30,7 +30,7 @@ document.
 NOTE: Before 7.0.0, the 'mappings' definition used to include a type name.
 For more details, please see <<removal-of-types>>.
 
-[float]
+[discrete]
 [[field-datatypes]]
 == Field data types
 
@@ -55,7 +55,7 @@ This is the purpose of _multi-fields_.  Most data types support multi-fields
 via the <<multi-fields>> parameter.
 
 [[mapping-limit-settings]]
-[float]
+[discrete]
 === Settings to prevent mappings explosion
 
 Defining too many fields in an index can lead to a
@@ -115,7 +115,7 @@ If your field mappings contain a large, arbitrary set of keys, consider using th
     unless a user starts to add a huge number of fields with really long names. Default is
     `Long.MAX_VALUE` (no limit).
 
-[float]
+[discrete]
 == Dynamic mapping
 
 Fields and mapping types do not need to be defined before being used. Thanks
@@ -126,7 +126,7 @@ type, and to inner <<object,`object`>>  and <<nested,`nested`>> fields.
 The <<dynamic-mapping,dynamic mapping>> rules can be configured to customise
 the mapping that is used for new fields.
 
-[float]
+[discrete]
 == Explicit mappings
 
 You know more about your data than Elasticsearch can guess, so while dynamic
@@ -136,7 +136,7 @@ your own explicit mappings.
 You can create field mappings when you <<create-mapping,create an index>> and
 <<add-field-mapping,add fields to an existing index>>.
 
-[float]
+[discrete]
 [[create-mapping]]
 == Create an index with an explicit mapping
 
@@ -161,7 +161,7 @@ PUT /my-index
 <2> Creates `email`, a <<keyword,`keyword`>> field
 <3> Creates `name`, a <<text,`text`>> field
 
-[float]
+[discrete]
 [[add-field-mapping]]
 == Add a field to an existing mapping
 
@@ -186,7 +186,7 @@ PUT /my-index/_mapping
 ----
 // TEST[continued]
 
-[float]
+[discrete]
 [[update-mapping]]
 === Update the mapping of a field
 
@@ -194,7 +194,7 @@ include::{es-repo-dir}/indices/put-mapping.asciidoc[tag=change-field-mapping]
 
 include::{es-repo-dir}/indices/put-mapping.asciidoc[tag=rename-field]
 
-[float]
+[discrete]
 [[view-mapping]]
 == View the mapping of an index
 
@@ -235,7 +235,7 @@ The API returns the following response:
 ----
 
 
-[float]
+[discrete]
 [[view-field-mapping]]
 == View the mapping of specific fields
 

--- a/docs/reference/mapping/fields.asciidoc
+++ b/docs/reference/mapping/fields.asciidoc
@@ -5,7 +5,7 @@ Each document has metadata associated with it, such as the `_index`, mapping
 <<mapping-type-field,`_type`>>, and `_id` meta-fields.  The behaviour of some of these meta-fields
 can be customised when a mapping type is created.
 
-[float]
+[discrete]
 === Identity meta-fields
 
 [horizontal]
@@ -21,7 +21,7 @@ can be customised when a mapping type is created.
 
     The document's ID.
 
-[float]
+[discrete]
 === Document source meta-fields
 
 <<mapping-source-field,`_source`>>::
@@ -33,7 +33,7 @@ can be customised when a mapping type is created.
     The size of the `_source` field in bytes, provided by the
     {plugins}/mapper-size.html[`mapper-size` plugin].
 
-[float]
+[discrete]
 === Indexing meta-fields
 
 <<mapping-field-names-field,`_field_names`>>::
@@ -45,14 +45,14 @@ can be customised when a mapping type is created.
     All fields in the document that have been ignored at index time because of
     <<ignore-malformed,`ignore_malformed`>>.
 
-[float]
+[discrete]
 === Routing meta-field
 
 <<mapping-routing-field,`_routing`>>::
 
     A custom routing value which routes a document to a particular shard.
 
-[float]
+[discrete]
 === Other meta-field
 
 <<mapping-meta-field,`_meta`>>::

--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -7,7 +7,7 @@ in Elasticsearch 6.x. Types are deprecated in APIs in 7.0, with breaking changes
 to the index creation, put mapping, get mapping, put template, get template and
 get field mappings APIs.
 
-[float]
+[discrete]
 === What are mapping types?
 
 Since the first release of Elasticsearch, each document has been stored in a
@@ -46,7 +46,7 @@ Mapping types were also used to establish a
 between documents, so documents of type `question` could be parents to
 documents of type `answer`.
 
-[float]
+[discrete]
 === Why are mapping types being removed?
 
 Initially, we spoke about an ``index'' being similar to a ``database'' in an
@@ -75,10 +75,10 @@ ability to compress documents efficiently.
 For these reasons, we have decided to remove the concept of mapping types from
 Elasticsearch.
 
-[float]
+[discrete]
 === Alternatives to mapping types
 
-[float]
+[discrete]
 ==== Index per document type
 
 The first alternative is to have an index per document type.  Instead of
@@ -100,7 +100,7 @@ Each index can be sized appropriately for the number of documents it will
 contain: you can use a smaller number of primary shards for `users` and a
 larger number of primary shards for `tweets`.
 
-[float]
+[discrete]
 ==== Custom type field
 
 Of course, there is a limit to how many primary shards can exist in a cluster
@@ -215,7 +215,7 @@ GET twitter/_search
 // NOTCONSOLE
 <1> The explicit `type` field takes the place of the implicit `_type` field.
 
-[float]
+[discrete]
 [[parent-child-mapping-types]]
 ==== Parent/Child without mapping types
 
@@ -227,7 +227,7 @@ relationship between documents has been changed to use the new
 <<parent-join,`join` field>>.
 
 
-[float]
+[discrete]
 === Schedule for removal of mapping types
 
 This is a big change for our users, so we have tried to make it as painless as
@@ -285,7 +285,7 @@ Elasticsearch 8.x::
 
 * The `include_type_name` parameter is removed.
 
-[float]
+[discrete]
 === Migrating multi-type indices to single-type
 
 The <<docs-reindex,Reindex API>> can be used to convert multi-type indices to
@@ -293,7 +293,7 @@ single-type indices. The following examples can be used in Elasticsearch 5.6
 or Elasticsearch 6.x.  In 6.x, there is no need to specify
 `index.mapping.single_type` as that is the default.
 
-[float]
+[discrete]
 ==== Index per document type
 
 This first example splits our `twitter` index into a `tweets` index and a
@@ -371,7 +371,7 @@ POST _reindex
 ----
 // NOTCONSOLE
 
-[float]
+[discrete]
 ==== Custom type field
 
 This next example adds a custom `type` field and sets it to the value of the
@@ -428,7 +428,7 @@ POST _reindex
 ----
 // NOTCONSOLE
 
-[float]
+[discrete]
 === Typeless APIs in 7.0
 
 In Elasticsearch 7.0, each API will support typeless requests,
@@ -439,7 +439,7 @@ For example, if an index has the custom type name `my_type`, we can add
 documents to it using typeless `index` calls, and load documents with typeless
 `get` calls.
 
-[float]
+[discrete]
 ==== Index APIs
 
 Index creation, index template, and mapping APIs support a new `include_type_name`
@@ -513,7 +513,7 @@ The above call returns
 
 <1> Mappings are included directly under the `mappings` key, without a type name.
 
-[float]
+[discrete]
 ==== Document APIs
 
 In 7.0, index APIs must be called with the `{index}/_doc` path for automatic
@@ -586,14 +586,14 @@ POST _bulk
 { "foo" : "qux" }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Search APIs
 
 When calling a search API such `_search`, `_msearch`, or `_explain`, types
 should not be included in the URL. Additionally, the `_type` field should not
 be used in queries, aggregations, or scripts.
 
-[float]
+[discrete]
 ==== Types in responses
 
 The document and search APIs will continue to return a `_type` key in
@@ -633,7 +633,7 @@ GET index/_doc/1
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Index templates
 
 It is recommended to make index templates typeless by re-adding them with
@@ -718,7 +718,7 @@ an index that doesn't exist yet, the template is always honored. This is
 usually not a problem due to the fact that typeless index calls work on typed
 indices.
 
-[float]
+[discrete]
 ==== Mixed-version clusters
 
 In a cluster composed of both 6.8 and 7.0 nodes, the parameter

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -4,7 +4,7 @@
 Elasticsearch supports a number of different data types for the fields in a
 document:
 
-[float]
+[discrete]
 [[_core_datatypes]]
 === Core data types
 
@@ -16,12 +16,12 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<binary>>::     `binary`
 <<range>>::      `integer_range`, `float_range`, `long_range`, `double_range`, `date_range`, `ip_range`
 
-[float]
+[discrete]
 === Complex data types
 <<object>>::    `object` for single JSON objects
 <<nested>>::    `nested` for arrays of JSON objects
 
-[float]
+[discrete]
 === Spatial data types
 
 <<geo-point>>::     `geo_point` for lat/lon points
@@ -29,7 +29,7 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<point>>::         `point` for arbitrary cartesian points.
 <<shape>>::         `shape` for arbitrary cartesian geometries.
 
-[float]
+[discrete]
 === Specialised data types
 
 <<ip>>::            `ip` for IPv4 and IPv6 addresses
@@ -62,14 +62,14 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 
 <<constant-keyword>>:: Specialization of `keyword` for the case when all documents have the same value.
 
-[float]
+[discrete]
 [[types-array-handling]]
 === Arrays
 In {es}, arrays do not require a dedicated field data type. Any field can contain
 zero or more values by default, however, all values in the array must be of the
 same data type. See <<array>>.
 
-[float]
+[discrete]
 === Multi-fields
 
 It is often useful to index the same field in different ways for different

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -13,7 +13,7 @@ You can query documents using this type using
 <<query-dsl-geo-shape-query,geo_shape Query>>.
 
 [[geo-shape-mapping-options]]
-[float]
+[discrete]
 ==== Mapping Options
 
 The geo_shape mapping maps geo_json geometry objects to the geo_shape
@@ -118,7 +118,7 @@ and reject the whole document.
 
 
 [[geoshape-indexing-approach]]
-[float]
+[discrete]
 ==== Indexing approach
 GeoShape types are indexed by decomposing the shape into a triangular mesh and
 indexing each triangle as a 7 dimension point in a BKD tree. This provides
@@ -140,7 +140,7 @@ ElasticSearch 7.5.0 or higher.
 
 
 [[prefix-trees]]
-[float]
+[discrete]
 ==== Prefix trees
 
 deprecated[6.6, PrefixTrees no longer used] To efficiently represent shapes in
@@ -171,7 +171,7 @@ represents 2 bits in this bit set, one for each coordinate. The maximum
 number of levels for the quad trees in Elasticsearch is 29; the default is 21.
 
 [[spatial-strategy]]
-[float]
+[discrete]
 ===== Spatial strategies
 deprecated[6.6, PrefixTrees no longer used]  The indexing implementation
 selected relies on a  SpatialStrategy for choosing how to decompose the shapes
@@ -194,7 +194,7 @@ are provided:
 
 |=======================================================================
 
-[float]
+[discrete]
 ===== Accuracy
 
 `Recursive` and `Term` strategies do not provide 100% accuracy and depending on
@@ -205,7 +205,7 @@ parameter and to adjust expectations accordingly. For example, a point may be ne
 the border of a particular grid cell and may thus not match a query that only matches
 the cell right next to it -- even though the shape is very close to the point.
 
-[float]
+[discrete]
 ===== Example
 
 [source,console]
@@ -227,7 +227,7 @@ This mapping definition maps the location field to the geo_shape
 type using the default vector implementation. It provides
 approximately 1e-7 decimal degree precision.
 
-[float]
+[discrete]
 ===== Performance considerations with Prefix Trees
 
 deprecated[6.6, PrefixTrees no longer used] With prefix trees,
@@ -251,7 +251,7 @@ Geo-shape queries on geo-shapes implemented with PrefixTrees will not be execute
 <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>> is set to false.
 
 [[input-structure]]
-[float]
+[discrete]
 ==== Input Structure
 
 Shapes can be represented using either the http://www.geojson.org[GeoJSON]
@@ -293,7 +293,7 @@ use the colloquial latitude, longitude (Y, X).
 =============================================
 
 [[geo-point-type]]
-[float]
+[discrete]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 
 A point is a single geographic coordinate, such as the location of a
@@ -321,7 +321,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geo-linestring]]
 ===== http://geojson.org/geojson-spec.html#id3[LineString]
 
@@ -354,7 +354,7 @@ POST /example/_doc
 The above `linestring` would draw a straight line starting at the White
 House to the US Capitol Building.
 
-[float]
+[discrete]
 [[geo-polygon]]
 ===== http://www.geojson.org/geojson-spec.html#id4[Polygon]
 
@@ -465,7 +465,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geo-multipoint]]
 ===== http://www.geojson.org/geojson-spec.html#id5[MultiPoint]
 
@@ -494,7 +494,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geo-multilinestring]]
 ===== http://www.geojson.org/geojson-spec.html#id6[MultiLineString]
 
@@ -525,7 +525,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geo-multipolygon]]
 ===== http://www.geojson.org/geojson-spec.html#id7[MultiPolygon]
 
@@ -556,7 +556,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geo-geometry_collection]]
 ===== http://geojson.org/geojson-spec.html#geometrycollection[Geometry Collection]
 
@@ -593,7 +593,7 @@ POST /example/_doc
 --------------------------------------------------
 
 
-[float]
+[discrete]
 ===== Envelope
 
 Elasticsearch supports an `envelope` type, which consists of coordinates
@@ -623,7 +623,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Circle
 
 Elasticsearch supports a `circle` type, which consists of a center
@@ -650,7 +650,7 @@ the units of the `radius` will default to `METERS`.
 
 *NOTE:* Neither GeoJSON or WKT support a point-radius circle type.
 
-[float]
+[discrete]
 ==== Sorting and Retrieving index Shapes
 
 Due to the complex input structure and index representation of shapes,

--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -213,7 +213,7 @@ as standard (flat) fields. Defaults to `false`.
 If `true`, all fields in the nested object are also added to the root
 document as standard (flat) fields. Defaults to `false`.
 
-[float]
+[discrete]
 === Limits on `nested` mappings and objects
 
 As described earlier, each nested object is indexed as a separate Lucene document.

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -57,7 +57,7 @@ add or update a mapping via the <<indices-create-index,create index>> or <<indic
 
 =====================================
 
-[float]
+[discrete]
 ==== Reindexing your percolator queries
 
 Reindexing percolator queries is sometimes required to benefit from improvements made to the `percolator` field type in
@@ -221,7 +221,7 @@ now returns matches from the new index:
 
 <1> Percolator query hit is now being presented from the new index.
 
-[float]
+[discrete]
 ==== Optimizing query time text analysis
 
 When the percolator verifies a percolator candidate match it is going to parse, perform query time text analysis and actually run
@@ -413,7 +413,7 @@ This results in a response like this:
 --------------------------------------------------
 // TESTRESPONSE[s/"took": 6,/"took": "$body.took",/]
 
-[float]
+[discrete]
 ==== Optimizing wildcard queries.
 
 Wildcard queries are  more expensive than other queries for the percolator,
@@ -683,7 +683,7 @@ GET /my_queries2/_search
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 ==== Dedicated Percolator Index
 
 Percolate queries can be added to any index. Instead of adding percolate queries to the index the data resides in,
@@ -692,7 +692,7 @@ can have its own index settings (For example the number of primary and replica s
 percolate index, you need to make sure that the mappings from the normal index are also available on the percolate index.
 Otherwise percolate queries can be parsed incorrectly.
 
-[float]
+[discrete]
 ==== Forcing Unmapped Fields to be Handled as Strings
 
 In certain cases it is unknown what kind of percolator queries do get registered, and if no field mapping exists for fields
@@ -703,17 +703,17 @@ if all unmapped fields are handled as if these were default text fields. In thos
 a percolator query does not exist, it will be handled as a default text field so that adding the percolator query doesn't
 fail.
 
-[float]
+[discrete]
 ==== Limitations
 
-[float]
+[discrete]
 [[parent-child]]
 ===== Parent/child
 
 Because the `percolate` query is processing one document at a time, it doesn't support queries and filters that run
 against child documents such as `has_child` and `has_parent`.
 
-[float]
+[discrete]
 ===== Fetching queries
 
 There are a number of queries that fetch data via a get call during query parsing. For example the `terms` query when
@@ -724,7 +724,7 @@ is that fetching of terms that these queries do, happens both each time the perc
 and replica shards, so the terms that are actually indexed can be different between shard copies, if the source index
 changed while indexing.
 
-[float]
+[discrete]
 ===== Script query
 
 The script inside a `script` query can only access doc values fields. The `percolate` query indexes the provided document
@@ -732,7 +732,7 @@ into an in-memory index. This in-memory index doesn't support stored fields and 
 other stored fields are not stored. This is the reason why in the `script` query the `_source` and other stored fields
 aren't available.
 
-[float]
+[discrete]
 ===== Field aliases
 
 Percolator queries that contain <<alias, field aliases>> may not always behave as expected. In particular, if a

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -15,7 +15,7 @@ You can query documents using this type using
 <<query-dsl-shape-query,shape Query>>.
 
 [[shape-mapping-options]]
-[float]
+[discrete]
 ==== Mapping Options
 
 Like the <<geo-shape, geo_shape>> field type, the `shape` field mapping maps
@@ -56,7 +56,7 @@ and reject the whole document.
 |=======================================================================
 
 [[shape-indexing-approach]]
-[float]
+[discrete]
 ==== Indexing approach
 Like `geo_shape`, the `shape` field type is indexed by decomposing geometries into
 a triangular mesh and indexing each triangle as a 7 dimension point in a BKD tree.
@@ -70,7 +70,7 @@ depends on the number of vertices that define the geometry.
 `CONTAINS` relation query - `shape` queries with `relation` defined as `contains` are supported
 for indices created with ElasticSearch 7.5.0 or higher.
 
-[float]
+[discrete]
 ===== Example
 
 [source,console]
@@ -93,7 +93,7 @@ precision floats for the vertex values so accuracy is guaranteed to the same pre
 `float` values provided by the java virtual machine approximately (typically 1E-38).
 
 [[shape-input-structure]]
-[float]
+[discrete]
 ==== Input Structure
 
 Shapes can be represented using either the http://www.geojson.org[GeoJSON]
@@ -130,7 +130,7 @@ typically use the colloquial latitude, longitude (Y, X) ordering.
 =============================================
 
 [[point-shape]]
-[float]
+[discrete]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 
 A point is a single coordinate in cartesian `x, y` space. It may represent the
@@ -158,7 +158,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[linestring]]
 ===== http://geojson.org/geojson-spec.html#id3[LineString]
 
@@ -188,7 +188,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[polygon]]
 ===== http://www.geojson.org/geojson-spec.html#id4[Polygon]
 
@@ -275,7 +275,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[multipoint]]
 ===== http://www.geojson.org/geojson-spec.html#id5[MultiPoint]
 
@@ -304,7 +304,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[multilinestring]]
 ===== http://www.geojson.org/geojson-spec.html#id6[MultiLineString]
 
@@ -335,7 +335,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[multipolygon]]
 ===== http://www.geojson.org/geojson-spec.html#id7[MultiPolygon]
 
@@ -366,7 +366,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[geometry_collection]]
 ===== http://geojson.org/geojson-spec.html#geometrycollection[Geometry Collection]
 
@@ -402,7 +402,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Envelope
 
 Elasticsearch supports an `envelope` type, which consists of coordinates
@@ -432,7 +432,7 @@ POST /example/_doc
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Sorting and Retrieving index Shapes
 
 Due to the complex input structure and index representation of shapes,

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -32,7 +32,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 * <<breaking_70_node_changes>>
 * <<breaking_70_java_time_changes>>
 
-[float]
+[discrete]
 === Indices created before 7.0
 
 Elasticsearch 7.0 can read indices created in version 6.0 or above.  An

--- a/docs/reference/migration/migrate_7_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_7_0/aggregations.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_aggregations_changes]]
 === Aggregations changes
 
@@ -10,13 +10,13 @@
 // end::notable-breaking-changes[]
 
 
-[float]
+[discrete]
 [[removed-global-ordinals-hash-and-global-ordinals-low-cardinality-terms-agg]]
 ==== Deprecated `global_ordinals_hash` and `global_ordinals_low_cardinality` execution hints for terms aggregations have been removed
 
 These `execution_hint` are removed and should be replaced by `global_ordinals`.
 
-[float]
+[discrete]
 [[search-max-buckets-cluster-setting]]
 ==== `search.max_buckets` in the cluster setting
 
@@ -24,14 +24,14 @@ The dynamic cluster setting named `search.max_buckets` now defaults
 to 10,000 (instead of unlimited in the previous version).
 Requests that try to return more than the limit will fail with an exception.
 
-[float]
+[discrete]
 [[missing-option-removed-composite-agg]]
 ==== `missing` option of the `composite` aggregation has been removed
 
 The `missing` option of the `composite` aggregation, deprecated in 6.x,
 has been removed. `missing_bucket` should be used instead.
 
-[float]
+[discrete]
 [[replace-params-agg-with-state-context-variable]]
 ==== Replaced `params._agg` with `state` context variable in scripted metric aggregations
 
@@ -39,14 +39,14 @@ The object used to share aggregation state between the scripts in a Scripted Met
 Aggregation is now a variable called `state` available in the script context, rather than
 being provided via the `params` object as `params._agg`.
 
-[float]
+[discrete]
 [[reduce-script-combine-script-params-mandatory]]
 ==== Make metric aggregation script parameters `reduce_script` and `combine_script` mandatory
 
 The metric aggregation has been changed to require these two script parameters to ensure users are
 explicitly defining how their data is processed.
 
-[float]
+[discrete]
 [[percentiles-percentile-ranks-return-null-instead-nan]]
 ==== `percentiles` and `percentile_ranks` now return `null` instead of `NaN`
 
@@ -54,7 +54,7 @@ The `percentiles` and `percentile_ranks` aggregations used to return `NaN` in
 the response if they were applied to an empty set of values. Because `NaN` is
 not officially supported by JSON, it has been replaced with `null`.
 
-[float]
+[discrete]
 [[stats-extended-stats-return-zero-instead-null]]
 ==== `stats` and `extended_stats` now return 0 instead of `null` for zero docs
 

--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_analysis_changes]]
 === Analysis changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[limit-number-of-tokens-produced-by-analyze]]
 ==== Limiting the number of tokens produced by _analyze
 
@@ -17,7 +17,7 @@ To safeguard against out of memory errors, the number of tokens that can be prod
 using the `_analyze` endpoint has been limited to 10000. This default limit can be changed
 for a particular index with the index setting `index.analyze.max_token_count`.
 
-[float]
+[discrete]
 ==== Limiting the length of an analyzed text during highlighting
 
 Highlighting a text that was indexed without offsets or term vectors,
@@ -27,7 +27,7 @@ To protect against this, the maximum number of characters that will be analyzed 
 limited to 1000000. This default limit can be changed
 for a particular index with the index setting `index.highlight.max_analyzed_offset`.
 
-[float]
+[discrete]
 [[delimited-payload-filter-renaming]]
 ==== `delimited_payload_filter` renaming
 
@@ -36,13 +36,13 @@ Using it in indices created before 7.0 will issue deprecation warnings. Using th
 name in new indices created in 7.0 will throw an error. Use the new name `delimited_payload`
 instead.
 
-[float]
+[discrete]
 [[standard-filter-removed]]
 ==== `standard` filter has been removed
 
 The `standard` token filter has been removed because it doesn't change anything in the stream.
 
-[float]
+[discrete]
 ==== Deprecated standard_html_strip analyzer
 
 The `standard_html_strip` analyzer has been deprecated, and should be replaced
@@ -50,7 +50,7 @@ with a combination of the `standard` tokenizer and `html_strip` char_filter.
 Indexes created using this analyzer will still be readable in elasticsearch 7.0,
 but it will not be possible to create new indexes using it.
 
-[float]
+[discrete]
 [[deprecated-ngram-edgengram-token-filter-cannot-be-used]]
 ==== The deprecated `nGram` and `edgeNGram` token filter cannot be used on new indices
 

--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_api_changes]]
 === API changes
 
@@ -10,7 +10,7 @@
 // end::notable-breaking-changes[]
 
 
-[float]
+[discrete]
 ==== Internal Versioning is no longer supported for optimistic concurrency control
 
 Elasticsearch maintains a numeric version field for each document it stores. That field
@@ -26,7 +26,7 @@ method based on sequence numbers. See <<optimistic-concurrency-control>> for mor
 
 Note that the `external` versioning type is still fully supported.
 
-[float]
+[discrete]
 ==== Camel case and underscore parameters deprecated in 6.x have been removed
 A number of duplicate parameters deprecated in 6.x have been removed from
 Bulk request, Multi Get request, Term Vectors request, and More Like This Query
@@ -48,7 +48,7 @@ The following parameters starting with underscore have been removed:
 Instead of these removed parameters, use their non camel case equivalents without
 starting underscore, e.g. use `version_type` instead of `_version_type` or `versionType`.
 
-[float]
+[discrete]
 ==== Thread pool info
 
 In previous versions of Elasticsearch, the thread pool info returned in the
@@ -75,13 +75,13 @@ aligns the output of the API with the configuration values for thread
 pools. Note that `core` and `max` will be populated for scaling thread pools,
 and `size` will be populated for fixed thread pools.
 
-[float]
+[discrete]
 [[fields-param-removed-bulk-update-request]]
 ==== The parameter `fields` deprecated in 6.x has been removed from Bulk request
 and Update request. The Update API returns `400 - Bad request` if request contains
 unknown parameters (instead of ignored in the previous version).
 
-[float]
+[discrete]
 ==== PUT Document with Version error message changed when document is missing
 
 If you attempt to `PUT` a document with versioning (e.g. `PUT /test/_doc/1?version=4`)
@@ -103,7 +103,7 @@ Although exceptions messages are liable to change and not generally subject to
 backwards compatibility, the nature of this message might mean clients are relying
 on parsing the version numbers and so the format change might impact some users.
 
-[float]
+[discrete]
 [[remove-suggest-metric]]
 ==== Remove support for `suggest` metric/index metric in indices stats and nodes stats APIs
 
@@ -118,7 +118,7 @@ In the past, `fields` could be provided either as a parameter, or as part of the
 body. Specifying `fields` in the request body as opposed to a parameter was deprecated
 in 6.4.0, and is now unsupported in 7.0.0.
 
-[float]
+[discrete]
 [[copy-settings-deprecated-shrink-split-apis]]
 ==== `copy_settings` is deprecated on shrink and split APIs
 
@@ -130,12 +130,12 @@ will be for such settings to be copied on such operations. To enable users in
 the only behavior in 8.0.0, this parameter is deprecated in 7.0.0 for removal in
 8.0.0.
 
-[float]
+[discrete]
 ==== The deprecated stored script contexts have now been removed
 When putting stored scripts, support for storing them with the deprecated `template` context or without a context is
 now removed. Scripts must be stored using the `script` context as mentioned in the documentation.
 
-[float]
+[discrete]
 ==== Removed Get Aliases API limitations when {security-features} are enabled
 
 The behavior and response codes of the get aliases API no longer vary
@@ -144,7 +144,7 @@ depending on whether {security-features} are enabled. Previously a
 current user was not authorized for any alias. An empty response with
 status 200 - OK is now returned instead at all times.
 
-[float]
+[discrete]
 [[user-object-removed-put-user-api]]
 ==== Put User API response no longer has `user` object
 
@@ -152,33 +152,33 @@ The Put User API response was changed in 6.5.0 to add the `created` field
 outside of the user object where it previously had been. In 7.0.0 the user
 object has been removed in favor of the top level `created` field.
 
-[float]
+[discrete]
 [[source-include-exclude-params-removed]]
 ==== Source filtering url parameters `_source_include` and `_source_exclude` have been removed
 
 The deprecated in 6.x url parameters are now removed. Use `_source_includes` and `_source_excludes` instead.
 
-[float]
+[discrete]
 ==== Multi Search Request metadata validation
 
 MultiSearchRequests issued through `_msearch` now validate all keys in the metadata section. Previously unknown keys were ignored
 while now an exception is thrown.
 
-[float]
+[discrete]
 ==== Deprecated graph endpoints removed
 
 The deprecated graph endpoints (those with `/_graph/_explore`) have been
 removed.
 
 
-[float]
+[discrete]
 [[deprecated-termvector-endpoint-removed]]
 ==== Deprecated `_termvector` endpoint removed
 
 The `_termvector` endpoint was deprecated in 2.0 and has now been removed.
 The endpoint `_termvectors` (plural) should be used instead.
 
-[float]
+[discrete]
 ==== When {security-features} are enabled, index monitoring APIs over restricted indices are not authorized implicitly anymore
 
 Restricted indices (currently only `.security-6` and `.security`) are special internal
@@ -190,21 +190,21 @@ has been forfeited and index monitoring privileges have to be granted explicitly
 using the `allow_restricted_indices` flag on the permission (as any other index
 privilege).
 
-[float]
+[discrete]
 [[remove-get-support-cache-clear-api]]
 ==== Removed support for `GET` on the `_cache/clear` API
 
 The `_cache/clear` API no longer supports the `GET` HTTP verb. It must be called
 with `POST`.
 
-[float]
+[discrete]
 ==== Cluster state size metrics removed from Cluster State API Response
 
 The `compressed_size` / `compressed_size_in_bytes` fields were removed from
 the Cluster State API response.  The calculation of the size was expensive and had
 dubious value, so the field was removed from the response.
 
-[float]
+[discrete]
 ==== Migration Assistance API has been removed
 
 The Migration Assistance API has been functionally replaced by the
@@ -213,21 +213,21 @@ transition from ES 6.x to 7.x, and does not need to be kept around to
 repair indices that were not properly upgraded before upgrading the
 cluster, as was the case in 6.
 
-[float]
+[discrete]
 ==== Changes to thread pool naming in Node and Cat APIs
 The `thread_pool` information returned from the Nodes and Cat APIs has been
 standardized to use the same terminology as the thread pool configurations.
 This means the response will align with the configuration instead of being
 the same across all the thread pools, regardless of type.
 
-[float]
+[discrete]
 ==== Return 200 when cluster has valid read-only blocks
 If the cluster was configured with `no_master_block: write` and lost its master,
 it would return a `503` status code from a main request (`GET /`) even though
 there are viable read-only nodes available.  The cluster now returns 200 status
 in this situation.
 
-[float]
+[discrete]
 ==== Clearing indices cache is now POST-only
 Clearing the cache indices could previously be done via GET and POST. As GET should
 only support read only non state-changing operations, this is no longer allowed.

--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_cluster_changes]]
 === Cluster changes
 
@@ -9,14 +9,14 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[_literal_literal_is_no_longer_allowed_in_cluster_name]]
 ==== `:` is no longer allowed in cluster name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,
 cluster names may no longer contain `:`.
 
-[float]
+[discrete]
 [[new-default-wait-for-active-shards-param]]
 ==== New default for `wait_for_active_shards` parameter of the open index command
 
@@ -24,12 +24,12 @@ The default value for the `wait_for_active_shards` parameter of the open index A
 is changed from 0 to 1, which means that the command will now by default wait for all
 primary shards of the opened index to be allocated.
 
-[float]
+[discrete]
 [[shard-preferences-removed]]
 ==== Shard preferences `_primary`, `_primary_first`, `_replica`, and `_replica_first` are removed
 These shard preferences are removed in favour of the `_prefer_nodes` and `_only_nodes` preferences.
 
-[float]
+[discrete]
 ==== Cluster-wide shard soft limit
 Clusters now have soft limits on the total number of open shards in the cluster
 based on the number of nodes and the `cluster.max_shards_per_node` cluster

--- a/docs/reference/migration/migrate_7_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_7_0/discovery.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_discovery_changes]]
 === Discovery changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Cluster bootstrapping is required if discovery is configured
 
 The first time a cluster is started, `cluster.initial_master_nodes` must be set
@@ -23,7 +23,7 @@ documentation>> describes this setting in more detail.
 The `discovery.zen.minimum_master_nodes` setting is permitted, but ignored, on
 7.x nodes.
 
-[float]
+[discrete]
 ==== Removing master-eligible nodes sometimes requires voting exclusions
 
 If you wish to remove half or more of the master-eligible nodes from a cluster,
@@ -35,7 +35,7 @@ such as data-only nodes or coordinating-only nodes, voting exclusions are not
 required. Likewise, if you add nodes to the cluster, voting exclusions are not
 required.
 
-[float]
+[discrete]
 ==== Discovery configuration is required in production
 
 Production deployments of Elasticsearch now require at least one of the
@@ -52,7 +52,7 @@ The first three settings in this list are only available in versions 7.0 and
 above. If you are preparing to upgrade from an earlier version, you must set
 `discovery.zen.ping.unicast.hosts` or `discovery.zen.hosts_provider`.
 
-[float]
+[discrete]
 [[new-name-no-master-block-setting]]
 ==== New name for `no_master_block` setting
 
@@ -61,7 +61,7 @@ The `discovery.zen.no_master_block` setting is now known as
 now ignored. You should remove this setting and, if needed, set
 `cluster.no_master_block` appropriately after the upgrade.
 
-[float]
+[discrete]
 ==== Reduced default timeouts for fault detection
 
 By default the <<cluster-fault-detection,cluster fault detection>> subsystem
@@ -71,7 +71,7 @@ unresponsive for longer than 30 seconds is liable to be removed from the
 cluster. Previously the default timeout for each ping was 30 seconds, so that
 an unresponsive node might be kept in the cluster for over 90 seconds.
 
-[float]
+[discrete]
 ==== Master-ineligible nodes are ignored by discovery
 
 In earlier versions it was possible to use master-ineligible nodes during the

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_indices_changes]]
 === Indices changes
 
@@ -9,26 +9,26 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Index creation no longer defaults to five shards
 Previous versions of Elasticsearch defaulted to creating five shards per index.
 Starting with 7.0.0, the default is now one shard per index.
 
-[float]
+[discrete]
 [[_literal_literal_is_no_longer_allowed_in_index_name]]
 ==== `:` is no longer allowed in index name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,
 index names may no longer contain `:`.
 
-[float]
+[discrete]
 [[index-unassigned-node-left-delayed-timeout-no-longer-negative]]
 ==== `index.unassigned.node_left.delayed_timeout` may no longer be negative
 
 Negative values were interpreted as zero in earlier versions but are no
 longer accepted.
 
-[float]
+[discrete]
 [[flush-force-merge-no-longer-refresh]]
 ==== `_flush` and `_force_merge` will no longer refresh
 
@@ -38,7 +38,7 @@ visible to searches and non-realtime GET operations. From now on these operation
 don't have this side-effect anymore. To make documents visible an explicit `_refresh`
 call is needed unless the index is refreshed by the internal scheduler.
 
-[float]
+[discrete]
 ==== Limit to the difference between max_size and min_size in NGramTokenFilter and NGramTokenizer
 
 To safeguard against creating too many index terms, the difference between `max_ngram` and
@@ -47,7 +47,7 @@ limit can be changed with the index setting `index.max_ngram_diff`. Note that if
 exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
 warning is logged.
 
-[float]
+[discrete]
 ==== Limit to the difference between max_shingle_size and min_shingle_size in ShingleTokenFilter
 
 To safeguard against creating too many tokens, the difference between `max_shingle_size` and
@@ -56,7 +56,7 @@ limit can be changed with the index setting `index.max_shingle_diff`. Note that 
 exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
 warning is logged.
 
-[float]
+[discrete]
 ==== Document distribution changes
 
 Indices created with version `7.0.0` onwards will have an automatic `index.number_of_routing_shards`
@@ -65,7 +65,7 @@ shards the index has. In order to maintain the exact same distribution as a pre 
 `index.number_of_routing_shards` must be set to the `index.number_of_shards` at index creation time.
 Note: if the number of routing shards equals the number of shards `_split` operations are not supported.
 
-[float]
+[discrete]
 ==== Skipped background refresh on search idle shards
 
 Shards belonging to an index that does not have an explicit
@@ -76,7 +76,7 @@ that access a search idle shard will be "parked" until the next refresh
 happens.  Indexing requests with `wait_for_refresh` will also trigger
 a background refresh.
 
-[float]
+[discrete]
 ==== Remove deprecated url parameters for Clear Indices Cache API
 
 The following previously deprecated url parameter have been removed:
@@ -86,7 +86,7 @@ The following previously deprecated url parameter have been removed:
 * `request_cache` - use `request` instead
 * `field_data` - use `fielddata` instead
 
-[float]
+[discrete]
 [[network-breaker-inflight-requests-overhead-increased-to-2]]
 ==== `network.breaker.inflight_requests.overhead` increased to 2
 
@@ -94,7 +94,7 @@ Previously the in flight requests circuit breaker considered only the raw byte r
 By bumping the value of `network.breaker.inflight_requests.overhead` from 1 to 2, this circuit
 breaker considers now also the memory overhead of representing the request as a structured object.
 
-[float]
+[discrete]
 ==== Parent circuit breaker changes
 
 The parent circuit breaker defines a new setting `indices.breaker.total.use_real_memory` which is
@@ -103,20 +103,20 @@ heap memory instead of only considering the reserved memory by child circuit bre
 setting is `true`, the default parent breaker limit also changes from 70% to 95% of the JVM heap size.
 The previous behavior can be restored by setting `indices.breaker.total.use_real_memory` to `false`.
 
-[float]
+[discrete]
 ==== Field data circuit breaker changes
 As doc values have been enabled by default in earlier versions of Elasticsearch,
 there is less need for fielddata. Therefore, the default value of the setting
 `indices.breaker.fielddata.limit` has been lowered from 60% to 40% of the JVM
 heap size.
 
-[float]
+[discrete]
 [[fix-value-for-index-shard-check-on-startup-removed]]
 ==== `fix` value for `index.shard.check_on_startup` is removed
 
 Deprecated option value `fix` for setting `index.shard.check_on_startup` is not supported.
 
-[float]
+[discrete]
 [[elasticsearch-translog-removed]]
 ==== `elasticsearch-translog` is removed
 

--- a/docs/reference/migration/migrate_7_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_7_0/ingest.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_ingest_changes]]
 === API changes
 
@@ -7,7 +7,7 @@
 
 //tag::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Ingest configuration exception information is now transmitted in metadata field
 
 Previously, some ingest configuration exception information about ingest processors
@@ -17,7 +17,7 @@ exceptions are conveyed in other parts of Elasticsearch.
 Configuration exception information is now conveyed as a field in the response
 body.
 //end::notable-breaking-changes[]
-[float]
+[discrete]
 ==== Ingest plugin special handling has been removed
 There was some special handling for installing and removing the `ingest-geoip` and
 `ingest-user-agent` plugins after they were converted to modules. This special handling

--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_java_changes]]
 === Java API changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[isshardsacked-removed]]
 ==== `isShardsAcked` deprecated in `6.2` has been removed
 
@@ -17,7 +17,7 @@
 `CreateIndexResponse`, `RolloverResponse` and
 `CreateIndexClusterStateUpdateResponse`.
 
-[float]
+[discrete]
 [[prepareexecute-removed-client-api]]
 ==== `prepareExecute` removed from the client api
 
@@ -25,7 +25,7 @@ The `prepareExecute` method which created a request builder has been
 removed from the client api. Instead, construct a builder for the
 appropriate request directly.
 
-[float]
+[discrete]
 ==== Some Aggregation classes have moved packages
 
 * All classes present in `org.elasticsearch.search.aggregations.metrics.*` packages
@@ -37,28 +37,28 @@ addition, `org.elasticsearch.search.aggregations.pipeline.PipelineAggregationBui
 was moved to `org.elasticsearch.search.aggregations.PipelineAggregationBuilders`
 
 
-[float]
+[discrete]
 [[retry-withbackoff-methods-removed]]
 ==== `Retry.withBackoff` methods with `Settings` removed
 
 The variants of `Retry.withBackoff` that included `Settings` have been removed
 because `Settings` is no longer needed.
 
-[float]
+[discrete]
 [[client-termvector-removed]]
 ==== Deprecated method `Client#termVector` removed
 
 The client method `termVector`, deprecated in 2.0, has been removed. The method
 `termVectors` (plural) should be used instead.
 
-[float]
+[discrete]
 [[abstractlifecyclecomponent-constructor-removed]]
 ==== Deprecated constructor `AbstractLifecycleComponent(Settings settings)` removed
 
 The constructor `AbstractLifecycleComponent(Settings settings)`, deprecated in 6.7
 has been removed. The parameterless constructor should be used instead.
 
-[float]
+[discrete]
 ==== Changes to Geometry classes
 
 Geometry classes used to represent geo values in SQL have been moved from the

--- a/docs/reference/migration/migrate_7_0/java_time.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java_time.asciidoc
@@ -5,7 +5,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[breaking_70_java_time_changes]]
 === Replacing Joda-Time with java time
 
@@ -18,7 +18,7 @@ to remove the Joda-Time dependency in the future.
 The mappings, aggregations and search code switched from Joda-Time to
 java time.
 
-[float]
+[discrete]
 ==== Joda based date formatters are replaced with java ones
 
 With the release of Elasticsearch 6.7 a backwards compatibility layer was
@@ -45,7 +45,7 @@ So, instead of using `YYYY.MM.dd` you should use `8yyyy.MM.dd`.
 You can find more information about available formatting strings in the
 https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter javadocs].
 
-[float]
+[discrete]
 ==== Date formats behavioural change
 
 The `epoch_millis` and `epoch_second` formatters no longer support
@@ -60,7 +60,7 @@ The year-of-era formatting character is a `Y` in Joda-Time, but a lowercase
 The week-based-year formatting character is a lowercase `x` in Joda-Time,
 but an upper-case `Y` in java time.
 
-[float]
+[discrete]
 ==== Using time zones in the Java client
 
 Timezones have to be specified as java time based zone objects. This means,
@@ -71,7 +71,7 @@ Examples of possible uses are the `QueryStringQueryBuilder`, the
 `RangeQueryBuilder` or the `DateHistogramAggregationBuilder`, each of them
 allow for an optional timezone for that part of the search request.
 
-[float]
+[discrete]
 ==== Parsing aggregation buckets in the Java client
 
 The date based aggregation buckets in responses used to be of
@@ -81,7 +81,7 @@ may run into class cast exceptions only when running the code, but not at
 compile time, ensure you have proper test coverage for this in your
 own code.
 
-[float]
+[discrete]
 [[parsing-gtm0-timezeone-jdk8-not-supported]]
 ==== Parsing `GMT0` timezone with JDK8 is not supported
 
@@ -91,7 +91,7 @@ JDK, which has not been fixed for JDK8. You can read more in the
 https://bugs.openjdk.java.net/browse/JDK-8138664[official issue]
 This bug is fixed in JDK9 and later versions.
 
-[float]
+[discrete]
 ==== Scripting with dates should use java time based methods
 
 If dates are used in scripting, a backwards compatibility layer has been added
@@ -121,14 +121,14 @@ and should be replaced.
 * `toString(String)` should be replaced with a `DateTimeFormatter`
 * `toString(String,Locale)` should be replaced with a `DateTimeFormatter`
 
-[float]
+[discrete]
 ==== Negative epoch timestamps are no longer supported
 
 With the switch to java time, support for negative timestamps has been removed.
 For dates before 1970, use a date format containing a year.
 
 
-[float]
+[discrete]
 ==== Migration guide
 For a detailed migration guide, see <<migrate-to-java-time>>.
 

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_logging_changes]]
 === Logging changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[new-json-format-log-directory]]
 ==== New JSON format log files in `log` directory
 
@@ -28,7 +28,7 @@ Following files should be expected now in log directory:
 
 Note: You can configure which of these files are written by editing `log4j2.properties`.
 
-[float]
+[discrete]
 [[log-files-ending-log-deprecated]]
 ==== Log files ending with `*.log` deprecated
 Log files with the `.log` file extension using the old pattern layout format
@@ -36,12 +36,12 @@ are now considered deprecated and the newly added JSON log file format with
 the `.json` file extension should be used instead.
 Note: GC logs which are written to the file `gc.log` will not be changed.
 
-[float]
+[discrete]
 ==== Docker output in JSON format
 
 All Docker console logs are now in JSON format. You can distinguish logs streams with the `type` field.
 
-[float]
+[discrete]
 ==== Audit plaintext log file removed, JSON file renamed
 
 Elasticsearch no longer produces the `${cluster_name}_access.log` plaintext

--- a/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_low_level_restclient_changes]]
 === Low-level REST client changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[maxretrytimeout-removed]]
 ==== Support for `maxRetryTimeout` removed from RestClient
 
@@ -17,7 +17,7 @@
 setting. The setting was removed as its counting mechanism was not accurate
 and caused issues while adding little value.
 
-[float]
+[discrete]
 ==== Deprecated flavors of performRequest have been removed
 
 We deprecated the flavors of `performRequest` and `performRequestAsync` that
@@ -25,13 +25,13 @@ do not take `Request` objects in 6.4.0 in favor of the flavors that take
 `Request` objects because those methods can be extended without breaking
 backwards compatibility.
 
-[float]
+[discrete]
 ==== Removed setHosts
 
 We deprecated `setHosts` in 6.4.0 in favor of `setNodes` because it supports
 host metadata used by the `NodeSelector`.
 
-[float]
+[discrete]
 ==== Minimum compiler version change
 The minimum compiler version on the low-level REST client has been bumped
 to JDK 8.

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_mappings_changes]]
 === Mapping changes
 
@@ -9,13 +9,13 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[all-meta-field-removed]]
 ==== The `_all` meta field is removed
 
 The `_all` field deprecated in 6 have now been removed.
 
-[float]
+[discrete]
 [[uid-meta-field-removed]]
 ==== The `_uid` meta field is removed
 
@@ -24,7 +24,7 @@ Now that indices cannot have multiple types, this has been removed in favour
 of `_id`.
 
 //tag::notable-breaking-changes[]
-[float]
+[discrete]
 [[default-mapping-not-allowed]]
 ==== The `_default_` mapping is no longer allowed
 
@@ -47,13 +47,13 @@ For more details on the `include_type_name` parameter and other types-related
 API changes, please see <<removal-of-types>>.
 //end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[index-options-numeric-fields-removed]]
 ==== `index_options` for numeric fields has been removed
 
 The `index_options` field for numeric  fields has been deprecated in 6 and has now been removed.
 
-[float]
+[discrete]
 [[limit-number-nested-json-objects]]
 ==== Limiting the number of `nested` json objects
 
@@ -61,13 +61,13 @@ To safeguard against out of memory errors, the number of nested json objects wit
 document across all fields has been limited to 10000. This default limit can be changed with
 the index setting `index.mapping.nested_objects.limit`.
 
-[float]
+[discrete]
 [[update-all-types-option-removed]]
 ==== The `update_all_types` option has been removed
 
 This option is useless now that all indices have at most one type.
 
-[float]
+[discrete]
 [[classic-similarity-removed]]
 ==== The `classic` similarity has been removed
 
@@ -77,13 +77,13 @@ Lucene, which means that the `classic` similarity now produces scores of lower
 quality. It is advised to switch to `BM25` instead, which is widely accepted
 as a better alternative.
 
-[float]
+[discrete]
 ==== Similarities fail when unsupported options are provided
 
 An error will now be thrown when unknown configuration options are provided
 to similarities. Such unknown parameters were ignored before.
 
-[float]
+[discrete]
 [[changed-default-geo-shape-index-strategy]]
 ==== Changed default `geo_shape` indexing strategy
 
@@ -97,7 +97,7 @@ IMPORTANT NOTE: If using timed index creation from templates, the `geo_shape` ma
 should also be changed in the template to explicitly define `tree` to one of `geohash`
 or `quadtree`. This will ensure compatibility with previously created indexes.
 
-[float]
+[discrete]
 [[deprecated-geo-shape-params]]
 ==== Deprecated `geo_shape` parameters
 
@@ -105,14 +105,14 @@ The following type parameters are deprecated for the `geo_shape` field type: `tr
 `precision`, `tree_levels`, `distance_error_pct`, `points_only`, and `strategy`. They
 will be removed in a future version.
 
-[float]
+[discrete]
 ==== Limiting the number of completion contexts
 
 The maximum allowed number of completion contexts in a mapping will be limited
 to 10 in the next major version. Completion fields that define more than 10
 contexts in a mapping will log a deprecation warning in this version.
 
-[float]
+[discrete]
 [[include-type-name-defaults-false]]
 ==== `include_type_name` now defaults to `false`
 The default for `include_type_name` is now `false` for all APIs that accept

--- a/docs/reference/migration/migrate_7_0/ml.asciidoc
+++ b/docs/reference/migration/migrate_7_0/ml.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_ml_changes]]
 === ML changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Types in Datafeed config are no longer valid
 Types have been removed from the datafeed config and are no longer
 valid parameters.

--- a/docs/reference/migration/migrate_7_0/node.asciidoc
+++ b/docs/reference/migration/migrate_7_0/node.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_node_changes]]
 === Node start up
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Nodes with left-behind data or metadata refuse to start
 Repurposing an existing node by changing node.master or node.data to false can leave lingering on-disk metadata and
 data around, which will not be accessible by the node's new role. Beside storing non-accessible data, this can lead

--- a/docs/reference/migration/migrate_7_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/packaging.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_packaging_changes]]
 === Packaging changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[systemd-service-file-config]]
 ==== systemd service file is no longer configuration
 
@@ -18,19 +18,19 @@ was previously marked as a configuration file in rpm and deb packages.
 Overrides to the systemd elasticsearch service should be made
 in `/etc/systemd/system/elasticsearch.service.d/override.conf`.
 
-[float]
+[discrete]
 ==== tar package no longer includes windows specific files
 
 The tar package previously included files in the `bin` directory meant only
 for windows. These files have been removed. Use the `zip` package instead.
 
-[float]
+[discrete]
 ==== Ubuntu 14.04 is no longer supported
 
 Ubuntu 14.04 will reach end-of-life on April 30, 2019. As such, we are no longer
 supporting Ubuntu 14.04.
 
-[float]
+[discrete]
 ==== CLI secret prompting is no longer supported
 The ability to use `${prompt.secret}` and `${prompt.text}` to collect secrets
 from the CLI at server start is no longer supported.  Secure settings have replaced

--- a/docs/reference/migration/migrate_7_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_7_0/plugins.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_plugins_changes]]
 === Plugins changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Azure Repository plugin
 
 * The legacy azure settings which where starting with `cloud.azure.storage.` prefix have been removed.
@@ -21,7 +21,7 @@ You must set it per azure client instead. Like `azure.client.default.timeout: 10
 
 See {plugins}/repository-azure-repository-settings.html#repository-azure-repository-settings[Azure Repository settings].
 
-[float]
+[discrete]
 ==== Google Cloud Storage Repository plugin
 
 * The repository settings `application_name`, `connect_timeout` and `read_timeout` have been removed and
@@ -29,20 +29,20 @@ must now be specified in the client settings instead.
 
 See {plugins}/repository-gcs-client.html#repository-gcs-client[Google Cloud Storage Client Settings].
 
-[float]
+[discrete]
 ==== S3 Repository Plugin
 
 * The plugin now uses the path style access pattern for all requests.
 In previous versions it was automatically determining whether to use virtual hosted style or path style
 access.
 
-[float]
+[discrete]
 ==== Analysis Plugin changes
 
 * The misspelled helper method `requriesAnalysisSettings(AnalyzerProvider<T> provider)` has been
 renamed to `requiresAnalysisSettings`
 
-[float]
+[discrete]
 ==== File-based discovery plugin
 
 * This plugin has been removed since its functionality is now part of
@@ -51,7 +51,7 @@ from `$ES_PATH_CONF/file-discovery/unicast_hosts.txt` to
 `$ES_PATH_CONF/unicast_hosts.txt`. See <<file-based-hosts-provider,the
 file-based hosts provider documentation>> for further information.
 
-[float]
+[discrete]
 ==== Security Extensions
 
 As a consequence of the <<include-realm-type-in-setting, change to Realm settings>>,
@@ -71,19 +71,19 @@ Setting.AffixSetting<String> MY_SETTING = Setting.affixKeySetting(
 
 The `RealmSettings.simpleString` method can be used as a convenience for the above.
 
-[float]
+[discrete]
 ==== Tribe node removed
 
 Tribe node functionality has been removed in favor of
 <<modules-cross-cluster-search,Cross Cluster Search>>.
 
-[float]
+[discrete]
 ==== Discovery implementations are no longer pluggable
 
 * The method `DiscoveryPlugin#getDiscoveryTypes()` was removed, so that plugins
   can no longer provide their own discovery implementations.
 
-[float]
+[discrete]
 [[watcher-hipchat-action-removed]]
 ==== Watcher 'hipchat' action removed
 

--- a/docs/reference/migration/migrate_7_0/restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/restclient.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_restclient_changes]]
 === High-level REST client changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[remove-header-args]]
 ==== API methods accepting `Header` argument have been removed
 
@@ -22,7 +22,7 @@ In case you are specifying headers
 e.g. `client.index(indexRequest, new Header("name" "value"))` becomes
 `client.index(indexRequest, RequestOptions.DEFAULT.toBuilder().addHeader("name", "value").build());`
 
-[float]
+[discrete]
 [[cluster-health-api-default-cluster-level]]
 ==== Cluster Health API default to `cluster` level
 

--- a/docs/reference/migration/migrate_7_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_7_0/scripting.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_scripting_changes]]
 === Scripting changes
 
@@ -10,7 +10,7 @@
 // end::notable-breaking-changes[]
 
 
-[float]
+[discrete]
 ==== getDate() and getDates() removed
 
 Fields of type `long` and `date` had `getDate()` and `getDates()` methods
@@ -22,7 +22,7 @@ now been removed. Instead, use `.value` on `date` fields, or explicitly
 parse `long` fields into a date object using
 `Instance.ofEpochMillis(doc["myfield"].value)`.
 
-[float]
+[discrete]
 ==== Accessing missing document values will throw an error
 `doc['field'].value` will throw an exception if
 the document is missing a value for the field `field`.
@@ -31,7 +31,7 @@ To check if a document is missing a value, you can use
 `doc['field'].size() == 0`.
 
 
-[float]
+[discrete]
 [[script-errors-return-400-error-codes]]
 ==== Script errors will return as `400` error codes
 
@@ -39,7 +39,7 @@ Malformed scripts, either in search templates, ingest pipelines or search
 requests, return `400 - Bad request` while they would previously return
 `500 - Internal Server Error`. This also applies for stored scripts.
 
-[float]
+[discrete]
 ==== getValues() removed
 
 The `ScriptDocValues#getValues()` method is deprecated in 6.6 and will

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_search_changes]]
 === Search and Query DSL changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Off-heap terms index
 
 The terms dictionary is the part of the inverted index that records all terms
@@ -34,7 +34,7 @@ requests if both below conditions are met:
 This change affects both existing indices created with Elasticsearch 6.x and new
 indices created with Elasticsearch 7.x.
 
-[float]
+[discrete]
 ==== Changes to queries
 *   The default value for `transpositions` parameter of `fuzzy` query
     has been changed to `true`.
@@ -58,7 +58,7 @@ indices created with Elasticsearch 7.x.
 
 *   Attempts to set `boost` on inner span queries will now throw a parsing exception.
 
-[float]
+[discrete]
 ==== Adaptive replica selection enabled by default
 
 Adaptive replica selection has been enabled by default. If you wish to return to
@@ -76,7 +76,7 @@ PUT /_cluster/settings
 --------------------------------------------------
 
 
-[float]
+[discrete]
 [[search-api-returns-400-invalid-requests]]
 ==== Search API returns `400` for invalid requests
 
@@ -91,7 +91,7 @@ The Search API returns `400 - Bad request` while it would previously return
 *   number of filters in the adjacency matrix aggregation is too large
 *   script compilation errors
 
-[float]
+[discrete]
 [[scroll-queries-cannot-use-request-cache]]
 ==== Scroll queries cannot use the `request_cache` anymore
 
@@ -99,7 +99,7 @@ Setting `request_cache:true` on a query that creates a scroll (`scroll=1m`)
 has been deprecated in 6 and will now return a `400 - Bad request`.
 Scroll queries are not meant to be cached.
 
-[float]
+[discrete]
 [[scroll-queries-cannot-use-rescore]]
 ==== Scroll queries cannot use `rescore`  anymore
 
@@ -109,7 +109,7 @@ rescore on scroll queries would break the scroll sort.  In the 6.x line, the
 rescore clause was silently ignored (for scroll queries), and it was allowed in
 the 5.x line.
 
-[float]
+[discrete]
 ==== Term Suggesters supported distance algorithms
 
 The following string distance algorithms were given additional names in 6.2 and
@@ -119,7 +119,7 @@ removed.
 * 	`levenstein` - replaced by `levenshtein`
 * 	`jarowinkler` - replaced by `jaro_winkler`
 
-[float]
+[discrete]
 [[popular-mode-suggesters]]
 ==== `popular` mode for Suggesters
 
@@ -127,7 +127,7 @@ The `popular` mode for Suggesters (`term` and `phrase`) now uses the doc frequen
 (instead of the sum of the doc frequency) of the input terms to compute the frequency
 threshold for candidate suggestions.
 
-[float]
+[discrete]
 ==== Limiting the number of terms that can be used in a Terms Query request
 
 Executing a Terms Query with a lot of terms may degrade the cluster performance,
@@ -136,7 +136,7 @@ To safeguard against this, the maximum number of terms that can be used in a
 Terms Query request has been limited to 65536. This default maximum can be changed
 for a particular index with the index setting `index.max_terms_count`.
 
-[float]
+[discrete]
 ==== Limiting the length of regex that can be used in a Regexp Query request
 
 Executing a Regexp Query with a long regex string may degrade search performance.
@@ -144,7 +144,7 @@ To safeguard against this, the maximum length of regex that can be used in a
 Regexp Query request has been limited to 1000. This default maximum can be changed
 for a particular index with the index setting `index.max_regex_length`.
 
-[float]
+[discrete]
 ==== Limiting the number of auto-expanded fields
 
 Executing queries that use automatic expansion of fields (e.g. `query_string`, `simple_query_string`
@@ -152,14 +152,14 @@ or `multi_match`) can have performance issues for indices with a large numbers o
 To safeguard against this, a hard limit of 1024 fields has been introduced for queries
 using the "all fields" mode ("default_field": "*") or other fieldname expansions (e.g. "foo*").
 
-[float]
+[discrete]
 [[invalid-search-request-body]]
 ==== Invalid `_search` request body
 
 Search requests with extra content after the main object will no longer be accepted
 by the `_search` endpoint. A parsing exception will be thrown instead.
 
-[float]
+[discrete]
 ==== Doc-value fields default format
 
 The format of doc-value fields is changing to be the same as what could be
@@ -169,7 +169,7 @@ configured in the mappings by default. This behavior can be changed by
 specifying a <<request-body-search-docvalue-fields,`format`>> within the doc-value
 field.
 
-[float]
+[discrete]
 ==== Context Completion Suggester
 
 The ability to query and index context enabled suggestions without context,
@@ -180,7 +180,7 @@ considerably.
 For geo context the value of the `path` parameter is now validated against the mapping,
 and the context is only accepted if `path` points to a field with `geo_point` type.
 
-[float]
+[discrete]
 [[semantics-changed-max-concurrent-shared-requests]]
 ==== Semantics changed for `max_concurrent_shard_requests`
 
@@ -188,20 +188,20 @@ and the context is only accepted if `path` points to a field with `geo_point` ty
 requests a single high level search request can execute. In 7.0 this changed to be the
 max number of concurrent shard requests per node. The default is now `5`.
 
-[float]
+[discrete]
 [[max-score-set-to-null-when-untracked]]
 ==== `max_score` set to `null` when scores are not tracked
 
 `max_score` used to be set to `0` whenever scores are not tracked. `null` is now used
 instead which is a more appropriate value for a scenario where scores are not available.
 
-[float]
+[discrete]
 ==== Negative boosts are not allowed
 
 Setting a negative `boost` for a query or a field, deprecated in 6x, is not allowed in this version.
 To deboost a specific query or field you can use a `boost` comprise between 0 and 1.
 
-[float]
+[discrete]
 ==== Negative scores are not allowed in Function Score Query
 
 Negative scores in the Function Score Query are deprecated in 6.x, and are
@@ -209,7 +209,7 @@ not allowed in this version. If a negative score is produced as a result
 of computation (e.g. in `script_score` or `field_value_factor` functions),
 an error will be thrown.
 
-[float]
+[discrete]
 ==== The filter context has been removed
 
 The `filter` context has been removed from Elasticsearch's query builders,
@@ -220,7 +220,7 @@ on whether queries need to access score or not. As a result `bool` queries with
 major version.
 
 //tag::notable-breaking-changes[]
-[float]
+[discrete]
 [[hits-total-now-object-search-response]]
 ==== `hits.total` is now an object in the search response
 
@@ -252,7 +252,7 @@ This parameter has been added to ease the transition to the new format and
 will be removed in the next major version (8.0).
 //end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[hits-total-omitted-if-disabled]]
 ==== `hits.total` is omitted in the response if `track_total_hits` is disabled (false)
 
@@ -262,7 +262,7 @@ layer. You can add `rest_total_hits_as_int=true` in the search request parameter
 to get the old format back (`"total": -1`).
 
 //tag::notable-breaking-changes[]
-[float]
+[discrete]
 [[track-total-hits-10000-default]]
 ==== `track_total_hits` defaults to 10,000
 
@@ -295,7 +295,7 @@ You can force the count to always be accurate by setting `track_total_hits`
 to true explicitly in the search request.
 //end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Limitations on Similarities
 Lucene 8 introduced more constraints on similarities, in particular:
 
@@ -303,11 +303,11 @@ Lucene 8 introduced more constraints on similarities, in particular:
 - scores must not decrease when term freq increases,
 - scores must not increase when norm (interpreted as an unsigned long) increases.
 
-[float]
+[discrete]
 ==== Weights in Function Score must be positive
 Negative `weight` parameters in the `function_score` are no longer allowed.
 
-[float]
+[discrete]
 ==== Query string and Simple query string limit expansion of fields to 1024
 The number of automatically expanded fields for the "all fields"
 mode (`"default_field": "*"`) for the query_string and simple_query_string

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_settings_changes]]
 === Settings changes
 
@@ -9,7 +9,7 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[default-node-name-now-hostname]]
 ==== The default for `node.name` is now the hostname
 
@@ -17,13 +17,13 @@
 is started. Previously the default node name was the first eight characters
 of the node id. It can still be configured explicitly in `elasticsearch.yml`.
 
-[float]
+[discrete]
 ==== Percolator
 
 * The deprecated `index.percolator.map_unmapped_fields_as_string` setting has been removed in favour of
   the `index.percolator.map_unmapped_fields_as_text` setting.
 
-[float]
+[discrete]
 ==== Index thread pool
 
 * Internally, single-document index/delete/update requests are executed as bulk
@@ -32,7 +32,7 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
   longer needed and has been removed. As such, the  settings
   `thread_pool.index.size` and `thread_pool.index.queue_size` have been removed.
 
-[float]
+[discrete]
 [[write-thread-pool-fallback]]
 ==== Write thread pool fallback
 
@@ -44,12 +44,12 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
   available to keep the display output in APIs as `bulk` instead of `write`.
   These fallback settings and this system property have been removed.
 
-[float]
+[discrete]
 ==== Disabling memory-mapping
 
 * The setting `node.store.allow_mmapfs` has been renamed to `node.store.allow_mmap`.
 
-[float]
+[discrete]
 [[remove-http-enabled]]
 ==== Http enabled setting removed
 
@@ -57,7 +57,7 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
 use of the transport client. This setting has been removed, as the transport client
 will be removed in the future, thus requiring HTTP to always be enabled.
 
-[float]
+[discrete]
 [[remove-http-pipelining-setting]]
 ==== Http pipelining setting removed
 
@@ -66,7 +66,7 @@ This setting has been removed, as disabling http pipelining support on the serve
 provided little value. The setting `http.pipelining.max_events` can still be used to
 limit the number of pipelined requests in-flight.
 
-[float]
+[discrete]
 ==== Cross-cluster search settings renamed
 
 The cross-cluster search remote cluster connection infrastructure is also used
@@ -80,7 +80,7 @@ in the cluster state, or set on dynamic settings updates, we will automatically
 upgrade the setting from `search.remote.*` to `cluster.remote.*`. The fallback
 settings will be removed in 8.0.0.
 
-[float]
+[discrete]
 [[audit-logfile-local-node-info]]
 ==== Audit logfile local node info
 
@@ -100,7 +100,7 @@ Moreover, `xpack.security.audit.logfile.emit_node_name` has changed its default
 from `true` to `false`. All other settings mentioned before, have kept their
 default value of `false`.
 
-[float]
+[discrete]
 [[include-realm-type-in-setting]]
 ==== Security realms settings
 
@@ -130,7 +130,7 @@ Any realm specific secure settings that have been stored in the elasticsearch
 keystore (such as ldap bind passwords, or passwords for ssl keys) must be updated
 in a similar way.
 
-[float]
+[discrete]
 [[tls-setting-fallback]]
 ==== TLS/SSL settings
 
@@ -140,7 +140,7 @@ fallback to a default configuration when using TLS. Each component (realm, trans
 http client, etc) must now be configured with their own settings for TLS if it is being
 used.
 
-[float]
+[discrete]
 [[tls-v1-removed]]
 ==== TLS v1.0 disabled
 
@@ -210,7 +210,7 @@ The following is an example that enables TLS v1.0 for incoming HTTP connections:
 xpack.security.http.ssl.supported_protocols: [ "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1" ]
 --------------------------------------------------
 
-[float]
+[discrete]
 [[trial-explicit-security]]
 ==== Security on Trial Licenses
 
@@ -226,7 +226,7 @@ This behaviour has been now removed, so security is only enabled if:
 * `xpack.security.enabled` is `true`; _or_
 * `xpack.security.enabled` is not set, and a gold or platinum license is installed.
 
-[float]
+[discrete]
 [[watcher-notifications-account-settings]]
 ==== Watcher notifications account settings
 
@@ -249,7 +249,7 @@ node's keystore, i.e., they are not to be specified via the cluster settings API
 - `xpack.notification.slack.account.<id>.url`, instead use
 `xpack.notification.slack.account.<id>.secure_url`
 
-[float]
+[discrete]
 [[remove-audit-index-output]]
 ==== Audit index output type removed
 
@@ -264,13 +264,13 @@ were allowed to continue as usual. The recommended replacement is the
 use of the `logfile` audit output type and using other components from the
 Elastic Stack to handle the indexing part.
 
-[float]
+[discrete]
 [[ingest-user-agent-ecs-always]]
 ==== Ingest User Agent processor defaults uses `ecs` output format
 https://github.com/elastic/ecs[ECS] format is now the default.
 The `ecs` setting for the user agent ingest processor now defaults to true.
 
-[float]
+[discrete]
 [[remove-action-master-force_local]]
 ==== Remove `action.master.force_local`
 
@@ -279,12 +279,12 @@ internally by the tribe node to force reads to local cluster state (instead of
 forwarding to a master, which tribe nodes did not have).  Since the tribe
 node was removed, this setting was removed too.
 
-[float]
+[discrete]
 ==== Enforce cluster-wide shard limit
 The cluster-wide shard limit is now enforced and not optional. The limit can
 still be adjusted as desired using the cluster settings API.
 
-[float]
+[discrete]
 ==== HTTP Max content length setting is no longer parsed leniently
 Previously, `http.max_content_length` would reset to `100mb` if the setting was
 greater than `Integer.MAX_VALUE`.  This leniency has been removed.

--- a/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
+++ b/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_snapshotstats_changes]]
 === Snapshot stats changes
 
@@ -15,7 +15,7 @@ Snapshot stats details are provided in a new structured way:
 * `incremental` section for those files that actually needed to be copied over as part of the incremental snapshotting.
 * In case of a snapshot that's still in progress, there's also a `processed` section for files that are in the process of being copied.
 
-[float]
+[discrete]
 [[snapshot-stats-deprecated]]
 ==== Deprecated `number_of_files`, `processed_files`, `total_size_in_bytes` and `processed_size_in_bytes` snapshot stats properties have been removed
 

--- a/docs/reference/migration/migrate_7_0/suggesters.asciidoc
+++ b/docs/reference/migration/migrate_7_0/suggesters.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[breaking_70_suggesters_changes]]
 === Suggesters changes
 
@@ -9,12 +9,12 @@
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 ==== Registration of suggesters in plugins has changed
 
 Plugins must now explicitly indicate the type of suggestion that they produce.
 
-[float]
+[discrete]
 ==== Phrase suggester now multiples alpha
 Previously, the laplace smoothing used by the phrase suggester added `alpha`,
 when it should instead multiply.  This behavior has been changed and will

--- a/docs/reference/migration/migrate_7_1.asciidoc
+++ b/docs/reference/migration/migrate_7_1.asciidoc
@@ -16,33 +16,33 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 // end::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[breaking_71_http_changes]]
 === HTTP changes
 
-[float]
+[discrete]
 ==== Deprecation of old HTTP settings
 
 The `http.tcp_no_delay` setting is deprecated in 7.1. It is replaced by
 `http.tcp.no_delay`.
 
-[float]
+[discrete]
 [[breaking_71_network_changes]]
 === Network changes
 
-[float]
+[discrete]
 ==== Deprecation of old network settings
 
 The `network.tcp.connect_timeout` setting is deprecated in 7.1. This setting
 was a fallback setting for `transport.connect_timeout`. To change the default
 connection timeout for client connections, modify `transport.connect_timeout`.
 
-[float]
+[discrete]
 [[breaking_71_transport_changes]]
 === Transport changes
 
 //tag::notable-breaking-changes[]
-[float]
+[discrete]
 ==== Deprecation of old transport settings
 
 The following settings are deprecated in 7.1. Each setting has a replacement

--- a/docs/reference/migration/migrate_7_2.asciidoc
+++ b/docs/reference/migration/migrate_7_2.asciidoc
@@ -14,11 +14,11 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 //tag::notable-breaking-changes[]
 
-[float]
+[discrete]
 [[breaking_72_discovery_changes]]
 === Discovery changes
 
-[float]
+[discrete]
 ==== Only a single port may be given for each seed host.
 
 In earlier versions you could include a range of ports in entries in the

--- a/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
@@ -20,7 +20,7 @@ The {ml-features} include the following count functions:
 * xref:ml-nonzero-count[`non_zero_count`, `high_non_zero_count`, `low_non_zero_count`]
 * xref:ml-distinct-count[`distinct_count`, `high_distinct_count`, `low_distinct_count`]
 
-[float]
+[discrete]
 [[ml-count]]
 == Count, high_count, low_count
 
@@ -143,7 +143,7 @@ function (for example, `sum(events_per_min)`). Instead, use the count function
 and the `summary_count_field_name` property. For more information, see 
 <<ml-configuring-aggregation>>.
 
-[float]
+[discrete]
 [[ml-nonzero-count]]
 == Non_zero_count, high_non_zero_count, low_non_zero_count
 
@@ -213,7 +213,7 @@ supported for the `non_zero_count`, `high_non_zero_count`, and
 data is sparse, use the `count` functions, which are optimized for that scenario.
 
 
-[float]
+[discrete]
 [[ml-distinct-count]]
 == Distinct_count, high_distinct_count, low_distinct_count
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-geo-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-geo-functions.asciidoc
@@ -11,7 +11,7 @@ NOTE: You cannot create forecasts for {anomaly-jobs} that contain geographic
 functions. You also cannot add rules with conditions to detectors that use
 geographic functions. 
 
-[float]
+[discrete]
 [[ml-lat-long]]
 == Lat_long
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-info-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-info-functions.asciidoc
@@ -10,7 +10,7 @@ The {ml-features} include the following information content functions:
 
 * `info_content`, `high_info_content`, `low_info_content`
 
-[float]
+[discrete]
 [[ml-info-content]]
 == Info_content, High_info_content, Low_info_content
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-metric-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-metric-functions.asciidoc
@@ -18,7 +18,7 @@ The {ml-features} include the following metric functions:
 NOTE: You cannot add rules with conditions to detectors that use the `metric` 
 function. 
 
-[float]
+[discrete]
 [[ml-metric-min]]
 == Min
 
@@ -53,7 +53,7 @@ where the smallest transaction is lower than previously observed. You can use
 this function to detect items for sale at unintentionally low prices due to data
 entry mistakes. It models the minimum amount for each product over time.
 
-[float]
+[discrete]
 [[ml-metric-max]]
 == Max
 
@@ -111,7 +111,7 @@ functions by application. By combining detectors and using the same influencer
 this job can detect both unusually long individual response times and average
 response times for each bucket.
 
-[float]
+[discrete]
 [[ml-metric-median]]
 == Median, high_median, low_median
 
@@ -149,7 +149,7 @@ If you use this `median` function in a detector in your {anomaly-job}, it models
 the median `responsetime` for each application over time. It detects when the
 median `responsetime` is unusual compared to previous `responsetime` values.
 
-[float]
+[discrete]
 [[ml-metric-mean]]
 == Mean, high_mean, low_mean
 
@@ -219,7 +219,7 @@ models the mean `responsetime` for each application over time. It detects when
 the mean `responsetime` is unusually low compared to previous `responsetime`
 values.
 
-[float]
+[discrete]
 [[ml-metric-metric]]
 == Metric
 
@@ -256,7 +256,7 @@ the mean, min, and max `responsetime` for each application over time. It detects
 when the mean, min, or max `responsetime` is unusual compared to previous
 `responsetime` values.
 
-[float]
+[discrete]
 [[ml-metric-varp]]
 == Varp, high_varp, low_varp
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-rare-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-rare-functions.asciidoc
@@ -33,7 +33,7 @@ The {ml-features} include the following rare functions:
 * <<ml-freq-rare,`freq_rare`>>
 
 
-[float]
+[discrete]
 [[ml-rare]]
 == Rare
 
@@ -91,7 +91,7 @@ of distinct status codes that occur, not the number of times the status code
 occurs. If a single client IP experiences a single unique status code, this
 is rare, even if it occurs for that client IP in every bucket.
 
-[float]
+[discrete]
 [[ml-freq-rare]]
 == Freq_rare
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
@@ -17,7 +17,7 @@ The {ml-features} include the following sum functions:
 * xref:ml-sum[`sum`, `high_sum`, `low_sum`]
 * xref:ml-nonnull-sum[`non_null_sum`, `high_non_null_sum`, `low_non_null_sum`]
 
-[float]
+[discrete]
 [[ml-sum]]
 == Sum, high_sum, low_sum
 
@@ -73,7 +73,7 @@ transferred from a client to a server on the internet that are unusual compared
 to other clients. This scenario could be useful to detect data exfiltration or
 to find users that are abusing internet privileges.
 
-[float]
+[discrete]
 [[ml-nonnull-sum]]
 == Non_null_sum, high_non_null_sum, low_non_null_sum
 

--- a/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
@@ -35,7 +35,7 @@ measured against a UTC baseline) has changed. This situation is treated as a
 step change in behavior and the new times will be learned quickly.
 ====
 
-[float]
+[discrete]
 [[ml-time-of-day]]
 == Time_of_day
 
@@ -71,7 +71,7 @@ models when events occur throughout a day for each process. It detects when an
 event occurs for a process that is at an unusual time in the day compared to
 its past behavior.
 
-[float]
+[discrete]
 [[ml-time-of-week]]
 == Time_of_week
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-url.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-url.asciidoc
@@ -47,7 +47,7 @@ results to the time period two hours before and after the anomaly.
 You can also specify these custom URL settings when you create or update
 {anomaly-jobs} by using the APIs.
 
-[float]
+[discrete]
 [[ml-configuring-url-strings]]
 == String substitution in custom URLs
 

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -7,7 +7,7 @@ filter and analyze log data stored on clusters in different data centers.
 
 IMPORTANT: {ccs-cap} requires <<modules-remote-clusters, remote clusters>>.
 
-[float]
+[discrete]
 [[ccs-supported-apis]]
 === Supported APIs
 
@@ -18,11 +18,11 @@ The following APIs support {ccs}:
 * <<search-template,Search template>>
 * <<multi-search-template,Multi search template>>
 
-[float]
+[discrete]
 [[ccs-example]]
 === {ccs-cap} examples
 
-[float]
+[discrete]
 [[ccs-remote-cluster-setup]]
 ==== Remote cluster setup
 
@@ -61,7 +61,7 @@ PUT _cluster/settings
 // TEST[setup:host]
 // TEST[s/127.0.0.1:930\d+/\${transport_host}/]
 
-[float]
+[discrete]
 [[ccs-search-remote-cluster]]
 ==== Search a single remote cluster
 
@@ -130,7 +130,7 @@ The API returns the following response:
 <1> The search response body includes the name of the remote cluster in the
 `_index` parameter.
 
-[float]
+[discrete]
 [[ccs-search-multi-remote-cluster]]
 ==== Search multiple remote clusters
 
@@ -229,7 +229,7 @@ means the document came from the local cluster.
 <2> This document came from `cluster_one`.
 <3> This document came from `cluster_two`.
 
-[float]
+[discrete]
 [[skip-unavailable-clusters]]
 === Skip unavailable clusters
 

--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -94,7 +94,7 @@ match exactly.
 
 ==================================================
 
-[float]
+[discrete]
 ==== Choosing a cluster name
 
 The <<cluster.name,`cluster.name`>> setting enables you to create multiple
@@ -104,7 +104,7 @@ will only form a cluster from nodes that all have the same cluster name. The
 default value for the cluster name is `elasticsearch`, but it is recommended to
 change this to reflect the logical name of the cluster.
 
-[float]
+[discrete]
 ==== Auto-bootstrapping in development mode
 
 If the cluster is running with a completely default configuration then it will

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -53,7 +53,7 @@ compatibility. Support for the old name will be removed in a future version.
     default this list is empty, meaning that this node expects to join a cluster
     that has already been bootstrapped. See <<initial_master_nodes>>.
             
-[float]
+[discrete]
 ==== Expert settings
 
 Discovery and cluster formation are also affected by the following

--- a/docs/reference/modules/discovery/discovery.asciidoc
+++ b/docs/reference/modules/discovery/discovery.asciidoc
@@ -52,7 +52,7 @@ the timeout for each lookup is controlled by `discovery.seed_resolver.timeout`
 which defaults to `5s`. Note that DNS lookups are subject to
 <<networkaddress-cache-ttl,JVM DNS caching>>.
 
-[float]
+[discrete]
 [[settings-based-hosts-provider]]
 ===== Settings-based seed hosts provider
 
@@ -76,7 +76,7 @@ discovery.seed_hosts:
 <2> If a hostname resolves to multiple IP addresses, {es} will attempt to
     connect to every resolved address.
 
-[float]
+[discrete]
 [[file-based-hosts-provider]]
 ===== File-based seed hosts provider
 
@@ -132,7 +132,7 @@ needed, coming after the brackets.
 You can also add comments to this file. All comments must appear on their lines
 starting with `#` (i.e. comments cannot start in the middle of a line).
 
-[float]
+[discrete]
 [[ec2-hosts-provider]]
 ===== EC2 hosts provider
 
@@ -140,14 +140,14 @@ The {plugins}/discovery-ec2.html[EC2 discovery plugin] adds a hosts provider
 that uses the https://github.com/aws/aws-sdk-java[AWS API] to find a list of
 seed nodes.
 
-[float]
+[discrete]
 [[azure-classic-hosts-provider]]
 ===== Azure Classic hosts provider
 
 The {plugins}/discovery-azure-classic.html[Azure Classic discovery plugin] adds
 a hosts provider that uses the Azure Classic API find a list of seed nodes.
 
-[float]
+[discrete]
 [[gce-hosts-provider]]
 ===== Google Compute Engine hosts provider
 

--- a/docs/reference/modules/discovery/quorums.asciidoc
+++ b/docs/reference/modules/discovery/quorums.asciidoc
@@ -38,7 +38,7 @@ cluster-state update that adjusts the voting configuration to match, and this
 can take a short time to complete. It is important to wait for this adjustment
 to complete before removing more nodes from the cluster.
 
-[float]
+[discrete]
 ==== Master elections
 
 Elasticsearch uses an election process to agree on an elected master node, both
@@ -52,7 +52,7 @@ election will succeed (with arbitrarily high probability). The scheduling of
 master elections are controlled by the <<master-election-settings,master
 election settings>>.
 
-[float]
+[discrete]
 ==== Cluster maintenance, rolling restarts and migrations
 
 Many cluster maintenance tasks involve temporarily shutting down one or more

--- a/docs/reference/modules/discovery/voting.asciidoc
+++ b/docs/reference/modules/discovery/voting.asciidoc
@@ -73,7 +73,7 @@ setting affects only its availability in the event of the failure of some of its
 nodes and the administrative tasks that must be performed as nodes join and
 leave the cluster.
 
-[float]
+[discrete]
 ==== Even numbers of master-eligible nodes
 
 There should normally be an odd number of master-eligible nodes in a cluster.
@@ -98,7 +98,7 @@ node, but quorum-based decisions require votes from two of the three voting
 nodes. In the event of an even split, one half will contain two of the three
 voting nodes so that half will remain available.
 
-[float]
+[discrete]
 ==== Setting the initial voting configuration
 
 When a brand-new cluster starts up for the first time, it must elect its first

--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -9,7 +9,7 @@ live cluster with the <<cluster-update-settings,cluster-update-settings>> API.
 // end::circuit-breaker-description-tag[]
 
 [[parent-circuit-breaker]]
-[float]
+[discrete]
 ==== Parent circuit breaker
 
 The parent-level breaker can be configured with the following settings:
@@ -30,7 +30,7 @@ The parent-level breaker can be configured with the following settings:
 // end::indices-breaker-total-limit-tag[]
 
 [[fielddata-circuit-breaker]]
-[float]
+[discrete]
 ==== Field data circuit breaker
 The field data circuit breaker allows Elasticsearch to estimate the amount of
 memory a field will require to be loaded into memory. It can then prevent the
@@ -54,7 +54,7 @@ parameters:
 // end::fielddata-circuit-breaker-overhead-tag[]
 
 [[request-circuit-breaker]]
-[float]
+[discrete]
 ==== Request circuit breaker
 
 The request circuit breaker allows Elasticsearch to prevent per-request data
@@ -77,7 +77,7 @@ request) from exceeding a certain amount of memory.
 // end::request-breaker-overhead-tag[]
 
 [[in-flight-circuit-breaker]]
-[float]
+[discrete]
 ==== In flight requests circuit breaker
 
 The in flight requests circuit breaker allows Elasticsearch to limit the memory usage of all
@@ -97,7 +97,7 @@ also as a structured object which is reflected by default overhead.
     final estimation. Defaults to 2.
 
 [[accounting-circuit-breaker]]
-[float]
+[discrete]
 ==== Accounting requests circuit breaker
 
 The accounting circuit breaker allows Elasticsearch to limit the memory
@@ -115,7 +115,7 @@ completed. This includes things like the Lucene segment memory.
     final estimation. Defaults to 1
 
 [[script-compilation-circuit-breaker]]
-[float]
+[discrete]
 ==== Script compilation circuit breaker
 
 Slightly different than the previous memory-based circuit breaker, the script

--- a/docs/reference/modules/indices/fielddata.asciidoc
+++ b/docs/reference/modules/indices/fielddata.asciidoc
@@ -21,7 +21,7 @@ and  perform poorly.
 NOTE: These are static settings which must be configured on every data node in
 the cluster.
 
-[float]
+[discrete]
 [[fielddata-monitoring]]
 ==== Monitoring field data
 

--- a/docs/reference/modules/indices/recovery.asciidoc
+++ b/docs/reference/modules/indices/recovery.asciidoc
@@ -12,7 +12,7 @@ Peer recovery automatically occurs when {es}:
 You can view a list of in-progress and completed recoveries using the
 <<cat-recovery, cat recovery API>>.
 
-[float]
+[discrete]
 ==== Recovery settings
 
 `indices.recovery.max_bytes_per_sec`::
@@ -37,7 +37,7 @@ you are using <<overview-index-lifecycle-management,Index Lifecycle Management>>
 then you may be able to give your hot nodes a higher recovery bandwidth limit
 than your warm nodes.
 
-[float]
+[discrete]
 ==== Expert peer recovery settings
 You can use the following _expert_ setting to manage resources for peer
 recoveries.

--- a/docs/reference/modules/indices/request_cache.asciidoc
+++ b/docs/reference/modules/indices/request_cache.asciidoc
@@ -26,7 +26,7 @@ Scripted queries that use the API calls which are non-deterministic, such as
 `Math.random()` or `new Date()` are not cached.
 ===================================
 
-[float]
+[discrete]
 ==== Cache invalidation
 
 The cache is smart -- it keeps the same _near real-time_ promise as uncached
@@ -49,7 +49,7 @@ POST /kimchy,elasticsearch/_cache/clear?request=true
 ------------------------
 // TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]
 
-[float]
+[discrete]
 ==== Enabling and disabling caching
 
 The cache is enabled by default, but can be disabled when creating a new
@@ -76,7 +76,7 @@ PUT /my_index/_settings
 // TEST[continued]
 
 
-[float]
+[discrete]
 ==== Enabling and disabling caching per request
 
 The `request_cache` query-string parameter can be used to enable or disable
@@ -102,7 +102,7 @@ Requests where `size` is greater than 0 will not be cached even if the request c
 enabled in the index settings. To cache these requests you will need to use the
 query-string parameter detailed here.
 
-[float]
+[discrete]
 ==== Cache key
 
 The whole JSON body is used as the cache key.  This means that if the JSON
@@ -113,7 +113,7 @@ TIP: Most JSON libraries support a _canonical_ mode which ensures that JSON
 keys are always emitted in the same order. This canonical mode can be used in
 the application to ensure that a request is always serialized in the same way.
 
-[float]
+[discrete]
 ==== Cache settings
 
 The cache is managed at the node level, and has a default maximum size of `1%`
@@ -129,7 +129,7 @@ for cached results, but there should be no reason to do so.  Remember that
 stale results are automatically invalidated when the index is refreshed. This
 setting is provided for completeness' sake only.
 
-[float]
+[discrete]
 ==== Monitoring cache usage
 
 The size of the cache (in bytes) and the number of evictions can be viewed

--- a/docs/reference/modules/memcached.asciidoc
+++ b/docs/reference/modules/memcached.asciidoc
@@ -14,14 +14,14 @@ under the `plugins` directory.
 The memcached protocol supports both the binary and the text protocol,
 automatically detecting the correct one to use.
 
-[float]
+[discrete]
 === Mapping REST to Memcached Protocol
 
 Memcached commands are mapped to REST and handled by the same generic
 REST layer in Elasticsearch. Here is a list of the memcached commands
 supported:
 
-[float]
+[discrete]
 ==== GET
 
 The memcached `GET` command maps to a REST `GET`. The key used is the
@@ -30,24 +30,24 @@ URI (with parameters). The main downside is the fact that the memcached
 return a result...). For this reason, most REST APIs (like search) allow
 to accept the "source" as a URI parameter as well.
 
-[float]
+[discrete]
 ==== SET
 
 The memcached `SET` command maps to a REST `POST`. The key used is the
 URI (with parameters), and the body maps to the REST body.
 
-[float]
+[discrete]
 ==== DELETE
 
 The memcached `DELETE` command maps to a REST `DELETE`. The key used is
 the URI (with parameters).
 
-[float]
+[discrete]
 ==== QUIT
 
 The memcached `QUIT` command is supported and disconnects the client.
 
-[float]
+[discrete]
 === Settings
 
 The following are the settings the can be configured for memcached:
@@ -61,7 +61,7 @@ The following are the settings the can be configured for memcached:
 It also uses the common
 <<modules-network,network settings>>.
 
-[float]
+[discrete]
 === Disable memcached
 
 The memcached module can be completely disabled and not started using by

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -15,7 +15,7 @@ goes through the <<modules-transport,transport layer>>. Remote cluster
 connections consist of uni-directional connections from the coordinating
 node to the remote remote connections.
 
-[float]
+[discrete]
 [[sniff-mode]]
 === Sniff mode
 
@@ -27,7 +27,7 @@ are accessible by the local cluster.
 
 Sniff mode is the default connection mode.
 
-[float]
+[discrete]
 [[gateway-nodes-selection]]
 ==== Gateway nodes selection
 
@@ -62,7 +62,7 @@ communicate with 6.7. The matrix below summarizes compatibility as described abo
 (see <<remote-cluster-settings>>), though such tagged nodes still have
 to satisfy the two above requirements.
 
-[float]
+[discrete]
 [[proxy-mode]]
 === Proxy mode
 
@@ -77,7 +77,7 @@ to the sniff <<gateway-nodes-selection,gateway nodes>>, the remote
 connections are subject to the same version compatibility rules as
 <<rolling-upgrades>>.
 
-[float]
+[discrete]
 [[configuring-remote-clusters]]
 ==== Configuring remote clusters
 
@@ -229,7 +229,7 @@ PUT _cluster/settings
 <1> `cluster_two` would be removed from the cluster settings, leaving
 `cluster_one` and `cluster_three` intact.
 
-[float]
+[discrete]
 [[remote-cluster-settings]]
 === Remote cluster settings for all modes
 
@@ -279,7 +279,7 @@ and <<remote-cluster-proxy-settings,proxy mode settings>> are described below.
   Elasticsearch compresses the response. If unset, the global
   `transport.compress` is used as the fallback setting.
 
-[float]
+[discrete]
 [[remote-cluster-sniff-settings]]
 === Remote cluster settings for sniff mode
 
@@ -299,7 +299,7 @@ and <<remote-cluster-proxy-settings,proxy mode settings>> are described below.
   `node.attr.gateway: true` such that only nodes with this attribute will be
   connected to if `cluster.remote.node.attr` is set to `gateway`.
 
-[float]
+[discrete]
 [[remote-cluster-proxy-settings]]
 === Remote cluster settings for proxy mode
 
@@ -321,7 +321,7 @@ and <<remote-cluster-proxy-settings,proxy mode settings>> are described below.
   remote connections if this field is not a valid hostname as defined by the
   TLS SNI specification.
 
-[float]
+[discrete]
 [[retrieve-remote-clusters-info]]
 === Retrieving remote clusters info
 

--- a/docs/reference/monitoring/collectors.asciidoc
+++ b/docs/reference/monitoring/collectors.asciidoc
@@ -120,7 +120,7 @@ NOTE: Collection is currently done serially, rather than in parallel, to avoid
 For more information about the configuration options for the collectors, see
 <<monitoring-collection-settings>>.
 
-[float]
+[discrete]
 [[es-monitoring-stack]]
 ==== Collecting data from across the Elastic Stack
 

--- a/docs/reference/monitoring/exporters.asciidoc
+++ b/docs/reference/monitoring/exporters.asciidoc
@@ -76,7 +76,7 @@ again. While an active monitoring index is read-only, it will naturally fail to
 write (index) new data and will continuously log errors that indicate the write
 failure. For more information, see <<disk-based-shard-allocation>>.
 
-[float]
+[discrete]
 [[es-monitoring-default-exporter]]
 === Default exporters
 
@@ -96,7 +96,7 @@ If another exporter is already defined, the default exporter is _not_ created.
 When you define a new exporter, if the default exporter exists, it is
 automatically removed.
 
-[float]
+[discrete]
 [[es-monitoring-templates]]
 === Exporter templates and ingest pipelines
 

--- a/docs/reference/query-dsl/common-terms-query.asciidoc
+++ b/docs/reference/query-dsl/common-terms-query.asciidoc
@@ -7,7 +7,7 @@ The `common` terms query is a modern alternative to stopwords which
 improves the precision and recall of search results (by taking stopwords
 into account), without sacrificing performance.
 
-[float]
+[discrete]
 ==== The problem
 
 Every term in a query has a cost. A search for `"The brown fox"`
@@ -26,7 +26,7 @@ we lose precision, (eg we are unable to distinguish between `"happy"`
 and `"not happy"`) and we lose recall (eg text like `"The The"` or
 `"To be or not to be"` would simply not exist in the index).
 
-[float]
+[discrete]
 ==== The solution
 
 The `common` terms query divides the query terms into two groups: more
@@ -64,7 +64,7 @@ domain specific stopwords automatically. For example, on a video hosting
 site, common terms like `"clip"` or `"video"` will automatically behave
 as stopwords without the need to maintain a manual list.
 
-[float]
+[discrete]
 ==== Examples
 
 In this example, words that have a document frequency greater than 0.1%

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -67,7 +67,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Query Options
 
 [cols="<,<",options="header",]
@@ -85,13 +85,13 @@ Default is `memory`.
 |=======================================================================
 
 [[query-dsl-geo-bounding-box-query-accepted-formats]]
-[float]
+[discrete]
 ==== Accepted Formats
 
 In much the same way the geo_point type can accept different
 representations of the geo point, the filter can accept it as well:
 
-[float]
+[discrete]
 ===== Lat Lon As Properties
 
 [source,console]
@@ -122,7 +122,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Lat Lon As Array
 
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
@@ -150,7 +150,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Lat Lon As String
 
 Format in `lat,lon`.
@@ -177,7 +177,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Bounding Box as Well-Known Text (WKT)
 
 [source,console]
@@ -201,7 +201,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Geohash
 
 [source,console]
@@ -257,7 +257,7 @@ In this example, the geohash `dr` will produce the bounding box
 query with the top left corner at `45.0,-78.75` and the bottom right
 corner at `39.375,-67.5`.
 
-[float]
+[discrete]
 ==== Vertices
 
 The vertices of the bounding box can either be set by `top_left` and
@@ -292,20 +292,20 @@ GET my_locations/_search
 --------------------------------------------------
 
 
-[float]
+[discrete]
 ==== geo_point Type
 
 The filter *requires* the `geo_point` type to be set on the relevant
 field.
 
-[float]
+[discrete]
 ==== Multi Location Per Document
 
 The filter can work with multiple locations / points per document. Once
 a single location / point matches the filter, the document will be
 included in the filter
 
-[float]
+[discrete]
 [[geo-bbox-type]]
 ==== Type
 
@@ -345,7 +345,7 @@ GET my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Ignore Unmapped
 
 When set to `true` the `ignore_unmapped` option will ignore an unmapped field
@@ -354,7 +354,7 @@ querying multiple indexes which might have different mappings. When set to
 `false` (the default value) the query will throw an exception if the field
 is not mapped.
 
-[float]
+[discrete]
 ==== Notes on Precision
 
 Geopoints have limited precision and are always rounded down during index time.

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -64,13 +64,13 @@ GET /my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Accepted Formats
 
 In much the same way the `geo_point` type can accept different
 representations of the geo point, the filter can accept it as well:
 
-[float]
+[discrete]
 ===== Lat Lon As Properties
 
 [source,console]
@@ -96,7 +96,7 @@ GET /my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Lat Lon As Array
 
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
@@ -123,7 +123,7 @@ GET /my_locations/_search
 --------------------------------------------------
 
 
-[float]
+[discrete]
 ===== Lat Lon As String
 
 Format in `lat,lon`.
@@ -148,7 +148,7 @@ GET /my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Geohash
 
 [source,console]
@@ -171,7 +171,7 @@ GET /my_locations/_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Options
 
 The following are options allowed on the filter:
@@ -198,20 +198,20 @@ The following are options allowed on the filter:
     longitude, set to `COERCE` to additionally try and infer correct
     coordinates (default is `STRICT`).
 
-[float]
+[discrete]
 ==== geo_point Type
 
 The filter *requires* the `geo_point` type to be set on the relevant
 field.
 
-[float]
+[discrete]
 ==== Multi Location Per Document
 
 The `geo_distance` filter can work with multiple locations / points per
 document. Once a single location / point matches the filter, the
 document will be included in the filter.
 
-[float]
+[discrete]
 ==== Ignore Unmapped
 
 When set to `true` the `ignore_unmapped` option will ignore an unmapped field

--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -32,7 +32,7 @@ GET /_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== Query Options
 
 [cols="<,<",options="header",]
@@ -45,10 +45,10 @@ invalid latitude or longitude, `COERCE` to try and infer correct latitude
 or longitude, or `STRICT` (default is `STRICT`).
 |=======================================================================
 
-[float]
+[discrete]
 ==== Allowed Formats
 
-[float]
+[discrete]
 ===== Lat Long as Array
 
 Format as `[lon, lat]`
@@ -81,7 +81,7 @@ GET /_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Lat Lon as String
 
 Format in `lat,lon`.
@@ -111,7 +111,7 @@ GET /_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ===== Geohash
 
 [source,console]
@@ -139,13 +139,13 @@ GET /_search
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ==== geo_point Type
 
 The query *requires* the <<geo-point,`geo_point`>> type to be set on the
 relevant field.
 
-[float]
+[discrete]
 ==== Ignore Unmapped
 
 When set to `true` the `ignore_unmapped` option will ignore an unmapped field

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -253,7 +253,7 @@ relation operator:
 intersects the query geometry.
 
 
-[float]
+[discrete]
 ==== Ignore Unmapped
 
 When set to `true` the `ignore_unmapped` option will ignore an unmapped field

--- a/docs/reference/query-dsl/match-all-query.asciidoc
+++ b/docs/reference/query-dsl/match-all-query.asciidoc
@@ -30,7 +30,7 @@ GET /_search
 --------------------------------------------------
 
 [[query-dsl-match-none-query]]
-[float]
+[discrete]
 == Match None Query
 
 This is the inverse of the `match_all` query, which matches no documents.

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -151,7 +151,7 @@ The only required parameter is `like`, all other parameters have sensible
 defaults. There are three types of parameters: one to specify the document
 input, the other one for term selection and for query formation.
 
-[float]
+[discrete]
 ==== Document Input Parameters
 
 [horizontal]
@@ -177,7 +177,7 @@ is the same as `like`.
 `fields`::
 A list of fields to fetch and analyze the text from.
 
-[float]
+[discrete]
 [[mlt-query-term-selection]]
 ==== Term Selection Parameters
 
@@ -219,7 +219,7 @@ reasonable to assume that "a stop word is never interesting".
 The analyzer that is used to analyze the free form text. Defaults to the
 analyzer associated with the first field in `fields`.
 
-[float]
+[discrete]
 ==== Query Formation Parameters
 
 [horizontal]

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -23,7 +23,7 @@ GET /_search
 <1> The query string.
 <2> The fields to be queried.
 
-[float]
+[discrete]
 [[field-boost]]
 ==== `fields` and per-field boosting
 
@@ -71,7 +71,7 @@ at once. It is defined by the `indices.query.bool.max_clause_count` <<search-set
 which defaults to 1024.
 
 [[multi-match-types]]
-[float]
+[discrete]
 ==== Types of `multi_match` query:
 
 The way the `multi_match` query is executed internally depends on the `type`

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -25,7 +25,7 @@ The `rewrite` parameter determines:
 query or bit set
 * If changed to a `bool` query, which `term` query clauses are included
 
-[float]
+[discrete]
 [[rewrite-param-valid-values]]
 === Valid values
 
@@ -99,7 +99,7 @@ You can use this method to avoid exceeding the clause limit in the
 <<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
 setting.
 
-[float]
+[discrete]
 [[rewrite-param-perf-considerations]]
 === Performance considerations for the `rewrite` parameter
 For most uses, we recommend using the `constant_score`,

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -9,7 +9,7 @@ stored in an index. The `percolate` query itself
 contains the document that will be used as query
 to match with the stored queries.
 
-[float]
+[discrete]
 === Sample Usage
 
 Create an index with two fields:
@@ -123,7 +123,7 @@ TIP: To provide a simple example, this documentation uses one index `my-index` f
 This set-up can work well when there are just a few percolate queries registered. However, with heavier usage it is recommended
 to store queries and documents in separate indices. Please see <<how-it-works, How it Works Under the Hood>> for more details.
 
-[float]
+[discrete]
 ==== Parameters
 
 The following parameters are required when percolating a document:
@@ -149,7 +149,7 @@ In that case the `document` parameter can be substituted with the following para
 `preference`:: Optionally, preference to be used to fetch document to percolate.
 `version`:: Optionally, the expected version of the document to be fetched.
 
-[float]
+[discrete]
 ==== Percolating in a filter context
 
 In case you are not interested in the score, better performance can be expected by wrapping
@@ -184,7 +184,7 @@ should be wrapped in a `constant_score` query or a `bool` query's filter clause.
 
 Note that the `percolate` query never gets cached by the query cache.
 
-[float]
+[discrete]
 ==== Percolating multiple documents
 
 The `percolate` query can match multiple documents simultaneously with the indexed percolator queries.
@@ -267,14 +267,14 @@ GET /my-index/_search
 <1> The `_percolator_document_slot` indicates that the first, second and last documents specified in the `percolate` query
     are matching with this query.
 
-[float]
+[discrete]
 ==== Percolating an Existing Document
 
 In order to percolate a newly indexed document, the `percolate` query can be used. Based on the response
 from an index request, the `_id` and other meta information can be used to immediately percolate the newly added
 document.
 
-[float]
+[discrete]
 ===== Example
 
 Based on the previous example.
@@ -333,14 +333,14 @@ case the search request would fail with a version conflict error.
 
 The search response returned is identical as in the previous example.
 
-[float]
+[discrete]
 ==== Percolate query and highlighting
 
 The `percolate` query is handled in a special way when it comes to highlighting. The queries hits are used
 to highlight the document that is provided in the `percolate` query. Whereas with regular highlighting the query in
 the search request is used to highlight the hits.
 
-[float]
+[discrete]
 ===== Example
 
 This example is based on the mapping of the first example.
@@ -561,7 +561,7 @@ The slightly different response:
 <1> The highlight fields have been prefixed with the document slot they belong to,
     in order to know which highlight field belongs to what document.
 
-[float]
+[discrete]
 ==== Specifying multiple percolate queries
 
 It is possible to specify multiple `percolate` queries in a single search request:
@@ -648,7 +648,7 @@ The above search request returns a response similar to this:
 <1> The `_percolator_document_slot_query1` percolator slot field indicates that these matched slots are from the `percolate`
     query with `_name` parameter set to `query1`.
 
-[float]
+[discrete]
 [[how-it-works]]
 ==== How it Works Under the Hood
 

--- a/docs/reference/query-dsl/query_filter_context.asciidoc
+++ b/docs/reference/query-dsl/query_filter_context.asciidoc
@@ -1,7 +1,7 @@
 [[query-filter-context]]
 == Query and filter context
 
-[float]
+[discrete]
 [[relevance-scores]]
 === Relevance scores
 
@@ -14,7 +14,7 @@ The relevance score is a positive floating point number, returned in the
 relevance scores differently, score calculation also depends on whether the
 query clause is run in a **query** or **filter** context.
 
-[float]
+[discrete]
 [[query-context]]
 === Query context
 In the query context, a query clause answers the question ``__How well does this
@@ -26,7 +26,7 @@ Query context is in effect whenever a query clause is passed to a `query`
 parameter, such as the `query` parameter in the
 <<request-body-search-query,search>> API.
 
-[float]
+[discrete]
 [[filter-context]]
 === Filter context
 In a filter context, a query clause answers the question ``__Does this
@@ -46,7 +46,7 @@ parameter, such as the `filter` or `must_not` parameters in the
 <<query-dsl-constant-score-query,`constant_score`>> query, or the
 <<search-aggregations-bucket-filter-aggregation,`filter`>> aggregation.
 
-[float]
+[discrete]
 [[query-filter-context-ex]]
 === Example of query and filter contexts
 Below is an example of query clauses being used in query and filter context

--- a/docs/reference/query-dsl/regexp-syntax.asciidoc
+++ b/docs/reference/query-dsl/regexp-syntax.asciidoc
@@ -12,7 +12,7 @@ match patterns in data using placeholder characters, called operators.
 {es} uses https://lucene.apache.org/core/[Apache Lucene]'s regular expression
 engine to parse these queries.
 
-[float]
+[discrete]
 [[regexp-reserved-characters]]
 === Reserved characters
 Lucene's regular expression engine supports all Unicode characters. However, the
@@ -39,7 +39,7 @@ backslash or surround it with double quotes. For example:
 ....
     
 
-[float]
+[discrete]
 [[regexp-standard-operators]]
 === Standard operators
 
@@ -152,7 +152,7 @@ example:
 ....
 --
 
-[float]
+[discrete]
 [[regexp-optional-operators]]
 === Optional operators
 
@@ -162,7 +162,7 @@ Lucene's regular expression engine.
 To enable multiple operators, use a `|` separator. For example, a `flags` value
 of `COMPLEMENT|INTERVAL` enables the `COMPLEMENT` and `INTERVAL` operators.
 
-[float]
+[discrete]
 ==== Valid values 
 
 `ALL` (Default)::
@@ -216,7 +216,7 @@ You can combine the `@` operator with `&` and `~` operators to create an
 ....
 --
 
-[float]
+[discrete]
 [[regexp-unsupported-operators]]
 === Unsupported operators
 Lucene's regular expression engine does not support anchor operators, such as

--- a/docs/reference/query-dsl/shape-query.asciidoc
+++ b/docs/reference/query-dsl/shape-query.asciidoc
@@ -180,7 +180,7 @@ is within the query geometry.
 * `CONTAINS` - Return all documents whose `shape` field
 contains the query geometry.
 
-[float]
+[discrete]
 ==== Ignore Unmapped
 
 When set to `true` the `ignore_unmapped` option will ignore an unmapped field

--- a/docs/reference/query-dsl/term-level-queries.asciidoc
+++ b/docs/reference/query-dsl/term-level-queries.asciidoc
@@ -16,7 +16,7 @@ Term-level queries still normalize search terms for `keyword` fields with the
 `normalizer` property. For more details, see <<normalizer, `normalizer`>>.
 ====
 
-[float]
+[discrete]
 [[term-level-query-types]]
 === Types of term-level queries
 

--- a/docs/reference/release-notes/7.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha1.asciidoc
@@ -4,7 +4,7 @@
 The changes listed below have been released for the first time in Elasticsearch 7.0.0-alpha1.
 
 [[breaking-7.0.0-alpha1]]
-[float]
+[discrete]
 === Breaking changes
 
 Aggregations::
@@ -127,7 +127,7 @@ Suggesters::
 
 
 [[breaking-java-7.0.0-alpha1]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Aggregations::
@@ -154,7 +154,7 @@ Infra/Transport API::
 * Java api clean up: remove deprecated `isShardsAcked` {es-pull}28311[#28311] (issues: {es-issue}27784[#27784], {es-issue}27819[#27819])
 
 [[deprecation-7.0.0-alpha1]]
-[float]
+[discrete]
 === Deprecations
 
 Analysis::
@@ -176,7 +176,7 @@ Search::
 
 
 [[feature-7.0.0-alpha1]]
-[float]
+[discrete]
 === New features
 
 Analysis::
@@ -239,7 +239,7 @@ Suggesters::
 
 
 [[enhancement-7.0.0-alpha1]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -374,7 +374,7 @@ ZenDiscovery::
 
 
 [[bug-7.0.0-alpha1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -446,7 +446,7 @@ ZenDiscovery::
 
 
 [[upgrade-7.0.0-alpha1]]
-[float]
+[discrete]
 === Upgrades
 
 Geo::

--- a/docs/reference/release-notes/7.0.0-alpha2.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha2.asciidoc
@@ -2,7 +2,7 @@
 == {es} version 7.0.0-alpha2
 
 [[breaking-7.0.0-alpha2]]
-[float]
+[discrete]
 === Breaking changes
 
 Authentication::
@@ -35,14 +35,14 @@ ZenDiscovery::
 * Best-effort cluster formation if unconfigured {es-pull}36215[#36215]
 
 [[breaking-java-7.0.0-alpha2]]
-[float]
+[discrete]
 === Breaking Java changes
 
 ZenDiscovery::
 * Make node field in JoinRequest private {es-pull}36405[#36405]
 
 [[deprecation-7.0.0-alpha2]]
-[float]
+[discrete]
 === Deprecations
 
 Core::
@@ -96,7 +96,7 @@ Watcher::
 
 
 [[feature-7.0.0-alpha2]]
-[float]
+[discrete]
 === New features
 
 Analysis::
@@ -130,7 +130,7 @@ Search::
 * Added soft limit to open scroll contexts #25244 {es-pull}36009[#36009] (issue: {es-issue}25244[#25244])
 
 [[enhancement-7.0.0-alpha2]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -405,7 +405,7 @@ ZenDiscovery::
 * Zen2: Add basic Zen1 transport-level BWC {es-pull}35443[#35443]
 
 [[bug-7.0.0-alpha2]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -567,7 +567,7 @@ ZenDiscovery::
 
 
 [[regression-7.0.0-alpha2]]
-[float]
+[discrete]
 === Regressions
 
 Scripting::
@@ -575,7 +575,7 @@ Scripting::
 
 
 [[upgrade-7.0.0-alpha2]]
-[float]
+[discrete]
 === Upgrades
 
 Ingest::

--- a/docs/reference/release-notes/7.0.0-beta1.asciidoc
+++ b/docs/reference/release-notes/7.0.0-beta1.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.0,Breaking changes in 7.0>>.
 
 [[breaking-7.0.0-beta1]]
-[float]
+[discrete]
 === Breaking changes
 
 Audit::
@@ -67,7 +67,7 @@ ZenDiscovery::
 
 
 [[breaking-java-7.0.0-beta1]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Features/Java Low Level REST Client::
@@ -79,7 +79,7 @@ Infra/Core::
 
 
 [[deprecation-7.0.0-beta1]]
-[float]
+[discrete]
 === Deprecations
 
 Aggregations::
@@ -140,7 +140,7 @@ Search::
 
 
 [[feature-7.0.0-beta1]]
-[float]
+[discrete]
 === New features
 
 Authentication::
@@ -186,7 +186,7 @@ Search::
 
 
 [[enhancement-7.0.0-beta1]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -447,7 +447,7 @@ ZenDiscovery::
 
 
 [[bug-7.0.0-beta1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -663,7 +663,7 @@ ZenDiscovery::
 
 
 [[regression-7.0.0-beta1]]
-[float]
+[discrete]
 === Regressions
 
 Infra/Core::
@@ -676,7 +676,7 @@ Mapping::
 
 
 [[upgrade-7.0.0-beta1]]
-[float]
+[discrete]
 === Upgrades
 
 Engine::

--- a/docs/reference/release-notes/7.0.0-rc1.asciidoc
+++ b/docs/reference/release-notes/7.0.0-rc1.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.0,Breaking changes in 7.0.0-rc1>>.
 
 [[breaking-7.0.0-rc1]]
-[float]
+[discrete]
 === Breaking changes
 
 Distributed::
@@ -16,7 +16,7 @@ Features/Features::
 
 
 [[deprecation-7.0.0-rc1]]
-[float]
+[discrete]
 === Deprecations
 
 Cluster Coordination::
@@ -28,7 +28,7 @@ Infra/Packaging::
 
 
 [[feature-7.0.0-rc1]]
-[float]
+[discrete]
 === New features
 
 Allocation::
@@ -40,7 +40,7 @@ Security::
 
 
 [[enhancement-7.0.0-rc1]]
-[float]
+[discrete]
 === Enhancements
 
 CCR::
@@ -89,7 +89,7 @@ SQL::
 
 
 [[bug-7.0.0-rc1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -174,7 +174,7 @@ Search::
 
 
 [[upgrade-7.0.0-rc1]]
-[float]
+[discrete]
 === Upgrades
 
 Discovery-Plugins::

--- a/docs/reference/release-notes/7.0.0-rc2.asciidoc
+++ b/docs/reference/release-notes/7.0.0-rc2.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.0,Breaking changes in 7.0.0>>.
 
 [[deprecation-7.0.0-rc2]]
-[float]
+[discrete]
 === Deprecations
 
 Analysis::
@@ -16,7 +16,7 @@ Graph::
 
 
 [[enhancement-7.0.0-rc2]]
-[float]
+[discrete]
 === Enhancements
 
 CCR::
@@ -79,7 +79,7 @@ Infra/Core::
 
 
 [[bug-7.0.0-rc2]]
-[float]
+[discrete]
 === Bug fixes
 
 Analysis::
@@ -207,7 +207,7 @@ Snapshot/Restore::
 
 
 [[upgrade-7.0.0-rc2]]
-[float]
+[discrete]
 === Upgrades
 
 Snapshot/Restore::

--- a/docs/reference/release-notes/7.0.asciidoc
+++ b/docs/reference/release-notes/7.0.asciidoc
@@ -6,7 +6,7 @@ releases of 7.0.0.
 
 Also see <<breaking-changes-7.0,Breaking changes in 7.0>>.
 
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -24,7 +24,7 @@ This is fixed in {es} 7.7 and later versions.
 
 
 [[breaking-7.0.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Aggregations::
@@ -197,7 +197,7 @@ ZenDiscovery::
 * Remove DiscoveryPlugin#getDiscoveryTypes {es-pull}38414[#38414] (issue: {es-issue}38410[#38410])
 
 [[breaking-java-7.0.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Aggregations::
@@ -229,7 +229,7 @@ ZenDiscovery::
 * Make node field in JoinRequest private {es-pull}36405[#36405]
 
 [[deprecation-7.0.0]]
-[float]
+[discrete]
 === Deprecations
 
 Aggregations::
@@ -350,7 +350,7 @@ Watcher::
 
 
 [[feature-7.0.0]]
-[float]
+[discrete]
 === New features
 
 Allocation::
@@ -466,7 +466,7 @@ Suggesters::
 
 
 [[enhancement-7.0.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -1103,7 +1103,7 @@ ZenDiscovery::
 
 
 [[bug-7.0.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -1606,7 +1606,7 @@ ZenDiscovery::
 * Fix cluster state persistence for single-node discovery {es-pull}36825[#36825]
 
 [[regression-7.0.0]]
-[float]
+[discrete]
 === Regressions
 
 Infra/Core::
@@ -1620,7 +1620,7 @@ Scripting::
 * Use Number as a return value for BucketAggregationScript {es-pull}35653[#35653] (issue: {es-issue}35351[#35351])
 
 [[upgrade-7.0.0]]
-[float]
+[discrete]
 === Upgrades
 
 Discovery-Plugins::

--- a/docs/reference/release-notes/7.1.asciidoc
+++ b/docs/reference/release-notes/7.1.asciidoc
@@ -3,7 +3,7 @@
 
 Also see <<breaking-changes-7.1,Breaking changes in 7.1>>.
 
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -20,7 +20,7 @@ https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
 [[bug-7.1.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Distributed::
@@ -36,7 +36,7 @@ Infra/REST API::
 Also see <<breaking-changes-7.1,Breaking changes in 7.1>>.
 
 [[enhancement-7.1.0]]
-[float]
+[discrete]
 === Enhancements
 
 Security::
@@ -50,7 +50,7 @@ Infra/Settings::
 
 
 [[bug-7.1.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Cluster Coordination::

--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 
 [[stats-7.10.0]]
-[float]
+[discrete]
 === Stats changes
 
 Estimates removed from filesystem stats::

--- a/docs/reference/release-notes/7.2.asciidoc
+++ b/docs/reference/release-notes/7.2.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.2,Breaking changes in 7.2>>.
 
 [[enhancement-7.2.1]]
-[float]
+[discrete]
 === Enhancements
 
 Infra/Core::
@@ -18,7 +18,7 @@ Machine Learning::
 * Introduce a setting for the process connect timeout {es-pull}43234[#43234]
 
 [[bug-7.2.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Analysis::
@@ -85,7 +85,7 @@ Security::
 
 Also see <<breaking-changes-7.2,Breaking changes in 7.2>>.
 
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -102,7 +102,7 @@ https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
 [[breaking-7.2.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Cluster Coordination::
@@ -110,7 +110,7 @@ Cluster Coordination::
 
 
 [[breaking-java-7.2.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Infra/Plugins::
@@ -118,7 +118,7 @@ Infra/Plugins::
 
 
 [[deprecation-7.2.0]]
-[float]
+[discrete]
 === Deprecations
 
 Authorization::
@@ -141,7 +141,7 @@ Security::
 * Deprecate the native realm migration tool {es-pull}42142[#42142]
 
 [[feature-7.2.0]]
-[float]
+[discrete]
 === New features
 
 Authentication::
@@ -182,7 +182,7 @@ Search::
 
 
 [[enhancement-7.2.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -398,7 +398,7 @@ Suggesters::
 
 
 [[bug-7.2.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -559,7 +559,7 @@ Suggesters::
 
 
 [[upgrade-7.2.0]]
-[float]
+[discrete]
 === Upgrades
 
 Features/Watcher::

--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.3,Breaking changes in 7.3>>.
 
 [[bug-7.3.2]]
-[float]
+[discrete]
 === Bug fixes
 
 Data Frame::
@@ -38,7 +38,7 @@ Search::
 Also see <<breaking-changes-7.3,Breaking changes in 7.3>>.
 
 [[enhancement-7.3.1]]
-[float]
+[discrete]
 === Enhancements
 
 CCR::
@@ -58,7 +58,7 @@ SQL::
 
 
 [[bug-7.3.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -127,7 +127,7 @@ Security::
 
 
 [[upgrade-7.3.1]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Packaging::
@@ -140,7 +140,7 @@ Infra/Packaging::
 Also see <<breaking-changes-7.3,Breaking changes in 7.3>>.
 
 
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -158,7 +158,7 @@ This is fixed in {es} 7.7 and later versions.
 
 
 [[breaking-7.3.0]]
-[float]
+[discrete]
 === Breaking changes
 
 CCR::
@@ -168,7 +168,7 @@ Data Frame::
 * Removing format support in date_histogram group_by {es-pull}43659[#43659]
 
 [[breaking-java-7.3.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Mapping::
@@ -180,7 +180,7 @@ Search::
 
 
 [[deprecation-7.3.0]]
-[float]
+[discrete]
 === Deprecations
 
 Features/Java High Level REST Client::
@@ -198,7 +198,7 @@ Search::
 
 
 [[feature-7.3.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -233,7 +233,7 @@ Search::
 
 
 [[enhancement-7.3.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -385,7 +385,7 @@ Store::
 
 
 [[bug-7.3.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -579,7 +579,7 @@ Suggesters::
 
 
 [[regression-7.3.0]]
-[float]
+[discrete]
 === Regressions
 
 Infra/Core::
@@ -588,7 +588,7 @@ Infra/Core::
 
 
 [[upgrade-7.3.0]]
-[float]
+[discrete]
 === Upgrades
 
 Discovery-Plugins::

--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -1,7 +1,7 @@
 [[release-notes-7.4.2]]
 == {es} version 7.4.2
 
-[float]
+[discrete]
 [[bug-7.4.2]]
 === Bug fixes
 
@@ -14,7 +14,7 @@ Transform::
 Also see <<breaking-changes-7.4,Breaking changes in 7.4>>.
 
 [[enhancement-7.4.1]]
-[float]
+[discrete]
 === Enhancements
 
 Engine::
@@ -33,7 +33,7 @@ Machine Learning::
 
 
 [[bug-7.4.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -108,7 +108,7 @@ Transform::
 
 Also see <<breaking-changes-7.4,Breaking changes in 7.4>>.
 
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -130,7 +130,7 @@ https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
 [[breaking-7.4.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Infra/REST API::
@@ -154,7 +154,7 @@ Transforms::
 
 
 [[breaking-java-7.4.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Geo::
@@ -166,7 +166,7 @@ Network::
 
 
 [[deprecation-7.4.0]]
-[float]
+[discrete]
 === Deprecations
 
 Geo::
@@ -189,7 +189,7 @@ Machine Learning::
 
 
 [[feature-7.4.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -227,7 +227,7 @@ Machine Learning::
 
 
 [[enhancement-7.4.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -404,7 +404,7 @@ Transforms::
 
 
 [[bug-7.4.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -629,7 +629,7 @@ Transforms::
 * Audit message missing for autostop {es-pull}43984[#43984] (issue: {es-issue}43977[#43977])
 
 [[regression-7.4.0]]
-[float]
+[discrete]
 === Regressions
 
 Aggregations::
@@ -638,7 +638,7 @@ Aggregations::
 
 
 [[upgrade-7.4.0]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Core::

--- a/docs/reference/release-notes/7.5.asciidoc
+++ b/docs/reference/release-notes/7.5.asciidoc
@@ -2,7 +2,7 @@
 == {es} version 7.5.2
 
 [[enhancement-7.5.2]]
-[float]
+[discrete]
 === Enhancements
 
 Features/Ingest::
@@ -13,7 +13,7 @@ Infra/Core::
 
 
 [[bug-7.5.2]]
-[float]
+[discrete]
 === Bug fixes
 
 Analysis::
@@ -64,7 +64,7 @@ Security::
 Also see <<breaking-changes-7.5,Breaking changes in 7.5>>.
 
 [[enhancement-7.5.1]]
-[float]
+[discrete]
 === Enhancements
 
 Features/Watcher::
@@ -76,7 +76,7 @@ Network::
 
 
 [[bug-7.5.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Authentication::
@@ -138,7 +138,7 @@ Transform::
 Also see <<breaking-changes-7.5,Breaking changes in 7.5>>.
 
 [[known-issues-7.5.0]]
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -159,7 +159,7 @@ https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
 [[breaking-7.5.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Search::
@@ -168,7 +168,7 @@ Search::
 
 
 [[deprecation-7.5.0]]
-[float]
+[discrete]
 === Deprecations
 
 Aggregations::
@@ -186,7 +186,7 @@ Search::
 
 
 [[feature-7.5.0]]
-[float]
+[discrete]
 === New features
 
 Features/ILM+SLM::
@@ -213,7 +213,7 @@ SQL::
 
 
 [[enhancement-7.5.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -344,7 +344,7 @@ Transform::
 
 
 [[bug-7.5.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -554,7 +554,7 @@ Transform::
 
 
 [[regression-7.5.0]]
-[float]
+[discrete]
 === Regressions
 
 Aggregations::
@@ -567,7 +567,7 @@ Infra/Core::
 
 
 [[upgrade-7.5.0]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Scripting::

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -4,14 +4,14 @@
 Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 
 [[breaking-7.6.2]]
-[float]
+[discrete]
 === Breaking changes
 
 Authorization::
 * Creation of derived API keys (keys created by existing keys) now requires explicit "no privileges" configuration {es-pull}53647[#53647], https://www.elastic.co/community/security[CVE-2020-7009]
 
 [[bug-7.6.2]]
-[float]
+[discrete]
 === Bug fixes
 
 Allocation::
@@ -71,7 +71,7 @@ Search::
 * Fix potential NPE in FuzzyTermsEnum {es-pull}53231[#53231] (issue: {es-issue}52894[#52894])
 
 [[upgrade-7.6.2]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Core::
@@ -83,7 +83,7 @@ Infra/Core::
 Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 
 [[bug-7.6.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -140,7 +140,7 @@ Store::
 
 
 [[upgrade-7.6.1]]
-[float]
+[discrete]
 === Upgrades
 
 Authentication::
@@ -152,7 +152,7 @@ Authentication::
 Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 
 [[known-issues-7.6.0]]
-[float]
+[discrete]
 === Known issues
 
 * Applying deletes or updates on an index after it has been shrunk may corrupt
@@ -186,7 +186,7 @@ incorrect date calculations. A workaround is to add the following line to the `j
 This issue is fixed in {es} 7.7.0 and later versions (issue: {es-issue}50916[#50916]).
 
 [[breaking-7.6.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Mapping::
@@ -195,7 +195,7 @@ Mapping::
 
 
 [[breaking-java-7.6.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Security::
@@ -204,7 +204,7 @@ Security::
 
 
 [[deprecation-7.6.0]]
-[float]
+[discrete]
 === Deprecations
 
 Analysis::
@@ -234,7 +234,7 @@ Search::
 
 
 [[feature-7.6.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -272,7 +272,7 @@ Search::
 
 
 [[enhancement-7.6.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -508,7 +508,7 @@ Transform::
 
 
 [[bug-7.6.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -736,7 +736,7 @@ Transform::
 
 
 [[upgrade-7.6.0]]
-[float]
+[discrete]
 === Upgrades
 
 Engine::

--- a/docs/reference/release-notes/7.7.asciidoc
+++ b/docs/reference/release-notes/7.7.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
 
 [[enhancement-7.7.1]]
-[float]
+[discrete]
 === Enhancements
 
 Authorization::
@@ -17,7 +17,7 @@ SQL::
 * Change error message for comparison against fields in filtering {es-pull}57126[#57126] (issue: {es-issue}57005[#57005])
 
 [[bug-7.7.1]]
-[float]
+[discrete]
 === Bug fixes
 
 Authentication::
@@ -118,7 +118,7 @@ Snapshot/Restore::
 * Fix Path Style Access Setting Priority {es-pull}55439[#55439] (issue: {es-issue}55407[#55407])
 
 [[upgrade-7.7.1]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Core::
@@ -136,7 +136,7 @@ SQL::
 Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
 
 [[breaking-7.7.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Highlighting::
@@ -160,7 +160,7 @@ Search::
 
 
 [[breaking-java-7.7.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Infra/Core::
@@ -175,7 +175,7 @@ Transform::
 
 
 [[deprecation-7.7.0]]
-[float]
+[discrete]
 === Deprecations
 
 Allocation::
@@ -210,7 +210,7 @@ Search::
 
 
 [[feature-7.7.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -259,7 +259,7 @@ Search::
 
 
 [[enhancement-7.7.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -524,7 +524,7 @@ Transform::
 
 
 [[bug-7.7.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -744,7 +744,7 @@ Transform::
 
 
 [[upgrade-7.7.0]]
-[float]
+[discrete]
 === Upgrades
 
 Authentication::

--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -12,7 +12,7 @@ coming::[7.8.1]
 Also see <<breaking-changes-7.8,Breaking changes in 7.8>>.
 
 [[breaking-7.8.1]]
-[float]
+[discrete]
 === Breaking changes
 
 License::
@@ -21,7 +21,7 @@ License::
 
 
 [[feature-7.8.1]]
-[float]
+[discrete]
 === New features
 
 SQL::
@@ -30,7 +30,7 @@ SQL::
 
 
 [[enhancement-7.8.1]]
-[float]
+[discrete]
 === Enhancements
 
 Authorization::
@@ -56,7 +56,7 @@ Transform::
 
 
 [[bug-7.8.1]]
-[float]
+[discrete]
 === Bug fixes
 
 CCR::
@@ -143,7 +143,7 @@ Transform::
 
 
 [[upgrade-7.8.1]]
-[float]
+[discrete]
 === Upgrades
 
 Infra/Core::
@@ -156,7 +156,7 @@ Infra/Core::
 Also see <<breaking-changes-7.8,Breaking changes in 7.8>>.
 
 [[breaking-7.8.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Aggregations::
@@ -171,7 +171,7 @@ Mapping::
 
 
 [[deprecation-7.8.0]]
-[float]
+[discrete]
 === Deprecations
 
 Authentication::
@@ -200,7 +200,7 @@ Infra/Plugins::
 
 
 [[feature-7.8.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -226,7 +226,7 @@ SQL::
 
 
 [[enhancement-7.8.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -402,7 +402,7 @@ Transform::
 
 
 [[bug-7.8.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -473,7 +473,7 @@ Transform::
 
 
 [[regression-7.8.0]]
-[float]
+[discrete]
 === Regressions
 
 Infra/Scripting::

--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -6,7 +6,7 @@ Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 coming::[7.9.0]
 
 [[breaking-7.9.0]]
-[float]
+[discrete]
 === Breaking changes
 
 Script Cache::
@@ -41,7 +41,7 @@ Dangling indices::
   {es-pull}58176[#58176] {es-pull}58898[#58898] (issue: {es-issue}48366[#48366])
 
 [[breaking-java-7.9.0]]
-[float]
+[discrete]
 === Breaking Java changes
 
 Aggregations::
@@ -53,7 +53,7 @@ Features/Ingest::
 
 
 [[feature-7.9.0]]
-[float]
+[discrete]
 === New features
 
 Aggregations::
@@ -80,7 +80,7 @@ Search::
 
 
 [[enhancement-7.9.0]]
-[float]
+[discrete]
 === Enhancements
 
 Aggregations::
@@ -247,7 +247,7 @@ Transform::
 
 
 [[bug-7.9.0]]
-[float]
+[discrete]
 === Bug fixes
 
 Aggregations::
@@ -309,7 +309,7 @@ Snapshot/Restore::
 
 
 [[upgrade-7.9.0]]
-[float]
+[discrete]
 === Upgrades
 
 Search::

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -35,7 +35,7 @@ Other versions:
 // end::notable-highlights[]
 
 // Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [float]
+// [discrete]
 // === Heading
 //
 // Description.

--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -16,7 +16,7 @@ Most rollup endpoints have the following base:
 ----
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[rollup-api-jobs]]
 ==== /job/
 
@@ -27,14 +27,14 @@ Most rollup endpoints have the following base:
 * {ref}/rollup-stop-job.html[POST /_rollup/job/<job_id>/_stop]: Stop a {rollup-job}
 * {ref}/rollup-delete-job.html[DELETE /_rollup/job/<job_id+++>+++]: Delete a {rollup-job}
 
-[float]
+[discrete]
 [[rollup-api-data]]
 ==== /data/
 
 * {ref}/rollup-get-rollup-caps.html[GET /_rollup/data/<index_pattern+++>/_rollup_caps+++]: Get Rollup Capabilities
 * {ref}/rollup-get-rollup-index-caps.html[GET /<index_name+++>/_rollup/data/+++]: Get Rollup Index Capabilities
 
-[float]
+[discrete]
 [[rollup-api-index]]
 ==== /<index_name>/
 

--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -25,7 +25,7 @@ So while the cost of storing a millisecond of sensor data from ten years ago is 
 reading often diminishes with time.  It's not useless -- it could easily contribute to a useful analysis -- but it's reduced
 value often leads to deletion rather than paying the fixed storage cost.
 
-[float]
+[discrete]
 ==== Rollup stores historical data at reduced granularity
 
 That's where Rollup comes into play.  The Rollup functionality summarizes old, high-granularity data into a reduced
@@ -41,7 +41,7 @@ automates this process of summarizing historical data.
 
 Details about setting up and configuring Rollup are covered in <<rollup-put-job,Create Job API>>
 
-[float]
+[discrete]
 ==== Rollup uses standard query DSL
 
 The Rollup feature exposes a new search endpoint (`/_rollup_search` vs the standard `/_search`) which knows how to search
@@ -55,7 +55,7 @@ are covered more in <<rollup-search-limitations, Rollup Search limitations>>.
 But if your queries, aggregations and dashboards only use the available functionality, redirecting them to historical
 data is trivial.
 
-[float]
+[discrete]
 ==== Rollup merges "live" and "rolled" data
 
 A useful feature of Rollup is the ability to query both "live", realtime data in addition to historical "rolled" data
@@ -69,7 +69,7 @@ would only see data older than a month.  The RollupSearch endpoint, however, sup
 It will take the results from both data sources and merge them together.  If there is overlap between the "live" and
 "rolled" data, live data is preferred to increase accuracy.
 
-[float]
+[discrete]
 ==== Rollup is multi-interval aware
 
 Finally, Rollup is capable of intelligently utilizing the best interval available.  If you've worked with summarizing

--- a/docs/reference/rollup/rollup-agg-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-agg-limitations.asciidoc
@@ -8,7 +8,7 @@ experimental[]
 There are some limitations to how fields can be rolled up / aggregated.  This page highlights the major limitations so that
 you are aware of them.
 
-[float]
+[discrete]
 ==== Limited aggregation components
 
 The Rollup functionality allows fields to be grouped with the following aggregations:

--- a/docs/reference/rollup/rollup-api.asciidoc
+++ b/docs/reference/rollup/rollup-api.asciidoc
@@ -3,7 +3,7 @@
 [[rollup-apis]]
 == Rollup APIs
 
-[float]
+[discrete]
 [[rollup-jobs-endpoint]]
 === Jobs
 
@@ -11,14 +11,14 @@
 * <<rollup-start-job,Start>> or <<rollup-stop-job,stop {rollup-jobs}>>
 * <<rollup-get-job,Get {rollup-jobs}>>
 
-[float]
+[discrete]
 [[rollup-data-endpoint]]
 === Data
 
 * <<rollup-get-rollup-caps,Get Rollup Capabilities>>
 * <<rollup-get-rollup-index-caps,Get Rollup Index Capabilities>>
 
-[float]
+[discrete]
 [[rollup-search-endpoint]]
 === Search
 

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -25,7 +25,7 @@ look like this:
 --------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 ==== Creating a rollup job
 
 We'd like to rollup these documents into hourly summaries, which will allow us to generate reports and dashboards with any time interval
@@ -127,7 +127,7 @@ After you execute the above command and create the job, you'll receive the follo
 }
 ----
 
-[float]
+[discrete]
 ==== Starting the job
 
 After the job is created, it will be sitting in an inactive state.  Jobs need to be started before they begin processing data (this allows
@@ -141,7 +141,7 @@ POST _rollup/job/sensor/_start
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
 
-[float]
+[discrete]
 ==== Searching the rolled results
 
 After the job has run and processed some data, we can use the <<rollup-search>> endpoint to do some searching.  The Rollup feature is designed
@@ -316,7 +316,7 @@ Which returns a corresponding response:
 In addition to being more complicated (date histogram and a terms aggregation, plus an additional average metric), you'll notice
 the date_histogram uses a `7d` interval instead of `60m`.
 
-[float]
+[discrete]
 ==== Conclusion
 
 This quickstart should have provided a concise overview of the core functionality that Rollup exposes.  There are more tips and things

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -10,7 +10,7 @@ live data is thrown away, you will always lose some flexibility.
 
 This page highlights the major limitations so that you are aware of them.
 
-[float]
+[discrete]
 ==== Only one {rollup} index per search
 
 When using the <<rollup-search>> endpoint, the `index` parameter accepts one or more indices.  These can be a mix of regular, non-rollup
@@ -31,7 +31,7 @@ Needless to say, this is a technically challenging piece of code.
 To help simplify the problem, we have limited search to just one rollup index at a time (which may contain multiple jobs).  In the future we
 may be able to open this up to multiple rollup jobs.
 
-[float]
+[discrete]
 [[aggregate-stored-only]]
 ==== Can only aggregate what's been stored
 
@@ -80,7 +80,7 @@ The response will tell you that the field and aggregation were not possible, bec
 ----
 // TESTRESPONSE[s/"stack_trace": \.\.\./"stack_trace": $body.$_path/]
 
-[float]
+[discrete]
 ==== Interval granularity
 
 Rollups are stored at a certain granularity, as defined by the `date_histogram` group in the configuration.  This means you
@@ -110,7 +110,7 @@ as needed.
 That said, if multiple jobs are present in a single rollup index with varying intervals, the search endpoint will identify and use the job(s)
 with the largest interval to satisfy the search request.
 
-[float]
+[discrete]
 ==== Limited querying components
 
 The Rollup functionality allows `query`'s in the search request, but with a limited subset of components.  The queries currently allowed are:
@@ -127,7 +127,7 @@ If you wish to filter on a keyword `hostname` field, that field must have been c
 If you attempt to use an unsupported query, or the query references a field that wasn't configured in the rollup job, an exception will be
 thrown.  We expect the list of support queries to grow over time as more are implemented.
 
-[float]
+[discrete]
 ==== Timezones
 
 Rollup documents are stored in the timezone of the `date_histogram` group configuration in the job.  If no timezone is specified, the default

--- a/docs/reference/scripting.asciidoc
+++ b/docs/reference/scripting.asciidoc
@@ -12,7 +12,7 @@ Additional `lang` plugins enable you to run scripts written in other languages.
 Everywhere a script can be used, you can include a `lang` parameter
 to specify the language of the script.
 
-[float]
+[discrete]
 == General-purpose languages
 
 These languages can be used for any purpose in the scripting APIs,
@@ -30,7 +30,7 @@ and give the most flexibility.
 
 |=======================================================================
 
-[float]
+[discrete]
 == Special-purpose languages
 
 These languages are less flexible, but typically have higher performance for

--- a/docs/reference/scripting/expression.asciidoc
+++ b/docs/reference/scripting/expression.asciidoc
@@ -5,7 +5,7 @@ Lucene's expressions compile a `javascript` expression to bytecode. They are
 designed for high-performance custom ranking and sorting functions and are
 enabled for `inline` and `stored` scripting by default.
 
-[float]
+[discrete]
 === Performance
 
 Expressions were designed to have competitive performance with custom Lucene code.
@@ -14,7 +14,7 @@ scripting engines: expressions do more "up-front".
 
 This allows for very fast execution, even faster than if you had written a `native` script.
 
-[float]
+[discrete]
 === Syntax
 
 Expressions support a subset of javascript syntax: a single expression.
@@ -32,7 +32,7 @@ Variables in `expression` scripts are available to access:
 You can use Expressions scripts for `script_score`, `script_fields`, sort scripts, and numeric aggregation
 scripts, simply set the `lang` parameter to `expression`.
 
-[float]
+[discrete]
 === Numeric field API
 [cols="<,<",options="header",]
 |=======================================================================
@@ -66,7 +66,7 @@ When a document is missing the field completely, by default the value will be tr
 Boolean fields are exposed as numerics, with `true` mapped to `1` and `false` mapped to `0`.
 For example: `doc['on_sale'].value ? doc['price'].value * 0.5 : doc['price'].value`
 
-[float]
+[discrete]
 === Date field API
 Date fields are treated as the number of milliseconds since January 1, 1970 and
 support the Numeric Fields API above, plus access to some date-specific fields:
@@ -111,7 +111,7 @@ The following example shows the difference in years between the `date` fields da
 
 `doc['date1'].date.year - doc['date0'].date.year`
 
-[float]
+[discrete]
 [[geo-point-field-api]]
 === `geo_point` field API
 [cols="<,<",options="header",]
@@ -132,7 +132,7 @@ The following example computes distance in kilometers from Washington, DC:
 In this example the coordinates could have been passed as parameters to the script,
 e.g. based on geolocation of the user.
 
-[float]
+[discrete]
 === Limitations
 
 There are a few limitations relative to other script languages:

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -4,7 +4,7 @@
 Depending on where a script is used, it will have access to certain special
 variables and document fields.
 
-[float]
+[discrete]
 == Update scripts
 
 A script used in the <<docs-update,update>>,
@@ -16,7 +16,7 @@ API will have access to the `ctx` variable which exposes:
 `ctx.op`::          The operation that should be applied to the document: `index` or `delete`.
 `ctx._index` etc::  Access to <<mapping-fields,document meta-fields>>, some of which may be read-only.
 
-[float]
+[discrete]
 == Search and aggregation scripts
 
 With the exception of <<request-body-search-script-fields,script fields>> which are
@@ -32,7 +32,7 @@ Field values can be accessed from a script using
 each of which is explained below.
 
 [[scripting-score]]
-[float]
+[discrete]
 === Accessing the score of a document within a script
 
 Scripts used in the <<query-dsl-function-score-query,`function_score` query>>,
@@ -79,7 +79,7 @@ GET my_index/_search
 -------------------------------------
 
 
-[float]
+[discrete]
 [[modules-scripting-doc-vals]]
 === Doc values
 
@@ -138,7 +138,7 @@ access `text` fields from scripts.
 
 ===================================================
 
-[float]
+[discrete]
 [[modules-scripting-source]]
 === The document `_source`
 
@@ -200,7 +200,7 @@ GET my_index/_search
 }
 -------------------------------
 
-[float]
+[discrete]
 [[modules-scripting-stored]]
 === Stored fields
 

--- a/docs/reference/scripting/security.asciidoc
+++ b/docs/reference/scripting/security.asciidoc
@@ -8,7 +8,7 @@ all software has bugs and it is important to minimize the risk of failure in
 any security layer. Find below rules of thumb for how to keep Elasticsearch
 from being a vulnerability.
 
-[float]
+[discrete]
 === Do not run as root
 First and foremost, never run Elasticsearch as the `root` user as this would
 allow any successful effort to circumvent the other security layers to do
@@ -16,7 +16,7 @@ allow any successful effort to circumvent the other security layers to do
 that it is running as `root` but this is so important that it is worth double
 and triple checking.
 
-[float]
+[discrete]
 === Do not expose Elasticsearch directly to users
 Do not expose Elasticsearch directly to users, instead have an application
 make requests on behalf of users. If this is not possible, have an application
@@ -26,7 +26,7 @@ to write a <<search, `_search`>> that overwhelms Elasticsearch and brings down
 the cluster. All such searches should be considered bugs and the Elasticsearch
 contributors make an effort to prevent this but they are still possible.
 
-[float]
+[discrete]
 === Do not expose Elasticsearch directly to the Internet
 Do not expose Elasticsearch to the Internet, instead have an application
 make requests on behalf of the Internet. Do not entertain the thought of having
@@ -49,7 +49,7 @@ Bad:
 * Users can write arbitrary scripts, queries, `_search` requests.
 * User actions make documents with structure defined by users.
 
-[float]
+[discrete]
 [[modules-scripting-other-layers]]
 === Other security layers
 In addition to user privileges and script sandboxing Elasticsearch uses the
@@ -75,7 +75,7 @@ when allowing more than the defaults. Any extra permissions weakens the total
 security of the Elasticsearch deployment.
 
 [[allowed-script-types-setting]]
-[float]
+[discrete]
 === Allowed script types setting
 
 By default all script types are allowed to be executed.  This can be modified using the
@@ -91,7 +91,7 @@ script.allowed_types: inline <1>
 (or any other types).
 
 [[allowed-script-contexts-setting]]
-[float]
+[discrete]
 === Allowed script contexts setting
 
 By default all script contexts are allowed to be executed.  This can be modified using the

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -43,7 +43,7 @@ GET my_index/_search
 }
 -------------------------------------
 
-[float]
+[discrete]
 === Script parameters
 
 `lang`::
@@ -106,7 +106,7 @@ for `ingest` contexts. You can change these settings dynamically by setting
 
 ========================================
 
-[float]
+[discrete]
 [[modules-scripting-short-script-form]]
 === Short script form
 A short script form can be used for brevity. In the short form, `script` is represented
@@ -130,7 +130,7 @@ The same script in the normal form:
 ----------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[modules-scripting-stored-scripts]]
 === Stored scripts
 
@@ -145,7 +145,7 @@ privileges to create, retrieve, and delete stored scripts:
 For more information, see <<security-privileges>>.
 
 
-[float]
+[discrete]
 ==== Request examples
 
 The following are examples of using a stored script that lives at
@@ -222,7 +222,7 @@ DELETE _scripts/calculate-score
 -----------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[modules-scripting-search-templates]]
 === Search templates
 You can also use the `_scripts` API to store **search templates**. Search
@@ -237,7 +237,7 @@ mistakes.
 Search templates use the http://mustache.github.io/mustache.5.html[mustache
 templating language]. See <<search-template>> for more information and examples.
 
-[float]
+[discrete]
 [[modules-scripting-using-caching]]
 === Script caching
 
@@ -420,7 +420,7 @@ DELETE /_ingest/pipeline/my_test_scores_pipeline
 We recommend testing and benchmarking any indexing changes before deploying them
 in production.
 
-[float]
+[discrete]
 [[modules-scripting-errors]]
 === Script errors
 Elasticsearch returns error details when there is a compliation or runtime

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -4,7 +4,7 @@
 Most search APIs support <<search-multi-index,multi-target syntax>>, with the
 exception of the <<search-explain>> endpoints.
 
-[float]
+[discrete]
 [[search-routing]]
 === Routing
 
@@ -52,7 +52,7 @@ The routing parameter can be multi valued represented as a comma
 separated string. This will result in hitting the relevant shards where
 the routing values match to.
 
-[float]
+[discrete]
 [[search-adaptive-replica]]
 === Adaptive Replica Selection
 
@@ -82,7 +82,7 @@ If adaptive replica selection is turned off, searches are sent to the
 index/indices shards in a round robin fashion between all copies of the data
 (primaries and replicas).
 
-[float]
+[discrete]
 [[stats-groups]]
 === Stats Groups
 
@@ -104,7 +104,7 @@ POST /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[global-search-timeout]]
 === Global Search Timeout
 
@@ -121,7 +121,7 @@ The setting key is `search.default_search_timeout` and can be set using the
 <<cluster-update-settings>> endpoints. The default value is no global timeout.
 Setting this value to `-1` resets the global search timeout to no timeout.
 
-[float]
+[discrete]
 [[global-search-cancellation]]
 === Search Cancellation
 
@@ -131,7 +131,7 @@ perform the request is closed by the client. It is fundamental that the http
 client sending requests closes connections whenever requests time out or are
 aborted.
 
-[float]
+[discrete]
 [[search-concurrency-and-parallelism]]
 === Search concurrency and parallelism
 

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -356,7 +356,7 @@ times.
 
 The meaning of the stats are as follows:
 
-[float]
+[discrete]
 ===== All parameters:
 
 [horizontal]
@@ -890,7 +890,7 @@ overall time, the breakdown is inclusive of all children times.
 
 The meaning of the stats are as follows:
 
-[float]
+[discrete]
 ===== All parameters:
 
 [horizontal]

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -208,7 +208,7 @@ GET /my_index/_rank_eval
 The `metric` section determines which of the available evaluation metrics 
 will be used. The following metrics are supported:
 
-[float]
+[discrete]
 [[k-precision]]
 ===== Precision at K (P@k)
 
@@ -263,7 +263,7 @@ If set to 'true', unlabeled documents are ignored and neither count as relevant 
 |=======================================================================
 
 
-[float]
+[discrete]
 [[k-recall]]
 ===== Recall at K (R@k)
 
@@ -315,7 +315,7 @@ in the query. Defaults to 10.
 |=======================================================================
 
 
-[float]
+[discrete]
 ===== Mean reciprocal rank
 
 For every query in the test suite, this metric calculates the reciprocal of the 
@@ -356,7 +356,7 @@ in the query. Defaults to 10.
 |=======================================================================
 
 
-[float]
+[discrete]
 ===== Discounted cumulative gain (DCG)
 
 In contrast to the two metrics above, 
@@ -399,7 +399,7 @@ in the query. Defaults to 10.
 |=======================================================================
 
 
-[float]
+[discrete]
 ===== Expected Reciprocal Rank (ERR)
 
 Expected Reciprocal Rank (ERR) is an extension of the classical reciprocal rank 

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -269,7 +269,7 @@ type:: The highlighter to use: `unified`, `plain`, or `fvh`. Defaults to
 * <<specify-fragmenter, Specify a fragmenter for the plain highlighter>>
 
 [[override-global-settings]]
-[float]
+[discrete]
 === Override global settings
 
 You can specify highlighter settings globally and selectively override them for
@@ -296,7 +296,7 @@ GET /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[specify-highlight-query]]
 === Specify a highlight query
 
@@ -365,7 +365,7 @@ GET /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[set-highlighter-type]]
 === Set highlighter type
 
@@ -390,7 +390,7 @@ GET /_search
 // TEST[setup:twitter]
 
 [[configure-tags]]
-[float]
+[discrete]
 === Configure highlighting tags
 
 By default, the highlighting will wrap highlighted text in `<em>` and
@@ -455,7 +455,7 @@ GET /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[highlight-source]]
 === Highlight on source
 
@@ -480,7 +480,7 @@ GET /_search
 
 
 [[highlight-all]]
-[float]
+[discrete]
 === Highlight in all fields
 
 By default, only fields that contains a query match are highlighted. Set
@@ -504,7 +504,7 @@ GET /_search
 // TEST[setup:twitter]
 
 [[matched-fields]]
-[float]
+[discrete]
 === Combine matches on multiple fields
 
 WARNING: This is only supported by the `fvh` highlighter
@@ -638,7 +638,7 @@ to
 
 
 [[explicit-field-order]]
-[float]
+[discrete]
 === Explicitly order highlighted fields
 Elasticsearch highlights the fields in the order that they are sent, but per the
 JSON spec, objects are unordered.  If you need to be explicit about the order
@@ -664,7 +664,7 @@ fields are highlighted but a plugin might.
 
 
 
-[float]
+[discrete]
 [[control-highlighted-frags]]
 === Control highlighted fragments
 
@@ -761,7 +761,7 @@ GET /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-[float]
+[discrete]
 [[highlight-postings-list]]
 === Highlight using the postings list
 
@@ -801,7 +801,7 @@ PUT /example
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[specify-fragmenter]]
 === Specify a fragmenter for the plain highlighter
 

--- a/docs/reference/search/suggesters.asciidoc
+++ b/docs/reference/search/suggesters.asciidoc
@@ -115,7 +115,7 @@ suggested text, its document frequency and score compared to the suggest
 entry text. The meaning of the score depends on the used suggester. The
 term suggester's score is based on the edit distance.
 
-[float]
+[discrete]
 [[global-suggest]]
 ===== Global suggest text
 

--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -84,7 +84,7 @@ NOTE: Adding context mappings increases the index size for completion field. The
 is entirely heap resident, you can monitor the completion field index size using <<indices-stats>>.
 
 [[suggester-context-category]]
-[float]
+[discrete]
 ===== Category Context
 
 The `category` context allows you to associate one or more categories with suggestions at index
@@ -128,7 +128,7 @@ are explicitly indexed, the suggestions are indexed with both set
 of categories.
 
 
-[float]
+[discrete]
 ====== Category Query
 
 Suggestions can be filtered by one or more categories. The following
@@ -216,7 +216,7 @@ NOTE: If a suggestion entry matches multiple contexts the final score is compute
 maximum score produced by any matching contexts.
 
 [[suggester-context-geo]]
-[float]
+[discrete]
 ===== Geo location Context
 
 A `geo` context allows you to associate one or more geo points or geohashes with suggestions
@@ -225,7 +225,7 @@ a certain distance of a specified geo location.
 
 Internally, geo points are encoded as geohashes with the specified precision.
 
-[float]
+[discrete]
 ====== Geo Mapping
 
 In addition to the `path` setting, `geo` context mapping accepts the following settings:
@@ -239,7 +239,7 @@ In addition to the `path` setting, `geo` context mapping accepts the following s
 NOTE: The index time `precision` setting sets the maximum geohash precision that
 can be used at query time.
 
-[float]
+[discrete]
 ====== Indexing geo contexts
 
 `geo` contexts can be explicitly set with suggestions or be indexed from a geo point field in the
@@ -269,7 +269,7 @@ PUT place/_doc/1
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 ====== Geo location Query
 
 Suggestions can be filtered and boosted with respect to how close they are to one or

--- a/docs/reference/settings/ccr-settings.asciidoc
+++ b/docs/reference/settings/ccr-settings.asciidoc
@@ -5,7 +5,7 @@
 These {ccr} settings can be dynamically updated on a live cluster with the
 <<cluster-update-settings,cluster update settings API>>.
 
-[float]
+[discrete]
 [[ccr-recovery-settings]]
 ==== Remote recovery settings
 
@@ -23,7 +23,7 @@ leader and follower clusters. For example if it is set to `20mb` on a leader,
 the leader will only send `20mb/s` to the follower even if the follower is
 requesting and can accept `60mb/s`. Defaults to `40mb`.
 
-[float]
+[discrete]
 [[ccr-advanced-recovery-settings]]
 ==== Advanced remote recovery settings
 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -24,7 +24,7 @@ file.
 
 // end::ml-settings-description-tag[]
 
-[float]
+[discrete]
 [[general-ml-settings]]
 ==== General machine learning settings
 
@@ -110,7 +110,7 @@ each node. Typically, jobs spend a small amount of time in this state before
 they move to `open` state. Jobs that must restore large models when they are
 opening spend more time in the `opening` state. Defaults to `2`.
 
-[float]
+[discrete]
 [[advanced-ml-settings]]
 ==== Advanced machine learning settings
 
@@ -147,7 +147,7 @@ JVM. If such a process does not connect within the time period specified by this
 setting then the process is assumed to have failed. Defaults to `10s`. The minimum
 value for this setting is `5s`.
 
-[float]
+[discrete]
 [[model-inference-circuit-breaker]]
 ==== {ml-cap} circuit breaker settings
 

--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -22,7 +22,7 @@ configure monitoring settings in `logstash.yml`.
 
 For more information, see <<monitor-elasticsearch-cluster>>.
 
-[float]
+[discrete]
 [[general-monitoring-settings]]
 ==== General Monitoring Settings
 
@@ -30,7 +30,7 @@ For more information, see <<monitor-elasticsearch-cluster>>.
 deprecated:[7.8.0,Basic License features should always be enabled] +
 This deprecated setting has no effect.
 
-[float]
+[discrete]
 [[monitoring-collection-settings]]
 ==== Monitoring Collection Settings
 
@@ -124,7 +124,7 @@ information, see <<local-exporter-settings,Local exporter settings>>,
 <<http-exporter-settings,HTTP exporter settings>>, and
 <<how-monitoring-works>>.
 
-[float]
+[discrete]
 [[local-exporter-settings]]
 ==== Local Exporter Settings
 
@@ -163,7 +163,7 @@ cluster alerts are not displayed.
 (<<time-units,time value>>) Time to wait for the master node to setup `local` exporter for monitoring.
 After that, the non-master nodes will warn the user for possible missing X-Pack configuration. Defaults to `30s`.
 
-[float]
+[discrete]
 [[http-exporter-settings]]
 ==== HTTP Exporter Settings
 

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -21,7 +21,7 @@ For more information about creating and updating the {es} keystore, see
 <<cluster-update-settings,cluster update settings API>>.
 // end::notification-settings-description-tag[]
 
-[float]
+[discrete]
 [[general-notification-settings]]
 ==== General Watcher Settings
 `xpack.watcher.enabled`::
@@ -89,7 +89,7 @@ corresponding endpoints are explicitly allowed as well.
 
 include::ssl-settings.asciidoc[]
 
-[float]
+[discrete]
 [[email-notification-settings]]
 ==== Email Notification Settings
 You can configure the following email notification settings in
@@ -231,7 +231,7 @@ Defaults to `true`.
 
 include::ssl-settings.asciidoc[]
 
-[float]
+[discrete]
 [[slack-notification-settings]]
 ==== Slack Notification Settings
 You can configure the following Slack notification settings in
@@ -272,7 +272,7 @@ via Slack. You can specify the following Slack account attributes:
                                    Slack attachments documentation].
 --
 
-[float]
+[discrete]
 [[jira-notification-settings]]
 ==== Jira Notification Settings
 You can configure the following Jira notification settings in
@@ -301,7 +301,7 @@ issues in Jira. You can specify the following Jira account attributes:
   Optional.
 --
 
-[float]
+[discrete]
 [[pagerduty-notification-settings]]
 ==== PagerDuty Notification Settings
 You can configure the following PagerDuty notification settings in

--- a/docs/reference/settings/security-hash-settings.asciidoc
+++ b/docs/reference/settings/security-hash-settings.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[hashing-settings]]
 ==== User cache and password hash algorithms
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -22,7 +22,7 @@ with the exception of the secure settings, which you add to the {es} keystore.
 For more information about creating and updating the {es} keystore, see
 <<secure-settings>>.
 
-[float]
+[discrete]
 [[general-security-settings]]
 ==== General security settings
 `xpack.security.enabled`::
@@ -53,14 +53,14 @@ the sensitive nature of the information.
 `xpack.security.fips_mode.enabled`::
 Enables fips mode of operation. Set this to `true` if you run this {es} instance in a FIPS 140-2 enabled JVM.  For more information, see <<fips-140-compliance>>. Defaults to `false`.
 
-[float]
+[discrete]
 [[password-hashing-settings]]
 ==== Password hashing settings
 `xpack.security.authc.password_hashing.algorithm`::
 Specifies the hashing algorithm that is used for secure user credential storage.
 See <<password-hashing-algorithms>>. Defaults to `bcrypt`.
 
-[float]
+[discrete]
 [[anonymous-access-settings]]
 ==== Anonymous access settings
 You can configure the following anonymous access settings in
@@ -80,7 +80,7 @@ resource. When set to `false`, an HTTP 401 response is returned and the user
 can provide credentials with the appropriate permissions to gain
 access. Defaults to `true`.
 
-[float]
+[discrete]
 [[security-automata-settings]]
 ==== Automata Settings
 In places where the {security-features} accept wildcard patterns (e.g. index
@@ -108,7 +108,7 @@ The length of time to retain in an item in the automata cache (based on most
 recent usage).
 Defaults to `48h` (48 hours).
 
-[float]
+[discrete]
 [[field-document-security-settings]]
 ==== Document and field level security settings
 
@@ -132,7 +132,7 @@ Document level security queries may depend on Lucene BitSet objects, and these a
 automatically cached to improve performance. Defaults to `50mb`, after which
 least-recently-used entries will be evicted.
 
-[float]
+[discrete]
 [[token-service-settings]]
 ==== Token service settings
 
@@ -148,7 +148,7 @@ Set to `false` to disable the built-in token service. Defaults to `true` unless
 The length of time that a token is valid for. By default this value is `20m` or
 20 minutes. The maximum value is 1 hour.
 
-[float]
+[discrete]
 [[api-key-service-settings]]
 ==== API key service settings
 
@@ -178,7 +178,7 @@ The hashing algorithm that is used for the
 in-memory cached API key credentials. For possible values, see <<cache-hash-algo>>.
 Defaults to `ssha256`.
 
-[float]
+[discrete]
 [[realm-settings]]
 ==== Realm settings
 // tag::realm-settings-description-tag[]
@@ -212,7 +212,7 @@ The valid settings vary depending on the realm type. For more
 information, see <<setting-up-authentication>>.
 // end::realm-settings-description-tag[]
 
-[float]
+[discrete]
 [[ref-realm-settings]]
 ===== Settings valid for all realms
 // tag::realm-order-tag[]
@@ -226,7 +226,7 @@ Indicates whether a realm is enabled. You can use this setting to disable a
 realm without removing its configuration information. Defaults to `true`.
 
 [[ref-native-settings]]
-[float]
+[discrete]
 ===== Native realm settings
 For a native realm, the `type` must be set to `native`. In addition to the
 <<ref-realm-settings,settings that are valid for all realms>>, you can specify
@@ -251,7 +251,7 @@ Defaults to `true`.
 
 [[ref-users-settings]]
 
-[float]
+[discrete]
 ===== File realm settings
 
 The `type` setting must be set to `file`. In addition to the
@@ -279,7 +279,7 @@ this realm, so that it only supports user lookups.
 Defaults to `true`.
 
 [[ref-ldap-settings]]
-[float]
+[discrete]
 ===== LDAP realm settings
 
 The `type` setting must be set to `ldap`. In addition to the
@@ -549,7 +549,7 @@ this realm, so that it only supports user lookups.
 Defaults to `true`.
 
 [[ref-ad-settings]]
-[float]
+[discrete]
 ===== Active Directory realm settings
 
 The `type` setting must be set to `active_directory`. In addition to the
@@ -807,7 +807,7 @@ Referrals are URLs returned by the server that are to be used to continue the
 LDAP operation (such as `search`). Defaults to `true`.
 
 [[ref-pki-settings]]
-[float]
+[discrete]
 ===== PKI realm settings
 
 The `type` setting must be set to `pki`. In addition to the
@@ -871,7 +871,7 @@ must be defined. For more details, see <<pki-realm-for-proxied-clients,
 Configuring authentication delegation for PKI realms>>.
 
 [[ref-saml-settings]]
-[float]
+[discrete]
 ===== SAML realm settings
 // tag::saml-description-tag[]
 The `type` setting must be set to `saml`. In addition to the
@@ -1048,7 +1048,7 @@ For more information, see
 <<req-authn-context>>.
 // end::saml-req-authn-context-tag[]
 
-[float]
+[discrete]
 [[ref-saml-signing-settings]]
 ===== SAML realm signing settings
 // tag::saml-signing-description-tag[]
@@ -1112,7 +1112,7 @@ The password to the keystore in `signing.keystore.path`.
 The password for the key in the keystore (`signing.keystore.path`).
 Defaults to the keystore password.
 
-[float]
+[discrete]
 [[ref-saml-encryption-settings]]
 ===== SAML realm encryption settings
 // tag::saml-encryption-description-tag[]
@@ -1170,7 +1170,7 @@ The password for the key in the keystore (`encryption.keystore.path`). Only a
 single password is supported. If you are using multiple decryption keys,
 they cannot have individual passwords.
 
-[float]
+[discrete]
 [[ref-saml-ssl-settings]]
 ===== SAML realm SSL settings
 // tag::saml-ssl-description-tag[]
@@ -1273,7 +1273,7 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 // end::saml-ssl-cipher-suites-tag[]
 
-[float]
+[discrete]
 [[ref-kerberos-settings]]
 ===== Kerberos realm settings
 // tag::kerberos-description-tag[]
@@ -1318,7 +1318,7 @@ See <<authorization_realms>>.
 // end::kerberos-authorization-realms-tag[]
 
 [[ref-oidc-settings]]
-[float]
+[discrete]
 ===== OpenID Connect realm settings
 // tag::oidc-description-tag[]
 In addition to the <<ref-realm-settings,settings that are valid for all realms>>, you
@@ -1541,7 +1541,7 @@ the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed per endpoint.
 // end::oidc-http-max-endpoint-connections-tag[]
 
-[float]
+[discrete]
 [[ref-oidc-ssl-settings]]
 ===== OpenID Connect realm SSL settings
 // tag::oidc-ssl-description-tag[]
@@ -1645,7 +1645,7 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 // end::oidc-ssl-cipher-suites-tag[]
 
-[float]
+[discrete]
 [[load-balancing]]
 ===== Load balancing and failover
 
@@ -1671,7 +1671,7 @@ IP addresses that correspond to this DNS name. Connections will continuously
 iterate through the list of addresses. If a server is unavailable, iterating
 through the list of URLs will continue until a successful connection is made.
 
-[float]
+[discrete]
 [[ssl-tls-settings]]
 ==== General TLS settings
 `xpack.security.ssl.diagnose.trust`::
@@ -1684,7 +1684,7 @@ cause of the failure and assist with resolving the problem.
 Set to `false` to disable these messages.
 NOTE: This defaults to `false` when `xpack.security.fips_mode.enabled` is `true`.
 
-[float]
+[discrete]
 [[tls-ssl-key-settings]]
 ===== TLS/SSL key and trusted certificate settings
 
@@ -1730,7 +1730,7 @@ include::ssl-settings.asciidoc[]
 include::ssl-settings.asciidoc[]
 
 [[ssl-tls-profile-settings]]
-[float]
+[discrete]
 ===== Transport profile TLS/SSL settings
 The same settings that are available for the <<transport-tls-ssl-settings, default transport>>
 are also available for each transport profile. By default, the settings for a
@@ -1743,7 +1743,7 @@ transport profile, use the prefix `transport.profiles.$PROFILE.xpack.security.` 
 append the portion of the setting after `xpack.security.transport.`. For the key
 setting, this would be `transport.profiles.$PROFILE.xpack.security.ssl.key`.
 
-[float]
+[discrete]
 [[ip-filtering-settings]]
 ==== IP filtering settings
 You can configure the following settings for <<ip-filtering,IP filtering>>.

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -17,7 +17,7 @@ The dynamic settings can also be updated across a cluster with the
 TIP: Dynamic settings take precedence over settings in the `elasticsearch.yml`
 file.
 
-[float]
+[discrete]
 [[general-transform-settings]]
 ==== General {transforms} settings
 

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -12,14 +12,14 @@ running, including:
 * Configuring
 
 [[supported-platforms]]
-[float]
+[discrete]
 == Supported platforms
 
 The matrix of officially supported operating systems and JVMs is available here:
 link:/support/matrix[Support Matrix]. Elasticsearch is tested on the listed
 platforms, but it is possible that it will work on other platforms too.
 
-[float]
+[discrete]
 [[jvm-version]]
 == Java (JVM) Version
 

--- a/docs/reference/setup/bootstrap-checks-xes.asciidoc
+++ b/docs/reference/setup/bootstrap-checks-xes.asciidoc
@@ -5,7 +5,7 @@
 In addition to the <<bootstrap-checks,{es} bootstrap checks>>, there are
 checks that are specific to {xpack} features.
 
-[float]
+[discrete]
 === Encrypt sensitive data check
 //See EncryptSensitiveDAtaBootstrapCheck.java
 
@@ -16,7 +16,7 @@ the secure settings store.
 To pass this bootstrap check, you must set the `xpack.watcher.encryption_key`
 on each node in the cluster. For more information, see <<encrypting-data>>.
 
-[float]
+[discrete]
 === PKI realm check
 //See PkiRealmBootstrapCheckTests.java
 
@@ -28,7 +28,7 @@ information, see <<pki-realm>> and <<ssl-tls>>.
 To pass this bootstrap check, if a PKI realm is enabled, you must configure TLS
 and enable client authentication on at least one network communication layer.
 
-[float]
+[discrete]
 === Role mappings check
 
 If you authenticate users with realms other than `native` or `file` realms, you
@@ -46,7 +46,7 @@ To pass this bootstrap check, the role mapping files must exist and must be
 valid. The Distinguished Names (DNs) that are listed in the role mappings files
 must also be valid.
 
-[float]
+[discrete]
 [[bootstrap-checks-tls]]
 === SSL/TLS check
 //See TLSLicenseBootstrapCheck.java
@@ -62,7 +62,7 @@ To pass this bootstrap check, you must
 <<ssl-tls,set up SSL/TLS in your cluster>>.
 
 
-[float]
+[discrete]
 === Token SSL check
 //See TokenSSLBootstrapCheckTests.java
 

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -20,7 +20,7 @@ There are some bootstrap checks that are always enforced to prevent
 Elasticsearch from running with incompatible settings. These checks are
 documented individually.
 
-[float]
+[discrete]
 [[dev-vs-prod-mode]]
 === Development vs. production mode
 
@@ -41,7 +41,7 @@ can be useful for configuring a single node to be reachable via HTTP for testing
 purposes without triggering production mode.
 
 [[single-node-discovery]]
-[float]
+[discrete]
 === Single-node discovery
 We recognize that some users need to bind transport to an external interface for
 testing their usage of the transport client. For this situation, we provide the
@@ -50,7 +50,7 @@ discovery type `single-node` (configure it by setting `discovery.type` to
 join a cluster with any other node.
 
 
-[float]
+[discrete]
 === Forcing the bootstrap checks
 If you are running a single node in production, it is possible to evade the
 bootstrap checks (either by not binding transport to an external interface, or

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -10,7 +10,7 @@ as `node.name` and paths), or settings which a node requires in order to be
 able to join a cluster, such as `cluster.name` and `network.host`.
 
 [[config-files-location]]
-[float]
+[discrete]
 === Config files location
 
 Elasticsearch has three configuration files:
@@ -45,7 +45,7 @@ shell is not sufficient. Instead, this variable is sourced from
 change the config directory location.
 
 
-[float]
+[discrete]
 === Config file format
 
 The configuration format is http://www.yaml.org/[YAML]. Here is an
@@ -66,7 +66,7 @@ path.data: /var/lib/elasticsearch
 path.logs: /var/log/elasticsearch
 --------------------------------------------------
 
-[float]
+[discrete]
 === Environment variable substitution
 
 Environment variables referenced with the `${...}` notation within the

--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -8,7 +8,7 @@ There are two important discovery and cluster formation settings that should be
 configured before going to production so that nodes in the cluster can discover
 each other and elect a master node.
 
-[float]
+[discrete]
 [[unicast.hosts]]
 ==== `discovery.seed_hosts`
 
@@ -29,7 +29,7 @@ If your master-eligible nodes do not have fixed names or addresses, use an
 <<built-in-hosts-providers,alternative hosts provider>> to find their addresses
 dynamically.
 
-[float]
+[discrete]
 [[initial_master_nodes]]
 ==== `cluster.initial_master_nodes`
 

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -1,7 +1,7 @@
 [[install-elasticsearch]]
 == Installing Elasticsearch
 
-[float]
+[discrete]
 === Hosted Elasticsearch
 
 You can run Elasticsearch on your own hardware, or use our
@@ -10,7 +10,7 @@ on Elastic Cloud. The Elasticsearch Service is available on both AWS and GCP.
 {ess-trial}[Try out the
 Elasticsearch Service for free].
 
-[float]
+[discrete]
 === Installing Elasticsearch Yourself
 
 Elasticsearch is provided in the following package formats:
@@ -66,7 +66,7 @@ Formulae are available from the Elastic Homebrew tap for installing
 +
 {ref}/brew.html[Install {es} on macOS with Homebrew]
 
-[float]
+[discrete]
 [[config-mgmt-tools]]
 === Configuration Management Tools
 

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -144,7 +144,7 @@ installation. However, upgrading across JVM types (e.g. JRE versus SE) is not
 supported, and does require the service to be reinstalled.
 
 [[windows-service-settings]]
-[float]
+[discrete]
 === Customizing service settings
 
 The Elasticsearch service can be configured prior to installation by setting the following environment variables (either using the https://technet.microsoft.com/en-us/library/cc754250(v=ws.10).aspx[set command] from the command line, or through the `System Properties->Environment Variables` GUI).

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -120,7 +120,7 @@ appenders can be found on the
 http://logging.apache.org/log4j/2.x/manual/configuration.html[Log4j
 documentation].
 
-[float]
+[discrete]
 [[configuring-logging-levels]]
 === Configuring logging levels
 
@@ -187,7 +187,7 @@ example, you want to send the logger to another file, or manage the logger
 differently; this is a rare use-case).
 --
 
-[float]
+[discrete]
 [[deprecation-logging]]
 === Deprecation logging
 
@@ -239,7 +239,7 @@ The user ID is included in the `X-Opaque-ID` field in deprecation JSON logs.
 ---------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[json-logging]]
 === JSON log format
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -9,7 +9,7 @@ nodes in the cluster while in the case of
 time, so the service remains uninterrupted.
 
 
-[float]
+[discrete]
 [[restart-cluster-full]]
 === Full-cluster restart
 
@@ -164,7 +164,7 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 // end::restart_ml[]
 
 
-[float]
+[discrete]
 [[restart-cluster-rolling]]
 === Rolling restart
 

--- a/docs/reference/setup/starting.asciidoc
+++ b/docs/reference/setup/starting.asciidoc
@@ -3,20 +3,20 @@
 
 The method for starting {es} varies depending on how you installed it. 
 
-[float]
+[discrete]
 [[start-targz]]
 === Archive packages (`.tar.gz`)
 
 If you installed {es} with a `.tar.gz` package, you can start {es} from the 
 command line.  
 
-[float]
+[discrete]
 include::install/targz-start.asciidoc[]
 
-[float]
+[discrete]
 include::install/targz-daemon.asciidoc[]
 
-[float]
+[discrete]
 [[start-zip]]
 === Archive packages (`.zip`)
 
@@ -24,24 +24,24 @@ If you installed {es} on Windows with a `.zip` package, you can start {es} from
 the command line. If you want {es} to start automatically at boot time without 
 any user interaction, <<windows-service,install {es} as a service>>.
 
-[float]
+[discrete]
 include::install/zip-windows-start.asciidoc[]
 
-[float]
+[discrete]
 [[start-deb]]
 === Debian packages
 
 include::install/init-systemd.asciidoc[]
 
-[float]
+[discrete]
 [[start-es-deb-init]]
 include::install/deb-init.asciidoc[]
 
-[float]
+[discrete]
 [[start-es-deb-systemd]]
 include::install/systemd.asciidoc[]
 
-[float]
+[discrete]
 [[start-docker]]
 === Docker images
 
@@ -49,7 +49,7 @@ If you installed a Docker image, you can start {es} from the command line. There
 are different methods depending on whether you're using development mode or 
 production mode. See <<docker-cli-run>>. 
 
-[float]
+[discrete]
 [[start-msi]]
 === MSI packages
 
@@ -58,19 +58,19 @@ from the command line. If you want it to start automatically at boot time
 without any user interaction, 
 <<msi-installer-windows-service,install {es} as a Windows service>>.
 
-[float]
+[discrete]
 include::install/msi-windows-start.asciidoc[]
 
-[float]
+[discrete]
 [[start-rpm]]
 === RPM packages
 
 include::install/init-systemd.asciidoc[]
 
-[float]
+[discrete]
 [[start-es-rpm-init]]
 include::install/rpm-init.asciidoc[]
 
-[float]
+[discrete]
 [[start-es-rpm-systemd]]
 include::install/systemd.asciidoc[]

--- a/docs/reference/setup/stopping.asciidoc
+++ b/docs/reference/setup/stopping.asciidoc
@@ -36,7 +36,7 @@ $ cat /tmp/elasticsearch-pid && echo
 $ kill -SIGTERM 15516
 --------------------------------------------------
 
-[float]
+[discrete]
 [[fatal-errors]]
 === Stopping on Fatal Errors
 

--- a/docs/reference/setup/sysconfig.asciidoc
+++ b/docs/reference/setup/sysconfig.asciidoc
@@ -16,7 +16,7 @@ The following settings *must* be considered before going to production:
 * <<executable-jna-tmpdir,Temporary directory not mounted with `noexec`>>
 
 [[dev-vs-prod]]
-[float]
+[discrete]
 === Development mode vs production mode
 
 By default, Elasticsearch assumes that you are working in development mode.

--- a/docs/reference/slm/apis/index.asciidoc
+++ b/docs/reference/slm/apis/index.asciidoc
@@ -14,7 +14,7 @@ view and manage snapshots, and restore data streams or indices.
 You can stop and restart SLM to temporarily pause automatic backups while performing
 upgrades or other maintenance.
 
-[float]
+[discrete]
 [[slm-and-security]]
 === Security and SLM
 

--- a/docs/reference/slm/apis/slm-api.asciidoc
+++ b/docs/reference/slm/apis/slm-api.asciidoc
@@ -7,7 +7,7 @@ You use the following APIs to set up policies to automatically take snapshots an
 control how long they are retained. 
 For more information about {slm} ({slm-init}), see <<snapshot-lifecycle-management>>.
 
-[float]
+[discrete]
 [[slm-api-policy-endpoint]]
 === Policy management APIs
 
@@ -15,14 +15,14 @@ For more information about {slm} ({slm-init}), see <<snapshot-lifecycle-manageme
 * <<slm-api-get-policy,Get lifecycle policy>>
 * <<slm-api-delete-policy,Delete lifecycle policy>>
 
-[float]
+[discrete]
 [[slm-api-index-endpoint]]
 === Snapshot management APIs
 
 * <<slm-api-execute-lifecycle,Execute snapshot lifecycle policy>> (take snapshots)
 * <<slm-api-execute-retention,Execute snapshot retention policy>> (delete expired snapshots)
 
-[float]
+[discrete]
 [[slm-api-management-endpoint]]
 === Operation management APIs
 

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -47,7 +47,7 @@ cluster is by using the snapshot and restore functionality.
 
 // end::backup-warning[]
 
-[float]
+[discrete]
 [[snapshot-restore-version-compatibility]]
 === Version compatibility
 

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -96,7 +96,7 @@ When a repository is unregistered, {es} only removes the reference to the
 location where the repository is storing the snapshots. The snapshots themselves
 are left untouched and in place.
 
-[float]
+[discrete]
 [[snapshots-filesystem-repository]]
 === Shared file system repository
 
@@ -163,7 +163,7 @@ unit, for example: `1GB`, `10MB`, `5KB`, `500B`. Defaults to `null` (unlimited c
 `max_snapshot_bytes_per_sec`:: Throttles per node snapshot rate. Defaults to `40mb` per second.
 `readonly`:: Makes repository read-only.  Defaults to `false`.
 
-[float]
+[discrete]
 [[snapshots-read-only-repository]]
 === Read-only URL repository
 
@@ -217,7 +217,7 @@ repositories.url.allowed_urls: ["http://www.example.org/root/*", "https://*.mydo
 NOTE: URLs using the `ftp`, `http`, `https`, or `jar` protocols do not need to
 be registered in the `path.repo` setting.
 
-[float]
+[discrete]
 [role="xpack"]
 [testenv="basic"]
 [[snapshots-source-only-repository]]
@@ -261,7 +261,7 @@ PUT _snapshot/my_src_only_repository
 -----------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[snapshots-repository-plugins]]
 === Repository plugins
 
@@ -272,7 +272,7 @@ Other repository backends are available in these official plugins:
 * {plugins}/repository-azure.html[repository-azure] for Azure storage repositories
 * {plugins}/repository-gcs.html[repository-gcs] for Google Cloud Storage repositories
 
-[float]
+[discrete]
 [[snapshots-repository-verification]]
 === Repository verification
 When a repository is registered, it's immediately verified on all master and data nodes to make sure that it is functional
@@ -301,7 +301,7 @@ POST /_snapshot/my_unverified_backup/_verify
 
 It returns a list of nodes where repository was successfully verified or an error message if verification process failed.
 
-[float]
+[discrete]
 [[snapshots-repository-cleanup]]
 === Repository cleanup
 Repositories can over time accumulate data that is not referenced by any existing snapshot. This is a result of the data safety guarantees

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -8,7 +8,7 @@ It is Type 4 driver, meaning it is a platform independent, stand-alone, Direct t
 pure Java driver that converts JDBC calls to {es-sql}.
 
 [[sql-jdbc-installation]]
-[float]
+[discrete]
 === Installation
 
 The JDBC driver can be obtained from:
@@ -40,7 +40,7 @@ from `artifacts.elastic.co/maven` by adding it to the repositories list:
 ----
 
 [[jdbc-setup]]
-[float]
+[discrete]
 === Setup
 
 The driver main class is `org.elasticsearch.xpack.sql.jdbc.EsDriver`. 
@@ -70,7 +70,7 @@ Optional.
 The driver recognized the following properties:
 
 [[jdbc-cfg]]
-[float]
+[discrete]
 ===== Essential
 [[jdbc-cfg-timezone]]
 `timezone` (default JVM timezone)::
@@ -78,7 +78,7 @@ Timezone used by the driver _per connection_ indicated by its `ID`.
 *Highly* recommended to set it (to, say, `UTC`) as the JVM timezone can vary, is global for the entire JVM and can't be changed easily when running under a security manager.
 
 [[jdbc-cfg-network]]
-[float]
+[discrete]
 ===== Network
 
 `connect.timeout` (default 30s)::
@@ -97,7 +97,7 @@ Page size (in entries). The number of results returned per page by the server.
 Query timeout (in seconds). That is the maximum amount of time waiting for a query to return.
 
 [[jdbc-cfg-auth]]
-[float]
+[discrete]
 ==== Basic Authentication
 
 `user`:: Basic Authentication user name
@@ -105,7 +105,7 @@ Query timeout (in seconds). That is the maximum amount of time waiting for a que
 `password`:: Basic Authentication password
 
 [[jdbc-cfg-ssl]]
-[float]
+[discrete]
 ==== SSL
 
 `ssl` (default false):: Enable SSL
@@ -124,23 +124,23 @@ Query timeout (in seconds). That is the maximum amount of time waiting for a que
 
 `ssl.protocol`(default `TLS`):: SSL protocol to be used
 
-[float]
+[discrete]
 ==== Proxy
 
 `proxy.http`:: Http proxy host name
 
 `proxy.socks`:: SOCKS proxy host name
 
-[float]
+[discrete]
 ==== Mapping
 `field.multi.value.leniency` (default `true`):: Whether to be lenient and return the first value (without any guarantees of what that
 will be - typically the first in natural ascending order) for fields with multiple values (true) or throw an exception.
 
-[float]
+[discrete]
 ==== Index
 `index.include.frozen` (default `false`):: Whether to include <<frozen-indices, frozen-indices>> in the query execution or not (default).
 
-[float]
+[discrete]
 ==== Additional
 
 `validate.properties` (default true):: If disabled, it will ignore any misspellings or unrecognizable properties. When enabled, an exception

--- a/docs/reference/sql/endpoints/odbc.asciidoc
+++ b/docs/reference/sql/endpoints/odbc.asciidoc
@@ -6,7 +6,7 @@
 == SQL ODBC
 
 [[sql-odbc-overview]]
-[float]
+[discrete]
 === Overview
 
 {odbc} is a 3.80 compliant ODBC driver for {es}.

--- a/docs/reference/sql/endpoints/odbc/configuration.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/configuration.asciidoc
@@ -60,7 +60,7 @@ Such a file can be then shared among multiple systems and the user will need to 
 
 The configuration steps are similar for all the above points. Following is an example of configuring a System DSN.
 
-[float]
+[discrete]
 ===== 2.1 Launch {odbc} DSN Editor
 Click on the _System DSN_ tab, then on the _Add..._ button:
 
@@ -82,7 +82,7 @@ image:images/sql/odbc/dsn_editor_basic.png[]
 
 This new window has three tabs, each responsible for a set of configuration parameters, as follows.
 
-[float]
+[discrete]
 ===== 2.2 Connection parameters
 This tab allows configuration for the following items:
 
@@ -129,7 +129,7 @@ At a minimum, the _Name_ and _Hostname_ fields must be provisioned, before the D
 
 WARNING: Connection encryption is enabled by default. This will need to be changed if connecting to an {es} node with no encryption.
 
-[float]
+[discrete]
 ===== 2.3 Cryptography parameters
 One of the following SSL options can be chosen:
 
@@ -180,7 +180,7 @@ will be considered by default. Choose _All Files (\*.*)_ from the drop down, if 
 .Certificate file browser
 image:images/sql/odbc/dsn_editor_security_cert.png[]
 
-[float]
+[discrete]
 ===== 2.4 Connection parameters
 The connection configuration can further be tweaked by the following parameters.
 
@@ -255,7 +255,7 @@ This corresponds to the `EarlyExecution` setting in <<odbc-cfg-dsnparams>>.
 .Connection parameters
 image:images/sql/odbc/dsn_editor_misc.png[]
 
-[float]
+[discrete]
 ===== 2.5 Logging parameters
 For troubleshooting purposes, the {odbc} offers functionality to log the API calls that an application makes; this is enabled in the Administrator application:
 
@@ -289,7 +289,7 @@ When authentication is enabled, the password will be redacted from the logs.
 NOTE: Debug-logging can quickly lead to the creation of many very large files and generate significant processing overhead. Only enable if
 instructed so and preferably only when fetching low volumes of data.
 
-[float]
+[discrete]
 [[connection_testing]]
 ===== 2.5 Testing the connection
 Once the _Hostname_, the _Port_ (if different from implicit default) and the SSL options are configured, you can test if the provided
@@ -352,7 +352,7 @@ once, the connection logging taking precedence over the environment variable
 logging.
 
 [[odbc-cfg-dsnparams]]
-[float]
+[discrete]
 ==== Connection string parameters
 
 The following is a list of additional parameters that can be configured for a

--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -7,7 +7,7 @@ Functions for computing a _single_ result from a set of input values.
 {es-sql} supports aggregate functions only alongside <<sql-syntax-group-by,grouping>> (implicit or explicit).
 
 [[sql-functions-aggs-general]]
-[float]
+[discrete]
 === General Purpose
 
 [[sql-functions-aggs-avg]]
@@ -404,7 +404,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[aggSumScalars]
 --------------------------------------------------
 
 [[sql-functions-aggs-statistics]]
-[float]
+[discrete]
 === Statistics
 
 [[sql-functions-aggs-kurtosis]]

--- a/docs/reference/sql/functions/math.asciidoc
+++ b/docs/reference/sql/functions/math.asciidoc
@@ -7,7 +7,7 @@ All math and trigonometric functions require their input (where applicable)
 to be numeric.
 
 [[sql-functions-math-generic]]
-[float]
+[discrete]
 === Generic
 
 [[sql-functions-math-abs]]
@@ -388,7 +388,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[mathTruncateWithNegativeParameter
 --------------------------------------------------
 
 [[sql-functions-math-trigonometric]]
-[float]
+[discrete]
 === Trigonometric
 
 [[sql-functions-math-acos]]

--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -90,7 +90,7 @@ s|SQL precision
 
 
 [[sql-multi-field]]
-[float]
+[discrete]
 ==== SQL and multi-fields
 
 A core concept in {es} is that of an `analyzed` field, that is a full-text value that is interpreted in order

--- a/docs/reference/sql/language/indices.asciidoc
+++ b/docs/reference/sql/language/indices.asciidoc
@@ -6,7 +6,7 @@
 {es-sql} supports two types of patterns for matching multiple indices or tables:
 
 [[sql-index-patterns-multi]]
-[float]
+[discrete]
 ==== {es} multi-index
 
 The {es} notation for enumerating, including or excluding <<multi-index,multi-target syntax>>
@@ -36,7 +36,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[fromTablePatternQuoted]
 NOTE: There is the restriction that all resolved concrete tables have the exact same mapping.
 
 [[sql-index-patterns-like]]
-[float]
+[discrete]
 ==== SQL `LIKE` notation
 
 The common `LIKE` statement (including escaping if needed) to match a wildcard pattern, based on one `_`

--- a/docs/reference/sql/language/syntax/lexic/index.asciidoc
+++ b/docs/reference/sql/language/syntax/lexic/index.asciidoc
@@ -62,7 +62,7 @@ Hence why in general, *especially* when dealing with user input it is *highly* r
 {es-sql} supports two kind of __implicitly-typed__ literals: strings and numbers.
 
 [[sql-syntax-string-literals]]
-[float]
+[discrete]
 ===== String Literals
 
 A string literal is an arbitrary number of characters bounded by single quotes `'`: `'Giant Robot'`. 
@@ -71,7 +71,7 @@ To include a single quote in the string, escape it using another single quote: `
 NOTE: An escaped single quote is *not* a double quote (`"`), but a single quote `'` _repeated_ (`''`).
 
 [sql-syntax-numeric-literals]
-[float]
+[discrete]
 ===== Numeric Literals
 
 Numeric literals are accepted both in decimal and scientific notation with exponent marker (`e` or `E`), starting either with a digit or decimal point `.`:
@@ -88,7 +88,7 @@ Numeric literals are accepted both in decimal and scientific notation with expon
 Numeric literals that contain a decimal point are always interpreted as being of type `double`. Those without are considered `integer` if they fit otherwise their type is `long` (or `BIGINT` in ANSI SQL types).
 
 [[sql-syntax-generic-literals]]
-[float]
+[discrete]
 ===== Generic Literals
 
 When dealing with arbitrary type literal, one creates the object by casting, typically, the string representation to the desired type. This can be achieved through the dedicated <<sql-operators-cast, cast operator>> and <<sql-functions-type-conversion, functions>>:

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -3,7 +3,7 @@
 [[sql-limitations]]
 == SQL Limitations
 
-[float]
+[discrete]
 [[large-parsing-trees]]
 === Large queries may throw `ParsingExpection`
 
@@ -11,7 +11,7 @@ Extremely large queries can consume too much memory during the parsing phase, in
 abort parsing and throw an error. In such cases, consider reducing the query to a smaller size by potentially
 simplifying it or splitting it into smaller queries.
 
-[float]
+[discrete]
 [[sys-columns-describe-table-nested-fields]]
 === Nested fields in `SYS COLUMNS` and `DESCRIBE TABLE`
 
@@ -31,7 +31,7 @@ For example:
 SELECT dep.dep_name.keyword FROM test_emp GROUP BY languages;
 --------------------------------------------------
 
-[float]
+[discrete]
 === Scalar functions on nested fields are not allowed in `WHERE` and `ORDER BY` clauses
 {es-sql} doesn't support the usage of scalar functions on top of nested fields in `WHERE`
 and `ORDER BY` clauses with the exception of comparison and logical operators.
@@ -59,7 +59,7 @@ SELECT * FROM test_emp WHERE dep.start_date >= CAST('2020-01-01' AS DATE) OR dep
 
 is supported.
 
-[float]
+[discrete]
 === Multi-nested fields
 
 {es-sql} doesn't support multi-nested documents, so a query cannot reference more than one nested field in an index.
@@ -80,20 +80,20 @@ nested_B.text         |VARCHAR        |KEYWORD
 `nested_A` and `nested_B` cannot be used at the same time, nor `nested_A`/`nested_B` and `nested_A.nested_X` combination.
 For such situations, {es-sql} will display an error message.
 
-[float]
+[discrete]
 === Paginating nested inner hits
 
 When SELECTing a nested field, pagination will not work as expected, {es-sql} will return __at least__ the page size records. 
 This is because of the way nested queries work in {es}: the root nested field will be returned and it's matching inner nested fields as well,
 pagination taking place on the **root nested document and not on its inner hits**.
 
-[float]
+[discrete]
 [[normalized-keyword-fields]]
 === Normalized `keyword` fields
 
 `keyword` fields in {es} can be normalized by defining a `normalizer`. Such fields are not supported in {es-sql}.
 
-[float]
+[discrete]
 === Array type of fields
 
 Array fields are not supported due to the "invisible" way in which {es} handles an array of values: the mapping doesn't indicate whether
@@ -101,7 +101,7 @@ a field is an array (has multiple values) or not, so without reading all the dat
 When multiple values are returned for a field, by default, {es-sql} will throw an exception. However, it is possible to change this behavior through `field_multi_value_leniency` parameter in REST (disabled by default) or
 `field.multi.value.leniency` in drivers (enabled by default).
 
-[float]
+[discrete]
 === Sorting by aggregation
 
 When doing aggregations (`GROUP BY`) {es-sql} relies on {es}'s `composite` aggregation for its support for paginating results.
@@ -129,7 +129,7 @@ SELECT age, ROUND(AVG(salary)) AS avg FROM test GROUP BY age ORDER BY avg;
 SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY age ORDER BY diff;
 --------------------------------------------------
 
-[float]
+[discrete]
 === Using a sub-select
 
 Using sub-selects (`SELECT X FROM (SELECT Y)`) is **supported to a small degree**: any sub-select that can be "flattened" into a single
@@ -150,7 +150,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[limitationSubSelectRewritten]
 But, if the sub-select would include a `GROUP BY` or `HAVING` or the enclosing `SELECT` would be more complex than `SELECT X
 FROM (SELECT ...) WHERE [simple_condition]`, this is currently **un-supported**.
 
-[float]
+[discrete]
 [[first-last-agg-functions-having-clause]]
 === Using <<sql-functions-aggs-first, `FIRST`>>/<<sql-functions-aggs-last,`LAST`>> aggregation functions in `HAVING` clause
 
@@ -158,7 +158,7 @@ Using `FIRST` and `LAST` in the `HAVING` clause is not supported. The same appli
 <<sql-functions-aggs-min,`MIN`>> and <<sql-functions-aggs-max,`MAX`>> when their target column
 is of type <<keyword, `keyword`>> as they are internally translated to `FIRST` and `LAST`.
 
-[float]
+[discrete]
 [[group-by-time]]
 === Using TIME data type in GROUP BY or <<sql-functions-grouping-histogram>>
 
@@ -184,7 +184,7 @@ SELECT count(*) FROM test GROUP BY MINUTE((CAST(date_created AS TIME));
 SELECT HISTOGRAM(CAST(birth_date AS TIME), INTERVAL '10' MINUTES) as h, COUNT(*) FROM t GROUP BY h
 -------------------------------------------------------------
 
-[float]
+[discrete]
 [[geo-sql-limitations]]
 === Geo-related functions
 
@@ -195,7 +195,7 @@ indexed with some loss of precision from the original values (4.190951585769653E
 8.381903171539307E-8 for longitude). The altitude component is accepted but not stored in doc values nor indexed.
 Therefore calling `ST_Z` function in the filtering, grouping or sorting will return `null`.
 
-[float]
+[discrete]
 [[fields-from-source]]
 === Retrieving from `_source`
 
@@ -205,7 +205,7 @@ If a column, for which there is no source stored, is asked for in a query, {es-s
 this restriction are: `keyword`, `date`, `scaled_float`, `geo_point`, `geo_shape` since they are NOT returned from `_source` but
 from `docvalue_fields`.
 
-[float]
+[discrete]
 [[fields-from-docvalues]]
 === Retrieving from `docvalue_fields`
 
@@ -213,13 +213,13 @@ When the number of columns retrievable from `docvalue_fields` is greater than th
 the query will fail with `IllegalArgumentException: Trying to retrieve too many docvalue_fields` error. Either the mentioned {es}
 setting needs to be adjusted or fewer columns retrievable from `docvalue_fields` need to be selected.
 
-[float]
+[discrete]
 [[aggs-in-pivot]]
 === Aggregations in the <<sql-syntax-pivot, `PIVOT`>> clause
 
 The aggregation expression in <<sql-syntax-pivot, `PIVOT`>> will currently accept only one aggregation. It is thus not possible to obtain multiple aggregations for any one pivoted column.
 
-[float]
+[discrete]
 [[subquery-in-pivot]]
 === Using a subquery in <<sql-syntax-pivot, `PIVOT`>>'s `IN`-subclause
 

--- a/docs/reference/sql/overview.asciidoc
+++ b/docs/reference/sql/overview.asciidoc
@@ -6,7 +6,7 @@
 {es-sql} aims to provide a powerful yet lightweight SQL interface to {es}.
 
 [[sql-introduction]]
-[float]
+[discrete]
 === Introduction
 
 {es-sql} is an X-Pack component that allows SQL-like queries to be executed in real-time against {es}.
@@ -15,7 +15,7 @@ _natively_ inside {es}.
 One can think of {es-sql} as a _translator_, one that understands both SQL and {es} and makes it easy to read and process data in real-time, at scale by leveraging {es} capabilities.
 
 [[sql-why]]
-[float]
+[discrete]
 === Why {es-sql} ?
 
 Native integration::

--- a/docs/reference/sql/security.asciidoc
+++ b/docs/reference/sql/security.asciidoc
@@ -6,7 +6,7 @@
 {es-sql} integrates with security, if this is enabled on your cluster. 
 In such a scenario, {es-sql} supports both security at the transport layer (by encrypting the communication between the consumer and the server) and authentication (for the access layer).
 
-[float]
+[discrete]
 [[ssl-tls-config]]
 ==== SSL/TLS configuration
 
@@ -14,7 +14,7 @@ In case of an encrypted transport, the SSL/TLS support needs to be enabled in {e
 Depending on your SSL configuration (whether the certificates are signed by a CA or not, whether they are global at JVM level or just local to one application), might require setting up the `keystore` and/or `truststore`, that is where the _credentials_ are stored (`keystore` - which typically stores private keys and certificates) and how to _verify_ them (`truststore` - which typically stores certificates from third party also known as CA - certificate authorities). +
 Typically (and again, do note that your environment might differ significantly), if the SSL setup for {es-sql} is not already done at the JVM level, one needs to setup the keystore if the {es-sql} security requires client authentication (PKI - Public Key Infrastructure), and setup `truststore` if SSL is enabled.
 
-[float]
+[discrete]
 ==== Authentication
 
 The authentication support in {es-sql} is of two types:
@@ -22,7 +22,7 @@ The authentication support in {es-sql} is of two types:
 Username/Password:: Set these through `user` and `password` properties.
 PKI/X.509:: Use X.509 certificates to authenticate {es-sql} to {es}. For this, one would need to setup the `keystore` containing the private key and certificate to the appropriate user (configured in {es}) and the `truststore` with the CA certificate used to sign the SSL/TLS certificates in the {es} cluster. That is, one should setup the key to authenticate {es-sql} and also to verify that is the right one. To do so, one should set the `ssl.keystore.location` and `ssl.truststore.location` properties to indicate the `keystore` and `truststore` to use. It is recommended to have these secured through a password in which case `ssl.keystore.pass` and `ssl.truststore.pass` properties are required.
 
-[float]
+[discrete]
 [[sql-security-permissions]]
 ==== Permissions (server-side)
 Lastly, one the server one need to add a few permissions to

--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -11,7 +11,7 @@ and reindex your old indices or bring up a new {version} cluster and
 
 include::preparing_to_upgrade.asciidoc[]
 
-[float]
+[discrete]
 === Upgrading your cluster
 
 To perform a full cluster restart upgrade to {version}:

--- a/docs/reference/upgrade/preparing_to_upgrade.asciidoc
+++ b/docs/reference/upgrade/preparing_to_upgrade.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 === Preparing to upgrade
 
 It is important to prepare carefully before starting an upgrade. Once you have

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -43,7 +43,7 @@ Upgrading directly to {version} from 6.7 or earlier requires a
 
 include::preparing_to_upgrade.asciidoc[]
 
-[float]
+[discrete]
 === Upgrading your cluster
 
 To perform a rolling upgrade to {version}:

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -40,7 +40,7 @@ are fully informed when you are architecting your system.
 
 == Work in Progress
 
-[float]
+[discrete]
 === Known Unknowns (STATUS: ONGOING)
 
 We consider this topic to be the most important in our quest for
@@ -55,7 +55,7 @@ If you encounter an issue, https://github.com/elastic/elasticsearch/issues[pleas
 
 We are committed to tracking down and fixing all the issues that are posted.
 
-[float]
+[discrete]
 ==== Jepsen Tests
 
 The Jepsen platform is specifically designed to test distributed systems. It is not a single test and is regularly adapted
@@ -63,7 +63,7 @@ to create new scenarios. We have currently ported all published Jepsen scenarios
 framework. As the Jepsen tests evolve, we will continue porting new scenarios that are not covered yet. We are committed to investigating
 all new scenarios and will report issues that we find on this page and in our GitHub repository.
 
-[float]
+[discrete]
 === Better request retry mechanism when nodes are disconnected (STATUS: ONGOING)
 
 If the node holding a primary shard is disconnected for whatever reason, the
@@ -88,7 +88,7 @@ Further issues remain with the retry mechanism:
 
 See {GIT}9967[#9967]. (STATUS: ONGOING)
 
-[float]
+[discrete]
 === OOM resiliency (STATUS: ONGOING)
 
 The family of circuit breakers has greatly reduced the occurrence of OOM
@@ -102,7 +102,7 @@ space.  The following issues have been identified:
 
 Other safeguards are tracked in the meta-issue {GIT}11511[#11511].
 
-[float]
+[discrete]
 === The _version field may not uniquely identify document content during a network partition (STATUS: ONGOING)
 
 When a primary has been partitioned away from the cluster there is a short period of time until it detects this. During that time it will continue
@@ -116,27 +116,27 @@ writes for the same document (see {GIT}19269[#19269]).
 We are currently implementing Sequence numbers {GIT}10708[#10708] which better track primary changes. Sequence numbers thus provide a basis
 for uniquely identifying writes even in the presence of network partitions and will replace `_version` in operations that require this.
 
-[float]
+[discrete]
 === Relocating shards omitted by reporting infrastructure (STATUS: ONGOING)
 
 Indices stats and indices segments requests reach out to all nodes that have shards of that index. Shards that have relocated from a node
 while the stats request arrives will make that part of the request fail and are just ignored in the overall stats result. {GIT}13719[#13719]
 
-[float]
+[discrete]
 === Documentation of guarantees and handling of failures (STATUS: ONGOING)
 
 This status page is a start, but we can do a better job of explicitly documenting the processes at work in Elasticsearch and what happens
 in the case of each type of failure. The plan is to have a test case that validates each behavior under simulated conditions. Every test
  will document the expected results, the associated test code, and an explicit PASS or FAIL status for each simulated case.
 
-[float]
+[discrete]
 === Run Jepsen (STATUS: ONGOING)
 
 We have ported the known scenarios in the Jepsen blogs that check loss of acknowledged writes to our testing infrastructure.
 The new tests are run continuously in our testing farm and are passing. We are also working on running Jepsen independently to verify
 that no failures are found.
 
-[float]
+[discrete]
 === Replicas can fall out of sync when a primary shard fails (STATUS: ONGOING)
 
 When a primary shard fails, a replica shard will be promoted to be the
@@ -154,7 +154,7 @@ shard.
 
 == Completed
 
-[float]
+[discrete]
 === Repeated network partitions can cause cluster state updates to be lost (STATUS: DONE, v7.0.0)
 
 During a networking partition, cluster state updates (like mapping changes or
@@ -181,7 +181,7 @@ sub-issues. See particularly {GIT}32171[#32171] and
 https://github.com/elastic/elasticsearch-formal-models/blob/master/ZenWithTerms/tla/ZenWithTerms.tla[the
 TLA+ formal model] used to verify these changes.
 
-[float]
+[discrete]
 === Divergence between primary and replica shard copies when documents deleted (STATUS: DONE, V6.3.0)
 
 Certain combinations of delays in performing activities related to the deletion
@@ -221,7 +221,7 @@ formal model of the replica's behaviour] using TLA+. Running the TLC model
 checker on this model found all three issues. We then applied the proposed
 fixes to the model and validated that the fixed design behaved as expected.
 
-[float]
+[discrete]
 === Port Jepsen tests dealing with loss of acknowledged writes to our testing framework (STATUS: DONE, V5.0.0)
 
 We have increased our test coverage to include scenarios tested by Jepsen that demonstrate loss of acknowledged writes, as described in
@@ -232,7 +232,7 @@ https://github.com/elastic/elasticsearch/blob/master/core/src/test/java/org/elas
 where the `testAckedIndexing` test was specifically added to check that we don't lose acknowledged writes in various failure scenarios.
 
 
-[float]
+[discrete]
 === Loss of documents during network partition (STATUS: DONE, v5.0.0)
 
 If a network partition separates a node from the master, there is some window of time before the node detects it. The length of the window is dependent on the type of the partition. This window is extremely small if a socket is broken. More adversarial partitions, for example, silently dropping requests without breaking the socket can take longer (up to 3x30s using current defaults).
@@ -240,7 +240,7 @@ If a network partition separates a node from the master, there is some window of
 If the node hosts a primary shard at the moment of partition, and ends up being isolated from the cluster (which could have resulted in {GIT}2488[split-brain] before), some documents that are being indexed into the primary may be lost if they fail to reach one of the allocated replicas (due to the partition) and that replica is later promoted to primary by the master ({GIT}7572[#7572]).
 To prevent this situation, the primary needs to wait for the master to acknowledge replica shard failures before acknowledging the write to the client. {GIT}14252[#14252]
 
-[float]
+[discrete]
 === Safe primary relocations (STATUS: DONE, v5.0.0)
 
 When primary relocation completes, a cluster state is propagated that deactivates the old primary and marks the new primary as active. As
@@ -254,7 +254,7 @@ In the reverse situation where a cluster state update that completes primary rel
 on the relocation target, each of the nodes believes the other to be the active primary. This leads to the issue of indexing requests
 chasing the primary being quickly sent back and forth between the nodes, potentially making them both go OOM. {GIT}12573[#12573]
 
-[float]
+[discrete]
 === Do not allow stale shards to automatically be promoted to primary (STATUS: DONE, v5.0.0)
 
 In some scenarios, after the loss of all valid copies, a stale replica shard can be automatically assigned as a primary, preferring old data
@@ -264,7 +264,7 @@ this tracking information to allocate primary shards. When all shard copies are 
 for one of the good shard copies to reappear. In case where all good copies are lost, a manual override command can be used to allocate a
 stale shard copy.
 
-[float]
+[discrete]
 === Make index creation resilient to index closing and full cluster crashes (STATUS: DONE, v5.0.0)
 
 Recovering an index requires a quorum (with an exception for 2) of shard copies to be available to allocate a primary. This means that
@@ -276,7 +276,7 @@ but none of the shards have been started. If such an index was inadvertently clo
 shard will be allocated upon reopening the index.
 
 
-[float]
+[discrete]
 === Use two phase commit for Cluster State publishing (STATUS: DONE, v5.0.0)
 
 A master node in Elasticsearch continuously https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-fault-detection.html[monitors the cluster nodes]
@@ -290,7 +290,7 @@ a new phase to cluster state publishing where the proposed cluster state is sent
 but is not yet committed. Only once enough nodes actively acknowledge
 the change, it is committed and commit messages are sent to the nodes. See {GIT}13062[#13062].
 
-[float]
+[discrete]
 === Wait on incoming joins before electing local node as master (STATUS: DONE, v2.0.0)
 
 During master election each node pings in order to discover other nodes and validate the liveness of existing
@@ -301,7 +301,7 @@ node should wait for the incoming joins from other nodes, thus validating that t
 nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is updated.
 {GIT}12161[#12161]
 
-[float]
+[discrete]
 === Mapping changes should be applied synchronously (STATUS: DONE, v2.0.0)
 
 When introducing new fields using dynamic mapping, it is possible that the same
@@ -312,12 +312,12 @@ can result in a corrupt shard.  To prevent this, new fields should not
 be added to a shard's mapping until confirmed by the master.
 {GIT}8688[#8688] (STATUS: DONE)
 
-[float]
+[discrete]
 === Add per-segment and per-commit ID to help replication (STATUS: DONE, v2.0.0)
 
 {JIRA}5895[LUCENE-5895] adds a unique ID for each segment and each commit point. File-based replication (as performed by snapshot/restore) can use this ID to know whether the segment/commit on the source and destination machines are the same.  Fixed in Lucene 5.0.
 
-[float]
+[discrete]
 === Write index metadata on data nodes where shards allocated (STATUS: DONE, v2.0.0)
 
 Today, index metadata is written only on nodes that are master-eligible, not on
@@ -327,7 +327,7 @@ However, users running with a single master node are at risk of losing
 their index metadata if the master fails.  Instead, this metadata should
 also be written on any node where a shard is allocated. {GIT}8823[#8823], {GIT}9952[#9952]
 
-[float]
+[discrete]
 === Better file distribution with multiple data paths (STATUS: DONE, v2.0.0)
 
 Today, a node configured with multiple data paths distributes writes across
@@ -336,7 +336,7 @@ failure of a single disk corrupts many shards at once.  Instead, by allocating
 an entire shard to a single data path, the extent of the damage can be limited
 to just the shards on that disk. {GIT}9498[#9498]
 
-[float]
+[discrete]
 === Lucene checksums phase 3 (STATUS: DONE, v2.0.0)
 
 Almost all files in Elasticsearch now have checksums which are validated before use.  A few changes remain:
@@ -346,12 +346,12 @@ Almost all files in Elasticsearch now have checksums which are validated before 
 * {JIRA}5894[LUCENE-5894] lays the groundwork for extending more efficient checksum validation to all files during optimized bulk merges. (STATUS: DONE, Fixed in v2.0.0)
 * {GIT}8403[#8403] to add validation of checksums on Lucene `segments_N` files. (STATUS: DONE, v2.0.0)
 
-[float]
+[discrete]
 === Report shard-level statuses on write operations (STATUS: DONE, v2.0.0)
 
 Make write calls return the number of total/successful/missing shards in the same way that we do in search, which ensures transparency in the consistency of write operations. {GIT}7994[#7994]. (STATUS: DONE, v2.0.0)
 
-[float]
+[discrete]
 === Take filter cache key size into account (STATUS: DONE, v2.0.0)
 
 Commonly used filters are cached in Elasticsearch. That cache is limited in size
@@ -369,7 +369,7 @@ This puts an effective limit on the number of entries in the cache. See {GIT}830
 
 The issue has been completely solved by the move to Lucene's query cache. See {GIT}10897[#10897]
 
-[float]
+[discrete]
 === Ensure shard state ID is incremental (STATUS: DONE, v1.5.1)
 
 It is possible in very extreme cases during a complicated full cluster restart,
@@ -378,7 +378,7 @@ Elasticsearch now ensures that the state ID always moves
 forwards, and throws an exception when a legacy ID is higher than the
 current ID.  See {GIT}10316[#10316] (STATUS: DONE, v1.5.1)
 
-[float]
+[discrete]
 === Verification of index UUIDs (STATUS: DONE, v1.5.0)
 
 When deleting and recreating indices rapidly, it is possible that cluster state
@@ -387,7 +387,7 @@ Elasticsearch now checks the index UUID to ensure that cluster state updates
 refer to the same index version that is present on the local node.
 See {GIT}9541[#9541] and {GIT}10200[#10200] (STATUS: DONE, Fixed in v1.5.0)
 
-[float]
+[discrete]
 === Disable recovery from known buggy versions (STATUS: DONE, v1.5.0)
 
 Corruptions have been known to occur when doing a rolling restart from older, buggy versions.
@@ -395,7 +395,7 @@ Now, shards from versions before v1.4.0 are copied over in full and recovery fro
 before v1.3.2 are disabled entirely. See {GIT}9925[#9925] (STATUS: DONE, Fixed in v1.5.0)
 
 
-[float]
+[discrete]
 === Upgrade 3.x segments metadata on engine startup (STATUS: DONE, v1.5.0)
 
 Upgrading the metadata of old 3.x segments on node upgrade can be error prone
@@ -403,7 +403,7 @@ and can result in corruption when merges are being run concurrently. Instead,
 Elasticsearch will now upgrade the metadata of 3.x segments before the engine
 starts.  See {GIT}9899[#9899] (STATUS; DONE, fixed in v1.5.0)
 
-[float]
+[discrete]
 === Prevent setting minimum_master_nodes to more than the current node count (STATUS: DONE, v1.5.0)
 
 Setting `zen.discovery.minimum_master_nodes` to a value higher than the current node count
@@ -412,7 +412,7 @@ way to fix this is to add more master-eligible nodes.  {GIT}8321[#8321] adds a m
 to validate settings before applying them, and {GIT}9051[#9051] extends this validation
 support to settings applied during a cluster restore. (STATUS: DONE, Fixed in v1.5.0)
 
-[float]
+[discrete]
 === Simplify and harden shard recovery and allocation (STATUS: DONE, v1.5.0)
 
 Randomized testing combined with chaotic failures has revealed corner cases
@@ -429,17 +429,17 @@ these operations in order to make them more deterministic.  These include:
 * Rapid creation and deletion of an index can cause reuse of old index metadata {GIT}9489[#9489]. (STATUS: DONE, Fixed in v1.5.0)
 * Flush immediately after the last concurrent recovery finishes to clear out the translog before a new recovery starts {GIT}9439[#9439]. (STATUS: DONE, Fixed in v1.5.0)
 
-[float]
+[discrete]
 === Prevent use of known-bad Java versions (STATUS: DONE, v1.5.0)
 
 Certain versions of the JVM are known to have bugs which can cause index corruption.  {GIT}7580[#7580] prevents Elasticsearch startup if known bad versions are in use.
 
-[float]
+[discrete]
 === Make recovery be more resilient to partial network partitions (STATUS: DONE, v1.5.0)
 
 When a node is experience network issues, the master detects it and removes the node from the cluster. That causes all ongoing recoveries from and to that node to be stopped and a new location is found for the relevant shards. However, in the of case partial network partition, where there are connectivity issues between the source and target nodes of a recovery but not between those nodes and the current master things may go wrong. While the nodes successfully restore the connection, the on going recoveries may have encountered issues. In {GIT}8720[#8720], we added test simulations for these and solved several issues that were flagged by them.
 
-[float]
+[discrete]
 === Improving Zen Discovery (STATUS: DONE, v1.4.0.Beta1)
 
 Recovery from failure is a complicated process, especially in an asynchronous distributed system like Elasticsearch. With several processes happening in parallel, it is important to ensure that recovery proceeds swiftly and safely. While fixing the {GIT}2488[split-brain issue] we have been hunting down corner cases that were not handled optimally, adding tests to demonstrate the issues, and working on fixes:
@@ -449,7 +449,7 @@ Recovery from failure is a complicated process, especially in an asynchronous di
 * After joining a cluster, validate that the join was successful and that the master has been set in the local cluster state. {GIT}6969[#6969]. (STATUS: DONE, v1.4.0.Beta1)
 * Write additional tests that use the test infrastructure to verify proper behavior during network disconnections and garbage collections. {GIT}7082[#7082] (STATUS: DONE, v1.4.0.Beta1)
 
-[float]
+[discrete]
 === Lucene checksums phase 2 (STATUS:DONE, v1.4.0.Beta1)
 
 When Lucene opens a segment for reading, it validates the checksum on the smaller segment files -- those which it reads entirely into memory -- but not the large files like term frequencies and positions, as this would be very expensive. During merges, term vectors and stored fields are validated, as long the segments being merged come from the same version of Lucene. Checksumming for term vectors and stored fields is important because merging consists of performing optimized byte copies. Term frequencies, term positions, payloads, doc values, and norms are currently not checked during merges, although Lucene provides the option to do so.  These files are less prone to silent corruption as they are actively decoded during merge, and so are more likely to throw exceptions if there is any corruption.
@@ -460,17 +460,17 @@ The following changes have been made:
 * {JIRA}5842[LUCENE-5842] validates the structure of the checksum footer of the postings lists, doc values, stored fields and term vectors when opening a new segment, to ensure that these files have not been truncated. (STATUS: DONE, Fixed in Lucene 4.10 and v1.4.0.Beta1)
 * {GIT}8407[#8407] validates Lucene checksums for legacy files. (STATUS: DONE; Fixed in v1.3.6)
 
-[float]
+[discrete]
 === Don't allow unsupported codecs (STATUS: DONE, v1.4.0.Beta1)
 
 Lucene 4 added a number of alternative codecs for experimentation purposes, and Elasticsearch exposed the ability to change codecs.  Since then, Lucene has settled on the best choice of codec and provides backwards compatibility only for the default codec.  {GIT}7566[#7566] removes the ability to set alternate codecs.
 
-[float]
+[discrete]
 === Use checksums to identify entire segments (STATUS: DONE, v1.4.0.Beta1)
 
 A hash collision makes it possible for two different files to have the same length and the same checksum. Instead, a segment's identity should rely on checksums from all of the files in a single segment, which greatly reduces the chance of a collision. This change has been merged ({GIT}7351[#7351]).
 
-[float]
+[discrete]
 === Fix ''Split Brain can occur even with minimum_master_nodes'' (STATUS: DONE, v1.4.0.Beta1)
 
 Even when minimum master nodes is set, split brain can still occur under certain conditions, e.g. disconnection between master eligible nodes, which can lead to data loss. The scenario is described in detail in {GIT}2488[issue 2488]:
@@ -479,19 +479,19 @@ Even when minimum master nodes is set, split brain can still occur under certain
 * Added tests that simulated the bug described in issue 2488. You can take a look at the https://github.com/elastic/elasticsearch/commit/7bf3ffe73c44f1208d1f7a78b0629eb48836e726[original commit] of a reproduction on master. (STATUS: DONE, v1.2.0)
 * The bug described in {GIT}2488[issue 2488] is caused by an issue in our zen discovery gossip protocol. This specific issue has been fixed, and work has been done to make the algorithm more resilient. (STATUS: DONE, v1.4.0.Beta1)
 
-[float]
+[discrete]
 === Translog Entry Checksum (STATUS: DONE, v1.4.0.Beta1)
 
 Each translog entry in Elasticsearch should have its own checksum, and potentially additional information, so that we can properly detect corrupted translog entries and act accordingly. You can find more detail in issue {GIT}6554[#6554].
 
 To start, we will begin by adding checksums to the translog to detect corrupt entries. Once this work has been completed, we will add translog entry markers so that corrupt entries can be skipped in the translog if/when desired.
 
-[float]
+[discrete]
 === Request-Level Memory Circuit Breaker (STATUS: DONE, v1.4.0.Beta1)
 
 We are in the process of introducing multiple circuit breakers in Elasticsearch, which can “borrow” space from each other in the event that one runs out of memory. This architecture will allow limits for certain parts of memory, but still allow flexibility in the event that another reserve like field data is not being used. This change includes adding a breaker for the BigArrays internal object used for some aggregations. See issue {GIT}6739[#6739] for more details.
 
-[float]
+[discrete]
 === Doc Values (STATUS: DONE, v1.4.0.Beta1)
 
 Fielddata is one of the largest consumers of heap memory, and thus one of the primary reasons for running out of memory and causing node instability. Elasticsearch has had the “doc values” option for a while, which allows you to build these structures at index time so that they live on disk instead of in memory. Up until recently, doc values were significantly slower than in-memory fielddata.
@@ -500,32 +500,32 @@ By benchmarking and profiling both Lucene and Elasticsearch, we identified the b
 
 See {GIT}6967[#6967], {GIT}6908[#6908], {GIT}4548[#4548], {GIT}3829[#3829], {GIT}4518[#4518], {GIT}5669[#5669], {JIRA}5748[LUCENE-5748], {JIRA}5703[LUCENE-5703], {JIRA}5750[LUCENE-5750], {JIRA}5721[LUCENE-5721], {JIRA}5799[LUCENE-5799].
 
-[float]
+[discrete]
 === Index corruption when upgrading Lucene 3.x indices (STATUS: DONE, v1.4.0.Beta1)
 
 Upgrading indices create with Lucene 3.x (Elasticsearch v0.20 and before) to Lucene 4.7 - 4.9 (Elasticsearch v1.1.0 to v1.3.x), could result in index corruption. {JIRA}5907[LUCENE-5907] fixes this issue in Lucene 4.10.
 
-[float]
+[discrete]
 === Improve error handling when deleting files (STATUS: DONE, v1.4.0.Beta1)
 
 Lucene uses reference counting to prevent files that are still in use from being deleted.  Lucene testing discovered a bug ({JIRA}5919[LUCENE-5919]) when decrementing the ref count on a batch of files. If deleting some of the files resulted in an exception (e.g. due to interference from a virus scanner), the files that had their ref counts decremented successfully could later have their ref counts deleted again, incorrectly, resulting in files being physically deleted before their time. This is fixed in Lucene 4.10.
 
-[float]
+[discrete]
 === Using Lucene Checksums to verify shards during snapshot/restore (STATUS:DONE, v1.3.3)
 
 The snapshot process should verify checksums for each file that is being snapshotted to make sure that created snapshot doesn’t contain corrupted files. If a corrupted file is detected, the snapshot should fail with an error. In order to implement this feature we need to have correct and verifiable checksums stored with segment files, which is only possible for files that were written by the officially supported append-only codecs. See {GIT}7159[#7159].
 
-[float]
+[discrete]
 === Rare compression corruption during shard recovery (STATUS: DONE, v1.3.2)
 
 During recovery, the primary shard is copied over the network to become a new replica shard. In rare cases, it was possible for a hash collision to trigger a bug in the compression library that is used to produce corruption in the replica shard. This bug was exposed by the change to validate checksums during recovery. We tracked down the bug in the in compression library and submitted a patch, which was accepted and merged by the upstream project. See {GIT}7210[#7210].
 
-[float]
+[discrete]
 === Safer recovery of replica shards (STATUS: DONE, v1.3.0)
 
 If a primary shard fails or is closed while a replica is using it for recovery, we need to ensure that the replica is properly failed as well, and allow recovery to start from the new primary. Also check that an active copy of a shard is available on another node before physically removing an inactive shard from disk. {GIT}6825[#6825], {GIT}6645[#6645], {GIT}6995[#6995].
 
-[float]
+[discrete]
 === Using Lucene Checksums to verify shards during recovery (STATUS: DONE, v1.3.0)
 
 Elasticsearch can use Lucene checksums to validate files while {GIT}6776[recovering a replica shard from a primary].
@@ -534,17 +534,17 @@ This issue exposed a bug in Elasticsearch’s handling of primary shard failure 
 
 In order to verify the checksumming mechanism, we added functionality to our testing infrastructure that can corrupt an arbitrary index file and at any point, such as while it’s traveling over the wire or residing on disk. The tests utilizing this feature expect full or partial recovery from the failure while neither losing data nor spreading the corruption.
 
-[float]
+[discrete]
 === Detect File Corruption (STATUS: DONE, v1.3.0)
 
 When a corrupted index can be detected during merging or refresh, Elasticsearch will fail the shard if a checksum failure is detected. You can read the full details in pull request {GIT}6776[#6776].
 
-[float]
+[discrete]
 === Network disconnect events could be lost, causing a zombie node to stay in the cluster state (STATUS: DONE, v1.3.0)
 
 Previously, there was a very short window in which we could lose a node disconnect event. To prevent this from occurring, we added extra handling of connection errors to our nodes & master fault detection pinging to make sure the node disconnect event is detected. See issue {GIT}6686[#6686].
 
-[float]
+[discrete]
 === Other fixes to Lucene to address resiliency (STATUS: DONE, v1.3.0)
 
 * NativeLock is released if Lock is closed after failing on obtain {JIRA}5738[LUCENE-5738].
@@ -552,7 +552,7 @@ Previously, there was a very short window in which we could lose a node disconne
 * FSDirectory’s fsync() is lenient, now throws exceptions when errors occur {JIRA}5570[LUCENE-5570]
 * fsync() directory when committing {JIRA}5588[LUCENE-5588]
 
-[float]
+[discrete]
 === Backwards Compatibility Testings (STATUS: DONE, v1.3.0)
 
 Since founding Elasticsearch Inc, we grew our test base from ~1k tests to about 4k in just about over a year. We invested massively into our testing infrastructure, running our tests continuously on different operating systems, bare metal hardware and cloud environments, all while randomizing JVMs and their settings.
@@ -567,24 +567,24 @@ The work on our testing infrastructure is more than just issue prevention, it al
 
 You can read more about backwards compatibility tests in issue {GIT}6497[#6497].
 
-[float]
+[discrete]
 === Full Translog Writes on all Platforms (STATUS: DONE, v1.2.2 and v1.3.0)
 
 We have recently received bug reports of transaction log corruption that can occur when indexing very large documents (in the area of 300 KB). Although some Linux users reported this behavior, it appears the problem occurs more frequently when running Windows. We traced the source of the problem to the fact that when serializing documents to the transaction log, the Operating System can actually write only part of the document before returning from the write call. We can now detect this situation and make sure that the entire document is properly written. You can read the full details in pull request {GIT}6576[#6576].
 
-[float]
+[discrete]
 === Lucene Checksums (STATUS: DONE, v1.2.0)
 
 Before Apache Lucene version 4.8, checksums were not computed on generated index files. The result was that it was difficult to identify when or if a Lucene index got corrupted, whether by hardware failure, JVM bug or for an entirely different reason.
 
 For an idea of the checksum efforts in progress in Apache Lucene, see issues {JIRA}2446[LUCENE-2446], {JIRA}5580[LUCENE-5580] and {JIRA}5602[LUCENE-5602]. The gist is that Lucene 4.8+ now computes full checksums on all index files and it verifies them when opening metadata or other smaller files as well as other files during merges.
 
-[float]
+[discrete]
 === Detect errors faster by locally failing a shard upon an indexing error (STATUS: DONE, v1.2.0)
 
 Previously, Elasticsearch notified the master of the shard failure and waited for the master to close the local copy of the shard, thus assigning it to other nodes. This architecture caused delays in failure detection, potentially causing unneeded failures of other incoming requests. In rare cases, such as concurrency racing conditions or certain network partitions configurations, we could lose these failure notifications. We solved this issue by locally failing shards upon indexing errors. See issue {GIT}5847[#5847].
 
-[float]
+[discrete]
 === Snapshot/Restore API (STATUS: DONE, v1.0.0)
 
 In Elasticsearch version 1.0, we significantly improved the backup process by introducing the Snapshot/Restore API. While it was always possible to make backups of Elasticsearch, the Snapshot/Restore API made the backup process much easier.
@@ -595,19 +595,19 @@ Since that first release in version 1.0, the API has continued to evolve. In ver
 
 The Snapshot/Restore API supports a number of different repository types for storing backups. Currently, it’s possible to make backups to a shared file system, Amazon S3, HDFS, and Azure storage. We are continuing to work on adding other types of storage systems, as well as improving the robustness of the snapshot/restore process.
 
-[float]
+[discrete]
 === Circuit Breaker: Fielddata (STATUS: DONE, v1.0.0)
 
 Currently, the circuit breaker protects against loading too much field data by estimating how much memory the field data will take to load, then aborting the request if the memory requirements are too high. This feature was added in Elasticsearch version 1.0.0.
 
-[float]
+[discrete]
 === Use of Paginated Data Structures to Ease Garbage Collection (STATUS: DONE, v1.0.0 & v1.2.0)
 
 Elasticsearch has moved from an object-based cache to a page-based cache recycler as described in issue {GIT}4557[#4557]. This change makes garbage collection easier by limiting fragmentation, since all pages have the same size and are recycled. It also allows managing the size of the cache not based on the number of objects it contains, but on the memory that it uses.
 
 These pages are used for two main purposes: implementing higher level data structures such as hash tables that are used internally by aggregations to e.g. map terms to counts, as well as reusing memory in the translog/transport layer as detailed in issue {GIT}5691[#5691].
 
-[float]
+[discrete]
 === Dedicated Master Nodes Resiliency (STATUS: DONE, v1.0.0)
 
 In order to run a more resilient cluster, we recommend running dedicated master nodes to ensure master nodes are not affected by resources consumed by data nodes. We also have made master nodes more resilient to heavy resource usage, mainly associated with large clusters / cluster states.
@@ -619,12 +619,12 @@ These changes include:
 * Improve master handling of large scale mapping updates from data nodes by batching them into a single cluster event. (See issue {GIT}4373[#4373].)
 * Add an ack mechanism where next phase cluster updates are processed only when nodes acknowledged they received the previous cluster state. (See issues {GIT}3736[#3736], {GIT}3786[#3786], {GIT}4114[#4114], {GIT}4169[#4169], {GIT}4228[#4228] and {GIT}4421[#4421], which also include enhancements to the ack mechanism implementation.)
 
-[float]
+[discrete]
 === Multi Data Paths May Falsely Report Corrupt Index (STATUS: DONE, v1.0.0)
 
 When using multiple data paths, an index could be falsely reported as corrupted. This has been fixed with pull request {GIT}4674[#4674].
 
-[float]
+[discrete]
 === Randomized Testing (STATUS: DONE, v1.0.0)
 
 In order to best validate for resiliency in Elasticsearch, we rewrote the Elasticsearch test infrastructure to introduce the concept of http://berlinbuzzwords.de/sites/berlinbuzzwords.de/files/media/documents/dawidweiss-randomizedtesting-pub.pdf[randomized testing]. Randomized testing allows us to easily enhance the Elasticsearch testing infrastructure with predictably irrational conditions, making the resulting code base more resilient.
@@ -633,7 +633,7 @@ Each of our integration tests runs against a cluster with a random number of nod
 
 At Elasticsearch, we live the philosophy that we can miss a bug once, but never a second time. We make our tests more evil as you go, introducing randomness in all the areas where we discovered bugs. We figure if our tests don’t fail, we are not trying hard enough! If you are interested in how we have evolved our test infrastructure over time check out https://github.com/elastic/elasticsearch/issues?q=label%3Atest[issues labeled with ``test'' on GitHub].
 
-[float]
+[discrete]
 === Lucene Loses Data On File Descriptors Failure (STATUS: DONE, v0.90.0)
 
 When a process runs out of file descriptors, Lucene can causes an index to be completely deleted. This issue was fixed in Lucene ({JIRA}4870[version 4.2.1]) and fixed in an early version of Elasticsearch. See issue {GIT}2812[#2812].

--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -11,7 +11,7 @@ You can use the following APIs to perform security activities.
 * <<security-api-ssl>>
 * <<security-api-get-builtin-privileges>>
 
-[float]
+[discrete]
 [[security-api-app-privileges]]
 === Application privileges
 
@@ -23,7 +23,7 @@ privileges:
 * <<security-api-delete-privilege,Delete privileges>>
 * <<security-api-get-privileges,Get privileges>>
 
-[float]
+[discrete]
 [[security-role-mapping-apis]]
 === Role mappings
 
@@ -33,7 +33,7 @@ You can use the following APIs to add, remove, update, and retrieve role mapping
 * <<security-api-delete-role-mapping,Delete role mappings>>
 * <<security-api-get-role-mapping,Get role mappings>>
 
-[float]
+[discrete]
 [[security-role-apis]]
 === Roles
 
@@ -44,7 +44,7 @@ You can use the following APIs to add, remove, update, and retrieve roles in the
 * <<security-api-delete-role,Delete roles>>
 * <<security-api-get-role,Get roles>>
 
-[float]
+[discrete]
 [[security-token-apis]]
 === Tokens
 
@@ -54,7 +54,7 @@ without requiring basic authentication:
 * <<security-api-get-token,Get token>>
 * <<security-api-invalidate-token,Invalidate token>>
 
-[float]
+[discrete]
 [[security-api-keys]]
 === API Keys
 
@@ -65,7 +65,7 @@ without requiring basic authentication:
 * <<security-api-get-api-key,Get API Key>>
 * <<security-api-invalidate-api-key,Invalidate API Key>>
 
-[float]
+[discrete]
 [[security-user-apis]]
 === Users
 
@@ -79,7 +79,7 @@ native realm:
 * <<security-api-enable-user,Enable users>>
 * <<security-api-get-user,Get users>>
 
-[float]
+[discrete]
 [[security-openid-apis]]
 === OpenID Connect
 
@@ -90,7 +90,7 @@ authentication realm when using a custom web application other than Kibana
 * <<security-api-oidc-authenticate, Submit an authentication response>>
 * <<security-api-oidc-logout, Logout an authenticated user>>
 
-[float]
+[discrete]
 [[security-saml-apis]]
 === SAML
 

--- a/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
+++ b/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
@@ -31,7 +31,7 @@ A rule is a logical condition that is expressed by using a JSON DSL. The DSL sup
 its child is `false`, the `except` is `true`.
 
 
-[float]
+[discrete]
 [[mapping-roles-rule-field]]
 ==== Field rules
 
@@ -57,7 +57,7 @@ The value specified in the field rule can be one of the following types:
                       If _any_ of elements match, the match is successful.             | ["admin", "operator"]
 |=======================
 
-[float]
+[discrete]
 ===== User fields
 
 The _user object_ against which rules are evaluated has the following fields:

--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -41,7 +41,7 @@ The following is a list of the events that can be generated:
                                           profile.
 |======
 
-[float]
+[discrete]
 [[audit-event-attributes]]
 === Audit event attributes
 
@@ -235,7 +235,7 @@ that have been previously described:
                             This attribute is only provided for authentication using an API key.
 
 
-[float]
+[discrete]
 [[audit-event-attributes-deprecated-formats]]
 === Audit event attributes for the deprecated formats
 

--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -38,7 +38,7 @@ any of the audit trails, audit events are forwarded to the root appender, which
 by default points to the `elasticsearch.log` file.
 
 
-[float]
+[discrete]
 [[audit-log-entry-format]]
 === Log entry format
 
@@ -56,7 +56,7 @@ The log entries in the `<clustername>_audit.json` file have the following format
 There is a list of <<audit-event-types, audit event types>> specifying the
 set of fields for each sog entry type.
 
-[float]
+[discrete]
 [[deprecated-audit-log-entry-format]]
 === Deprecated log entry format
 
@@ -84,7 +84,7 @@ The log entries in the `<clustername>_access.log` file have the following format
                             Audit Entry Attributes>> for the attributes that can be included
                             for each type of event.
 
-[float]
+[discrete]
 [[audit-log-settings]]
 === Logfile output settings
 
@@ -108,7 +108,7 @@ of information that is in place to assure backwards compatibility. If you are
 not strict about the audit format it is strongly recommended to only use the
 `<clustername>_audit.json` log appender.
 
-[float]
+[discrete]
 [[audit-log-ignore-policy]]
 === Logfile audit events ignore policies
 

--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -21,7 +21,7 @@ use. In particular, do not use the `elastic` superuser unless full access to
 the cluster is required. Instead, create users that have the minimum necessary
 roles or privileges for their activities.
 
-[float]
+[discrete]
 [[built-in-user-explanation]]
 ==== How the built-in users work
 These built-in users are stored in a special `.security` index, which is managed
@@ -36,7 +36,7 @@ realm will not have any effect on the built-in users. The built-in users can
 be disabled individually, using the
 {ref}/security-api-disable-user.html[disable users API].
 
-[float]
+[discrete]
 [[bootstrap-elastic-passwords]]
 ==== The Elastic bootstrap password
 
@@ -55,7 +55,7 @@ NOTE: After you <<set-built-in-user-passwords,set passwords for the built-in use
 in particular for the `elastic` user, there is no further use for the bootstrap
 password.
 
-[float]
+[discrete]
 [[set-built-in-user-passwords]]
 ==== Setting built-in user passwords
 
@@ -103,7 +103,7 @@ since at that point the bootstrap password is no longer required.
 
 [[add-built-in-user-passwords]]
 
-[float]
+[discrete]
 [[add-built-in-user-kibana]]
 ==== Adding built-in user passwords to {kib}
 
@@ -118,7 +118,7 @@ elasticsearch.password: kibanapassword
 
 See {kibana-ref}/using-kibana-with-security.html[Configuring security in {kib}].
 
-[float]
+[discrete]
 [[add-built-in-user-logstash]]
 ==== Adding built-in user passwords to {ls}
 
@@ -145,7 +145,7 @@ PUT _security/user/logstash_system/_enable
 
 See {logstash-ref}/ls-security.html#ls-monitoring-user[Configuring credentials for {ls} monitoring].
 
-[float]
+[discrete]
 [[add-built-in-user-beats]]
 ==== Adding built-in user passwords to Beats
 
@@ -172,7 +172,7 @@ the case, then you should use the *Management > Users* page in {kib} or the
 {ref}/security-api-change-password.html[Change Password API] to set a password
 for these users.
 
-[float]
+[discrete]
 [[add-built-in-user-apm]]
 ==== Adding built-in user passwords to APM
 
@@ -196,7 +196,7 @@ then you should use the *Management > Users* page in {kib} or the
 {ref}/security-api-change-password.html[Change Password API] to set a password
 for these users.
 
-[float]
+[discrete]
 [[disabling-default-password]]
 ==== Disabling default password functionality
 [IMPORTANT]

--- a/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
@@ -138,7 +138,7 @@ would be as follows:
 --------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 ==== Managing aliases
 
 Unlike creating indices, which requires the `create_index` privilege, adding,
@@ -185,7 +185,7 @@ The privileges required for such a request are the same as above. Both index and
 alias need the `manage` permission.
 
 
-[float]
+[discrete]
 ==== Filtered aliases
 
 Aliases can hold a filter, which allows to select a subset of documents that can

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -190,14 +190,14 @@ custom roles providers.  If you need to integrate with another system to retriev
 user roles, you can build a custom roles provider plugin. For more information,
 see <<custom-roles-authorization, Customizing Roles and Authorization>>.
 
-[float]
+[discrete]
 [[roles-management-ui]]
 === Role management UI
 
 You can manage users and roles easily in {kib}. To
 manage roles, log in to {kib} and go to *Management / Security / Roles*. 
 
-[float]
+[discrete]
 [[roles-management-api]]
 === Role management API
 
@@ -206,7 +206,7 @@ dynamically. When you use the APIs to manage roles in the `native` realm, the
 roles are stored in an internal {es} index. For more information and examples, 
 see {ref}/security-api.html#security-role-apis[role management APIs]. 
 
-[float]
+[discrete]
 [[roles-management-file]]
 === File-based role management
 

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -85,7 +85,7 @@ IMPORTANT: You cannot view, edit, or remove any roles that are defined in the ro
 mapping files by using the the role mapping APIs. 
 
 ==== Realm specific details
-[float]
+[discrete]
 [[ldap-role-mapping]]
 ===== Active Directory and LDAP realms
 
@@ -138,7 +138,7 @@ PUT /_security/role_mapping/basic_users
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[pki-role-mapping]]
 ===== PKI realms
 

--- a/x-pack/docs/en/security/authorization/overview.asciidoc
+++ b/x-pack/docs/en/security/authorization/overview.asciidoc
@@ -9,7 +9,7 @@ This process takes place after the user is successfully identified and
 <<setting-up-authentication,authenticated>>. 
 
 [[roles]]
-[float]
+[discrete]
 === Role-based access control
 
 The {security-features} provide a role-based access control (RBAC) mechanism,
@@ -61,7 +61,7 @@ The method for assigning roles to users varies depending on which realms you use
 to authenticate users. For more information, see <<mapping-roles>>.
 
 [[attributes]]
-[float]
+[discrete]
 === Attribute-based access control
 
 The {security-features} also provide an attribute-based access control (ABAC)

--- a/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
@@ -11,7 +11,7 @@ and unmarshall JSON requests like a typical REST client.
 NOTE: Using the Java Node Client with secured clusters is not recommended or
       supported.
 
-[float]
+[discrete]
 [[transport-client]]
 ==== Configuring the Transport Client to work with a Secured Cluster
 
@@ -138,7 +138,7 @@ TransportClient client = new PreBuiltXPackTransportClient(Settings.builder()
 --------------------------------------------------------------------------------------------------
 --
 
-[float]
+[discrete]
 [[disabling-client-auth]]
 ===== Disabling client authentication
 
@@ -168,7 +168,7 @@ TransportClient client = new PreBuiltXPackTransportClient(Settings.builder()
 NOTE: If you are using a public CA that is already trusted by the Java runtime,
       you do not need to set the `xpack.security.transport.ssl.certificate_authorities`.
 
-[float]
+[discrete]
 [[connecting-anonymously]]
 ===== Connecting anonymously
 
@@ -177,7 +177,7 @@ anonymous user the privileges defined in the <<java-transport-client-role,transp
 role. Anonymous access must also be enabled, of course. For more information,
 see <<anonymous-access,Enabling Anonymous Access>>.
 
-[float]
+[discrete]
 [[security-client]]
 ==== Security client
 

--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -18,7 +18,7 @@ For {es}, adherence to FIPS 140-2 is ensured by
 - Allowing the configuration of {es} in a FIPS 140-2 compliant manner, as
   documented below.
 
-[float]
+[discrete]
 === Upgrade considerations
 
 If you plan to upgrade your existing cluster to a version that can be run in
@@ -40,14 +40,14 @@ regenerate your `elasticsearch.keystore` and migrate all secure settings to it,
 in addition to the necessary configuration changes outlined below, before
 starting each node.
 
-[float]
+[discrete]
 === Configuring {es} for FIPS 140-2
 
 Apart from setting `xpack.security.fips_mode.enabled`, a number of security
 related settings need to be configured accordingly in order to be compliant
 and able to run {es} successfully in a FIPS 140-2 enabled JVM.
 
-[float]
+[discrete]
 ==== TLS
 
 SSLv2 and SSLv3 are not allowed by FIPS 140-2, so `SSLv2Hello` and `SSLv3` cannot
@@ -58,7 +58,7 @@ NOTE: The use of TLS ciphers is mainly governed by the relevant crypto module
 are configured by default in {es} are FIPS 140-2 compliant and as such can be
 used in a FIPS 140-2 JVM. See <<ssl-tls-settings,`ssl.cipher_suites`>>.
 
-[float]
+[discrete]
 ==== TLS Keystores and keys
 
 Keystores can be used in a number of <<ssl-tls-settings>> in order to
@@ -84,7 +84,7 @@ keys must have corresponding length according to the following table:
 | `AES-256`               | 15630          | 512+
 |=======================
 
-[float]
+[discrete]
 ==== Password Hashing
 
 {es} offers a number of algorithms for securely hashing credentials in memory and
@@ -107,7 +107,7 @@ The user cache will be emptied upon node restart, so any existing hashes using
 non-compliant algorithms will be discarded and the new ones will be created
 using the compliant `PBKDF2` algorithm you have selected.
 
-[float]
+[discrete]
 === Limitations
 
 Due to the limitations that FIPS 140-2 compliance enforces, a small number of

--- a/x-pack/docs/en/security/get-started-security.asciidoc
+++ b/x-pack/docs/en/security/get-started-security.asciidoc
@@ -6,7 +6,7 @@
 In this tutorial, you learn how to secure a cluster by configuring users and
 roles in {es}, {kib}, {ls}, and {metricbeat}.
 
-[float]
+[discrete]
 [[get-started-security-prerequisites]]
 === Before you begin
 
@@ -344,7 +344,7 @@ These roles enable the user to see the system metrics in {kib} (for example, on
 the *Discover* page or in the
 http://localhost:5601/app/kibana#/dashboard/Metricbeat-system-overview[{metricbeat} system overview dashboard]).
 
-[float]
+[discrete]
 [[gs-security-nextsteps]]
 === What's next?
 

--- a/x-pack/docs/en/security/limitations.asciidoc
+++ b/x-pack/docs/en/security/limitations.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
-[float]
+[discrete]
 === Plugins
 
 Elasticsearch's plugin infrastructure is extremely flexible in terms of what can
@@ -17,21 +17,21 @@ source or not) and therefore we cannot guarantee their compliance with
 {stack-security-features}. For this reason, third-party plugins are not
 officially supported on clusters with {security-features} enabled.
 
-[float]
+[discrete]
 === Changes in wildcard behavior
 
 Elasticsearch clusters with the {security-features} enabled apply the `/_all`
 wildcard, and all other wildcards, to the data streams, indices, and index aliases that the current user has
 privileges for, not all data streams, indices, and index aliases on the cluster.
 
-[float]
+[discrete]
 === Multi document APIs
 
 Multi get and multi term vectors API throw IndexNotFoundException when trying to access non existing indices that the user is
 not authorized for. By doing that they leak information regarding the fact that the data stream or index doesn't exist, while the user is not
 authorized to know anything about those data streams or indices.
 
-[float]
+[discrete]
 === Filtered index aliases
 
 Aliases containing filters are not a secure way to restrict access to individual
@@ -41,7 +41,7 @@ The {stack-security-features} provide a secure way to restrict access to
 documents through the 
 <<field-and-document-access-control, document-level security>> feature.
 
-[float]
+[discrete]
 === Field and document level security limitations
 
 When a user's role enables document or field level security for a data stream or index:
@@ -71,7 +71,7 @@ When a user's role enables document level security for a data stream or index:
   the specified suggesters are ignored.
 * A search request cannot be profiled if document level security is enabled.
 
-[float]
+[discrete]
 [[alias-limitations]]
 === Index and field names can be leaked when using aliases
 
@@ -83,7 +83,7 @@ index name and mappings for each index that the alias applies to.
 Until this limitation is addressed, avoid index and field names that contain
 confidential or sensitive information.
 
-[float]
+[discrete]
 === LDAP realm
 
 The <<ldap-realm, LDAP Realm>> does not currently support the discovery of nested

--- a/x-pack/docs/en/security/overview.asciidoc
+++ b/x-pack/docs/en/security/overview.asciidoc
@@ -19,7 +19,7 @@ Security protects {es} clusters by:
 * <<maintaining-audit-trail, Maintaining an audit trail>>
   so you know who's doing what to your cluster and the data it stores.  
 
-[float]
+[discrete]
 [[preventing-unauthorized-access]]
 === Preventing unauthorized access
 
@@ -48,7 +48,7 @@ can connect to the cluster based on <<ip-filtering,IP filters>>. You can
 block and allow specific IP addresses, subnets, or DNS domains to
 control network-level access to a cluster.
 
-[float]
+[discrete]
 [[preserving-data-integrity]]
 === Preserving data integrity
 
@@ -60,7 +60,7 @@ data by encrypting communications to, from, and within the cluster. See
 <<encrypting-communications>>. For even	greater protection, you can increase the
 <<ciphers,encryption strength>>.
 
-[float]
+[discrete]
 [[maintaining-audit-trail]]
 === Maintaining an audit trail
 

--- a/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
@@ -13,7 +13,7 @@ For further details, see
 <<encrypting-communications>> and
 https://www.elastic.co/subscriptions[available subscriptions].
 
-[float]
+[discrete]
 ==== Prepare the environment
 
 <<docker,Install {es} with Docker>>.
@@ -169,7 +169,7 @@ volumes: {"data01", "data02", "certs"}
 creating self-signed certificates without having to pin specific internal IP addresses.
 endif::[]
 
-[float]
+[discrete]
 ==== Run the example
 . Generate the certificates (only needed once):
 +
@@ -209,7 +209,7 @@ auto --batch \
 ----
 --
 
-[float]
+[discrete]
 ==== Tear everything down
 To remove all the Docker resources created by the example, issue:
 --

--- a/x-pack/docs/en/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -176,7 +176,7 @@ cluster in multiple primary and replica shards. For more information about the
 concepts of clusters, nodes, and shards, see
 {ref}/getting-started.html[Getting started with {es}].
 
-[float]
+[discrete]
 [[encrypting-internode-nextsteps]]
 === What's next?
 

--- a/x-pack/docs/en/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -23,7 +23,7 @@ requirements that are not covered in this tutorial. See
 {ref}/bootstrap-checks.html#dev-vs-prod-mode[Development vs production mode] and
 {ref}/add-elasticsearch-nodes.html[Adding nodes to your cluster].
 
-[float]
+[discrete]
 [[encrypting-internode-prerequisites]]
 === Before you begin
 

--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -13,7 +13,7 @@ NOTE: Elasticsearch installations are not designed to be publicly accessible
       over the Internet. IP Filtering and the other capabilities of the
       {es} {security-features} do not change this condition.
 
-[float]
+[discrete]
 === Enabling IP filtering
 
 The {es} {security-features} contain an access control feature that allows or
@@ -54,7 +54,7 @@ xpack.security.transport.filter.allow: localhost
 xpack.security.transport.filter.deny: '*.google.com'
 --------------------------------------------------
 
-[float]
+[discrete]
 === Disabling IP Filtering
 
 Disabling IP filtering can slightly improve performance under some conditions.
@@ -75,7 +75,7 @@ xpack.security.transport.filter.enabled: false
 xpack.security.http.filter.enabled: true
 --------------------------------------------------
 
-[float]
+[discrete]
 === Specifying TCP transport profiles
 
 {ref}/modules-transport.html[TCP transport profiles]
@@ -92,7 +92,7 @@ transport.profiles.client.xpack.security.filter.deny: _all
 
 NOTE: When you do not specify a profile, `default` is used automatically.
 
-[float]
+[discrete]
 === HTTP filtering
 
 You may want to have different IP filtering for the transport and HTTP protocols.
@@ -105,7 +105,7 @@ xpack.security.http.filter.allow: 172.16.0.0/16
 xpack.security.http.filter.deny: _all
 --------------------------------------------------
 
-[float]
+[discrete]
 [[dynamic-ip-filtering]]
 ==== Dynamically updating IP filter settings
 

--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -20,7 +20,7 @@ serve as a model for a templated email body.
 <<actions-logging,`logging`>>, <<actions-slack,`slack`>>,
 and <<actions-pagerduty,`pagerduty`>>.
 
-[float]
+[discrete]
 [[actions-ack-throttle]]
 === Acknowledgement and throttling
 
@@ -316,7 +316,7 @@ include::actions/pagerduty.asciidoc[]
 
 include::actions/jira.asciidoc[]
 
-[float]
+[discrete]
 [[actions-ssl-openjdk]]
 === Using SSL/TLS with OpenJDK
 

--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -291,7 +291,7 @@ xpack.notification.email:
       ...
 --------------------------------------------------
 
-[float]
+[discrete]
 [[gmail]]
 ===== Sending email from Gmail
 
@@ -329,7 +329,7 @@ a unique App Password to send email from {watcher}. See
 https://support.google.com/accounts/answer/185833?hl=en[Sign in using App Passwords]
 for more information.
 
-[float]
+[discrete]
 [[outlook]]
 ===== Sending email from Outlook.com
 
@@ -365,7 +365,7 @@ NOTE:   You need to use a unique App Password if two-step verification is enable
         See http://windows.microsoft.com/en-us/windows/app-passwords-two-step-verification[App
         passwords and two-step verification] for more information.
 
-[float]
+[discrete]
 [[amazon-ses]]
 ===== Sending email from Amazon SES (Simple Email Service)
 
@@ -402,7 +402,7 @@ NOTE:   You need to use your Amazon SES SMTP credentials to send email through
         or https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html[your whole domain]
         at AWS.
 
-[float]
+[discrete]
 [[exchange]]
 ===== Sending email from Microsoft Exchange
 
@@ -437,7 +437,7 @@ To store the account SMTP password, use the keystore command
 bin/elasticsearch-keystore add xpack.notification.email.account.exchange_account.smtp.secure_password
 --------------------------------------------------
 
-[float]
+[discrete]
 [[email-html-sanitization]]
 ===== Configuring HTML sanitization options
 

--- a/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
@@ -13,7 +13,7 @@ Elasticsearch cluster:
 
 * <<health-take-action,Take action>> if the cluster is RED.
 
-[float]
+[discrete]
 [[health-add-input]]
 ==== Schedule the watch and add an input
 
@@ -122,7 +122,7 @@ GET .watcher-history*/_search
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[health-add-condition]]
 ==== Add a condition
 
@@ -176,7 +176,7 @@ GET .watcher-history*/_search?pretty
 ------------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[health-take-action]]
 ==== Take action
 
@@ -266,7 +266,7 @@ GET .watcher-history*/_search?pretty
 -------------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[health-delete]]
 ==== Delete the watch
 

--- a/x-pack/docs/en/watcher/getting-started.asciidoc
+++ b/x-pack/docs/en/watcher/getting-started.asciidoc
@@ -16,7 +16,7 @@ needs to be sent.
 * <<log-take-action, Configure an action>> to send an alert when the
 condition is met.
 
-[float]
+[discrete]
 [[log-add-input]]
 === Schedule the watch and define an input
 
@@ -73,7 +73,7 @@ GET .watcher-history*/_search?pretty
 ------------------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[log-add-condition]]
 === Add a condition
 
@@ -148,7 +148,7 @@ GET .watcher-history*/_search?pretty
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[log-take-action]]
 === Configure an action
 
@@ -192,7 +192,7 @@ PUT _watcher/watch/log_error_watch
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[log-delete]]
 === Delete the Watch
 
@@ -209,7 +209,7 @@ DELETE _watcher/watch/log_error_watch
 --------------------------------------------------
 // TEST[continued]
 
-[float]
+[discrete]
 [[required-security-privileges]]
 === Required security privileges
 To enable users to create and manipulate watches, assign them the `watcher_admin`
@@ -220,7 +220,7 @@ To allow users to view watches and the watch history, assign them the `watcher_u
 security role. Watcher users cannot create or manipulate watches; they are only
 allowed to execute read-only watch operations.
 
-[float]
+[discrete]
 [[next-steps]]
 === Where to go next
 

--- a/x-pack/docs/en/watcher/gs-index.asciidoc
+++ b/x-pack/docs/en/watcher/gs-index.asciidoc
@@ -37,7 +37,7 @@ All of these use-cases share a few key properties:
 * One or more actions are taken if the condition is true -- an email is sent, a
   3rd party system is notified, or the query results are stored.
 
-[float]
+[discrete]
 === How watches work
 
 The {alert-features} provide an API for creating, managing and testing _watches_.

--- a/x-pack/docs/en/watcher/how-watcher-works.asciidoc
+++ b/x-pack/docs/en/watcher/how-watcher-works.asciidoc
@@ -14,7 +14,7 @@ search in the logs data indicates that there are too many 503 errors in the last
 
 This topic describes the elements of a watch and how watches operate.
 
-[float]
+[discrete]
 [[watch-definition]]
 === Watch definition
 
@@ -129,7 +129,7 @@ PUT _watcher/watch/log_errors
                 The watch payload that contains the errors is attached to the
                 email.
 
-[float]
+[discrete]
 [[watch-execution]]
 === Watch execution
 
@@ -196,7 +196,7 @@ The following diagram shows the watch execution process:
 
 image::images/watch-execution.jpg[align="center"]
 
-[float]
+[discrete]
 [[watch-acknowledgment-throttling]]
 === Watch acknowledgment and throttling
 
@@ -216,7 +216,7 @@ the watch actions normally.
 
 For more information, see <<actions-ack-throttle>>.
 
-[float]
+[discrete]
 [[watch-active-state]]
 === Watch active state
 
@@ -245,7 +245,7 @@ reporting availability issues during the maintenance window.
 Deactivating a watch also enables you to keep it around for future use without
 deleting it from the system.
 
-[float]
+[discrete]
 [[scripts-templates]]
 === Scripts and templates
 
@@ -261,7 +261,7 @@ and cached by Elasticsearch to optimize recurring execution. Autoloading is also
 supported. For more information, see <<modules-scripting>> and
 <<modules-scripting-using>>.
 
-[float]
+[discrete]
 [[watch-execution-context]]
 ==== Watch execution context
 
@@ -295,7 +295,7 @@ The following snippet shows the basic structure of the _Watch Execution Context_
     (i.e they're not persisted and can't be used between different executions
     of the same watch)
 
-[float]
+[discrete]
 [[scripts]]
 ==== Using scripts
 
@@ -320,7 +320,7 @@ For example, if the watch metadata contains a `color` field
 condition or transform definition (e.g. `"params" : {"color": "red"}`), you can
 access its value via the `color` variable.
 
-[float]
+[discrete]
 [[templates]]
 ==== Using templates
 
@@ -350,7 +350,7 @@ in sent emails:
 ----------------------------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[inline-templates-scripts]]
 ===== Inline templates and scripts
 
@@ -412,7 +412,7 @@ The formal object definition for a script would be:
 ----------------------------------------------------------------------
 // NOTCONSOLE
 
-[float]
+[discrete]
 [[stored-templates-scripts]]
 ===== Stored templates and scripts
 

--- a/x-pack/docs/en/watcher/index.asciidoc
+++ b/x-pack/docs/en/watcher/index.asciidoc
@@ -38,7 +38,7 @@ All of these use-cases share a few key properties:
 * One or more actions are taken if the condition is true -- an email is sent, a
   3rd party system is notified, or the query results are stored.
 
-[float]
+[discrete]
 === How watches work
 
 The {alert-features} provide an API for creating, managing and testing _watches_.

--- a/x-pack/docs/en/watcher/java.asciidoc
+++ b/x-pack/docs/en/watcher/java.asciidoc
@@ -9,7 +9,7 @@ support for the {watcher}.
 To obtain a `WatcherClient` instance, make sure you first set up the
 `XPackClient`.
 
-[float]
+[discrete]
 === Installing XPackClient
 
 You first need to make sure the +x-pack-transport-{version}+ JAR file is in the classpath.
@@ -76,7 +76,7 @@ dependencies {
 You can also download the https://artifacts.elastic.co/maven/org/elasticsearch/client/x-pack-transport/{version}/x-pack-transport-{version}.jar[X-Pack Transport JAR]
 manually, directly from our Maven repository.
 
-[float]
+[discrete]
 === Obtaining the `WatcherClient`
 
 To obtain an instance of the `WatcherClient` you first need to create the

--- a/x-pack/docs/en/watcher/java/ack-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/ack-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-ack-watch]]
 === Ack watch API
 

--- a/x-pack/docs/en/watcher/java/activate-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/activate-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-activate-watch]]
 === Activate watch API
 

--- a/x-pack/docs/en/watcher/java/deactivate-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/deactivate-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-deactivate-watch]]
 === Deactivate watch API
 

--- a/x-pack/docs/en/watcher/java/delete-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/delete-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-delete-watch]]
 === Delete watch API
 

--- a/x-pack/docs/en/watcher/java/execute-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/execute-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-execute-watch]]
 === Execute watch API
 

--- a/x-pack/docs/en/watcher/java/get-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/get-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-get-watch]]
 === Get watch API
 

--- a/x-pack/docs/en/watcher/java/put-watch.asciidoc
+++ b/x-pack/docs/en/watcher/java/put-watch.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-put-watch]]
 === Put watch API
 

--- a/x-pack/docs/en/watcher/java/service.asciidoc
+++ b/x-pack/docs/en/watcher/java/service.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-service]]
 === Service API
 

--- a/x-pack/docs/en/watcher/java/stats.asciidoc
+++ b/x-pack/docs/en/watcher/java/stats.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[api-java-stats]]
 === Stats API
 

--- a/x-pack/docs/en/watcher/managing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/managing-watches.asciidoc
@@ -11,7 +11,7 @@
 * Use the <<watcher-api-deactivate-watch,deactivate watch API>> to deactivate watches
 * Use the <<watcher-api-ack-watch,ack watch API>> to acknowledge watches
 
-[float]
+[discrete]
 [[listing-watches]]
 === Listing watches
 

--- a/x-pack/docs/en/watcher/release-notes.asciidoc
+++ b/x-pack/docs/en/watcher/release-notes.asciidoc
@@ -2,11 +2,11 @@
 [[watcher-release-notes]]
 == Watcher Release Notes (Pre-5.0)
 
-[float]
+[discrete]
 [[watcher-change-list]]
 === Change List
 
-[float]
+[discrete]
 ==== 2.4.2
 November 22, 2016
 
@@ -15,7 +15,7 @@ November 22, 2016
 order to prevent failed deletions with watches having small intervals
 * Chain input: Parsing now throws an exception if a data structure is added, that cannot keep its order
 
-[float]
+[discrete]
 ==== 2.4.1
 September 28, 2016
 
@@ -35,7 +35,7 @@ in the watch history.
 HTTP actions.
 * Running watches can be updated and deleted.
 
-[float]
+[discrete]
 ==== 2.4.0
 August 31, 2016
 
@@ -43,7 +43,7 @@ August 31, 2016
 * The HTTP headers of a response are now part of the payload and can be accessed via `ctx.payload._headers`
 
 
-[float]
+[discrete]
 ==== 2.3.5
 August 3, 2016
 
@@ -59,7 +59,7 @@ need to wait one day for this update to take effect when a new history index is
 created.
 * The `watcher.http.proxy.port` setting for global proxy configuration was not applied correctly.
 
-[float]
+[discrete]
 ==== 2.3.4
 July 7, 2016
 
@@ -77,14 +77,14 @@ created.
 elements and the colspan and rowspan attributes on <td> and <tr> elements.
 * Fixed the Watcher/Marvel examples in the documentation.
 
-[float]
+[discrete]
 ==== 2.3.3
 May 18, 2016
 
 .Enhancements
 * Adds support for Elasticsearch 2.3.3
 
-[float]
+[discrete]
 ==== 2.3.2
 April 26, 2016
 
@@ -99,14 +99,14 @@ becomes `foo_bar`
 are not specified at the account level or within the action itself, instead
 of failing.
 
-[float]
+[discrete]
 ==== 2.3.1
 April 4, 2016
 
 .Enhancements
 * Adds support for Elasticsearch 2.3.1
 
-[float]
+[discrete]
 ==== 2.3.0
 March 30, 2016
 
@@ -125,35 +125,35 @@ March 30, 2016
   via HTTP requests and superseding and deprecating the usage of `attach_data`
   in order to use this feature
 
-[float]
+[discrete]
 ==== 2.2.1
 March 10, 2016
 
 .Bug Fixes
 * The `croneval` CLI tool sets the correct environment to run
 
-[float]
+[discrete]
 ==== 2.2.0
 February 2, 2016
 
 .Enhancements
 * Adds support for Elasticsearch 2.2.0.
 
-[float]
+[discrete]
 ==== 2.1.2
 February 2, 2016
 
 .Enhancements
 * Adds support for Elasticsearch 2.1.2
 
-[float]
+[discrete]
 ==== 2.1.1
 December 17, 2015
 
 .Bug Fixes
 * Fixed an issue that prevented sending of emails
 
-[float]
+[discrete]
 ==== 2.1.0
 November 24, 2015
 
@@ -174,7 +174,7 @@ November 24, 2015
   running and those watch execution are unable the execute during the current
   start process.
 
-[float]
+[discrete]
 ==== 2.0.1
 November 24, 2015
 
@@ -187,7 +187,7 @@ November 24, 2015
   was running and those watch execution are unable the execute during the current
   start process.
 
-[float]
+[discrete]
 ==== 2.0.0
 October 28, 2015
 
@@ -242,7 +242,7 @@ October 28, 2015
 * Fixed url encoding issue in http input and webhook output. The url params were
   url encoded twice.
 
-[float]
+[discrete]
 ==== 1.0.1
 July 29, 2015
 
@@ -256,7 +256,7 @@ July 29, 2015
 * Fixed a compatibility issue with Elasticsearch 1.6.1 and 1.7.2, which were
   released earlier today.
 
-[float]
+[discrete]
 ==== 1.0.0
 June 25, 2015
 
@@ -269,7 +269,7 @@ June 25, 2015
 * Cleaned up the <<watcher-api-stats, Stats API>> response.
 
 
-[float]
+[discrete]
 ==== 1.0.0-rc1
 June 19, 2015
 
@@ -282,7 +282,7 @@ June 19, 2015
 * It is now possible to configure timeouts for http requests in
   <<http-input-attributes,HTTP input>> and <<webhook-action-attributes,webhook actions>>.
 
-[float]
+[discrete]
 ==== 1.0.0-Beta2
 June 10, 2015
 


### PR DESCRIPTION
7.x backport of #60124