### PR TITLE
Fix IPV6 Scope Id in InetAddressesTests (#60368)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -23,6 +23,7 @@ import org.hamcrest.Matchers;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
 
 public class InetAddressesTests extends ESTestCase {
     public void testForStringBogusInput() {
@@ -130,7 +131,17 @@ public class InetAddressesTests extends ESTestCase {
     }
 
     public void testForStringIPv6WithScopeIdInput() throws java.io.IOException {
-        String ipStr = "0:0:0:0:0:0:0:1%" + NetworkInterface.getNetworkInterfaces().nextElement().getName();
+        final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        String scopeId = null;
+        while (interfaces.hasMoreElements()) {
+            final NetworkInterface nint = interfaces.nextElement();
+            if (nint.isLoopback()) {
+                scopeId = nint.getName();
+                break;
+            }
+        }
+        assertNotNull(scopeId);
+        String ipStr = "0:0:0:0:0:0:0:1%" + scopeId;
         InetAddress ipv6Addr = InetAddress.getByName(ipStr);
         assertEquals(ipv6Addr, InetAddresses.forString(ipStr));
         assertTrue(InetAddresses.isInetAddress(ipStr));


### PR DESCRIPTION
Follow up to #60360, turns out at times the name of an interface that isn't loopback is not a valid scope id.

backport of #60368 