### PR TITLE
Scripting: Expose all doc field str const accesses

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -24,6 +24,7 @@ import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.painless.ir.ClassNode;
 import org.elasticsearch.painless.lookup.PainlessLookup;
 import org.elasticsearch.painless.node.SClass;
+import org.elasticsearch.painless.phase.DocFieldsPhase;
 import org.elasticsearch.painless.phase.SemanticHeaderPhase;
 import org.elasticsearch.painless.phase.UserTreeToIRTreeVisitor;
 import org.elasticsearch.painless.spi.Whitelist;
@@ -216,6 +217,8 @@ final class Compiler {
         ScriptScope scriptScope = new ScriptScope(painlessLookup, settings, scriptClassInfo, scriptName, source, root.getIdentifier() + 1);
         new SemanticHeaderPhase().visitClass(root, scriptScope);
         root.analyze(scriptScope);
+        // TODO(stu): Make this phase optional #60156
+        new DocFieldsPhase().visitClass(root, scriptScope);
         new UserTreeToIRTreeVisitor().visitClass(root, scriptScope);
         ClassNode classNode = (ClassNode)scriptScope.getDecoration(root, IRNodeDecoration.class).getIRNode();
         DefBootstrapInjectionPhase.phase(classNode);
@@ -249,6 +252,8 @@ final class Compiler {
         ScriptScope scriptScope = new ScriptScope(painlessLookup, settings, scriptClassInfo, scriptName, source, root.getIdentifier() + 1);
         new SemanticHeaderPhase().visitClass(root, scriptScope);
         root.analyze(scriptScope);
+        // TODO(stu): Make this phase optional #60156
+        new DocFieldsPhase().visitClass(root, scriptScope);
         new UserTreeToIRTreeVisitor().visitClass(root, scriptScope);
         ClassNode classNode = (ClassNode)scriptScope.getDecoration(root, IRNodeDecoration.class).getIRNode();
         classNode.setDebugStream(debugStream);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DocFieldsPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DocFieldsPhase.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.phase;
+
+import org.elasticsearch.painless.node.AExpression;
+import org.elasticsearch.painless.node.EBrace;
+import org.elasticsearch.painless.node.ECall;
+import org.elasticsearch.painless.node.EDot;
+import org.elasticsearch.painless.node.EString;
+import org.elasticsearch.painless.node.ESymbol;
+import org.elasticsearch.painless.symbol.Decorations;
+import org.elasticsearch.painless.symbol.ScriptScope;
+
+import java.util.List;
+
+/**
+ * Find all document field accesses.
+ */
+public class DocFieldsPhase extends UserTreeBaseVisitor<ScriptScope> {
+    @Override
+    public void visitSymbol(ESymbol userSymbolNode, ScriptScope scriptScope) {
+        // variables are a leaf node
+        if (userSymbolNode.getSymbol().equals("doc")) {
+            scriptScope.setCondition(userSymbolNode, Decorations.IsDocument.class);
+        }
+    }
+
+    @Override
+    public void visitBrace(EBrace userBraceNode, ScriptScope scriptScope) {
+        userBraceNode.getPrefixNode().visit(this, scriptScope);
+        scriptScope.replicateCondition(userBraceNode.getPrefixNode(), userBraceNode.getIndexNode(), Decorations.IsDocument.class);
+        userBraceNode.getIndexNode().visit(this, scriptScope);
+    }
+
+    @Override
+    public void visitDot(EDot userDotNode, ScriptScope scriptScope) {
+        AExpression prefixNode = userDotNode.getPrefixNode();
+        prefixNode.visit(this, scriptScope);
+        if (scriptScope.getCondition(prefixNode, Decorations.IsDocument.class)) {
+            scriptScope.addDocField(userDotNode.getIndex());
+        }
+    }
+
+    @Override
+    public void visitCall(ECall userCallNode, ScriptScope scriptScope) {
+        // looking for doc.get
+        AExpression prefixNode = userCallNode.getPrefixNode();
+        prefixNode.visit(this, scriptScope);
+
+        List<AExpression> argumentNodes = userCallNode.getArgumentNodes();
+        if (argumentNodes.size() != 1 || userCallNode.getMethodName().equals("get") == false) {
+            for (AExpression argumentNode : argumentNodes) {
+                argumentNode.visit(this, scriptScope);
+            }
+            return;
+        }
+
+        AExpression argument = argumentNodes.get(0);
+        scriptScope.replicateCondition(prefixNode, argument, Decorations.IsDocument.class);
+        argument.visit(this, scriptScope);
+    }
+
+    @Override
+    public void visitString(EString userStringNode, ScriptScope scriptScope) {
+        if (scriptScope.getCondition(userStringNode, Decorations.IsDocument.class)) {
+            scriptScope.addDocField(userStringNode.getString());
+        }
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DocFieldsPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DocFieldsPhase.java
@@ -69,12 +69,11 @@ public class DocFieldsPhase extends UserTreeBaseVisitor<ScriptScope> {
             for (AExpression argumentNode : argumentNodes) {
                 argumentNode.visit(this, scriptScope);
             }
-            return;
+        } else {
+            AExpression argument = argumentNodes.get(0);
+            scriptScope.replicateCondition(prefixNode, argument, Decorations.IsDocument.class);
+            argument.visit(this, scriptScope);
         }
-
-        AExpression argument = argumentNodes.get(0);
-        scriptScope.replicateCondition(prefixNode, argument, Decorations.IsDocument.class);
-        argument.visit(this, scriptScope);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
@@ -583,4 +583,8 @@ public class Decorations {
             return irNode;
         }
     }
+
+    public interface IsDocument extends Condition {
+
+    }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/ScriptScope.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/ScriptScope.java
@@ -24,8 +24,10 @@ import org.elasticsearch.painless.ScriptClassInfo;
 import org.elasticsearch.painless.lookup.PainlessLookup;
 import org.elasticsearch.painless.node.ANode;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -45,6 +47,7 @@ public class ScriptScope extends Decorator {
     protected int syntheticCounter = 0;
 
     protected boolean deterministic = true;
+    protected List<String> docFields = new ArrayList<>();
     protected Set<String> usedVariables = Collections.emptySet();
     protected Map<String, Object> staticConstants = new HashMap<>();
 
@@ -102,6 +105,17 @@ public class ScriptScope extends Decorator {
 
     public boolean isDeterministic() {
         return deterministic;
+    }
+
+    /**
+     * Document fields read or written using constant strings
+     */
+    public List<String> docFields() {
+        return Collections.unmodifiableList(docFields);
+    }
+
+    public void addDocField(String field) {
+        docFields.add(field);
     }
 
     public void setUsedVariables(Set<String> usedVariables) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DocFieldsPhaseTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DocFieldsPhaseTests.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.lookup.PainlessLookup;
+import org.elasticsearch.painless.lookup.PainlessLookupBuilder;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.symbol.ScriptScope;
+import org.elasticsearch.script.ScriptContext;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DocFieldsPhaseTests extends ScriptTestCase {
+    PainlessLookup lookup = PainlessLookupBuilder.buildFromWhitelists(Whitelist.BASE_WHITELISTS);
+
+    ScriptScope compile(String script) {
+        Compiler compiler = new Compiler(
+            MockDocTestScript.CONTEXT.instanceClazz,
+            MockDocTestScript.CONTEXT.factoryClazz,
+            MockDocTestScript.CONTEXT.statefulFactoryClazz, lookup
+        );
+
+        // Create our loader (which loads compiled code with no permissions).
+        final Compiler.Loader loader = AccessController.doPrivileged(new PrivilegedAction<>() {
+            @Override
+            public Compiler.Loader run() {
+                return compiler.createLoader(getClass().getClassLoader());
+            }
+        });
+
+        return compiler.compile(loader,"test", script, new CompilerSettings());
+    }
+
+    public abstract static class MockDocTestScript {
+        public static final String[] PARAMETERS = {"doc", "other"};
+        public abstract void execute(Map<String, Object> doc, Map<String, Object> other);
+
+        public interface Factory {
+            MockDocTestScript newInstance();
+        }
+
+        public static final ScriptContext<Factory> CONTEXT =
+            new ScriptContext<>("test", MockDocTestScript.Factory.class);
+    }
+
+    public void testArray() {
+        List<String> expected = List.of("my_field");
+        // Order shouldn't matter
+        assertEquals(expected, compile("def a = doc['my_field']; def b = other['foo']").docFields());
+        assertEquals(expected, compile("def b = other['foo']; def a = doc['my_field']").docFields());
+
+        // Only collect array on doc
+        assertEquals(Collections.emptyList(), compile("def a = other['bar']").docFields());
+
+        // Only handle str const
+        assertEquals(Collections.emptyList(), compile("String f = 'bar'; def a = other[f]").docFields());
+    }
+
+    public void testDot() {
+        List<String> expected = List.of("my_field");
+        // Order shouldn't matter
+        assertEquals(expected, compile("def a = doc.my_field; def b = other.foo").docFields());
+        assertEquals(expected, compile("def b = other.foo; def a = doc.my_field").docFields());
+
+        // Only collect doc dots
+        assertEquals(Collections.emptyList(), compile("def a = other.bar").docFields());
+    }
+
+    public void testGet() {
+        // Order shouldn't matter
+        List<String> expected = List.of("my_field");
+        assertEquals(expected, compile("def a = doc.get('my_field'); def b = other.get('foo')").docFields());
+        assertEquals(expected, compile("def b = other.get('foo'); def a = doc.get('my_field')").docFields());
+
+        // Should work in Lambda
+        assertEquals(expected, compile("[].sort((a, b) -> doc.get('my_field')); [].sort((a, b) -> doc.equals('bar') ? 1:2)").docFields());
+
+        // Only collect get on doc
+        assertEquals(Collections.emptyList(), compile("def a = other.get('bar')").docFields());
+        assertEquals(Collections.emptyList(), compile("def a = doc.equals('bar')").docFields());
+
+        // Only handle str const
+        assertEquals(Collections.emptyList(), compile("String f = 'bar'; def b = doc.get(f)").docFields());
+    }
+}


### PR DESCRIPTION
* Add DocFieldsPhase visitor during compilation
* Fields are accessible via ScriptScope.docFields()

Doc field accesses that are expressions, even constant expressions are not
handled.

Refs: #60001