### PR TITLE
Increase Timeouts in SLMBlockingIntegTests

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -340,14 +340,18 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
             logger.info("--> waiting for snapshot to complete");
             successfulSnapshotName.set(snapshotResponse.get().getSnapshotName());
             assertNotNull(successfulSnapshotName.get());
-            Thread.sleep(TimeValue.timeValueSeconds(10).millis());
             logger.info("-->  verify that snapshot [{}] succeeded", successfulSnapshotName.get());
             assertBusy(() -> {
                 GetSnapshotsResponse snapshotsStatusResponse = client().admin().cluster()
-                    .prepareGetSnapshots(REPO).setSnapshots(successfulSnapshotName.get()).get();
-                SnapshotInfo snapshotInfo = snapshotsStatusResponse.getSnapshots(REPO).get(0);
+                        .prepareGetSnapshots(REPO).setSnapshots(successfulSnapshotName.get()).execute().actionGet();
+                final SnapshotInfo snapshotInfo;
+                try {
+                    snapshotInfo = snapshotsStatusResponse.getSnapshots(REPO).get(0);
+                } catch (SnapshotMissingException sme) {
+                    throw new AssertionError(sme);
+                }
                 assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
-            });
+            }, 30L, TimeUnit.SECONDS);
         }
 
         // Check that the failed snapshot from before still exists, now that retention has run
@@ -378,7 +382,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
                     .prepareGetSnapshots(REPO).setSnapshots(successfulSnapshotName.get()).get();
                 SnapshotInfo snapshotInfo = snapshotsStatusResponse.getSnapshots(REPO).get(0);
                 assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
-            });
+            }, 30L, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
The retention run goes through a number of steps and can randomly take more than 10s.
=> increased timeout to 30s like we did in other spots in this test

Also, noticed that we had a hard wait of 10s in this test, removed it and adjusted following
busy assert in a way that can deal with a missing snapshot (from when the assert runs before
the snapshot was put into the CS).

Closes #60336
