### PR TITLE
[DOCS] Remove reference to non-existent action.

### DIFF
--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -34,7 +34,7 @@ Reduce the number of primary shards by shrinking the index into a new index.
 
 [[ilm-unfollow-action]]<<ilm-unfollow,Unfollow>>::
 Convert a follower index to a regular index.
-Performed automatically before a rollover, shrink, or searchable snapshot action. 
+Performed automatically before a rollover, shrink action. 
 
 [[ilm-wait-for-snapshot-action]]<<ilm-wait-for-snapshot,Wait For Snapshot>>::
 Ensure that a snapshot exists before deleting the index. 


### PR DESCRIPTION
Remove in-text reference to searchable snapshot action.