### PR TITLE
[DOCS] Remove reference to non-existent action.

### DIFF
--- a/docs/reference/ilm/actions/ilm-unfollow.asciidoc
+++ b/docs/reference/ilm/actions/ilm-unfollow.asciidoc
@@ -10,20 +10,10 @@ to be be performed safely on follower indices.
 You can also use unfollow directly when moving follower indices through the lifecycle.
 Has no effect on indices that are not followers, phase execution just moves to the next action.
 
-ifdef::permanently-unreleased-branch[]
-[NOTE]
-This action is triggered automatically by the <<ilm-rollover-action, rollover>>,
-<<ilm-shrink-action, shrink>>, and
-<<ilm-searchable-snapshot-action, searchable snapshot>> actions when they are
-applied to follower indices.
-endif::[]
-
-ifndef::permanently-unreleased-branch[]
 [NOTE]
 This action is triggered automatically by the <<ilm-rollover-action, rollover>>
 and <<ilm-shrink-action, shrink>> actions when they are applied to follower
 indices.
-endif::[]
 
 This action waits until is it safe to convert a follower index into a regular index. 
 The following conditions must be met:

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -40,12 +40,7 @@ Reduce the number of primary shards by shrinking the index into a new index.
 
 [[ilm-unfollow-action]]<<ilm-unfollow,Unfollow>>::
 Convert a follower index to a regular index.
-ifdef::permanently-unreleased-branch[]
 Performed automatically before a rollover or shrink action.
-endif::[]
-ifndef::permanently-unreleased-branch[]
-Performed automatically before a rollover, shrink, or searchable snapshot action. 
-endif::[]
 
 [[ilm-wait-for-snapshot-action]]<<ilm-wait-for-snapshot,Wait for snapshot>>::
 Ensure that a snapshot exists before deleting the index. 


### PR DESCRIPTION
Removes in-text references to searchable snapshots.