### PR TITLE
Format support for script doc fields

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -23,6 +23,7 @@ import org.elasticsearch.script.Script;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
@@ -140,5 +141,22 @@ abstract class AbstractScriptMappedFieldType extends MappedFieldType {
                     + "] is set to [false]."
             );
         }
+    }
+
+    /**
+     * The format that this field should use. The default implementation is
+     * {@code null} because most fields don't support formats.
+     */
+    protected String format() {
+        return null;
+    }
+
+    /**
+     * The locale that this field's format should use. The default
+     * implementation is {@code null} because most fields don't
+     * support formats.
+     */
+    protected Locale formatLocale() {
+        return null;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
@@ -242,10 +242,10 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
 
         private void formatAndLocaleNotSupported() {
             if (format.getValue() != null) {
-                throw new IllegalArgumentException("format not supported by runtime_type [" + runtimeType.getValue() + "]");
+                throw new IllegalArgumentException("format can not be specified for runtime_type [" + runtimeType.getValue() + "]");
             }
             if (locale.getValue() != null) {
-                throw new IllegalArgumentException("locale not supported by runtime_type [" + runtimeType.getValue() + "]");
+                throw new IllegalArgumentException("locale can not be specified for runtime_type [" + runtimeType.getValue() + "]");
             }
         }
     }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
@@ -6,10 +6,11 @@
 
 package org.elasticsearch.xpack.runtimefields.mapper;
 
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
@@ -23,6 +24,7 @@ import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
 import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -43,7 +45,7 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
 
     protected RuntimeScriptFieldMapper(
         String simpleName,
-        MappedFieldType mappedFieldType,
+        AbstractScriptMappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
         String runtimeType,
@@ -78,22 +80,33 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
 
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        static final Map<String, BiFunction<Builder, BuilderContext, MappedFieldType>> FIELD_TYPE_RESOLVER = Map.of(
+        static final Map<String, BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType>> FIELD_TYPE_RESOLVER = Map.of(
             DateFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
                 DateScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
                     builder.script.getValue(),
                     DateScriptFieldScript.CONTEXT
                 );
+                String format = builder.format.getValue();
+                if (format == null) {
+                    format = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern();
+                }
+                Locale locale = builder.locale.getValue();
+                if (locale == null) {
+                    locale = Locale.ROOT;
+                }
+                DateFormatter dateTimeFormatter = DateFormatter.forPattern(format).withLocale(locale);
                 return new ScriptDateMappedFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
+                    dateTimeFormatter,
                     builder.meta.getValue()
                 );
             },
             NumberType.DOUBLE.typeName(),
             (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
                 DoubleScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
                     builder.script.getValue(),
                     DoubleScriptFieldScript.CONTEXT
@@ -107,6 +120,7 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
             },
             KeywordFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
                 StringScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
                     builder.script.getValue(),
                     StringScriptFieldScript.CONTEXT
@@ -120,6 +134,7 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
             },
             NumberType.LONG.typeName(),
             (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
                 LongScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
                     builder.script.getValue(),
                     LongScriptFieldScript.CONTEXT
@@ -159,6 +174,27 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
                 throw new IllegalArgumentException("script must be specified for " + CONTENT_TYPE + " field [" + name + "]");
             }
         });
+        private final Parameter<String> format = Parameter.stringParam(
+            "format",
+            true,
+            mapper -> ((AbstractScriptMappedFieldType) mapper.fieldType()).format(),
+            null
+        ).setSerializer((b, n, v) -> {
+            if (v != null && false == v.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern())) {
+                b.field(n, v);
+            }
+        }).acceptsNull();
+        private final Parameter<Locale> locale = new Parameter<>(
+            "locale",
+            true,
+            () -> null,
+            (n, c, o) -> o == null ? null : LocaleUtils.parse(o.toString()),
+            mapper -> ((AbstractScriptMappedFieldType) mapper.fieldType()).formatLocale()
+        ).setSerializer((b, n, v) -> {
+            if (v != null && false == v.equals(Locale.ROOT)) {
+                b.field(n, v.toString());
+            }
+        }).acceptsNull();
 
         private final ScriptCompiler scriptCompiler;
 
