### PR TITLE
[DOCS] Add rollups to `Tune for disk usage`

### DIFF
--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -186,8 +186,9 @@ it is more likely to find longer duplicate strings in those `_source` documents
 if fields always occur in the same order.
 
 [discrete]
-=== Rolling up historical data
+[[roll-up-historical-data]]
+=== Roll up historical data
 
-Keeping historical data around for analysis is extremely useful but often avoided due to the financial cost of archiving massive amounts of data. Retention periods are thus driven by financial realities rather than by the usefulness of extensive historical data.
-
-The Elastic Stack data <<xpack-rollup,rollup>> features provide a means to summarize and store historical data so that it can still be used for analysis, but at a fraction of the storage cost of raw data.
+Keeping older data can useful for later analysis but is often avoided due to storage costs. 
+You can use data rollups to summarize and store historical data for later 
+at a fraction of the raw data's storage cost. See <<xpack-rollup>>.

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -189,6 +189,6 @@ if fields always occur in the same order.
 [[roll-up-historical-data]]
 === Roll up historical data
 
-Keeping older data can useful for later analysis but is often avoided due to storage costs. 
-You can use data rollups to summarize and store historical data for later 
+Keeping older data can useful for later analysis but is often avoided due to
+storage costs. You can use data rollups to summarize and store historical data
 at a fraction of the raw data's storage cost. See <<xpack-rollup>>.

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -184,3 +184,10 @@ structure, fields, and values together should improve the compression ratio.
 Due to the fact that multiple documents are compressed together into blocks,
 it is more likely to find longer duplicate strings in those `_source` documents
 if fields always occur in the same order.
+
+[discrete]
+=== Rolling up historical data
+
+Keeping historical data around for analysis is extremely useful but often avoided due to the financial cost of archiving massive amounts of data. Retention periods are thus driven by financial realities rather than by the usefulness of extensive historical data.
+
+The Elastic Stack data <<xpack-rollup,rollup>> features provide a means to summarize and store historical data so that it can still be used for analysis, but at a fraction of the storage cost of raw data.


### PR DESCRIPTION
Adding rollup to the tune disk usage page. This seems to be very useful, so I was surprised it was not mentioned on this page already? 

In addition, I also think some sort of reordering on this page where easier ones like `best_compression` or the ones with biggest disk saving should be ordered on top, and complicated ones should be ordered towards to the bottom.

