### PR TITLE
Fix Queued Snapshot Deletes After Finalization Failure

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1164,6 +1164,22 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(repositoryData.shardGenerations(), is(ShardGenerations.EMPTY));
     }
 
+    public void testQueuedDeleteAfterFinalizationFailure() throws Exception {
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        final String snapshotName = "snap-1";
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, snapshotName);
+        waitForBlock(masterNode, repoName, TimeValue.timeValueSeconds(30L));
+        final ActionFuture<AcknowledgedResponse> deleteFuture = startDelete(repoName, snapshotName);
+        awaitNDeletionsInProgress(1);
+        unblockNode(repoName, masterNode);
+        assertAcked(deleteFuture.get());
+        final SnapshotException sne = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
+        assertThat(sne.getCause().getMessage(), containsString("exception after block"));
+    }
+
     private static String startDataNodeWithLargeSnapshotPool() {
         return internalCluster().startDataOnlyNode(LARGE_SNAPSHOT_POOL_SETTINGS);
     }


### PR DESCRIPTION
This fixes the behavior of the snapshot state machine in the following edge case:

1. Snapshot is running
2. Delete/abort for the snapshot is started
3. Snapshot fails to finalize

We were not removing the failed snapshot id from the list of snapshots to delete in the delete.
This lead to an error in the repository, which throws if we try to delete a non-existing snapshot.
This commit updates the deletions in progress by removing the failed snapshot id.
The fact that this could lead to snapshot delete entries without any snapshot ids is not optimized
on purpose because it allows for another attempt at writing clean `RepositoryData` and will run basic
cleanup on the repository (root level blobs and stale indices) and thus bring the repository back into
a clean state after a failed finalization.

Closes #60274


"> non issue" because this has not been released yet and isn't really much of a bug but rather inefficient error handling for failed finalizations