### PR TITLE
Remove unused method IndexFieldData#clear.

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -542,11 +542,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void clear() {
-            scaledFieldData.clear();
-        }
-
-        @Override
         public NumericType getNumericType() {
             /*
              * {@link ScaledFloatLeafFieldData#getDoubleValues()} transforms the raw long values in `scaled` floats.

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -86,11 +86,6 @@ public interface IndexFieldData<FD extends LeafFieldData> {
     BucketedSort newBucketedSort(BigArrays bigArrays, @Nullable Object missingValue, MultiValueMode sortMode,
             Nested nested, SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra);
 
-    /**
-     * Clears any resources associated with this field data.
-     */
-    void clear();
-
     // we need this extended source we we have custom comparators to reuse our field data
     // in this case, we need to reduce type that will be used when search results are reduced
     // on another node (we don't have the custom source them...)

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexHistogramFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexHistogramFieldData.java
@@ -44,8 +44,4 @@ public abstract class IndexHistogramFieldData implements IndexFieldData<LeafHist
         return valuesSourceType;
     }
 
-    @Override
-    public final void clear() {
-        // can't do
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -118,9 +118,6 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
     }
 
     @Override
-    public void clear() {}
-
-    @Override
     public long ramBytesUsed() {
         return memorySizeInBytes;
     }
@@ -210,9 +207,6 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
                 SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra) {
             throw new IllegalArgumentException("only supported on numeric fields");
         }
-
-        @Override
-        public void clear() {}
 
         @Override
         public long ramBytesUsed() {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
@@ -59,11 +59,6 @@ public abstract class AbstractIndexFieldData<FD extends LeafFieldData> implement
     }
 
     @Override
-    public void clear() {
-        cache.clear(fieldName);
-    }
-
-    @Override
     public FD load(LeafReaderContext context) {
         if (context.reader().getFieldInfos().fieldInfo(fieldName) == null) {
             // Some leaf readers may be wrapped and report different set of fields and use the same cache key.

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
@@ -60,11 +60,6 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested,
             boolean reverse) {
         throw new IllegalArgumentException("can't sort on geo_point field without using specific sorting feature, like geo_distance");

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryIndexFieldData.java
@@ -69,10 +69,6 @@ public class BinaryIndexFieldData implements IndexFieldData<BinaryDVLeafFieldDat
         return valuesSourceType;
     }
 
-    @Override
-    public final void clear() {
-        // can't do
-    }
 
     @Override
     public BinaryDVLeafFieldData load(LeafReaderContext context) {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -58,11 +58,6 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
         throw new IllegalArgumentException("can't sort on binary field");
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -147,10 +147,6 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
     }
 
     @Override
-    public void clear() {
-    }
-
-    @Override
     public final LeafOrdinalsFieldData load(LeafReaderContext context) {
         return atomicFieldData;
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -93,11 +93,6 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     protected boolean sortRequiresCustomComparator() {
         return numericType == NumericType.HALF_FLOAT;
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
@@ -110,11 +110,6 @@ public class SortedSetOrdinalsIndexFieldData implements IndexOrdinalsFieldData {
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
         XFieldComparatorSource source = new BytesRefFieldComparatorSource(this, missingValue, sortMode, nested);
         /**

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -55,17 +55,12 @@ public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDV
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-    
-    @Override
     public SortField sortField(Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
         XFieldComparatorSource source = new BytesRefFieldComparatorSource(this, missingValue,
                 sortMode, nested);
         return new SortField(getFieldName(), source, reverse);
     }
-    
+
     @Override
     public StringBinaryDVLeafFieldData load(LeafReaderContext context) {
         try {
@@ -73,7 +68,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<StringBinaryDV
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }
-    } 
+    }
     @Override
     public BucketedSort newBucketedSort(BigArrays bigArrays, Object missingValue, MultiValueMode sortMode, Nested nested,
             SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -209,12 +209,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
                                 Nested nested, SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra) {
                             throw new UnsupportedOperationException("can't sort on the [" + CONTENT_TYPE + "] field");
                         }
-
-                        @Override
-                        public void clear() {
-                            fieldData.clear();
-                        }
-
                     };
                 }
             };

--- a/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -69,11 +69,6 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
                 throw new UnsupportedOperationException();
             }
 
-            @Override
-            public void clear() {
-                in.clear();
-            }
-
         };
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -159,11 +159,6 @@ public class FunctionScoreTests extends ESTestCase {
                 SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra) {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
-
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException(UNSUPPORTED);
-        }
     }
 
     /**
@@ -248,11 +243,6 @@ public class FunctionScoreTests extends ESTestCase {
         @Override
         protected boolean sortRequiresCustomComparator() {
             return false;
-        }
-
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException(UNSUPPORTED);
         }
     }
 

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -375,11 +375,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public void clear() {
-            delegate.clear();
-        }
-
-        @Override
         public LeafOrdinalsFieldData load(LeafReaderContext context) {
             LeafOrdinalsFieldData fieldData = delegate.load(context);
             return new KeyedFlatObjectLeafFieldData(key, fieldData);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractLatLonShapeIndexFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractLatLonShapeIndexFieldData.java
@@ -43,11 +43,6 @@ public abstract class AbstractLatLonShapeIndexFieldData implements IndexGeoShape
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested,
             boolean reverse) {
         throw new IllegalArgumentException("can't sort on geo_shape field without using specific sorting feature, like geo_distance");

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorIndexFieldData.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorIndexFieldData.java
@@ -44,11 +44,6 @@ public class VectorIndexFieldData implements IndexFieldData<VectorDVLeafFieldDat
     }
 
     @Override
-    public final void clear() {
-        // can't do
-    }
-
-    @Override
     public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
         throw new IllegalArgumentException("can't sort on the vector field");
     }


### PR DESCRIPTION
This method was never called. It also seemed tricky that calling a method on
`IndexFieldData` could clear the contents of a shared cache.