### PR TITLE
Set the systemd initial timeout to 75 seconds

### DIFF
--- a/distribution/packages/src/common/systemd/elasticsearch.service
+++ b/distribution/packages/src/common/systemd/elasticsearch.service
@@ -57,6 +57,9 @@ SendSIGKILL=no
 # When a JVM receives a SIGTERM signal it exits with code 143
 SuccessExitStatus=143
 
+# Allow a slow startup before the systemd notifier module kicks in to extend the timeout
+TimeoutStartSec=75
+
 [Install]
 WantedBy=multi-user.target
 


### PR DESCRIPTION
For systemd, while we are starting up, we notify the system every 15
seconds that we are still in the middle of starting up. However, if
initial startup before plugin initialization is slower than 15 seconds,
we won't ever get the chance to run the first timeout extension. This
commit sets the initial timeout to 75 seconds, up from the default 30
seconds used by systemd.

closes #60140