### PR TITLE
Fix race condition in SearchPhaseControllerTests#testPartialMergeFailure

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -278,6 +278,7 @@ class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhaseResult
                 failure.compareAndSet(null, exc);
                 MergeTask task = runningTask.get();
                 runningTask.compareAndSet(task, null);
+                onPartialMergeFailure.accept(exc);
                 List<MergeTask> toCancel = new ArrayList<>();
                 if (task != null) {
                     toCancel.add(task);
@@ -287,7 +288,6 @@ class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhaseResult
                 mergeResult = null;
                 toCancel.stream().forEach(MergeTask::cancel);
             }
-            onPartialMergeFailure.accept(exc);
         }
 
         private void onAfterMerge(MergeTask task, MergeResult newResult) {


### PR DESCRIPTION
This change ensures that we call the listener for partial merge failure **before**
calling the completion listener in order to avoid race condition in tests.

Closes #60446