### PR TITLE
Improve 'ignore_malformed' handling for dates

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -518,7 +518,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         } else {
             try {
                 timestamp = fieldType().parse(dateAsString);
-            } catch (IllegalArgumentException | ElasticsearchParseException | DateTimeException e) {
+            } catch (IllegalArgumentException | ElasticsearchParseException | DateTimeException | ArithmeticException e) {
                 if (ignoreMalformed) {
                     context.addIgnoredField(mappedFieldType.name());
                     return;

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -167,9 +167,10 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
                 "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]");
         testIgnoreMalfomedForValue("-2147483648",
                 "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
+        testIgnoreMalfomedForValue("-522000000", "long overflow");
     }
 
-    private void testIgnoreMalfomedForValue(String value, String expectedException) throws IOException {
+    private void testIgnoreMalfomedForValue(String value, String expectedCause) throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field").field("type", "date").endObject().endObject()
                 .endObject().endObject());
@@ -185,7 +186,9 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
-        assertThat(e.getCause().getMessage(), containsString(expectedException));
+        assertThat(e.getMessage(), containsString("failed to parse field [field] of type [date]"));
+        assertThat(e.getMessage(), containsString("Preview of field's value: '" + value + "'"));
+        assertThat(e.getCause().getMessage(), containsString(expectedCause));
 
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field").field("type", "date")


### PR DESCRIPTION
Currently we occasionally can get ArithmeticException from parsing bad input
values on 'date' fields that are passed on even if 'ignore_malformed' is set.
This change adds this exception to the ones we already catch for malformed
values.

Closes #52634