### PR TITLE
[DOCS] Update pre-existing data stream refs

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -146,7 +146,7 @@ releases 2.0 and later do not support rivers.
   Integration of Micronaut with Elasticsearch
 
 * https://streampipes.apache.org[Apache StreamPipes]:
-  StreamPipes is a framework that enables users to work with IoT data streams allowing to store data in Elasticsearch.
+  StreamPipes is a framework that enables users to work with IoT data sources.
 
 * https://metamodel.apache.org/[Apache MetaModel]:
   Providing a common interface for discovery, exploration of metadata and querying of different types of data sources.

--- a/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
@@ -41,7 +41,7 @@ output { <2>
 
 ----------------------------------------------------------
 // NOTCONSOLE
-<1> The meetup data stream is formatted in JSON.
+<1> The meetup data is formatted in JSON.
 <2> Index the meetup data into Elasticsearch.
 --
 


### PR DESCRIPTION
Changes some pre-existing `data streams` references to avoid confusion
with the new index abstraction of the same name.