### PR TITLE
SQL: Add option to provide the delimiter for the CSV format (#59907)

### DIFF
--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -15,7 +15,7 @@
 === Overview
 
 The SQL REST API accepts SQL in a JSON document, executes it,
-and returns the results. 
+and returns the results.
 For example:
 
 [source,console]
@@ -106,6 +106,10 @@ s|Description
 
 |===
 
+The `CSV` format accepts a formatting URL query attribute, `delimiter`, which indicates which character should be used to separate the CSV
+values. It defaults to comma (`,`) and cannot take any of the following values: double quote (`"`), carriage-return (`\r`) and new-line (`\n`).
+The tab (`\t`) can also not be used, the `tsv` format needs to be used instead.
+
 Here are some examples for the human readable formats:
 
 ==== CSV
@@ -120,7 +124,7 @@ POST /_sql?format=csv
 --------------------------------------------------
 // TEST[setup:library]
 
-Which returns:
+which returns:
 
 [source,text]
 --------------------------------------------------
@@ -130,6 +134,31 @@ Vernor Vinge,A Fire Upon the Deep,613,1992-06-01T00:00:00.000Z
 Frank Herbert,Dune,604,1965-06-01T00:00:00.000Z
 Alastair Reynolds,Revelation Space,585,2000-03-15T00:00:00.000Z
 James S.A. Corey,Leviathan Wakes,561,2011-06-02T00:00:00.000Z
+--------------------------------------------------
+// TESTRESPONSE[non_json]
+
+or:
+
+[source,console]
+--------------------------------------------------
+POST /_sql?format=csv&delimiter=%3b
+{
+    "query": "SELECT * FROM library ORDER BY page_count DESC",
+    "fetch_size": 5
+}
+--------------------------------------------------
+// TEST[setup:library]
+
+which returns:
+
+[source,text]
+--------------------------------------------------
+author;name;page_count;release_date
+Peter F. Hamilton;Pandora's Star;768;2004-03-02T00:00:00.000Z
+Vernor Vinge;A Fire Upon the Deep;613;1992-06-01T00:00:00.000Z
+Frank Herbert;Dune;604;1965-06-01T00:00:00.000Z
+Alastair Reynolds;Revelation Space;585;2000-03-15T00:00:00.000Z
+James S.A. Corey;Leviathan Wakes;561;2011-06-02T00:00:00.000Z
 --------------------------------------------------
 // TESTRESPONSE[non_json]
 
@@ -210,7 +239,7 @@ Which returns:
 
 [source,text]
 --------------------------------------------------
-     author      |        name        |  page_count   |      release_date      
+     author      |        name        |  page_count   |      release_date
 -----------------+--------------------+---------------+------------------------
 Peter F. Hamilton|Pandora's Star      |768            |2004-03-02T00:00:00.000Z
 Vernor Vinge     |A Fire Upon the Deep|613            |1992-06-01T00:00:00.000Z
@@ -275,8 +304,8 @@ cursor: "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmB
 === Paginating through a large response
 
 Using the example from the <<sql-rest-format,previous section>>, one can
-continue to the next page by sending back the cursor field. In case of text
-format, the cursor is returned as `Cursor` http header.
+continue to the next page by sending back the cursor field. In the case of CSV, TSV and TXT
+formats, the cursor is returned in the `Cursor` HTTP header.
 
 [source,console]
 --------------------------------------------------

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
@@ -50,14 +50,20 @@ public final class Protocol {
     public static final TimeValue PAGE_TIMEOUT = TimeValue.timeValueSeconds(45);
     public static final boolean FIELD_MULTI_VALUE_LENIENCY = false;
     public static final boolean INDEX_INCLUDE_FROZEN = false;
-    
+
     /*
-     * Using the Boolean object here so that SqlTranslateRequest to set this to null (since it doesn't need a "columnar" or 
+     * Using the Boolean object here so that SqlTranslateRequest to set this to null (since it doesn't need a "columnar" or
      * binary parameter).
      * See {@code SqlTranslateRequest.toXContent}
      */
     public static final Boolean COLUMNAR = Boolean.FALSE;
     public static final Boolean BINARY_COMMUNICATION = null;
+
+    /*
+     * URL parameters
+     */
+    public static final String URL_PARAM_FORMAT = "format";
+    public static final String URL_PARAM_DELIMITER = "delimiter";
 
     /**
      * SQL-related endpoints

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
@@ -24,15 +24,21 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.sql.proto.Protocol.URL_PARAM_DELIMITER;
+import static org.elasticsearch.xpack.sql.proto.Protocol.URL_PARAM_FORMAT;
 
 public class RestSqlQueryAction extends BaseRestHandler {
+
+    TextFormat textFormat;
 
     @Override
     public List<Route> routes() {
@@ -77,7 +83,7 @@ public class RestSqlQueryAction extends BaseRestHandler {
             // enforce CBOR response for drivers and CLI (unless instructed differently through the config param)
             accept = XContentType.CBOR.name();
         } else {
-            accept = request.param("format");
+            accept = request.param(URL_PARAM_FORMAT);
         }
         if (accept == null) {
             accept = request.header("Accept");
@@ -99,7 +105,7 @@ public class RestSqlQueryAction extends BaseRestHandler {
          * which we turn into a 400 error.
          */
         XContentType xContentType = accept == null ? XContentType.JSON : XContentType.fromMediaTypeOrFormat(accept);
-        TextFormat textFormat = xContentType == null ? TextFormat.fromMediaTypeOrFormat(accept) : null;
+        textFormat = xContentType == null ? TextFormat.fromMediaTypeOrFormat(accept) : null;
 
         if (xContentType == null && sqlRequest.columnar()) {
             throw new IllegalArgumentException("Invalid use of [columnar] argument: cannot be used in combination with "
@@ -134,6 +140,11 @@ public class RestSqlQueryAction extends BaseRestHandler {
                 return restResponse;
             }
         });
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return textFormat == TextFormat.CSV ? Collections.singleton(URL_PARAM_DELIMITER) : Collections.emptySet();
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.sql.session.Cursor;
 import org.elasticsearch.xpack.sql.session.Cursors;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -25,6 +27,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.sql.action.BasicFormatter.FormatOption.TEXT;
+import static org.elasticsearch.xpack.sql.proto.Protocol.URL_PARAM_DELIMITER;
 
 /**
  * Templating class for displaying SQL responses in text formats.
@@ -80,16 +83,16 @@ enum TextFormat {
 
         @Override
         String shortName() {
-            return "txt";
+            return FORMAT_TEXT;
         }
 
         @Override
         String contentType() {
-            return "text/plain";
+            return CONTENT_TYPE_TXT;
         }
 
         @Override
-        protected String delimiter() {
+        protected Character delimiter() {
             throw new UnsupportedOperationException();
         }
 
@@ -109,40 +112,64 @@ enum TextFormat {
      *
      */
     CSV() {
-
         @Override
-        protected String delimiter() {
-            return ",";
+        protected Character delimiter() {
+            return ',';
         }
 
         @Override
         protected String eol() {
-            //LFCR
+            //CRLF
             return "\r\n";
         }
 
         @Override
         String shortName() {
-            return "csv";
+            return FORMAT_CSV;
         }
 
         @Override
         String contentType() {
-            return "text/csv";
+            return CONTENT_TYPE_CSV;
         }
 
         @Override
         String contentType(RestRequest request) {
-            return contentType() + "; charset=utf-8; header=" + (hasHeader(request) ? "present" : "absent");
+            return contentType() + "; charset=utf-8; " +
+                URL_PARAM_HEADER + "=" + (hasHeader(request) ? PARAM_HEADER_PRESENT : PARAM_HEADER_ABSENT);
         }
 
         @Override
-        String maybeEscape(String value) {
+        protected Character delimiter(RestRequest request) {
+            String delimiterParam = request.param(URL_PARAM_DELIMITER);
+            if (delimiterParam == null) {
+                return delimiter();
+            }
+            delimiterParam = URLDecoder.decode(delimiterParam, StandardCharsets.UTF_8);
+            if (delimiterParam.length() != 1) {
+                throw new IllegalArgumentException("invalid " +
+                    (delimiterParam.length() > 0 ? "multi-character" : "empty") + " delimiter [" + delimiterParam + "]");
+            }
+            Character delimiter = delimiterParam.charAt(0);
+            switch (delimiter) {
+                case '"':
+                case '\n':
+                case '\r':
+                    throw new IllegalArgumentException("illegal reserved character specified as delimiter [" + delimiter + "]");
+                case '\t':
+                    throw new IllegalArgumentException("illegal delimiter [TAB] specified as delimiter for the [csv] format; " +
+                        "choose the [tsv] format instead");
+            }
+            return delimiter;
+        }
+
+        @Override
+        String maybeEscape(String value, Character delimiter) {
             boolean needsEscaping = false;
 
             for (int i = 0; i < value.length(); i++) {
                 char c = value.charAt(i);
-                if (c == '"' || c == ',' || c == '\n' || c == '\r') {
+                if (c == '"' || c == '\n' || c == '\r' || c == delimiter) {
                     needsEscaping = true;
                     break;
                 }
@@ -162,20 +189,21 @@ enum TextFormat {
                 sb.append('"');
                 value = sb.toString();
             }
+
             return value;
         }
 
         @Override
         boolean hasHeader(RestRequest request) {
-            String header = request.param("header");
+            String header = request.param(URL_PARAM_HEADER);
             if (header == null) {
                 List<String> values = request.getAllHeaderValues("Accept");
                 if (values != null) {
-                    // header is a parameter specified by ; so try breaking it down
+                    // header values are separated by `;` so try breaking it down
                     for (String value : values) {
                         String[] params = Strings.tokenizeToStringArray(value, ";");
                         for (String param : params) {
-                            if (param.toLowerCase(Locale.ROOT).equals("header=absent")) {
+                            if (param.toLowerCase(Locale.ROOT).equals(URL_PARAM_HEADER + "=" + PARAM_HEADER_ABSENT)) {
                                 return false;
                             }
                         }
@@ -183,31 +211,31 @@ enum TextFormat {
                 }
                 return true;
             } else {
-                return !header.toLowerCase(Locale.ROOT).equals("absent");
+                return !header.toLowerCase(Locale.ROOT).equals(PARAM_HEADER_ABSENT);
             }
         }
     },
 
     TSV() {
         @Override
-        protected String delimiter() {
-            return "\t";
+        protected Character delimiter() {
+            return '\t';
         }
 
         @Override
         protected String eol() {
-            // only CR
+            // only LF
             return "\n";
         }
 
         @Override
         String shortName() {
-            return "tsv";
+            return FORMAT_TSV;
         }
 
         @Override
         String contentType() {
-            return "text/tab-separated-values";
+            return CONTENT_TYPE_TSV;
         }
 
         @Override
@@ -216,7 +244,7 @@ enum TextFormat {
         }
 
         @Override
-        String maybeEscape(String value) {
+        String maybeEscape(String value, Character __) {
             StringBuilder sb = new StringBuilder();
 
             for (int i = 0; i < value.length(); i++) {
@@ -237,17 +265,27 @@ enum TextFormat {
         }
     };
 
+    private static final String FORMAT_TEXT = "txt";
+    private static final String FORMAT_CSV = "csv";
+    private static final String FORMAT_TSV = "tsv";
+    private static final String CONTENT_TYPE_TXT = "text/plain";
+    private static final String CONTENT_TYPE_CSV = "text/csv";
+    private static final String CONTENT_TYPE_TSV = "text/tab-separated-values";
+    private static final String URL_PARAM_HEADER = "header";
+    private static final String PARAM_HEADER_ABSENT = "absent";
+    private static final String PARAM_HEADER_PRESENT = "present";
 
     String format(RestRequest request, SqlQueryResponse response) {
         StringBuilder sb = new StringBuilder();
 
         // if the header is requested (and the column info is present - namely it's the first page) return the info
         if (hasHeader(request) && response.columns() != null) {
-            row(sb, response.columns(), ColumnInfo::name);
+            row(sb, response.columns(), ColumnInfo::name, delimiter(request));
         }
 
         for (List<Object> row : response.rows()) {
-            row(sb, row, f -> f instanceof ZonedDateTime ? DateUtils.toString((ZonedDateTime) f) : Objects.toString(f, StringUtils.EMPTY));
+            row(sb, row, f -> f instanceof ZonedDateTime ? DateUtils.toString((ZonedDateTime) f) : Objects.toString(f, StringUtils.EMPTY),
+                delimiter(request));
         }
 
         return sb.toString();
@@ -292,11 +330,11 @@ enum TextFormat {
     }
 
     // utility method for consuming a row.
-    <F> void row(StringBuilder sb, List<F> row, Function<F, String> toString) {
+    <F> void row(StringBuilder sb, List<F> row, Function<F, String> toString, Character delimiter) {
         for (int i = 0; i < row.size(); i++) {
-            sb.append(maybeEscape(toString.apply(row.get(i))));
+            sb.append(maybeEscape(toString.apply(row.get(i)), delimiter));
             if (i < row.size() - 1) {
-                sb.append(delimiter());
+                sb.append(delimiter);
             }
         }
         sb.append(eol());
@@ -305,7 +343,11 @@ enum TextFormat {
     /**
      * Delimiter between fields
      */
-    protected abstract String delimiter();
+    protected abstract Character delimiter();
+
+    protected Character delimiter(RestRequest request) {
+        return delimiter();
+    }
 
     /**
      * String indicating end-of-line or row.
@@ -315,7 +357,7 @@ enum TextFormat {
     /**
      * Method used for escaping (if needed) a given value.
      */
-    String maybeEscape(String value) {
+    String maybeEscape(String value, Character delimiter) {
         return value;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.sql.session.Cursor;
 import org.elasticsearch.xpack.sql.session.Cursors;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
@@ -145,7 +146,11 @@ enum TextFormat {
             if (delimiterParam == null) {
                 return delimiter();
             }
-            delimiterParam = URLDecoder.decode(delimiterParam, StandardCharsets.UTF_8);
+            try {
+                delimiterParam = URLDecoder.decode(delimiterParam, StandardCharsets.UTF_8.toString());
+            } catch (UnsupportedEncodingException uee) {
+                throw new IllegalArgumentException("delimiter [" + delimiterParam + "] cannot be decoded: " + uee.getMessage(), uee);
+            }
             if (delimiterParam.length() != 1) {
                 throw new IllegalArgumentException("invalid " +
                     (delimiterParam.length() > 0 ? "multi-character" : "empty") + " delimiter [" + delimiterParam + "]");

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
@@ -105,7 +105,7 @@ public class TextFormatTests extends ESTestCase {
     }
 
     public void testCsvFormatWithCustomDelimiterRegularData() {
-        Set<Character> forbidden = Set.of('"', '\r', '\n', '\t');
+        List<Character> forbidden = Arrays.asList('"', '\r', '\n', '\t');
         Character delim = randomValueOtherThanMany(forbidden::contains, () -> randomAlphaOfLength(1).charAt(0));
         String text = CSV.format(reqWithParam("delimiter", String.valueOf(delim)), regularData());
         List<String> terms = Arrays.asList("string", "number", "Along The River Bank", "708", "Mind Train", "280");

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.sql.proto.Mode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;


### PR DESCRIPTION
* Add option to provide the delimiter to the CSV fmt

This adds the option to provide the desired character as the separator
for the CSV format (the default remains comma).
A set of characters are excluded though - like CR, LF, `"` - to avoid
slipping onto the CSV-dialects slope. The tab is also forbidden, the
user needs to choose the "tsv" format explicitely.

Update the doc to make it clear that the textual CSV, TSV and TXT
formats pass the cursor back to the user through the Cursor HTTP header.

(cherry picked from commit 3a8b00cc7480f7ada57fcea3cbac957facac08fc)

