### PR TITLE
Fix IPV6 Scope ID Test

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
 public class InetAddressesTests extends ESTestCase {
@@ -128,9 +129,8 @@ public class InetAddressesTests extends ESTestCase {
         assertTrue(InetAddresses.isInetAddress(ipStr));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60332")
-    public void testForStringIPv6WithScopeIdInput() throws UnknownHostException {
-        String ipStr = "0:0:0:0:0:0:0:1%lo";
+    public void testForStringIPv6WithScopeIdInput() throws java.io.IOException {
+        String ipStr = "0:0:0:0:0:0:0:1%" + NetworkInterface.getNetworkInterfaces().nextElement().getName();
         InetAddress ipv6Addr = InetAddress.getByName(ipStr);
         assertEquals(ipv6Addr, InetAddresses.forString(ipStr));
         assertTrue(InetAddresses.isInetAddress(ipStr));


### PR DESCRIPTION
Use real scope id from first available interface instead of `lo` which might
not exist on non-Linux platforms.

Closes #60332
