### PR TITLE
Drop unused moving avg code

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnWhitelistedFunctionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnWhitelistedFunctionTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.collect.EvictingQueue;
-import org.elasticsearch.search.aggregations.pipeline.MovingFunctions;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;


### PR DESCRIPTION
Removes some unused moving average code now that the `moving_avg`
aggregation is gone. Most of the code remains because it is exposed by
the `moving_fn` aggregation.
