### PR TITLE
SQL: IN operator incorrectly handling specified date format (#58932)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -152,6 +152,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
     public Expression visitValueExpressionDefault(ValueExpressionDefaultContext ctx) {
         Expression expr = expression(ctx.primaryExpression());
         Source source = source(ctx);
+        ZoneId zoneId = params.zoneId();
 
         PredicateContext predicate = ctx.predicate();
 
@@ -160,7 +161,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
         }
 
         List<Expression> container = expressions(predicate.expression());
-        Expression checkInSet = new In(source, expr, container);
+        Expression checkInSet = new In(source, expr, container, zoneId);
 
         return predicate.NOT() != null ? new Not(source, checkInSet) : checkInSet;
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,16 +35,25 @@ public class In extends ScalarFunction {
 
     private final Expression value;
     private final List<Expression> list;
+    private final ZoneId zoneId;
 
     public In(Source source, Expression value, List<Expression> list) {
         super(source, CollectionUtils.combine(list, value));
         this.value = value;
         this.list = new ArrayList<>(new LinkedHashSet<>(list));
+        this.zoneId = null;
+    }
+    
+    public In(Source source, Expression value, List<Expression> list, ZoneId zoneId) {
+        super(source, CollectionUtils.combine(list, value));
+        this.value = value;
+        this.list = new ArrayList<>(new LinkedHashSet<>(list));
+        this.zoneId = zoneId;
     }
 
     @Override
     protected NodeInfo<In> info() {
-        return NodeInfo.create(this, In::new, value(), list());
+        return NodeInfo.create(this, In::new, value(), list(), zoneId());
     }
 
     @Override
@@ -51,7 +61,11 @@ public class In extends ScalarFunction {
         if (newChildren.size() < 2) {
             throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
         }
-        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1));
+        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
+    }
+    
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
     public Expression value() {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -358,7 +358,18 @@ public final class ExpressionTranslators {
                     set.add(handler.convert(valueOf(e), dt));
                 }
 
-                q = new TermsQuery(in.source(), fa.exactAttribute().name(), set);
+                if (dt == DATETIME) {
+                    q = null;
+                    DateFormatter formatter = DateFormatter.forPattern(DATE_FORMAT);
+        
+                    for (Object o : set) {
+                        RangeQuery right = new RangeQuery(in.source(), fa.exactAttribute().name(),
+                                o, true, o, true, formatter.pattern(), in.zoneId());
+                        q = q == null ? right : new BoolQuery(in.source(), false, q, right);
+                    }
+                } else {
+                    q = new TermsQuery(in.source(), fa.exactAttribute().name(), set);
+                }
             } else {
                 q = new ScriptQuery(in.source(), in.asScript());
             }

--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
@@ -129,3 +129,8 @@ whereWithInAndNullHandling1
 SELECT last_name l FROM "test_emp" WHERE languages in (2, 10)AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
 whereWithInAndNullHandling2
 SELECT last_name l FROM "test_emp" WHERE languages in (2, null, 10) AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
+
+whereWithInAndOneDatetimeValue
+SELECT birth_date FROM "test_emp" WHERE birth_date IN ('1959-12-25T12:12:12.000Z'::datetime);
+whereWithInAndMultipleDatetimeValues
+SELECT birth_date FROM "test_emp" WHERE birth_date IN ('1959-12-25T12:12:12.000Z'::datetime, '1959-07-23T12:12:12.000Z'::datetime);

--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
@@ -134,3 +134,6 @@ whereWithInAndOneDatetimeValue
 SELECT birth_date FROM "test_emp" WHERE birth_date IN ('1959-12-25T12:12:12.000Z'::datetime);
 whereWithInAndMultipleDatetimeValues
 SELECT birth_date FROM "test_emp" WHERE birth_date IN ('1959-12-25T12:12:12.000Z'::datetime, '1959-07-23T12:12:12.000Z'::datetime);
+
+whereWithInAndTimeValue
+SELECT birth_date FROM "test_emp" WHERE birth_date::time IN ('12:12:12.000'::time);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeConverter;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,10 +23,14 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
     public In(Source source, Expression value, List<Expression> list) {
         super(source, value, list);
     }
+    
+    public In(Source source, Expression value, List<Expression> list, ZoneId zoneId) {
+        super(source, value, list, zoneId);
+    }
 
     @Override
     protected NodeInfo<org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.In> info() {
-        return NodeInfo.create(this, In::new, value(), list());
+        return NodeInfo.create(this, In::new, value(), list(), zoneId());
     }
 
     @Override
@@ -33,7 +38,7 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
         if (newChildren.size() < 2) {
             throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
         }
-        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1));
+        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -233,7 +233,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 if (pCtx.query() != null) {
                     throw new ParsingException(source, "IN query not supported yet");
                 }
-                e = new In(source, exp, expressions(pCtx.valueExpression()));
+                e = new In(source, exp, expressions(pCtx.valueExpression()), zoneId);
                 break;
             case SqlBaseParser.LIKE:
                 e = new Like(source, exp, visitPattern(pCtx.pattern()));


### PR DESCRIPTION
Related to #58932

In `IN` operator, the ExpressionTranslator<In> translates expression into terms query, but when the expression is date format, the terms query get unexpected results. This commit changes the terms query into bool should query when data type is `DATETIME`.

The original translation of `IN ('2000-11-11 11:11:11'::timestamp)` was below, which got the error `failed to parse date field [2000-11-11T11:11:11Z] with format [yyyy-MM-dd' 'HH:mm:ss]: [failed to parse date field [2000-11-11T11:11:11Z] with format [yyyy-MM-dd' 'HH:mm:ss]]`, beacause the terms format is not the same as defined:

```
{
  "query" : {
    "terms" : {
      "datetime0" : [
        "2000-11-11T11:11:11.000Z"
      ],
      "boost" : 1.0
    }
  }
}
```

In this commit, the `IN ('2000-11-11 11:11:11'::timestamp)` translates to:
```
{
  "query" : {
    "range" : {
      "datetime0" : {
        "from" : "2000-11-11T11:11:11.000Z",
        "to" : "2000-11-11T11:11:11.000Z",
        "include_lower" : true,
        "include_upper" : true,
        "time_zone" : "Z",
        "format" : "strict_date_time",
        "boost" : 1.0
      }
    }
  }
}
```

And the `IN ('2000-11-11 11:11:11'::timestamp, '2000-11-11 22:22:22'::timestamp)` translate to:
```
{
 "query" : {
    "bool" : {
      "should" : [
        {
          "range" : {
            "datetime0" : {
              "from" : "2000-11-11T11:11:11.000Z",
              "to" : "2000-11-11T11:11:11.000Z",
              "include_lower" : true,
              "include_upper" : true,
              "time_zone" : "Z",
              "format" : "strict_date_time",
              "boost" : 1.0
            }
          }
        },
        {
          "range" : {
            "datetime0" : {
              "from" : "2000-11-11T22:22:22.000Z",
              "to" : "2000-11-11T22:22:22.000Z",
              "include_lower" : true,
              "include_upper" : true,
              "time_zone" : "Z",
              "format" : "strict_date_time",
              "boost" : 1.0
            }
          }
        }
      ],
      "boost" : 1.0
    }
  }
}
```

Finally, the problem is solved:

```
SELECT datetime0 FROM idx WHERE datetime0 IN ('2000-11-11 11:11:11'::timestamp)

       datetime0        
------------------------
2000-11-11T11:11:11.000Z
```