### PR TITLE
[7.x][ML] DFA result processor should only skip rows and model chunks…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -434,7 +434,6 @@ public class AnalyticsProcessManager {
             if (inferenceRunner.get() != null) {
                 inferenceRunner.get().cancel();
             }
-            statsPersister.cancel();
             if (process.get() != null) {
                 try {
                     process.get().kill();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/AnalyticsResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/AnalyticsResult.java
@@ -66,14 +66,14 @@ public class AnalyticsResult implements ToXContentObject {
     private final ModelSizeInfo modelSizeInfo;
     private final TrainedModelDefinitionChunk trainedModelDefinitionChunk;
 
-    public AnalyticsResult(@Nullable RowResults rowResults,
-                           @Nullable PhaseProgress phaseProgress,
-                           @Nullable MemoryUsage memoryUsage,
-                           @Nullable OutlierDetectionStats outlierDetectionStats,
-                           @Nullable ClassificationStats classificationStats,
-                           @Nullable RegressionStats regressionStats,
-                           @Nullable ModelSizeInfo modelSizeInfo,
-                           @Nullable TrainedModelDefinitionChunk trainedModelDefinitionChunk) {
+    private AnalyticsResult(@Nullable RowResults rowResults,
+                            @Nullable PhaseProgress phaseProgress,
+                            @Nullable MemoryUsage memoryUsage,
+                            @Nullable OutlierDetectionStats outlierDetectionStats,
+                            @Nullable ClassificationStats classificationStats,
+                            @Nullable RegressionStats regressionStats,
+                            @Nullable ModelSizeInfo modelSizeInfo,
+                            @Nullable TrainedModelDefinitionChunk trainedModelDefinitionChunk) {
         this.rowResults = rowResults;
         this.phaseProgress = phaseProgress;
         this.memoryUsage = memoryUsage;
@@ -171,5 +171,76 @@ public class AnalyticsResult implements ToXContentObject {
     public int hashCode() {
         return Objects.hash(rowResults, phaseProgress, memoryUsage, outlierDetectionStats, classificationStats,
             regressionStats, modelSizeInfo, trainedModelDefinitionChunk);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private RowResults rowResults;
+        private PhaseProgress phaseProgress;
+        private MemoryUsage memoryUsage;
+        private OutlierDetectionStats outlierDetectionStats;
+        private ClassificationStats classificationStats;
+        private RegressionStats regressionStats;
+        private ModelSizeInfo modelSizeInfo;
+        private TrainedModelDefinitionChunk trainedModelDefinitionChunk;
+
+        private Builder() {}
+
+        public Builder setRowResults(RowResults rowResults) {
+            this.rowResults = rowResults;
+            return this;
+        }
+
+        public Builder setPhaseProgress(PhaseProgress phaseProgress) {
+            this.phaseProgress = phaseProgress;
+            return this;
+        }
+
+        public Builder setMemoryUsage(MemoryUsage memoryUsage) {
+            this.memoryUsage = memoryUsage;
+            return this;
+        }
+
+        public Builder setOutlierDetectionStats(OutlierDetectionStats outlierDetectionStats) {
+            this.outlierDetectionStats = outlierDetectionStats;
+            return this;
+        }
+
+        public Builder setClassificationStats(ClassificationStats classificationStats) {
+            this.classificationStats = classificationStats;
+            return this;
+        }
+
+        public Builder setRegressionStats(RegressionStats regressionStats) {
+            this.regressionStats = regressionStats;
+            return this;
+        }
+
+        public Builder setModelSizeInfo(ModelSizeInfo modelSizeInfo) {
+            this.modelSizeInfo = modelSizeInfo;
+            return this;
+        }
+
+        public Builder setTrainedModelDefinitionChunk(TrainedModelDefinitionChunk trainedModelDefinitionChunk) {
+            this.trainedModelDefinitionChunk = trainedModelDefinitionChunk;
+            return this;
+        }
+
+        public AnalyticsResult build() {
+            return new AnalyticsResult(
+                rowResults,
+                phaseProgress,
+                memoryUsage,
+                outlierDetectionStats,
+                classificationStats,
+                regressionStats,
+                modelSizeInfo,
+                trainedModelDefinitionChunk
+            );
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
@@ -29,7 +29,6 @@ public class StatsPersister {
     private final String jobId;
     private final ResultsPersisterService resultsPersisterService;
     private final DataFrameAnalyticsAuditor auditor;
-    private volatile boolean isCancelled;
 
     public StatsPersister(String jobId, ResultsPersisterService resultsPersisterService, DataFrameAnalyticsAuditor auditor) {
         this.jobId = Objects.requireNonNull(jobId);
@@ -38,10 +37,6 @@ public class StatsPersister {
     }
 
     public void persistWithRetry(ToXContentObject result, Function<String, String> docIdSupplier) {
-        if (isCancelled) {
-            return;
-        }
-
         try {
             resultsPersisterService.indexWithRetry(jobId,
                 MlStatsIndex.writeAlias(),
@@ -49,7 +44,7 @@ public class StatsPersister {
                 new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true")),
                 WriteRequest.RefreshPolicy.NONE,
                 docIdSupplier.apply(jobId),
-                () -> isCancelled == false,
+                () -> true,
                 errorMsg -> auditor.error(jobId,
                     "failed to persist result with id [" + docIdSupplier.apply(jobId) + "]; " + errorMsg)
             );
@@ -58,9 +53,5 @@ public class StatsPersister {
         } catch (Exception e) {
             LOGGER.error(() -> new ParameterizedMessage("[{}] Failed indexing stats result", jobId), e);
         }
-    }
-
-    public void cancel() {
-        isCancelled = true;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
@@ -60,7 +60,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
     private static final String CONFIG_ID = "config-id";
     private static final int NUM_ROWS = 100;
     private static final int NUM_COLS = 4;
-    private static final AnalyticsResult PROCESS_RESULT = new AnalyticsResult(null, null, null, null, null, null, null, null);
+    private static final AnalyticsResult PROCESS_RESULT = AnalyticsResult.builder().build();
 
     private Client client;
     private DataFrameAnalyticsAuditor auditor;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/AnalyticsResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/AnalyticsResultTests.java
@@ -11,19 +11,14 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractXContentTestCase;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.common.MemoryUsage;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.common.MemoryUsageTests;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.classification.ClassificationStats;
 import org.elasticsearch.xpack.core.ml.dataframe.stats.classification.ClassificationStatsTests;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.outlierdetection.OutlierDetectionStats;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.common.MemoryUsageTests;
 import org.elasticsearch.xpack.core.ml.dataframe.stats.outlierdetection.OutlierDetectionStatsTests;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.regression.RegressionStats;
 import org.elasticsearch.xpack.core.ml.dataframe.stats.regression.RegressionStatsTests;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.ml.inference.modelsize.MlModelSizeNamedXContentProvider;
-import org.elasticsearch.xpack.ml.inference.modelsize.ModelSizeInfo;
 import org.elasticsearch.xpack.ml.inference.modelsize.ModelSizeInfoTests;
 
 import java.util.ArrayList;
@@ -42,41 +37,34 @@ public class AnalyticsResultTests extends AbstractXContentTestCase<AnalyticsResu
     }
 
     protected AnalyticsResult createTestInstance() {
-        RowResults rowResults = null;
-        PhaseProgress phaseProgress = null;
-        MemoryUsage memoryUsage = null;
-        OutlierDetectionStats outlierDetectionStats = null;
-        ClassificationStats classificationStats = null;
-        RegressionStats regressionStats = null;
-        ModelSizeInfo modelSizeInfo = null;
-        TrainedModelDefinitionChunk trainedModelDefinitionChunk = null;
+        AnalyticsResult.Builder builder = AnalyticsResult.builder();
+
         if (randomBoolean()) {
-            rowResults = RowResultsTests.createRandom();
+            builder.setRowResults(RowResultsTests.createRandom());
         }
         if (randomBoolean()) {
-            phaseProgress = new PhaseProgress(randomAlphaOfLength(10), randomIntBetween(0, 100));
+            builder.setPhaseProgress(new PhaseProgress(randomAlphaOfLength(10), randomIntBetween(0, 100)));
         }
         if (randomBoolean()) {
-            memoryUsage = MemoryUsageTests.createRandom();
+            builder.setMemoryUsage(MemoryUsageTests.createRandom());
         }
         if (randomBoolean()) {
-            outlierDetectionStats = OutlierDetectionStatsTests.createRandom();
+            builder.setOutlierDetectionStats(OutlierDetectionStatsTests.createRandom());
         }
         if (randomBoolean()) {
-            classificationStats = ClassificationStatsTests.createRandom();
+            builder.setClassificationStats(ClassificationStatsTests.createRandom());
         }
         if (randomBoolean()) {
-            regressionStats = RegressionStatsTests.createRandom();
+            builder.setRegressionStats(RegressionStatsTests.createRandom());
         }
         if (randomBoolean()) {
-            modelSizeInfo = ModelSizeInfoTests.createRandom();
+            builder.setModelSizeInfo(ModelSizeInfoTests.createRandom());
         }
         if (randomBoolean()) {
             String def = randomAlphaOfLengthBetween(100, 1000);
-            trainedModelDefinitionChunk = new TrainedModelDefinitionChunk(def, randomIntBetween(0, 10), randomBoolean());
+            builder.setTrainedModelDefinitionChunk(new TrainedModelDefinitionChunk(def, randomIntBetween(0, 10), randomBoolean()));
         }
-        return new AnalyticsResult(rowResults, phaseProgress, memoryUsage, outlierDetectionStats,
-            classificationStats, regressionStats, modelSizeInfo, trainedModelDefinitionChunk);
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
… on cancel (#60113)

When the job is force-closed or shutting down due to a fatal error we clean
up all cancellable job operations. This includes cancelling the results processor.
However, this means that we might not persist objects that are written from the
process like stats, memory usage, etc.

In hindsight, we do not gain from cancelling the results processor in its
entirety. It makes more sense to skip row results and model chunks but keep
stats and instrumentation about the job as the latter may contain useful information
to understand what happened to the job.

Backport of #60113
