### PR TITLE
Reenable BWC after memory limit api backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/60342" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/50_indexing_pressure.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/50_indexing_pressure.yml
@@ -32,8 +32,7 @@
 ---
 "Indexing pressure memory limit":
   - skip:
-      # Change to 7.9.99 on backport
-      version: " - 7.10.99"
+      version: " - 7.9.99"
       reason: "memory limit was added in 7.10"
       features: [arbitrary_key]
 

--- a/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
+++ b/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
@@ -61,8 +61,7 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
         primaryRejections = in.readVLong();
         replicaRejections = in.readVLong();
 
-        // TODO: Change to 7.10 after backport
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             memoryLimit = in.readVLong();
         } else {
             memoryLimit = -1L;
@@ -103,8 +102,7 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
         out.writeVLong(primaryRejections);
         out.writeVLong(replicaRejections);
 
-        // TODO: Change to 7.10 after backport
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeVLong(memoryLimit);
         }
     }


### PR DESCRIPTION
This commit reenables BWC and updates version constants after the
backport of #60342.