### PR TITLE
[7.8] [DOCS] Note remote reindex is not fwd compatible (#60425)

### DIFF
--- a/docs/reference/upgrade/reindex_upgrade.asciidoc
+++ b/docs/reference/upgrade/reindex_upgrade.asciidoc
@@ -115,6 +115,9 @@ indices from the previous major version to be upgraded to the
 current major version. Skipping a major version means that you must
 resolve any backward compatibility issues yourself.
 
+{es} does not support forward compatibility across major versions.
+For example, you cannot reindex from a 7.x cluster into a 6.x cluster.
+
 ifdef::include-xpack[]
 If you use {ml-features} and you're migrating indices from a 6.5 or earlier
 cluster, the job and {dfeed} configuration information are not stored in an


### PR DESCRIPTION
7.8 backport of #60425