### PR TITLE
[ML] Handle node closed exception in ML result processing

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -83,6 +84,8 @@ public class InferenceRunner {
             try (LocalModel localModel = localModelPlainActionFuture.actionGet()) {
                 inferTestDocs(localModel, testDocsIterator);
             }
+        } catch (NodeClosedException e) {
+            LOGGER.warn("[{}] inference interrupted by node closing", config.getId());
         } catch (Exception e) {
             throw ExceptionsHelper.serverError("[{}] failed running inference on model [{}]", e, config.getId(), modelId);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
@@ -48,6 +49,8 @@ public class StatsPersister {
                 errorMsg -> auditor.error(jobId,
                     "failed to persist result with id [" + docIdSupplier.apply(jobId) + "]; " + errorMsg)
             );
+        } catch (NodeClosedException e) {
+            LOGGER.warn("[{}] some stats not indexed due to the node being closed", jobId);
         } catch (IOException ioe) {
             LOGGER.error(() -> new ParameterizedMessage("[{}] Failed serializing stats result", jobId), ioe);
         } catch (Exception e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -67,6 +68,8 @@ public class JobDataCountsPersister {
                 DataCounts.documentId(jobId),
                 () -> true,
                 (msg) -> auditor.warning(jobId, "Job data_counts " + msg));
+        } catch (NodeClosedException e) {
+            logger.warn("[{}] some data_counts not indexed due to the node being closed", jobId);
         } catch (IOException ioe) {
             logger.error(() -> new ParameterizedMessage("[{}] Failed writing data_counts stats", jobId), ioe);
         } catch (Exception ex) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -242,9 +242,9 @@ public class JobResultsPersister {
                 return;
             }
             logger.trace("[{}] ES API CALL: bulk request with {} actions", jobId, bulkRequest.numberOfActions());
-            resultsPersisterService.bulkIndexWithRetry(bulkRequest, jobId, shouldRetry, (msg) -> {
-                auditor.warning(jobId, "Bulk indexing of results failed " + msg);
-            });
+            resultsPersisterService.bulkIndexWithRetry(bulkRequest, jobId, shouldRetry, (msg) ->
+                auditor.warning(jobId, "Bulk indexing of results failed " + msg)
+            );
             bulkRequest = new BulkRequest();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.process.logging.CppLogMessageHandler;
@@ -144,6 +145,8 @@ public abstract class AbstractNativeProcess implements NativeProcess {
                 if (processKilled == false) {
                     LOGGER.info("[{}] State output finished", jobId);
                 }
+            } catch (NodeClosedException e) {
+                LOGGER.warn("[{}] some state not indexed due to the node being closed", jobId);
             } catch (IOException e) {
                 if (processKilled == false) {
                     LOGGER.error(new ParameterizedMessage("[{}] Error reading {} state output", jobId, getName()), e);


### PR DESCRIPTION
As detailed in #60130 it is possible for ML code to receive
a NodeClosedException before the ML lifecycle listener has
had a chance to mark jobs as about to be killed.  In this
situation the ML code that receives the exception needs to
react on the basis that the node will imminently be shut
down and jobs will restart on a different node, either
immediately (in the case of a rolling restart) or when the
cluster is brought back up (in the case of a full cluster
restart).  In particular, no job must be set to failed status
and logging of stack traces should be avoided.

Fixes #60130