### PR TITLE
Avoid reloading _source for every inner hit.

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -97,83 +97,75 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
         }
 
         @Override
-        public TopDocsAndMaxScore[] topDocs(SearchHit[] hits) throws IOException {
-            Weight innerHitQueryWeight = createInnerHitQueryWeight();
-            TopDocsAndMaxScore[] result = new TopDocsAndMaxScore[hits.length];
-            for (int i = 0; i < hits.length; i++) {
-                SearchHit hit = hits[i];
-                String joinName = getSortedDocValue(joinFieldMapper.name(), context, hit.docId());
-                if (joinName == null) {
-                    result[i] = new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
-                    continue;
-                }
+        public TopDocsAndMaxScore topDocs(SearchHit hit) throws IOException {
+            Weight innerHitQueryWeight = getInnerHitQueryWeight();
+            String joinName = getSortedDocValue(joinFieldMapper.name(), context, hit.docId());
+            if (joinName == null) {
+                return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
+            }
 
-                QueryShardContext qsc = context.getQueryShardContext();
-                ParentIdFieldMapper parentIdFieldMapper =
-                    joinFieldMapper.getParentIdFieldMapper(typeName, fetchChildInnerHits == false);
-                if (parentIdFieldMapper == null) {
-                    result[i] = new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
-                    continue;
-                }
+            QueryShardContext qsc = context.getQueryShardContext();
+            ParentIdFieldMapper parentIdFieldMapper =
+                joinFieldMapper.getParentIdFieldMapper(typeName, fetchChildInnerHits == false);
+            if (parentIdFieldMapper == null) {
+                return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
+            }
 
-                Query q;
-                if (fetchChildInnerHits) {
-                    Query hitQuery = parentIdFieldMapper.fieldType().termQuery(hit.getId(), qsc);
-                    q = new BooleanQuery.Builder()
-                        // Only include child documents that have the current hit as parent:
-                        .add(hitQuery, BooleanClause.Occur.FILTER)
-                        // and only include child documents of a single relation:
-                        .add(joinFieldMapper.fieldType().termQuery(typeName, qsc), BooleanClause.Occur.FILTER)
-                        .build();
-                } else {
-                    String parentId = getSortedDocValue(parentIdFieldMapper.name(), context, hit.docId());
-                    if (parentId == null) {
-                        result[i] = new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
-                        continue;
-                    }
-                    q = context.mapperService().fieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
+            Query q;
+            if (fetchChildInnerHits) {
+                Query hitQuery = parentIdFieldMapper.fieldType().termQuery(hit.getId(), qsc);
+                q = new BooleanQuery.Builder()
+                    // Only include child documents that have the current hit as parent:
+                    .add(hitQuery, BooleanClause.Occur.FILTER)
+                    // and only include child documents of a single relation:
+                    .add(joinFieldMapper.fieldType().termQuery(typeName, qsc), BooleanClause.Occur.FILTER)
+                    .build();
+            } else {
+                String parentId = getSortedDocValue(parentIdFieldMapper.name(), context, hit.docId());
+                if (parentId == null) {
+                    return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
                 }
+                q = context.mapperService().fieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
+            }
 
-                Weight weight = context.searcher().createWeight(context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);
-                if (size() == 0) {
-                    TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-                    for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
-                        intersect(weight, innerHitQueryWeight, totalHitCountCollector, ctx);
-                    }
-                    result[i] = new TopDocsAndMaxScore(
-                        new TopDocs(
-                            new TotalHits(totalHitCountCollector.getTotalHits(), TotalHits.Relation.EQUAL_TO),
-                            Lucene.EMPTY_SCORE_DOCS
-                        ), Float.NaN);
-                } else {
-                    int topN = Math.min(from() + size(), context.searcher().getIndexReader().maxDoc());
-                    TopDocsCollector<?> topDocsCollector;
-                    MaxScoreCollector maxScoreCollector = null;
-                    if (sort() != null) {
-                        topDocsCollector = TopFieldCollector.create(sort().sort, topN, Integer.MAX_VALUE);
-                        if (trackScores()) {
-                            maxScoreCollector = new MaxScoreCollector();
-                        }
-                    } else {
-                        topDocsCollector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
+            Weight weight = context.searcher().createWeight(context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);
+            if (size() == 0) {
+                TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
+                for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
+                    intersect(weight, innerHitQueryWeight, totalHitCountCollector, ctx);
+                }
+                return new TopDocsAndMaxScore(
+                    new TopDocs(
+                        new TotalHits(totalHitCountCollector.getTotalHits(), TotalHits.Relation.EQUAL_TO),
+                        Lucene.EMPTY_SCORE_DOCS
+                    ), Float.NaN);
+            } else {
+                int topN = Math.min(from() + size(), context.searcher().getIndexReader().maxDoc());
+                TopDocsCollector<?> topDocsCollector;
+                MaxScoreCollector maxScoreCollector = null;
+                if (sort() != null) {
+                    topDocsCollector = TopFieldCollector.create(sort().sort, topN, Integer.MAX_VALUE);
+                    if (trackScores()) {
                         maxScoreCollector = new MaxScoreCollector();
                     }
-                    try {
-                        for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
-                            intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);
-                        }
-                    } finally {
-                        clearReleasables(Lifetime.COLLECTION);
-                    }
-                    TopDocs topDocs = topDocsCollector.topDocs(from(), size());
-                    float maxScore = Float.NaN;
-                    if (maxScoreCollector != null) {
-                        maxScore = maxScoreCollector.getMaxScore();
-                    }
-                    result[i] = new TopDocsAndMaxScore(topDocs, maxScore);
+                } else {
+                    topDocsCollector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
+                    maxScoreCollector = new MaxScoreCollector();
                 }
+                try {
+                    for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
+                        intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);
+                    }
+                } finally {
+                    clearReleasables(Lifetime.COLLECTION);
+                }
+                TopDocs topDocs = topDocsCollector.topDocs(from(), size());
+                float maxScore = Float.NaN;
+                if (maxScoreCollector != null) {
+                    maxScore = maxScoreCollector.getMaxScore();
+                }
+                return new TopDocsAndMaxScore(topDocs, maxScore);
             }
