### PR TITLE
Fix documentation about `indexing_pressure.memory.limit`

### DIFF
--- a/docs/reference/index-modules/indexing-pressure.asciidoc
+++ b/docs/reference/index-modules/indexing-pressure.asciidoc
@@ -66,7 +66,7 @@ retrieve indexing pressure metrics.
 [[indexing-pressure-settings]]
 === Indexing pressure settings
 
-`indexing_pressure`::
+`indexing_pressure.memory.limit`::
   Number of outstanding bytes that may be consumed by indexing requests. When
   this limit is reached or exceeded, the node will reject new coordinating and
   primary operations. When replica operations consume 1.5x this limit, the node


### PR DESCRIPTION
The documentation about this setting is currently mislabelled. This
commit fixes the issue.