### PR TITLE
Fix SimpleKdcLdapServerTests by overriding java.locale.providers

### DIFF
--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -6,7 +6,9 @@ dependencies {
 }
 
 unitTest {
-    systemProperty 'java.locale.providers','SPI,COMPAT'
+    if (project.runtimeJavaVersion >= JavaVersion.VERSION_1_9) {
+        systemProperty 'java.locale.providers', 'COMPAT'
+    }
     systemProperty 'tests.security.manager', 'false'
     include '**/*Tests.class'
 }

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 }
 
 unitTest {
+    systemProperty 'java.locale.providers','SPI,COMPAT'
     systemProperty 'tests.security.manager', 'false'
     include '**/*Tests.class'
 }

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
@@ -11,7 +11,6 @@ import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchScope;
 
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.env.Environment;

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
@@ -51,9 +51,6 @@ public class SimpleKdcLdapServerTests extends KerberosTestCase {
     }
 
     public void testClientServiceMutualAuthentication() throws PrivilegedActionException, GSSException, LoginException, ParseException {
-        assumeFalse("Java 15-ea causes issues with this test, see https://github.com/elastic/elasticsearch/issues/57749",
-            JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0);
-
         final String serviceUserName = randomFrom(serviceUserNames);
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);


### PR DESCRIPTION
The JDK system property makes sure date digits are always represented as ASCII chars.
This in turn helps the Kerberos response to be correctly encoded and recognised by the client.

Resolves: #57749 