### PR TITLE
Fix NPE in SnapshotsInProgress Constructor (#60355)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1303,6 +1303,11 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         final SnapshotInfo snapshot2 =
                 PlainActionFuture.get(f -> snapshotsService.executeSnapshotLegacy(new CreateSnapshotRequest(repoName, "snap-2"), f));
         assertThat(snapshot2.state(), is(SnapshotState.SUCCESS));
+
+        final SnapshotInfo snapshot3 =
+                PlainActionFuture.get(f -> snapshotsService.executeSnapshotLegacy(
+                        new CreateSnapshotRequest(repoName, "snap-3").indices("does-not-exist-*"), f));
+        assertThat(snapshot3.state(), is(SnapshotState.SUCCESS));
     }
 
     private long calculateTotalFilesSize(List<Path> files) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -565,7 +565,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         // No indices in this snapshot - we are done
                         userCreateSnapshotListener.onResponse(snapshot.snapshot());
                         endSnapshot(new SnapshotsInProgress.Entry(
-                            snapshot, State.STARTED, Collections.emptyList(), repositoryData.getGenId(), null, version,
+                            snapshot, State.STARTED, Collections.emptyList(), repositoryData.getGenId(), ImmutableOpenMap.of(), version,
                             null), clusterState.metadata(), repositoryData);
                         return;
                     }


### PR DESCRIPTION
Merge oversight between cleanups that removed `null` for `shards` and this corner case
spot of no indices in a snapshot.

Closes #60330

backport of #60355 