### PR TITLE
[7.9] Change severity of negative stats messages from WARN to DEBUG

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -92,7 +92,7 @@ public class OsProbe {
         try {
             final long freeMem = (long) getFreePhysicalMemorySize.invoke(osMxBean);
             if (freeMem < 0) {
-                logger.warn("OS reported a negative free memory value [{}]", freeMem);
+                logger.debug("OS reported a negative free memory value [{}]", freeMem);
                 return 0;
             }
             return freeMem;
@@ -113,7 +113,7 @@ public class OsProbe {
         try {
             final long totalMem = (long) getTotalPhysicalMemorySize.invoke(osMxBean);
             if (totalMem < 0) {
-                logger.warn("OS reported a negative total memory value [{}]", totalMem);
+                logger.debug("OS reported a negative total memory value [{}]", totalMem);
                 return 0;
             }
             return totalMem;
@@ -134,7 +134,7 @@ public class OsProbe {
         try {
             final long mem = (long) getFreeSwapSpaceSize.invoke(osMxBean);
             if (mem < 0) {
-                logger.warn("OS reported a negative free swap space size [{}]", mem);
+                logger.debug("OS reported a negative free swap space size [{}]", mem);
                 return 0;
             }
             return mem;
@@ -155,7 +155,7 @@ public class OsProbe {
         try {
             final long mem = (long) getTotalSwapSpaceSize.invoke(osMxBean);
             if (mem < 0) {
-                logger.warn("OS reported a negative total swap space size [{}]", mem);
+                logger.debug("OS reported a negative total swap space size [{}]", mem);
                 return 0;
             }
             return mem;

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -222,7 +222,7 @@ public class OsStats implements Writeable, ToXContentFragment {
                 // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
                 // cases where (free > total) which would be a different bug.
                 if (free > 0) {
-                    logger.warn("cannot compute used swap when total swap is 0 and free swap is " + free);
+                    logger.debug("cannot compute used swap when total swap is 0 and free swap is " + free);
                 }
                 return new ByteSizeValue(0);
             }
@@ -284,7 +284,7 @@ public class OsStats implements Writeable, ToXContentFragment {
                 // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
                 // cases where (free > total) which would be a different bug.
                 if (free > 0) {
-                    logger.warn("cannot compute used memory when total memory is 0 and free memory is " + free);
+                    logger.debug("cannot compute used memory when total memory is 0 and free memory is " + free);
                 }
                 return new ByteSizeValue(0);
             }


### PR DESCRIPTION
Because the incidence of negative stats values reported by the JVM has increased significantly as of JDK14 (at least partially due to this JVM bug: https://bugs.openjdk.java.net/browse/JDK-8242480), this message is ending up in logs fairly frequently and causing some concern and confusion among users. The message is largely harmless because the only effect is that the stats value, usually either free memory or free swap space, reported as negative by the OS will instead be recorded as zero by ES and no user action is necessary or possible. Should the JVM bug be fixed in the future, upgrading to an unaffected JVM may reduce the incidence of these occurrences.

Backport of #60375 
