### PR TITLE
[DOCS] Move field collapse content to separate page

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -68,7 +68,8 @@ See <<request-body-search-explain>>.
 
 [role="exclude",id="search-request-collapse"]
 === Collapse parameter for request body search API
-See <<request-body-search-collapse>>.
+
+See <<collapse-search-results>>.
 
 [role="exclude",id="search-request-from-size"]
 === From and size parameters for request body search API
@@ -929,20 +930,20 @@ For search API reference documentation, see <<search-search>>.
 
 For search examples, see <<run-a-search>>.
 
-[role="exclude",id="request-body-search-from-size"]
-==== From / size
-
-See <<paginate-search-results>>.
-
-[role="exclude",id="request-body-search-source-filtering"]
-==== Source filtering
-
-See <<source-filtering, source filtering>>.
-
 [role="exclude",id="request-body-search-docvalue-fields"]
 ==== Doc value fields
 
 See <<docvalue-fields, doc value fields>>.
+
+[role="exclude",id="request-body-search-collapse"]
+==== Field collapsing
+
+See <<collapse-search-results>>.
+
+[role="exclude",id="request-body-search-from-size"]
+==== From / size
+
+See <<paginate-search-results>>.
 
 [role="exclude",id="request-body-search-highlighting"]
 ==== Highlighting
@@ -955,4 +956,9 @@ See <<how-highlighters-work-internally>>.
 [role="exclude",id="request-body-search-sort"]
 ==== Sort
 See <<sort-search-results>>.
+
+[role="exclude",id="request-body-search-source-filtering"]
+==== Source filtering
+
+See <<source-filtering, source filtering>>.
 ////

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -137,6 +137,7 @@ See <<sort-search-results>>.
 
 [role="exclude",id="search-request-source-filtering"]
 === Source filtering parameter for request body search API
+
 See <<source-filtering>>.
 
 [role="exclude",id="search-request-stored-fields"]

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -108,7 +108,15 @@ executing a distributed search across the whole cluster and gathering all the
 results.
 
 
-include::request/docvalue-fields.asciidoc[]
+[[request-body-search-docvalue-fields]]
+==== Doc value fields
+
+See <<docvalue-fields>>.
+
+[[request-body-search-collapse]]
+==== Field collapsing
+
+See <<collapse-search-results>>.
 
 include::request/collapse.asciidoc[]
 

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -153,7 +153,7 @@ See <<sort-search-results>>.
 [[request-body-search-source-filtering]]
 ==== Source filtering
 
-See <<source filtering>>.
+See <<source-filtering>>.
 
 include::request/stored-fields.asciidoc[]
 

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -118,8 +118,6 @@ See <<docvalue-fields>>.
 
 See <<collapse-search-results>>.
 
-include::request/collapse.asciidoc[]
-
 [[request-body-search-highlighting]]
 ==== Highlighting
 

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -1,9 +1,10 @@
-[[request-body-search-collapse]]
-==== Field Collapsing
+[[collapse-search-results]]
+==== Collapse search results
 
-Allows to collapse search results based on field values.
-The collapsing is done by selecting only the top sorted document per collapse key.
-For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
+You can use the `collapse` parameter to collapse search results based
+on field values. The collapsing is done by selecting only the top sorted
+document per collapse key. For instance the query below retrieves the best tweet
+for each user and sorts them by number of likes.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -1,5 +1,5 @@
 [[collapse-search-results]]
-==== Collapse search results
+=== Collapse search results
 
 You can use the `collapse` parameter to collapse search results based
 on field values. The collapsing is done by selecting only the top sorted
@@ -36,7 +36,7 @@ The field used for collapsing must be a single valued <<keyword, `keyword`>> or 
 NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
 
 
-===== Expand collapse results
+==== Expand collapse results
 
 It is also possible to expand each collapsed top hits with the `inner_hits` option.
 
@@ -118,7 +118,7 @@ The default is based on the number of data nodes and the default search thread p
 WARNING: `collapse` cannot be used in conjunction with <<request-body-search-scroll, scroll>>,
 <<request-body-search-rescore, rescore>> or <<request-body-search-search-after, search after>>.
 
-===== Second level of collapsing
+==== Second level of collapsing
 
 Second level of collapsing is also supported and is applied to `inner_hits`.
 For example, the following request finds the top scored tweets for

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -35,7 +35,7 @@ The field used for collapsing must be a single valued <<keyword, `keyword`>> or 
 
 NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
 
-
+[[expand-collapse-results]]
 ==== Expand collapse results
 
 It is also possible to expand each collapsed top hits with the `inner_hits` option.
@@ -118,6 +118,7 @@ The default is based on the number of data nodes and the default search thread p
 WARNING: `collapse` cannot be used in conjunction with <<request-body-search-scroll, scroll>>,
 <<request-body-search-rescore, rescore>> or <<request-body-search-search-after, search after>>.
 
+[[second-level-of-collapsing]]
 ==== Second level of collapsing
 
 Second level of collapsing is also supported and is applied to `inner_hits`.

--- a/docs/reference/search/request/docvalue-fields.asciidoc
+++ b/docs/reference/search/request/docvalue-fields.asciidoc
@@ -1,4 +1,0 @@
-[[request-body-search-docvalue-fields]]
-==== Doc value fields
-
-See <<docvalue-fields, doc value fields>>.

--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -270,6 +270,8 @@ include::request/from-size.asciidoc[]
 
 include::search-fields.asciidoc[]
 
+include::request/collapse.asciidoc[]
+
 include::request/highlighting.asciidoc[]
 
 include::request/sort.asciidoc[]


### PR DESCRIPTION
Moves the field collapse docs from the deprecated 'Request Body Search'
page to a new subpage of 'Run a search'.

No substantive changes were made to the content.