@@ -169,12 +205,12 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         protected List<Parameter<?>> getParameters() {
-            return List.of(meta, runtimeType, script);
+            return List.of(meta, runtimeType, script, format, locale);
         }
 
         @Override
         public RuntimeScriptFieldMapper build(BuilderContext context) {
-            BiFunction<Builder, BuilderContext, MappedFieldType> fieldTypeResolver = Builder.FIELD_TYPE_RESOLVER.get(
+            BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType> fieldTypeResolver = Builder.FIELD_TYPE_RESOLVER.get(
                 runtimeType.getValue()
             );
             if (fieldTypeResolver == null) {
@@ -202,6 +238,15 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
                 );
             }
             return script;
+        }
+
+        private void formatAndLocaleNotSupported() {
+            if (format.getValue() != null) {
+                throw new IllegalArgumentException("format not supported by runtime_type [" + runtimeType.getValue() + "]");
+            }
+            if (locale.getValue() != null) {
+                throw new IllegalArgumentException("locale not supported by runtime_type [" + runtimeType.getValue() + "]");
+            }
         }
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
@@ -32,19 +32,24 @@ import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
     private final DateScriptFieldScript.Factory scriptFactory;
+    private final DateFormatter dateTimeFormatter;
 
-    ScriptDateMappedFieldType(String name, Script script, DateScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+    ScriptDateMappedFieldType(
+        String name,
+        Script script,
+        DateScriptFieldScript.Factory scriptFactory,
+        DateFormatter dateTimeFormatter,
+        Map<String, String> meta
+    ) {
         super(name, script, meta);
         this.scriptFactory = scriptFactory;
-    }
-
-    private DateFormatter dateTimeFormatter() {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;  // TODO make configurable
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 
     @Override
@@ -58,12 +63,12 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
         if (val == null) {
             return null;
         }
-        return dateTimeFormatter().format(Resolution.MILLISECONDS.toInstant(val).atZone(ZoneOffset.UTC));
+        return dateTimeFormatter.format(Resolution.MILLISECONDS.toInstant(val).atZone(ZoneOffset.UTC));
     }
 
     @Override
     public DocValueFormat docValueFormat(@Nullable String format, ZoneId timeZone) {
-        DateFormatter dateTimeFormatter = dateTimeFormatter();
+        DateFormatter dateTimeFormatter = this.dateTimeFormatter;
         if (format != null) {
             dateTimeFormatter = DateFormatter.forPattern(format).withLocale(dateTimeFormatter.locale());
         }
@@ -99,7 +104,7 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
         @Nullable DateMathParser parser,
         QueryShardContext context
     ) {
-        parser = parser == null ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser() : parser;
+        parser = parser == null ? dateTimeFormatter.toDateMathParser() : parser;
         checkAllowExpensiveQueries(context);
         return DateFieldType.dateRangeQuery(
             lowerTerm,
@@ -121,7 +126,7 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
                 value,
                 false,
                 null,
-                dateTimeFormatter().toDateMathParser(),
+                dateTimeFormatter.toDateMathParser(),
                 now,
                 DateFieldMapper.Resolution.MILLISECONDS
             );
@@ -143,7 +148,7 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
                         value,
                         false,
                         null,
-                        DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser(),
+                        dateTimeFormatter.toDateMathParser(),
                         now,
                         DateFieldMapper.Resolution.MILLISECONDS
                     )
@@ -152,5 +157,15 @@ public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
             checkAllowExpensiveQueries(context);
             return new LongScriptFieldTermsQuery(script, leafFactory(context.lookup())::newInstance, name(), terms);
         });
+    }
+
+    @Override
+    protected String format() {
+        return dateTimeFormatter.pattern();
+    }
+
+    @Override
+    protected Locale formatLocale() {
+        return dateTimeFormatter.locale();
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -34,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
@@ -145,6 +148,51 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(Strings.toString(mapping("date")), Strings.toString(mapperService.documentMapper()));
     }
 
