### PR TITLE
[7.9] Fix failing test for resolve index API (#60306)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: "7.9.99 - "
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "resolve index introduced in 7.9"
       features: allowed_warnings
 
   - do:
@@ -35,8 +35,8 @@ setup:
 ---
 "Resolve index with indices and aliases":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "resolve index introduced in 7.9"
 
   - do:
       indices.resolve_index:
@@ -63,37 +63,25 @@ setup:
 ---
 "Resolve index with hidden and closed indices":
   - skip:
-      version: " - 7.9.99"
-      reason: "enable in 7.9+ when backported"
+      version: " - 7.8.99"
+      reason: "resolve index introduced in 7.9"
 
   - do:
       indices.resolve_index:
         name: '*'
         expand_wildcards: [all]
 
-  - match: {indices.0.name: .ds-simple-data-stream1-000001}
-  - match: {indices.0.attributes.0: hidden}
-  - match: {indices.0.attributes.1: open}
-  - match: {indices.0.data_stream: simple-data-stream1}
-  - match: {indices.1.name: .ds-simple-data-stream2-000001}
-  - match: {indices.1.attributes.0: hidden}
-  - match: {indices.1.attributes.1: open}
-  - match: {indices.1.data_stream: simple-data-stream2}
-  - match: {indices.2.name: .ds-simple-data-stream2-000002}
-  - match: {indices.2.attributes.0: hidden}
-  - match: {indices.2.attributes.1: open}
-  - match: {indices.2.data_stream: simple-data-stream2}
-  - match: {indices.3.name: test_index1}
-  - match: {indices.3.aliases.0: test_alias}
-  - match: {indices.3.aliases.1: test_blias}
-  - match: {indices.3.aliases.2: test_clias}
-  - match: {indices.3.attributes.0: open}
-  - match: {indices.4.name: test_index2}
-  - match: {indices.4.aliases.0: test_alias}
-  - match: {indices.4.attributes.0: closed}
-  - match: {indices.5.name: test_index3}
-  - match: {indices.5.aliases.0: test_blias}
-  - match: {indices.5.attributes.0: open}
+  - match: {indices.0.name: test_index1}
+  - match: {indices.0.aliases.0: test_alias}
+  - match: {indices.0.aliases.1: test_blias}
+  - match: {indices.0.aliases.2: test_clias}
+  - match: {indices.0.attributes.0: open}
+  - match: {indices.1.name: test_index2}
+  - match: {indices.1.aliases.0: test_alias}
+  - match: {indices.1.attributes.0: closed}
+  - match: {indices.2.name: test_index3}
+  - match: {indices.2.aliases.0: test_blias}
+  - match: {indices.2.attributes.0: open}
   - match: {aliases.0.name: test_alias}
   - match: {aliases.0.indices.0: test_index1}
   - match: {aliases.0.indices.1: test_index2}


### PR DESCRIPTION
Corrects the `skip` version so the test is run for 7.9+ and removes references to data streams and their backing indices.

Backport of #60306