### PR TITLE
[DOCS] Add `number_of_routing_shards` index setting to index modules

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -46,6 +46,17 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 
 // end::index-number-of-shards-tag[]
 
+[[index-number-of-routing-shards]]
+`index.number_of_routing_shards`::
+Number of routing shards used to <<indices-split-index,split>> an index and its
+primary shards. This setting specifies the hashing space used internally to
+distribute documents for a split index across shards. See
+<<indices-split-index>>.
++
+This setting's default value depends on the number of primary shards in the
+index. The default is designed to allow you to split by factors of 2 up
+to a maximum of 1024 shards.
+
 `index.shard.check_on_startup`::
 
 Whether or not shards should be checked for corruption before opening. When

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -63,6 +63,8 @@ split as follows:
 This setting's default value depends on the number of primary shards in the
 index. The default is designed to allow you to split by factors of 2 up
 to a maximum of 1024 shards.
+
+See <<indices-split-index>>.
 --
 
 `index.shard.check_on_startup`::

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -48,14 +48,22 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 
 [[index-number-of-routing-shards]]
 `index.number_of_routing_shards`::
-Number of routing shards used to <<indices-split-index,split>> an index and its
-primary shards. This setting specifies the hashing space used internally to
-distribute documents for a split index across shards. See
-<<indices-split-index>>.
 +
+--
+Number of routing shards used to <<indices-split-index,split>> an index.
+
+For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x
+2 x 3`) could be split by a factor of `2` or `3`.  In other words, it could be
+split as follows:
+
+* `5` -> `10` -> `30`  (split by 2, then by 3)
+* `5` -> `15` -> `30` (split by 3, then by 2)
+* `5` -> `30` (split by 6)
+
 This setting's default value depends on the number of primary shards in the
 index. The default is designed to allow you to split by factors of 2 up
 to a maximum of 1024 shards.
+--
 
 `index.shard.check_on_startup`::
 

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -49,7 +49,7 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 [[index-number-of-routing-shards]]
 `index.number_of_routing_shards`::
 +
---
+====
 Number of routing shards used to <<indices-split-index,split>> an index.
 
 For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x
@@ -63,9 +63,7 @@ split as follows:
 This setting's default value depends on the number of primary shards in the
 index. The default is designed to allow you to split by factors of 2 up
 to a maximum of 1024 shards.
-
-See <<indices-split-index>>.
---
+====
 
 `index.shard.check_on_startup`::
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -97,6 +97,7 @@ PUT /my-index-000001
   }
 }
 ----
+// TEST[continued]
 ====
 
 The `index.number_of_routing_shards` setting's default value depends 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -88,12 +88,10 @@ The following <<indices-create-index,create index API>> creates the
 
 [source,console]
 ----
-PUT /twitter
+PUT /my-index-000001
 {
   "settings": {
     "index": {
-      "number_of_shards": 3, 
-      "number_of_replicas": 2
       "number_of_routing_shards": 30
     }
   }

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -80,6 +80,27 @@ factor of `2` or `3`.  In other words, it could be split as follows:
 setting>>. You can only set `index.number_of_routing_shards` at index creation
 time or on a <<indices-open-close,closed index>>.
 
+.*Index creation example*
+[%collapsible]
+====
+The following <<indices-create-index,create index API>> creates the
+`my-index-000001` index with an `index.number_of_routing_shards` setting of `30`.
+
+[source,console]
+----
+PUT /twitter
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 3, 
+      "number_of_replicas": 2
+      "number_of_routing_shards": 30
+    }
+  }
+}
+----
+====
+
 The `index.number_of_routing_shards` setting's default value depends 
 on the number of primary shards in the original index.
 The default is designed to allow you to split

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -76,11 +76,15 @@ factor of `2` or `3`.  In other words, it could be split as follows:
 * `5` -> `15` -> `30` (split by 3, then by 2)
 * `5` -> `30` (split by 6)
 
-While you can set the `index.number_of_routing_shards` setting explicitly at
-index creation time, the default value depends upon the number of primary
-shards in the original index.  The default is designed to allow you to split
-by factors of 2 up to a maximum of 1024 shards.  However, the original number
-of primary shards must taken into account.  For instance, an index created
+`index.number_of_routing_shards` is a <<index-modules-settings,static index
+setting>>. You can only set `index.number_of_routing_shards` at index creation
+time or on a <<indices-open-close,closed index>>.
+
+The `index.number_of_routing_shards` setting's default value depends 
+on the number of primary shards in the original index.
+The default is designed to allow you to split
+by factors of 2 up to a maximum of 1024 shards. However, the original number
+of primary shards must taken into account. For instance, an index created
 with 5 primary shards could be split into 10, 20, 40, 80, 160, 320, or a
 maximum of 640 shards (with a single split action or multiple split actions).
 


### PR DESCRIPTION
Changes:

* Adds the `number_of_routing_shards` index setting to index modules docs.
* Updates the split API docs to mention that `number_of_routing_shards`
is a static setting.

Closes #60182