### PR TITLE
[DOCS] Fix default gap policy for moving fn, moving avg aggs

### DIFF
--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -41,7 +41,7 @@ A `moving_avg` aggregation looks like this in isolation:
 |Parameter Name |Description |Required |Default Value
 |`buckets_path` |Path to the metric of interest (see <<buckets-path-syntax, `buckets_path` Syntax>> for more details |Required |
 |`model` |The moving average weighting model that we wish to use |Optional |`simple`
-|`gap_policy` |Determines what should happen when a gap in the data is encountered. |Optional |`insert_zeros`
+|`gap_policy` |The policy to apply when gaps are found in the data. See <<gap-policy>>. |Optional |`skip`
 |`window` |The size of window to "slide" across the histogram. |Optional |`5`
 |`minimize` |If the model should be algorithmically minimized.  See <<movavg-minimizer, Minimization>> for more
  details |Optional |`false` for most models

--- a/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
@@ -32,6 +32,7 @@ A `moving_fn` aggregation looks like this in isolation:
 |`buckets_path` |Path to the metric of interest (see <<buckets-path-syntax, `buckets_path` Syntax>> for more details |Required |
 |`window` |The size of window to "slide" across the histogram. |Required |
 |`script` |The script that should be executed on each window of data |Required |
+|`gap_policy` |The policy to apply when gaps are found in the data. See <<gap-policy>>. |Optional |`skip`
 |`shift` |<<shift-parameter, Shift>> of window position. |Optional | 0
 |===
 


### PR DESCRIPTION
Also rewords the gap policy definition to be consistent with other aggs.

Fixes #56987.

I plan to port these changes to 8.0 as well. I targeted 7.x because the moving avg
agg is no longer available in 8.0.