### PR TITLE
muting DateHistogramGroupSourceTests.testBackwardsSerialization72

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -59,7 +59,7 @@ public class DateHistogramGroupSourceTests extends AbstractSerializingTestCase<D
 
         return dateHistogramGroupSource;
     }
-
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60464")
     public void testBackwardsSerialization72() throws IOException {
         // version 7.7 introduced scripts, so test before that
         DateHistogramGroupSource groupSource = randomDateHistogramGroupSource(


### PR DESCRIPTION
related to https://github.com/elastic/elasticsearch/issues/60464