### PR TITLE
[DOCS] Add info about why we removed test fw docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -637,32 +637,67 @@ See:
 [role="exclude",id="testing"]
 === Testing
 
-This page was deleted.
+This page was deleted. 
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
 
 [role="exclude",id="testing-framework"]
 === Java testing framework
 
 This page was deleted.
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
+
 
 [role="exclude",id="why-randomized-testing"]
 === Why randomized testing?
 
 This page was deleted.
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
+
 
 [role="exclude",id="using-elasticsearch-test-classes"]
 === Using the {es} test classes
 
 This page was deleted.
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
+
 
 [role="exclude",id="unit-tests"]
 === Unit tests
 
 This page was deleted.
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
+
 
 [role="exclude",id="integration-tests"]
 === Integration tests
 
 This page was deleted.
+Information about the Java testing framework was removed 
+(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+because it was out of date and erroneously implied that it should be used by application developers.  
+There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+for providing general testing guidance for applications that communicate with {es}. 
+
 
 [role="exclude",id="number-of-shards"]
 ==== Number of shards

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -649,9 +649,9 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 
@@ -660,9 +660,9 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 
@@ -671,9 +671,9 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}55258[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 
@@ -682,9 +682,9 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}55258[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 
@@ -693,9 +693,9 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}55258[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -639,9 +639,9 @@ See:
 
 This page was deleted. 
 Information about the Java testing framework was removed 
-(https://github.com/elastic/elasticsearch/issues/55257[55257]) from the {es} Reference 
+({es-issue}55257[#55257]) from the {es} Reference 
 because it was out of date and erroneously implied that it should be used by application developers.  
-There is an open doc issue (https://github.com/elastic/elasticsearch/issues/55258[#55258]) 
+There is an issue ({es-issue}55258[#55258]) 
 for providing general testing guidance for applications that communicate with {es}. 
 
 [role="exclude",id="testing-framework"]


### PR DESCRIPTION
We've had a number of questions about the removal of the test framework docs, so I added a bit more context to the manual redirect page and linked to the related issues.