### PR TITLE
[DOCS] Fix typo in adapt auto expand replica comments

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -140,7 +140,7 @@ public final class AutoExpandReplicas {
     }
 
     /**
-     * Checks if the are replicas with the auto-expand feature that need to be adapted.
+     * Check if index with the auto-expand-replicas feature then replicas need to be adapted.
      * Returns a map of updates, which maps the indices to be updated to the desired number of replicas.
      * The map has the desired number of replicas as key and the indices to update as value, as this allows the result
      * of this method to be directly applied to RoutingTable.Builder#updateNumberOfReplicas.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -140,7 +140,7 @@ public final class AutoExpandReplicas {
     }
 
     /**
-     * Check if index with the auto-expand-replicas feature then replicas need to be adapted.
+     * Checks if there are replicas with the auto-expand feature that need to be adapted.
      * Returns a map of updates, which maps the indices to be updated to the desired number of replicas.
      * The map has the desired number of replicas as key and the indices to update as value, as this allows the result
      * of this method to be directly applied to RoutingTable.Builder#updateNumberOfReplicas.

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -263,7 +263,7 @@ public class AllocationService {
     }
 
     /**
-     * Check if index with the auto-expand-replicas feature then replicas need to be adapted.
+     * Checks if there are replicas with the auto-expand feature that need to be adapted.
      * Returns an updated cluster state if changes were necessary, or the identical cluster if no changes were required.
      */
     public ClusterState adaptAutoExpandReplicas(ClusterState clusterState) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -263,7 +263,7 @@ public class AllocationService {
     }
 
     /**
-     * Checks if the are replicas with the auto-expand feature that need to be adapted.
+     * Check if index with the auto-expand-replicas feature then replicas need to be adapted.
      * Returns an updated cluster state if changes were necessary, or the identical cluster if no changes were required.
      */
     public ClusterState adaptAutoExpandReplicas(ClusterState clusterState) {


### PR DESCRIPTION
The original comment has typo also it's hard to understand. Fix typo and optimize the comment.