+    public void testDateWithFormat() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping("date", b -> b.field("format", "yyyy-MM-dd"));
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping.get()).mapperService();
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDateWithLocale() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping("date", b -> b.field("locale", "en_GB"));
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping.get()).mapperService();
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDateWithLocaleAndFormat() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping(
+            "date",
+            b -> b.field("format", "yyyy-MM-dd").field("locale", "en_GB")
+        );
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping.get()).mapperService();
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testNonDateWithFormat() throws IOException {
+        String runtimeType = randomValueOtherThan("date", () -> randomFrom(runtimeTypes));
+        Exception e = expectThrows(
+            MapperParsingException.class,
+            () -> createIndex("test", Settings.EMPTY, mapping(runtimeType, b -> b.field("format", "yyyy-MM-dd")))
+        );
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping: format not supported by runtime_type [" + runtimeType + "]"));
+    }
+
+    public void testNonDateWithLocale() throws IOException {
+        String runtimeType = randomValueOtherThan("date", () -> randomFrom(runtimeTypes));
+        Exception e = expectThrows(
+            MapperParsingException.class,
+            () -> createIndex("test", Settings.EMPTY, mapping(runtimeType, b -> b.field("locale", "en_GB")))
+        );
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping: locale not supported by runtime_type [" + runtimeType + "]"));
+    }
+
     public void testFieldCaps() throws Exception {
         for (String runtimeType : runtimeTypes) {
             String scriptIndex = "test_" + runtimeType + "_script";
@@ -178,6 +226,10 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     private XContentBuilder mapping(String type) throws IOException {
+        return mapping(type, builder -> {});
+    }
+
+    private XContentBuilder mapping(String type, CheckedConsumer<XContentBuilder, IOException> extra) throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder().startObject();
         {
             mapping.startObject("_doc");
@@ -192,6 +244,7 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
                             mapping.field("source", "dummy_source").field("lang", "test");
                         }
                         mapping.endObject();
+                        extra.accept(mapping);
                     }
                     mapping.endObject();
                 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
@@ -181,7 +181,7 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
             MapperParsingException.class,
             () -> createIndex("test", Settings.EMPTY, mapping(runtimeType, b -> b.field("format", "yyyy-MM-dd")))
         );
-        assertThat(e.getMessage(), equalTo("Failed to parse mapping: format not supported by runtime_type [" + runtimeType + "]"));
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping: format can not be specified for runtime_type [" + runtimeType + "]"));
     }
 
     public void testNonDateWithLocale() throws IOException {
@@ -190,7 +190,7 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
             MapperParsingException.class,
             () -> createIndex("test", Settings.EMPTY, mapping(runtimeType, b -> b.field("locale", "en_GB")))
         );
-        assertThat(e.getMessage(), equalTo("Failed to parse mapping: locale not supported by runtime_type [" + runtimeType + "]"));
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping: locale can not be specified for runtime_type [" + runtimeType + "]"));
     }
 
     public void testFieldCaps() throws Exception {

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
@@ -23,10 +23,13 @@ import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -55,6 +58,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
@@ -72,6 +76,7 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
             simpleMappedFieldType().docValueFormat(null, ZoneId.of("America/New_York")).format(1595432181354L),
             equalTo("2020-07-22T11:36:21.354-04:00")
         );
+        assertThat(coolFormattedFieldType().docValueFormat(null, null).format(1595432181354L), equalTo("2020-07-22(-■_■)15:36:21.354Z"));
     }
 
     @Override
@@ -224,6 +229,35 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                     ),
                     equalTo(0)
                 );
+                checkBadDate(
+                    () -> searcher.count(
+                        ft.rangeQuery(
+                            "2020-07-22(-■_■)00:00:00.000Z",
+                            "2020-07-23(-■_■)00:00:00.000Z",
+                            false,
+                            false,
+                            null,
+                            null,
+                            null,
+                            mockContext()
+                        )
+                    )
+                );
+                assertThat(
+                    searcher.count(
+                        coolFormattedFieldType().rangeQuery(
+                            "2020-07-22(-■_■)00:00:00.000Z",
+                            "2020-07-23(-■_■)00:00:00.000Z",
+                            false,
+                            false,
+                            null,
+                            null,
+                            null,
+                            mockContext()
+                        )
+                    ),
+                    equalTo(3)
+                );
             }
         }
     }
@@ -250,6 +284,8 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                     searcher.count(build("add_days", Map.of("days", 1)).termQuery("2020-07-23T15:36:21.354Z", mockContext())),
                     equalTo(1)
                 );
+                checkBadDate(() -> searcher.count(simpleMappedFieldType().termQuery("2020-07-22(-■_■)15:36:21.354Z", mockContext())));
+                assertThat(searcher.count(coolFormattedFieldType().termQuery("2020-07-22(-■_■)15:36:21.354Z", mockContext())), equalTo(1));
             }
         }
     }
@@ -274,6 +310,23 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                 assertThat(searcher.count(ft.termsQuery(List.of(1595432181354L, 2595432181354L), mockContext())), equalTo(1));
                 assertThat(searcher.count(ft.termsQuery(List.of(2595432181354L, 1595432181354L), mockContext())), equalTo(1));
                 assertThat(searcher.count(ft.termsQuery(List.of(1595432181355L, 1595432181354L), mockContext())), equalTo(2));
