### PR TITLE
[DOCS] Add missing lang values to snowball token filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/snowball-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/snowball-tokenfilter.asciidoc
@@ -6,8 +6,8 @@
 
 A filter that stems words using a Snowball-generated stemmer. The
 `language` parameter controls the stemmer with the following available
-values: `Armenian`, `Basque`, `Catalan`, `Danish`, `Dutch`, `English`,
-`Finnish`, `French`, `German`, `German2`, `Hungarian`, `Italian`, `Kp`,
+values: `Arabic`, `Armenian`, `Basque`, `Catalan`, `Danish`, `Dutch`, `English`,
+`Estonian`, `Finnish`, `French`, `German`, `German2`, `Hungarian`, `Italian`, `Irish`, `Kp`,
 `Lithuanian`, `Lovins`, `Norwegian`, `Porter`, `Portuguese`, `Romanian`,
 `Russian`, `Spanish`, `Swedish`, `Turkish`.
 


### PR DESCRIPTION
Documents support for `Arabic`, `Estonian`, and `Irish` in the snowball token filter.