### PR TITLE
Error on bad shape relations in runtime fields

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -23,6 +23,7 @@ import org.elasticsearch.script.Script;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
@@ -67,12 +68,29 @@ abstract class AbstractScriptMappedFieldType extends MappedFieldType {
 
     public abstract Query termsQuery(List<?> values, QueryShardContext context);
 
-    public abstract Query rangeQuery(
+    @Override
+    public final Query rangeQuery(
         Object lowerTerm,
         Object upperTerm,
         boolean includeLower,
         boolean includeUpper,
         ShapeRelation relation,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        if (relation == ShapeRelation.DISJOINT) {
+            String message = "Field [%s] of type [%s] with runtime type [%s] does not support DISJOINT ranges";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName(), runtimeType()));
+        }
+        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
+    }
+
+    protected abstract Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
         QueryShardContext context

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
@@ -11,7 +11,6 @@ import com.carrotsearch.hppc.LongSet;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
@@ -94,7 +93,6 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
         Object upperTerm,
         boolean includeLower,
         boolean includeUpper,
-        ShapeRelation relation,
         ZoneId timeZone,
         @Nullable DateMathParser parser,
         QueryShardContext context

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldType.java
@@ -8,8 +8,8 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
+
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -67,7 +67,6 @@ public class ScriptDoubleMappedFieldType extends AbstractScriptMappedFieldType {
         Object upperTerm,
         boolean includeLower,
         boolean includeUpper,
-        ShapeRelation relation,
         ZoneId timeZone,
         DateMathParser parser,
         QueryShardContext context

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldType.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -111,7 +110,6 @@ public final class ScriptKeywordMappedFieldType extends AbstractScriptMappedFiel
         Object upperTerm,
         boolean includeLower,
         boolean includeUpper,
-        ShapeRelation relation,
         ZoneId timeZone,
         DateMathParser parser,
         QueryShardContext context

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldType.java
@@ -10,7 +10,6 @@ import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -68,7 +67,6 @@ public class ScriptLongMappedFieldType extends AbstractScriptMappedFieldType {
         Object upperTerm,
         boolean includeLower,
         boolean includeUpper,
-        ShapeRelation relation,
         ZoneId timeZone,
         DateMathParser parser,
         QueryShardContext context

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.runtimefields.mapper;
 
+import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -81,6 +82,17 @@ abstract class AbstractScriptMappedFieldTypeTestCase extends ESTestCase {
         );
         when(context.lookup()).thenReturn(lookup);
         return context;
+    }
+
+    public void testRangeQueryWithShapeRelationIsError() throws IOException {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> simpleMappedFieldType().rangeQuery(1, 2, true, true, ShapeRelation.DISJOINT, null, null, null)
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo("Field [test] of type [runtime_script] with runtime type [" + runtimeType() + "] does not support DISJOINT ranges")
+        );
     }
 
     public void testPhraseQueryIsError() {


### PR DESCRIPTION
Most core types throw back an error if the `relation` on a `range` query
is `disjoint`. This make runtime fields do the same.

Relates to #59332