### PR TITLE
Log and track open/close of transport connections

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1818,7 +1818,15 @@ Contains transport statistics for the node.
 ======
 `server_open`::
 (integer)
-Number of open TCP connections used for internal communication between nodes.
+Current number of inbound TCP connections used for internal communication between nodes.
+
+`total_outbound_connections`::
+(integer)
+The cumulative number of outbound transport connections that this node has
+opened since it started. Each transport connection may comprise multiple TCP
+connections but is only counted once in this statistic. Transport connections
+are typically <<long-lived-connections,long-lived>> so this statistic should
+remain constant in a stable cluster.
 
 `rx_count`::
 (integer)

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/60_transport_stats.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/60_transport_stats.yml
@@ -6,7 +6,7 @@
       features: [arbitrary_key]
 
   - do:
-      nodes.info:
+      nodes.info: {}
   - set:
       nodes._arbitrary_key_: node_id
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/60_transport_stats.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/60_transport_stats.yml
@@ -1,0 +1,24 @@
+---
+"Transport stats":
+  - skip:
+      version: " - 7.99.99"
+      reason: "total_outbound_connections field is not returned in prior versions"
+      features: [arbitrary_key]
+
+  - do:
+      nodes.info:
+  - set:
+      nodes._arbitrary_key_: node_id
+
+  - do:
+      nodes.stats:
+        metric: [ transport ]
+
+  - is_false: nodes.$node_id.store
+  - is_true:  nodes.$node_id.transport
+  - gte: { nodes.$node_id.transport.server_open: 0 }
+  - gte: { nodes.$node_id.transport.total_outbound_connections: 0 }
+  - gte: { nodes.$node_id.transport.rx_count: 0 }
+  - gte: { nodes.$node_id.transport.tx_count: 0 }
+  - gte: { nodes.$node_id.transport.rx_size_in_bytes: 0 }
+  - gte: { nodes.$node_id.transport.tx_size_in_bytes: 0 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -80,6 +80,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -130,6 +131,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private final InboundHandler inboundHandler;
     private final ResponseHandlers responseHandlers = new ResponseHandlers();
     private final RequestHandlers requestHandlers = new RequestHandlers();
+
+    private final AtomicLong outboundConnectionCount = new AtomicLong(); // also used as a correlation ID for open/close logs
 
     public TcpTransport(Settings settings, Version version, ThreadPool threadPool, PageCacheRecycler pageCacheRecycler,
                         CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
@@ -830,7 +833,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         final long messagesSent = statsTracker.getMessagesSent();
         final long messagesReceived = statsTracker.getMessagesReceived();
         final long bytesRead = statsTracker.getBytesRead();
-        return new TransportStats(acceptedChannels.size(), messagesReceived, bytesRead, messagesSent, bytesWritten);
+        return new TransportStats(acceptedChannels.size(), outboundConnectionCount.get(),
+                messagesReceived, bytesRead, messagesSent, bytesWritten);
     }
 
     /**
@@ -928,6 +932,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 final TcpChannel handshakeChannel = channels.get(0);
                 try {
                     executeHandshake(node, handshakeChannel, connectionProfile, ActionListener.wrap(version -> {
+                        final long connectionId = outboundConnectionCount.incrementAndGet();
+                        logger.debug("opened transport connection [{}] to [{}] using channels [{}]", connectionId, node, channels);
                         NodeChannels nodeChannels = new NodeChannels(node, channels, connectionProfile, version);
                         long relativeMillisTime = threadPool.relativeTimeInMillis();
                         nodeChannels.channels.forEach(ch -> {
@@ -936,6 +942,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                             ch.addCloseListener(ActionListener.wrap(nodeChannels::close));
                         });
                         keepAlive.registerNodeConnection(nodeChannels.channels, connectionProfile);
+                        nodeChannels.addCloseListener(new ChannelCloseLogger(node, connectionId, relativeMillisTime));
                         listener.onResponse(nodeChannels);
                     }, e -> closeAndFail(e instanceof ConnectTransportException ?
                         e : new ConnectTransportException(node, "general node connection failure", e))));
@@ -968,4 +975,28 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             }
         }
     }
+
+    private class ChannelCloseLogger implements ActionListener<Void> {
+        private final DiscoveryNode node;
+        private final long connectionId;
+        private final long openTimeMillis;
+
+        ChannelCloseLogger(DiscoveryNode node, long connectionId, long openTimeMillis) {
+            this.node = node;
+            this.connectionId = connectionId;
+            this.openTimeMillis = openTimeMillis;
+        }
+
+        @Override
+        public void onResponse(Void ignored) {
+            long closeTimeMillis = threadPool.relativeTimeInMillis();
+            logger.debug("closed transport connection [{}] to [{}] with age [{}ms]", connectionId, node, closeTimeMillis - openTimeMillis);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            assert false : e; // never called
+        }
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -32,13 +33,15 @@ import java.io.IOException;
 public class TransportStats implements Writeable, ToXContentFragment {
 
     private final long serverOpen;
+    private final long totalOutboundConnections;
     private final long rxCount;
     private final long rxSize;
     private final long txCount;
     private final long txSize;
 
-    public TransportStats(long serverOpen, long rxCount, long rxSize, long txCount, long txSize) {
+    public TransportStats(long serverOpen, long totalOutboundConnections, long rxCount, long rxSize, long txCount, long txSize) {
         this.serverOpen = serverOpen;
+        this.totalOutboundConnections = totalOutboundConnections;
         this.rxCount = rxCount;
         this.rxSize = rxSize;
         this.txCount = txCount;
@@ -47,6 +50,11 @@ public class TransportStats implements Writeable, ToXContentFragment {
 
     public TransportStats(StreamInput in) throws IOException {
         serverOpen = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            totalOutboundConnections = in.readVLong();
+        } else {
+            totalOutboundConnections = 0L;
+        }
         rxCount = in.readVLong();
         rxSize = in.readVLong();
         txCount = in.readVLong();
@@ -56,6 +64,9 @@ public class TransportStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeVLong(totalOutboundConnections);
+        }
         out.writeVLong(rxCount);
         out.writeVLong(rxSize);
         out.writeVLong(txCount);
@@ -106,6 +117,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.TRANSPORT);
         builder.field(Fields.SERVER_OPEN, serverOpen);
+        builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
         builder.field(Fields.RX_COUNT, rxCount);
         builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, new ByteSizeValue(rxSize));
         builder.field(Fields.TX_COUNT, txCount);
@@ -117,6 +129,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
     static final class Fields {
         static final String TRANSPORT = "transport";
         static final String SERVER_OPEN = "server_open";
+        static final String TOTAL_OUTBOUND_CONNECTIONS = "total_outbound_connections";
         static final String RX_COUNT = "rx_count";
         static final String RX_SIZE = "rx_size";
         static final String RX_SIZE_IN_BYTES = "rx_size_in_bytes";

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -440,7 +440,7 @@ public class NodeStatsTests extends ESTestCase {
             fsInfo = new FsInfo(randomNonNegativeLong(), ioStats, paths);
         }
         TransportStats transportStats = frequently() ? new TransportStats(randomNonNegativeLong(), randomNonNegativeLong(),
-                randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()) : null;
+                randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()) : null;
         HttpStats httpStats = frequently() ? new HttpStats(randomNonNegativeLong(), randomNonNegativeLong()) : null;
         AllCircuitBreakerStats allCircuitBreakerStats = null;
         if (frequently()) {


### PR DESCRIPTION
Transport connections between nodes remain in place until one or other
node shuts down or the connection is disrupted by a flaky network.
Today it is very difficult to demonstrate that transient failures and
cluster instability are caused by the network even though this is often
the case. In particular, transport connections open and close without
logging anything, even at `DEBUG` level, making it very hard to quantify
the scale of the problem or to correlate the networking problems with
external events.

This commit adds the missing `DEBUG`-level logging when transport
connections open and close, and also tracks the total number of
transport connections a node has opened as a measure of the stability of
the underlying network.