### PR TITLE
SQL: Fix field scripting for cast function

### DIFF
--- a/x-pack/plugin/ql/src/test/resources/mapping-multi-field-variation.json
+++ b/x-pack/plugin/ql/src/test/resources/mapping-multi-field-variation.json
@@ -27,6 +27,14 @@
                         }
                     }
                 },
+                "text": {
+                    "type": "text",
+                    "fields": {
+                        "typical": {
+                            "type": "keyword"
+                        }
+                    }
+                },
                 "ambiguous" : {
                     "type" : "text",
                     "fields" : {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/Cast.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/Cast.java
@@ -7,10 +7,12 @@ package org.elasticsearch.xpack.sql.expression.function.scalar;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
+import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
+import org.elasticsearch.xpack.ql.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
@@ -90,6 +92,13 @@ public class Cast extends UnaryScalarFunction {
                     .variable(dataType.name())
                     .build(),
                 dataType());
+    }
+
+    @Override
+    public ScriptTemplate scriptWithField(FieldAttribute field) {
+        return new ScriptTemplate(processScript(Scripts.DOC_VALUE),
+            paramsBuilder().variable(field.exactAttribute().name()).build(),
+            dataType());
     }
 
     @Override


### PR DESCRIPTION
Currently, Elasticsearch SQL will search for the first keyword of a text field when SQL requires exact values, as mentioned in https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-data-types.html#sql-multi-field

```
As SQL requires exact values, when encountering a text field Elasticsearch SQL will search for an exact multi-field that it can use for comparisons, sorting and aggregations. To do that, it will search for the first keyword that it can find that is not normalized and use that as the original field exact value.
```

Most functions are the same as mentioned above, except for CAST. If we use `CAST` as below

```
PUT myindex 
{}

PUT myindex/_mapping
{
  "properties": {
    "post_date" : {
        "type" : "text",
        "fields" : { "raw" : {"type" : "keyword"}}
    }
  }
}

POST myindex/_doc
{"post_date" : "2020-06-28T03:30:51.138798Z"}

POST /_sql
{"query":"SELECT CAST(post_date AS TIMESTAMP) AS dt FROM myindex GROUP BY dt"}
```
The SQL result will be an error
```
"root_cause": [
      {
        "type": "script_exception",
        "reason": "runtime error",
        "script_stack": [
          "org.elasticsearch.index.mapper.TextFieldMapper$TextFieldType.fielddataBuilder(TextFieldMapper.java:759)",
          "org.elasticsearch.index.fielddata.IndexFieldDataService.getForField(IndexFieldDataService.java:116)",
          "org.elasticsearch.index.query.QueryShardContext.lambda$lookup$0(QueryShardContext.java:308)",
          "org.elasticsearch.search.lookup.LeafDocLookup$1.run(LeafDocLookup.java:101)",
          "org.elasticsearch.search.lookup.LeafDocLookup$1.run(LeafDocLookup.java:98)",
          "java.security.AccessController.doPrivileged(Native Method)",
          "org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:98)",
          "org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:41)",
          "org.elasticsearch.xpack.sql.expression.function.scalar.whitelist.InternalSqlScriptUtils.docValue(InternalSqlScriptUtils.java:79)",
          "InternalSqlScriptUtils.cast(InternalSqlScriptUtils.docValue(doc,params.v0),params.v1)",
          "                                                                      ^---- HERE"
        ],
        "script": "InternalSqlScriptUtils.cast(InternalSqlScriptUtils.docValue(doc,params.v0),params.v1)",
        "lang": "painless"
      }
    ],
```
It is because Cast Function doesn't search for the keyword value of text field. 
```
{
  "size": 0,
  "_source": false,
  "stored_fields": "_none_",
  "aggregations": {
    "groupby": {
      "composite": {
        "size": 1000,
        "sources": [
          {
            "76": {
              "terms": {
                "script": {
                  "source": "InternalSqlScriptUtils.cast(InternalSqlScriptUtils.docValue(doc,params.v0),params.v1)",
                  "lang": "painless",
                  "params": {
                    "v0": "post_date",   ----  should be "post_date.raw"
                    "v1": "DATETIME"
                  }
                },
                "missing_bucket": true,
                "value_type": "long",
                "order": "asc"
              }
            }
          }
        ]
      }
    }
  }
}
```

This PR fixes the problem by optimizing field scripting of Cast Function.
