### PR TITLE
[7.x] [DOCS] Fix formatting in simple query string query docs

### DIFF
--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -281,7 +281,7 @@ GET /_search
 
 The `simple_query_string` query supports multi-terms synonym expansion with the <<analysis-synonym-graph-tokenfilter,
 synonym_graph>> token filter. When this filter is used, the parser creates a phrase query for each multi-terms synonyms.
-For example, the following synonym: `"ny, new york" would produce:`
+For example, the following synonym: `"ny, new york"` would produce:
 
 `(ny OR ("new york"))`
 


### PR DESCRIPTION
7.x backport of #60157