### PR TITLE
SQL: integer parameter validation in string functions (#58923)

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -61,22 +62,9 @@ public class InsertFunctionProcessor implements Processor {
         if (start == null || length == null) {
             return input;
         }
-        if (!(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
-        }
-        if (!(length instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
-        }
-        
-        if ((((Number) length).longValue() > Integer.MAX_VALUE) || (((Number) length).longValue() < 0) ) {
-            throw new SqlIllegalArgumentException("[length] must be in the interval [0..2147483647], but was ["
-                    + ((Number) length).longValue() + "]");
-        }
-        
-        if ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE)) {
-            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
-                    + ((Number) start).longValue() + "]");
-        }
+    
+        Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
+        Check.isNumberOutOfRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         int startInt = ((Number) start).intValue() - 1;
         int realStart = startInt < 0 ? 0 : startInt;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -67,8 +67,15 @@ public class InsertFunctionProcessor implements Processor {
         if (!(length instanceof Number)) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
         }
-        if (((Number) length).intValue() < 0) {
-            throw new SqlIllegalArgumentException("A positive number is required for [length]; received [{}]", length);
+        
+        if ((((Number) length).longValue() > Integer.MAX_VALUE) || (((Number) length).longValue() < 0) ) {
+            throw new SqlIllegalArgumentException("[length] must be in the interval [0..2147483647], but was ["
+                    + ((Number) length).longValue() + "]");
+        }
+        
+        if ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE)) {
+            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
+                    + ((Number) start).longValue() + "]");
         }
 
         int startInt = ((Number) start).intValue() - 1;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -63,8 +63,8 @@ public class InsertFunctionProcessor implements Processor {
             return input;
         }
     
-        Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
-        Check.isNumberOutOfRange(length, "length", 0L, (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         int startInt = ((Number) start).intValue() - 1;
         int realStart = startInt < 0 ? 0 : startInt;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
@@ -59,6 +59,11 @@ public class LocateFunctionProcessor implements Processor {
         if (start != null && !(start instanceof Number)) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
         }
+    
+        if (start != null && ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE))) {
+            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
+                    + ((Number) start).longValue() + "]");
+        }
         
         String stringInput = input instanceof Character ? input.toString() : (String) input;
         String stringPattern = pattern instanceof Character ? pattern.toString() : (String) pattern;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
@@ -59,7 +59,7 @@ public class LocateFunctionProcessor implements Processor {
         }
         
         if (start != null) {
-            Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
+            Check.isFixedNumberAndInRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
         }
         
         String stringInput = input instanceof Character ? input.toString() : (String) input;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -56,13 +57,9 @@ public class LocateFunctionProcessor implements Processor {
         if (!(pattern instanceof String || pattern instanceof Character)) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", pattern);
         }
-        if (start != null && !(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
-        }
-    
-        if (start != null && ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE))) {
-            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
-                    + ((Number) start).longValue() + "]");
+        
+        if (start != null) {
+            Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
         }
         
         String stringInput = input instanceof Character ? input.toString() : (String) input;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -59,8 +59,15 @@ public class SubstringFunctionProcessor implements Processor {
         if (!(length instanceof Number)) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
         }
