### PR TITLE
Update IDE compiler settings for IntelliJ 2020.2 support

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -67,8 +67,11 @@ if (System.getProperty('idea.active') == 'true') {
         }
         compiler {
           parallelCompilation = true
+          processHeapSize = 2048
+          addNotNullAssertions = false
           javac {
             generateDeprecationWarnings = false
+            preferTargetJDKCompiler = false
           }
         }
         runConfigurations {


### PR DESCRIPTION
This PR makes some updates to the IDE compiler options when importing the project to account for some changes in IntelliJ 2020.2. In this update the IDE is more aggressive in forking compilation processes under certain circumstances. Thes forked processes share a slice of the total build process heap size, which is 700MB by default. With several forked compilers, these each only receive 256MB, which isn't sufficient for compiling the largest modules, such as server. We bump this to 2G to give ample room for parallel and forked compilation in the IDE. We also tweak some other settings to minimize the amount of forking as well as disable annotation post-processing, which isn't needed.