### PR TITLE
[7.8] [DOCS] Fix `template` param in put index template API (#60474)

### DIFF
--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -73,7 +73,7 @@ If `true`, this request cannot replace or update existing index templates. Defau
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-
+[role="child_attributes"]
 [[put-index-template-api-request-body]]
 ==== {api-request-body-title}
 
@@ -82,16 +82,20 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Array of wildcard (`*`) expressions
 used to match the names of indices during creation.
 
+`template`::
+(Optional, object)
+Template to be applied. It may optionally include an `aliases`, `mappings`, or
+`settings` configuration.
++
+.Properties of `template`
+[%collapsible%open]
+====
 include::{docdir}/rest-api/common-parms.asciidoc[tag=aliases]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
-
-`template`::
-(Optional, object)
-This is the template to be applied, may optionally include a `mappings`,
-`settings`, or `aliases` configuration.
+====
 
 `composed_of`::
 (Optional, array of strings)


### PR DESCRIPTION
7.8 backport of #60474