### PR TITLE
[Transform] fix performance regression introduced in #60196

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -345,7 +345,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         // create the function
         function = FunctionFactory.create(getConfig());
 
-        if (isContinuous() && function.supportsIncrementalBucketUpdate()) {
+        if (isContinuous()) {
             changeCollector = function.buildChangeCollector(getConfig().getSyncConfig().getField());
         }
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -215,8 +215,15 @@ public class Pivot implements Function {
 
     @Override
     public ChangeCollector buildChangeCollector(String synchronizationField) {
+        CompositeAggregationBuilder aggregationBuilder = null;
+
+        // skip if none of the group_by's requires it
+        if (supportsIncrementalBucketUpdate()) {
+            aggregationBuilder = createCompositeAggregationSources(config, true);
+        }
+
         return CompositeBucketsChangeCollector.buildChangeCollector(
-            createCompositeAggregationSources(config, true),
+            aggregationBuilder,
             config.getGroupConfig().getGroups(),
             synchronizationField
         );


### PR DESCRIPTION
re-work #60196, to not skip building change collectors as otherwise date histogram only 
pivots would run slow

relates #60125

Note: I realized that #60196 fixes #60125, but introduced a different bad side effect as it would make pivots with only a date histogram slower (regression). This change now does not prevent the creation of the change detector, but avoids the NPE of the original issue #60125

(FWIW: the issue show that test coverage should be improved, I am working on that as part of a follow up PR)