-            return result;
         }
 
         private String getSortedDocValue(String field, SearchContext context, int docId) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -644,6 +644,17 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits().value, equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().size(), equalTo(0));
+
+        // Check that inner hits contain _source even when it's disabled on the root request.
+        response = client().prepareSearch()
+            .setFetchSource(false)
+            .setQuery(nestedQuery("comments", matchQuery("comments.message", "fox"), ScoreMode.None)
+                .innerHit(new InnerHitBuilder()))
+            .get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits().value, equalTo(2L));
+        assertFalse(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().isEmpty());
     }
 
     public void testInnerHitsWithIgnoreUnmapped() throws Exception {

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -388,61 +388,57 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         }
 
         @Override
-        public TopDocsAndMaxScore[] topDocs(SearchHit[] hits) throws IOException {
-            Weight innerHitQueryWeight = createInnerHitQueryWeight();
-            TopDocsAndMaxScore[] result = new TopDocsAndMaxScore[hits.length];
-            for (int i = 0; i < hits.length; i++) {
-                SearchHit hit = hits[i];
-                Query rawParentFilter;
-                if (parentObjectMapper == null) {
-                    rawParentFilter = Queries.newNonNestedFilter();
-                } else {
-                    rawParentFilter = parentObjectMapper.nestedTypeFilter();
-                }
+        public TopDocsAndMaxScore topDocs(SearchHit hit) throws IOException {
+            Weight innerHitQueryWeight = getInnerHitQueryWeight();
 
-                int parentDocId = hit.docId();
-                final int readerIndex = ReaderUtil.subIndex(parentDocId, searcher().getIndexReader().leaves());
-                // With nested inner hits the nested docs are always in the same segement, so need to use the other segments
-                LeafReaderContext ctx = searcher().getIndexReader().leaves().get(readerIndex);
+            Query rawParentFilter;
+            if (parentObjectMapper == null) {
+                rawParentFilter = Queries.newNonNestedFilter();
+            } else {
+                rawParentFilter = parentObjectMapper.nestedTypeFilter();
+            }
 
-                Query childFilter = childObjectMapper.nestedTypeFilter();
-                BitSetProducer parentFilter = context.bitsetFilterCache().getBitSetProducer(rawParentFilter);
-                Query q = new ParentChildrenBlockJoinQuery(parentFilter, childFilter, parentDocId);
-                Weight weight = context.searcher().createWeight(context.searcher().rewrite(q),
-                        org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, 1f);
-                if (size() == 0) {
-                    TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-                    intersect(weight, innerHitQueryWeight, totalHitCountCollector, ctx);
-                    result[i] = new TopDocsAndMaxScore(new TopDocs(new TotalHits(totalHitCountCollector.getTotalHits(),
-                        TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS), Float.NaN);
-                } else {
-                    int topN = Math.min(from() + size(), context.searcher().getIndexReader().maxDoc());
-                    TopDocsCollector<?> topDocsCollector;
-                    MaxScoreCollector maxScoreCollector = null;
-                    if (sort() != null) {
-                        topDocsCollector = TopFieldCollector.create(sort().sort, topN, Integer.MAX_VALUE);
-                        if (trackScores()) {
-                            maxScoreCollector = new MaxScoreCollector();
-                        }
-                    } else {
-                        topDocsCollector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
+            int parentDocId = hit.docId();
+            final int readerIndex = ReaderUtil.subIndex(parentDocId, searcher().getIndexReader().leaves());
+            // With nested inner hits the nested docs are always in the same segement, so need to use the other segments
+            LeafReaderContext ctx = searcher().getIndexReader().leaves().get(readerIndex);
+
+            Query childFilter = childObjectMapper.nestedTypeFilter();
+            BitSetProducer parentFilter = context.bitsetFilterCache().getBitSetProducer(rawParentFilter);
+            Query q = new ParentChildrenBlockJoinQuery(parentFilter, childFilter, parentDocId);
+            Weight weight = context.searcher().createWeight(context.searcher().rewrite(q),
+                    org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, 1f);
+            if (size() == 0) {
+                TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
+                intersect(weight, innerHitQueryWeight, totalHitCountCollector, ctx);
+                return new TopDocsAndMaxScore(new TopDocs(new TotalHits(totalHitCountCollector.getTotalHits(),
+                    TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS), Float.NaN);
+            } else {
+                int topN = Math.min(from() + size(), context.searcher().getIndexReader().maxDoc());
+                TopDocsCollector<?> topDocsCollector;
+                MaxScoreCollector maxScoreCollector = null;
+                if (sort() != null) {
+                    topDocsCollector = TopFieldCollector.create(sort().sort, topN, Integer.MAX_VALUE);
+                    if (trackScores()) {
                         maxScoreCollector = new MaxScoreCollector();
                     }
-                    try {
-                        intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);
-                    } finally {
-                        clearReleasables(Lifetime.COLLECTION);
-                    }
-
-                    TopDocs td = topDocsCollector.topDocs(from(), size());
-                    float maxScore = Float.NaN;
-                    if (maxScoreCollector != null) {
-                        maxScore = maxScoreCollector.getMaxScore();
-                    }
-                    result[i] = new TopDocsAndMaxScore(td, maxScore);
+                } else {
+                    topDocsCollector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
+                    maxScoreCollector = new MaxScoreCollector();
                 }
+                try {
+                    intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);
+                } finally {
+                    clearReleasables(Lifetime.COLLECTION);
+                }
+
+                TopDocs td = topDocsCollector.topDocs(from(), size());
+                float maxScore = Float.NaN;
+                if (maxScoreCollector != null) {
+                    maxScore = maxScoreCollector.getMaxScore();
+                }
+                return new TopDocsAndMaxScore(td, maxScore);
             }
-            return result;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -78,8 +79,10 @@ public final class InnerHitsContext {
         private final String name;
         protected final SearchContext context;
         private InnerHitsContext childInnerHits;
+        private Weight innerHitQueryWeight;
 
-        private String id;
+        private String rootId;
+        private SourceLookup rootLookup;
 
         protected InnerHitSubContext(String name, SearchContext context) {
             super(context);
@@ -87,7 +90,7 @@ public final class InnerHitsContext {
             this.context = context;
         }
 
-        public abstract TopDocsAndMaxScore[] topDocs(SearchHit[] hits) throws IOException;
+        public abstract TopDocsAndMaxScore topDocs(SearchHit hit) throws IOException;
 
         public String getName() {
             return name;
@@ -102,22 +105,33 @@ public final class InnerHitsContext {
             this.childInnerHits = new InnerHitsContext(childInnerHits);
         }
 
-        protected Weight createInnerHitQueryWeight() throws IOException {
-            final boolean needsScores = size() != 0 && (sort() == null || sort().sort.needsScores());
-            return context.searcher().createWeight(context.searcher().rewrite(query()),
+        protected Weight getInnerHitQueryWeight() throws IOException {
+            if (innerHitQueryWeight == null) {
+                final boolean needsScores = size() != 0 && (sort() == null || sort().sort.needsScores());
+                innerHitQueryWeight = context.searcher().createWeight(context.searcher().rewrite(query()),
                     needsScores ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES, 1f);
+            }
+            return innerHitQueryWeight;
         }
 
         public SearchContext parentSearchContext() {
             return context;
         }
 
-        public String getId() {
-            return id;
+        public String getRootId() {
+            return rootId;
         }
 
-        public void setId(String id) {
-            this.id = id;
+        public void setRootId(String rootId) {
+            this.rootId = rootId;
+        }
+
+        public SourceLookup getRootLookup() {
+            return rootLookup;
+        }
+
+        public void setRootLookup(SourceLookup rootLookup) {
+            this.rootLookup = rootLookup;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -118,6 +118,11 @@ public final class InnerHitsContext {
             return context;
         }
 
+        /**
+         * The _id of the root document.
+         *
+         * Since this ID is available on the context, inner hits can avoid re-loading the root _id.
+         */
         public String getRootId() {
             return rootId;
         }
@@ -126,6 +131,11 @@ public final class InnerHitsContext {
             this.rootId = rootId;
         }
 
+        /**
+         * A source lookup for the root document.
+         *
+         * This shared lookup allows inner hits to avoid re-loading the root _source.
+         */
         public SourceLookup getRootLookup() {
             return rootLookup;
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -42,44 +43,44 @@ public final class InnerHitsPhase implements FetchSubPhase {
     }
 
     @Override
-    public void hitsExecute(SearchContext context, SearchHit[] hits) throws IOException {
-        if ((context.innerHits() != null && context.innerHits().getInnerHits().size() > 0) == false) {
+    public void hitExecute(SearchContext context, HitContext hitContext) throws IOException {
+        if (context.innerHits() == null) {
             return;
         }
 
+        SearchHit hit = hitContext.hit();
+        SourceLookup sourceLookup = hitContext.sourceLookup();
+
         for (Map.Entry<String, InnerHitsContext.InnerHitSubContext> entry : context.innerHits().getInnerHits().entrySet()) {
             InnerHitsContext.InnerHitSubContext innerHits = entry.getValue();
-            TopDocsAndMaxScore[] topDocs = innerHits.topDocs(hits);
-            for (int i = 0; i < hits.length; i++) {
-                SearchHit hit = hits[i];
-                TopDocsAndMaxScore topDoc = topDocs[i];
+            TopDocsAndMaxScore topDoc = innerHits.topDocs(hit);
 
-                Map<String, SearchHits> results = hit.getInnerHits();
-                if (results == null) {
-                    hit.setInnerHits(results = new HashMap<>());
-                }
-                innerHits.queryResult().topDocs(topDoc, innerHits.sort() == null ? null : innerHits.sort().formats);
-                int[] docIdsToLoad = new int[topDoc.topDocs.scoreDocs.length];
-                for (int j = 0; j < topDoc.topDocs.scoreDocs.length; j++) {
-                    docIdsToLoad[j] = topDoc.topDocs.scoreDocs[j].doc;
-                }
-                innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
-                innerHits.setId(hit.getId());
-
-                fetchPhase.execute(innerHits);
-                FetchSearchResult fetchResult = innerHits.fetchResult();
-                SearchHit[] internalHits = fetchResult.fetchResult().hits().getHits();
-                for (int j = 0; j < internalHits.length; j++) {
-                    ScoreDoc scoreDoc = topDoc.topDocs.scoreDocs[j];
-                    SearchHit searchHitFields = internalHits[j];
-                    searchHitFields.score(scoreDoc.score);
-                    if (scoreDoc instanceof FieldDoc) {
-                        FieldDoc fieldDoc = (FieldDoc) scoreDoc;
-                        searchHitFields.sortValues(fieldDoc.fields, innerHits.sort().formats);
-                    }
-                }
-                results.put(entry.getKey(), fetchResult.hits());
+            Map<String, SearchHits> results = hit.getInnerHits();
+            if (results == null) {
+                hit.setInnerHits(results = new HashMap<>());
             }
+            innerHits.queryResult().topDocs(topDoc, innerHits.sort() == null ? null : innerHits.sort().formats);
+            int[] docIdsToLoad = new int[topDoc.topDocs.scoreDocs.length];
+            for (int j = 0; j < topDoc.topDocs.scoreDocs.length; j++) {
+                docIdsToLoad[j] = topDoc.topDocs.scoreDocs[j].doc;
+            }
+            innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
+            innerHits.setRootId(hit.getId());
+            innerHits.setRootLookup(sourceLookup);
+
+            fetchPhase.execute(innerHits);
+            FetchSearchResult fetchResult = innerHits.fetchResult();
+            SearchHit[] internalHits = fetchResult.fetchResult().hits().getHits();
+            for (int j = 0; j < internalHits.length; j++) {
+                ScoreDoc scoreDoc = topDoc.topDocs.scoreDocs[j];
+                SearchHit searchHitFields = internalHits[j];
+                searchHitFields.score(scoreDoc.score);
+                if (scoreDoc instanceof FieldDoc) {
+                    FieldDoc fieldDoc = (FieldDoc) scoreDoc;
+                    searchHitFields.sortValues(fieldDoc.fields, innerHits.sort().formats);
+                }
+            }
+            results.put(entry.getKey(), fetchResult.hits());
         }
     }
 }


### PR DESCRIPTION
Previously if an inner_hits block required _ source, we would reload and parse
the root document's source for every hit. This PR adds a shared SourceLookup to
the inner hits context that allows inner hits to reuse parsed source if it's
already available. This matches our approach for sharing the root document ID.

Relates to #32818.