+                checkBadDate(
+                    () -> searcher.count(
+                        simpleMappedFieldType().termsQuery(
+                            List.of("2020-07-22T15:36:21.354Z", "2020-07-22(-■_■)15:36:21.354Z"),
+                            mockContext()
+                        )
+                    )
+                );
+                assertThat(
+                    searcher.count(
+                        coolFormattedFieldType().termsQuery(
+                            List.of("2020-07-22(-■_■)15:36:21.354Z", "2020-07-22(-■_■)15:36:21.355Z"),
+                            mockContext()
+                        )
+                    ),
+                    equalTo(2)
+                );
             }
         }
     }
@@ -288,6 +341,10 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
         return build("read_timestamp");
     }
 
+    private ScriptDateMappedFieldType coolFormattedFieldType() throws IOException {
+        return build(simpleMappedFieldType().script, DateFormatter.forPattern("yyyy-MM-dd(-■_■)HH:mm:ss.SSSz"));
+    }
+
     @Override
     protected String runtimeType() {
         return "date";
@@ -298,10 +355,10 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     }
 
     private static ScriptDateMappedFieldType build(String code, Map<String, Object> params) throws IOException {
-        return build(new Script(ScriptType.INLINE, "test", code, params));
+        return build(new Script(ScriptType.INLINE, "test", code, params), DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER);
     }
 
-    private static ScriptDateMappedFieldType build(Script script) throws IOException {
+    private static ScriptDateMappedFieldType build(Script script, DateFormatter dateTimeFormatter) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -361,7 +418,7 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             DateScriptFieldScript.Factory factory = scriptService.compile(script, DateScriptFieldScript.CONTEXT);
-            return new ScriptDateMappedFieldType("test", script, factory, emptyMap());
+            return new ScriptDateMappedFieldType("test", script, factory, dateTimeFormatter, emptyMap());
         }
     }
 
@@ -372,5 +429,10 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
             e.getMessage(),
             equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
         );
+    }
+
+    private void checkBadDate(ThrowingRunnable queryBuilder) {
+        Exception e = expectThrows(ElasticsearchParseException.class, queryBuilder);
+        assertThat(e.getMessage(), containsString("failed to parse date field"));
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -56,6 +56,15 @@ setup:
                         date(dt.plus(i, ChronoUnit.DAYS));
                       }
                     }
+              # Test format parameter
+              formatted_tomorrow:
+                type: runtime_script
+                runtime_type: date
+                format: yyyy-MM-dd
+                script: |
+                  for (def dt : doc['timestamp']) {
+                    date(dt.plus(1, ChronoUnit.DAYS));
+                  }
 
   - do:
       bulk:
@@ -90,6 +99,16 @@ setup:
   - match: {sensor.mappings.properties.tomorrow.script.params: {days: 1} }
   - match: {sensor.mappings.properties.tomorrow.script.lang: painless }
 
+  - match: {sensor.mappings.properties.formatted_tomorrow.type: runtime_script }
+  - match: {sensor.mappings.properties.formatted_tomorrow.runtime_type: date }
+  - match:
+      sensor.mappings.properties.formatted_tomorrow.script.source: |
+        for (def dt : doc['timestamp']) {
+          date(dt.plus(1, ChronoUnit.DAYS));
+        }
+  - match: {sensor.mappings.properties.formatted_tomorrow.script.lang: painless }
+  - match: {sensor.mappings.properties.formatted_tomorrow.format: yyyy-MM-dd }
+
 ---
 "docvalue_fields":
   - do:
@@ -97,7 +116,7 @@ setup:
         index: sensor
         body:
           sort: timestamp
-          docvalue_fields: [tomorrow, tomorrow_from_source, the_past, all_week]
+          docvalue_fields: [tomorrow, tomorrow_from_source, the_past, all_week, formatted_tomorrow]
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.tomorrow: [2018-01-19T17:41:34.000Z] }
   - match: {hits.hits.0.fields.tomorrow_from_source: [2018-01-19T17:41:34.000Z] }
@@ -111,6 +130,7 @@ setup:
         - 2018-01-22T17:41:34.000Z
         - 2018-01-23T17:41:34.000Z
         - 2018-01-24T17:41:34.000Z
+  - match: {hits.hits.0.fields.formatted_tomorrow: [2018-01-19] }
 
 ---
 "terms agg":


### PR DESCRIPTION
Adds `format` and `locale` support to `runtime_script` fields,
specifically those with the `runtime_type` of `date`. Others
`runtime_type`s will return an error if provided with those parameters.

Relates to #59332