-        if (((Number) length).intValue() < 0) {
-            throw new SqlIllegalArgumentException("A positive number is required for [length]; received [{}]", length);
+        
+        if ((((Number) length).longValue() > Integer.MAX_VALUE) || (((Number) length).longValue() < 0) ) {
+            throw new SqlIllegalArgumentException("[length] must be in the interval [0..2147483647], but was ["
+                    + ((Number) length).longValue() + "]");
+        }
+    
+        if ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE)) {
+            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
+                    + ((Number) start).longValue() + "]");
         }
 
         return StringFunctionUtils.substring(input instanceof Character ? input.toString() : (String) input,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -53,22 +54,9 @@ public class SubstringFunctionProcessor implements Processor {
         if (start == null || length == null) {
             return input;
         }
-        if (!(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
-        }
-        if (!(length instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
-        }
         
-        if ((((Number) length).longValue() > Integer.MAX_VALUE) || (((Number) length).longValue() < 0) ) {
-            throw new SqlIllegalArgumentException("[length] must be in the interval [0..2147483647], but was ["
-                    + ((Number) length).longValue() + "]");
-        }
-    
-        if ((((Number) start).longValue() > Integer.MAX_VALUE) || (((Number) start).longValue() - 1 < Integer.MIN_VALUE)) {
-            throw new SqlIllegalArgumentException("[start] must be in the interval [-2147483647..2147483647], but was ["
-                    + ((Number) start).longValue() + "]");
-        }
+        Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
+        Check.isNumberOutOfRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         return StringFunctionUtils.substring(input instanceof Character ? input.toString() : (String) input,
                 ((Number) start).intValue() - 1, // SQL is 1-based when it comes to string manipulation

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -55,8 +55,8 @@ public class SubstringFunctionProcessor implements Processor {
             return input;
         }
         
-        Check.isNumberOutOfRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
-        Check.isNumberOutOfRange(length, "length", 0L, (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(start, "start", (long) (Integer.MIN_VALUE + 1), (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         return StringFunctionUtils.substring(input instanceof Character ? input.toString() : (String) input,
                 ((Number) start).intValue() - 1, // SQL is 1-based when it comes to string manipulation

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
@@ -37,13 +37,13 @@ public abstract class Check {
         }
     }
     
-    public static void isNumberOutOfRange(Object object, String objectName, Long from, Long to) {
-        if (!(object instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", object);
+    public static void isFixedNumberAndInRange(Object object, String objectName, Long from, Long to) {
+        if ((object instanceof Number) == false) {
+            throw new SqlIllegalArgumentException("A number is required for [{}]; received [{}]", objectName, object.getClass());
         }
         if (((Number) object).longValue() > to || ((Number) object).longValue() < from) {
-            throw new SqlIllegalArgumentException("[{}] must be in the interval [{}..{}], but was [{}]", 
-                    objectName, from, to, ((Number) object).longValue());
+            throw new SqlIllegalArgumentException("[{}] has the value [{}] out of allowed range [{}..{}]", 
+                    objectName, ((Number) object).longValue(), from, to);
         }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
@@ -36,4 +36,14 @@ public abstract class Check {
             throw new SqlIllegalArgumentException(message, values);
         }
     }
+    
+    public static void isNumberOutOfRange(Object object, String objectName, Long from, Long to) {
+        if (!(object instanceof Number)) {
+            throw new SqlIllegalArgumentException("A number is required; received [{}]", object);
+        }
+        if (((Number) object).longValue() > to || ((Number) object).longValue() < from) {
+            throw new SqlIllegalArgumentException("[{}] must be in the interval [{}..{}], but was [{}]", 
+                    objectName, from, to, ((Number) object).longValue());
+        }
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
@@ -83,14 +83,14 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
     }
     
     public void testInsertInputsOutOfRange() {
-        assertEquals("baroobar", new Insert(EMPTY, l("foobar"), l(-2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("baroobar", new Insert(EMPTY, l("foobar"), l(Integer.MIN_VALUE + 1), l(1), l("bar")).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Insert(EMPTY, l("foobarbar"), l(-2147483648), l(1), l("bar")).makePipe().asProcessor().process(null));
+                () -> new Insert(EMPTY, l("foobarbar"), l(Integer.MIN_VALUE), l(1), l("bar")).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
-        assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(Integer.MAX_VALUE), l(1), l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Insert(EMPTY, l("foobar"), l(2147483648L), l(1), l("bar")).makePipe().asProcessor().process(null));
+                () -> new Insert(EMPTY, l("foobar"), l((long) Integer.MAX_VALUE + 1), l(1), l("bar")).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("barfoobar", new Insert(EMPTY, l("foobar"), l(1), l(0), l("bar")).makePipe().asProcessor().process(null));
@@ -98,9 +98,9 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("bar")).makePipe().asProcessor().process(null));
         assertEquals("[length] has the value [-1] out of allowed range [0..2147483647]", siae.getMessage());
     
-        assertEquals("bar", new Insert(EMPTY, l("foobar"), l(1), l(2147483647), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("bar", new Insert(EMPTY, l("foobar"), l(1), l(Integer.MAX_VALUE), l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Insert(EMPTY, l("foobar"), l(1), l(2147483648L), l("bar")).makePipe().asProcessor().process(null));
+                () -> new Insert(EMPTY, l("foobar"), l(1), l((long) Integer.MAX_VALUE + 1), l("bar")).makePipe().asProcessor().process(null));
         assertEquals("[length] has the value [2147483648] out of allowed range [0..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
@@ -73,34 +73,34 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
         assertEquals("A string/char is required; received [66]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l("c"), l(3), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [c]", siae.getMessage());
+        assertEquals("A number is required for [start]; received [class java.lang.String]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l('z'), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [z]", siae.getMessage());
+        assertEquals("A number is required for [length]; received [class java.lang.Character]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+        assertEquals("[length] has the value [-1] out of allowed range [0..2147483647]", siae.getMessage());
     }
     
     public void testInsertInputsOutOfRange() {
         assertEquals("baroobar", new Insert(EMPTY, l("foobar"), l(-2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobarbar"), l(-2147483648), l(1), l("bar")).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(2147483648L), l(1), l("bar")).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("barfoobar", new Insert(EMPTY, l("foobar"), l(1), l(0), l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("bar")).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+        assertEquals("[length] has the value [-1] out of allowed range [0..2147483647]", siae.getMessage());
     
         assertEquals("bar", new Insert(EMPTY, l("foobar"), l(1), l(2147483647), l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(2147483648L), l("bar")).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [2147483648]", siae.getMessage());
+        assertEquals("[length] has the value [2147483648] out of allowed range [0..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
@@ -79,6 +79,28 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
         assertEquals("A number is required; received [z]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A positive number is required for [length]; received [-1]", siae.getMessage());
+        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+    }
+    
+    public void testInsertInputsOutOfRange() {
+        assertEquals("baroobar", new Insert(EMPTY, l("foobar"), l(-2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
+        SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Insert(EMPTY, l("foobarbar"), l(-2147483648), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+    
+        assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(2147483647), l(1), l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Insert(EMPTY, l("foobar"), l(2147483648L), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+    
+        assertEquals("barfoobar", new Insert(EMPTY, l("foobar"), l(1), l(0), l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+    
+        assertEquals("bar", new Insert(EMPTY, l("foobar"), l(1), l(2147483647), l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Insert(EMPTY, l("foobar"), l(1), l(2147483648L), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[length] must be in the interval [0..2147483647], but was [2147483648]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
@@ -70,14 +70,14 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
     }
     
     public void testLocateFunctionInputsOutOfRange() {
-        assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483647)).makePipe().asProcessor().process(null));
+        assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MIN_VALUE + 1)).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483648)).makePipe().asProcessor().process(null));
+                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MIN_VALUE)).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
-        assertEquals(0, new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483647)).makePipe().asProcessor().process(null));
+        assertEquals(0, new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MAX_VALUE)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483648L)).makePipe().asProcessor().process(null));
+                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l((long) Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
@@ -66,18 +66,18 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
         assertEquals("A string/char is required; received [1]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l("foobarbar"), l("bar"), l('c')).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [c]", siae.getMessage());
+        assertEquals("A number is required for [start]; received [class java.lang.Character]", siae.getMessage());
     }
     
     public void testLocateFunctionInputsOutOfRange() {
         assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483647)).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483648)).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals(0, new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483647)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483648L)).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
@@ -68,4 +68,16 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
                 () -> new Locate(EMPTY, l("foobarbar"), l("bar"), l('c')).makePipe().asProcessor().process(null));
         assertEquals("A number is required; received [c]", siae.getMessage());
     }
+    
+    public void testLocateFunctionInputsOutOfRange() {
+        assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483647)).makePipe().asProcessor().process(null));
+        SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(-2147483648)).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+    
+        assertEquals(0, new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483647)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(2147483648L)).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
@@ -74,14 +74,14 @@ public class SubstringProcessorTests extends AbstractWireSerializingTestCase<Sub
     }
     
     public void testSubstringFunctionInputsOutOfRange() {
-        assertEquals("f", new Substring(EMPTY, l("foobarbar"), l(-2147483647), l(1)).makePipe().asProcessor().process(null));
+        assertEquals("f", new Substring(EMPTY, l("foobarbar"), l(Integer.MIN_VALUE + 1), l(1)).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Substring(EMPTY, l("foobarbar"), l(-2147483648), l(1)).makePipe().asProcessor().process(null));
+                () -> new Substring(EMPTY, l("foobarbar"), l(Integer.MIN_VALUE), l(1)).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
-        assertEquals("", new Substring(EMPTY, l("foobarbar"), l(2147483647), l(1)).makePipe().asProcessor().process(null));
+        assertEquals("", new Substring(EMPTY, l("foobarbar"), l(Integer.MAX_VALUE), l(1)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Substring(EMPTY, l("foobarbar"), l(2147483648L), l(1)).makePipe().asProcessor().process(null));
+                () -> new Substring(EMPTY, l("foobarbar"), l((long) Integer.MAX_VALUE + 1), l(1)).makePipe().asProcessor().process(null));
         assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("", new Substring(EMPTY, l("foobarbar"), l(1), l(0)).makePipe().asProcessor().process(null));
@@ -89,9 +89,9 @@ public class SubstringProcessorTests extends AbstractWireSerializingTestCase<Sub
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l(-1)).makePipe().asProcessor().process(null));
         assertEquals("[length] has the value [-1] out of allowed range [0..2147483647]", siae.getMessage());
     
-        assertEquals("foobarbar", new Substring(EMPTY, l("foobarbar"), l(1), l(2147483647)).makePipe().asProcessor().process(null));
+        assertEquals("foobarbar", new Substring(EMPTY, l("foobarbar"), l(1), l(Integer.MAX_VALUE)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Substring(EMPTY, l("foobarbar"), l(1), l(2147483648L)).makePipe().asProcessor().process(null));
+                () -> new Substring(EMPTY, l("foobarbar"), l(1), l((long) Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
         assertEquals("[length] has the value [2147483648] out of allowed range [0..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
@@ -64,34 +64,34 @@ public class SubstringProcessorTests extends AbstractWireSerializingTestCase<Sub
         assertEquals("A string/char is required; received [5]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [baz]", siae.getMessage());
+        assertEquals("A number is required for [length]; received [class java.lang.String]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l("bar"), l(3)).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [bar]", siae.getMessage());
+        assertEquals("A number is required for [start]; received [class java.lang.String]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l(-3)).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [-3]", siae.getMessage());
+        assertEquals("[length] has the value [-3] out of allowed range [0..2147483647]", siae.getMessage());
     }
     
     public void testSubstringFunctionInputsOutOfRange() {
         assertEquals("f", new Substring(EMPTY, l("foobarbar"), l(-2147483647), l(1)).makePipe().asProcessor().process(null));
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(-2147483648), l(1)).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [-2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("", new Substring(EMPTY, l("foobarbar"), l(2147483647), l(1)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(2147483648L), l(1)).makePipe().asProcessor().process(null));
-        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+        assertEquals("[start] has the value [2147483648] out of allowed range [-2147483647..2147483647]", siae.getMessage());
     
         assertEquals("", new Substring(EMPTY, l("foobarbar"), l(1), l(0)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l(-1)).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+        assertEquals("[length] has the value [-1] out of allowed range [0..2147483647]", siae.getMessage());
     
         assertEquals("foobarbar", new Substring(EMPTY, l("foobarbar"), l(1), l(2147483647)).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l(2147483648L)).makePipe().asProcessor().process(null));
-        assertEquals("[length] must be in the interval [0..2147483647], but was [2147483648]", siae.getMessage());
+        assertEquals("[length] has the value [2147483648] out of allowed range [0..2147483647]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringProcessorTests.java
@@ -70,6 +70,28 @@ public class SubstringProcessorTests extends AbstractWireSerializingTestCase<Sub
         assertEquals("A number is required; received [bar]", siae.getMessage());
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Substring(EMPTY, l("foobarbar"), l(1), l(-3)).makePipe().asProcessor().process(null));
-        assertEquals("A positive number is required for [length]; received [-3]", siae.getMessage());
+        assertEquals("[length] must be in the interval [0..2147483647], but was [-3]", siae.getMessage());
+    }
+    
+    public void testSubstringFunctionInputsOutOfRange() {
+        assertEquals("f", new Substring(EMPTY, l("foobarbar"), l(-2147483647), l(1)).makePipe().asProcessor().process(null));
+        SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Substring(EMPTY, l("foobarbar"), l(-2147483648), l(1)).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [-2147483648]", siae.getMessage());
+    
+        assertEquals("", new Substring(EMPTY, l("foobarbar"), l(2147483647), l(1)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Substring(EMPTY, l("foobarbar"), l(2147483648L), l(1)).makePipe().asProcessor().process(null));
+        assertEquals("[start] must be in the interval [-2147483647..2147483647], but was [2147483648]", siae.getMessage());
+    
+        assertEquals("", new Substring(EMPTY, l("foobarbar"), l(1), l(0)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Substring(EMPTY, l("foobarbar"), l(1), l(-1)).makePipe().asProcessor().process(null));
+        assertEquals("[length] must be in the interval [0..2147483647], but was [-1]", siae.getMessage());
+    
+        assertEquals("foobarbar", new Substring(EMPTY, l("foobarbar"), l(1), l(2147483647)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+                () -> new Substring(EMPTY, l("foobarbar"), l(1), l(2147483648L)).makePipe().asProcessor().process(null));
+        assertEquals("[length] must be in the interval [0..2147483647], but was [2147483648]", siae.getMessage());
     }
 }


### PR DESCRIPTION
Related to #58923

In insert, locate, substring function, when argument `start` or `length` is greater than Integer.MAX_INT OR less then Integer.MIN_INT + 1 (note that `start` needs to minus 1), it causes overflow and leads to unexpected results.
