### PR TITLE
Search - remove allow-expensive-query checks from wildcard field.

### DIFF
--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -32,11 +32,11 @@ Certain types of queries will generally execute slowly due to the way they are i
 the stability of the cluster. Those queries can be categorised as follows:
 * Queries that need to do linear scans to identify matches:
 ** <<query-dsl-script-query, `script queries`>>
-* Queries that have a high up-front cost:
-** <<query-dsl-fuzzy-query,`fuzzy queries`>>
-** <<query-dsl-regexp-query,`regexp queries`>>
-** <<query-dsl-prefix-query,`prefix queries`>> without <<index-prefixes, `index_prefixes`>>
-** <<query-dsl-wildcard-query, `wildcard queries`>>
+* Queries that have a high up-front cost :
+** <<query-dsl-fuzzy-query,`fuzzy queries`>> (except on <<wildcard, `wildcard`>> fields)
+** <<query-dsl-regexp-query,`regexp queries`>> (except on <<wildcard, `wildcard`>> fields)
+** <<query-dsl-prefix-query,`prefix queries`>>  (except on <<wildcard, `wildcard`>> fields or those without <<index-prefixes, `index_prefixes`>>)
+** <<query-dsl-wildcard-query, `wildcard queries`>> (except on <<wildcard, `wildcard`>> fields)
 ** <<query-dsl-range-query, `range queries>> on <<text, `text`>> and <<keyword, `keyword`>> fields
 * <<joining-queries, `Joining queries`>>
 * Queries on <<prefix-trees, deprecated geo shapes>>

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -79,7 +79,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.index.mapper.TypeParsers.parseField;
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * A {@link FieldMapper} for indexing fields with ngrams for efficient wildcard matching
@@ -297,12 +296,6 @@ public class WildcardFieldMapper extends FieldMapper {
         public Query regexpQuery(String value, int flags, int maxDeterminizedStates, RewriteMethod method, QueryShardContext context) {
             if (value.length() == 0) {
                 return new MatchNoDocsQuery();
-            }
-
-            if (context.allowExpensiveQueries() == false) {
-                throw new ElasticsearchException(
-                    "[regexp] queries cannot be executed when '" + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false."
-                );
             }
 
             RegExp ngramRegex = new RegExp(addLineEndChars(toLowerCase(value)), flags);
@@ -670,10 +663,6 @@ public class WildcardFieldMapper extends FieldMapper {
             DateMathParser parser,
             QueryShardContext context
         ) {
-            if (context.allowExpensiveQueries() == false) {
-                throw new ElasticsearchException("[range] queries on [wildcard] fields cannot be executed when '" +
-                        ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
-            }
             BytesRef lower = lowerTerm == null ? null : BytesRefs.toBytesRef(lowerTerm);
             BytesRef upper = upperTerm == null ? null : BytesRefs.toBytesRef(upperTerm);
             Query accelerationQuery = null;

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -36,7 +36,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.apache.lucene.util.automaton.RegExp.Kind;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;


### PR DESCRIPTION
Removing regexp and range query checks for the expensive query flag because we think this field type should be fast enough at these operations.

Closes #60139