### PR TITLE
[ML] fixing minor change in langident model behavior

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/langident/LangIdentNeuralNetwork.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/langident/LangIdentNeuralNetwork.java
@@ -139,7 +139,7 @@ public class LangIdentNeuralNetwork implements StrictlyParsedTrainedModel, Lenie
             probabilities,
             LANGUAGE_NAMES,
             null,
-            classificationConfig.getNumTopClasses() == 0 ? 1 : classificationConfig.getNumTopClasses(),
+            classificationConfig.getNumTopClasses(),
             PredictionFieldType.STRING);
         final InferenceHelpers.TopClassificationValue classificationValue = topClasses.v1();
         assert classificationValue.getValue() >= 0 && classificationValue.getValue() < LANGUAGE_NAMES.size() :


### PR DESCRIPTION
inadvertent change where we always recorded at least one top class.

This is not required. 

backports:

 https://github.com/elastic/elasticsearch/pull/60398
 https://github.com/elastic/elasticsearch/pull/60397 

already address this change