### PR TITLE
Data streams: throw ResourceAlreadyExists exception

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -20,6 +20,7 @@ package org.elasticsearch.cluster.metadata;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
@@ -126,7 +127,7 @@ public class MetadataCreateDataStreamService {
             throw new IllegalStateException("data streams require minimum node version of " + Version.V_7_9_0);
         }
         if (currentState.metadata().dataStreams().containsKey(request.name)) {
-            throw new IllegalArgumentException("data_stream [" + request.name + "] already exists");
+            throw new ResourceAlreadyExistsException("data_stream [" + request.name + "] already exists");
         }
 
         MetadataCreateIndexService.validateIndexOrAliasName(request.name,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
 import org.elasticsearch.cluster.ClusterName;
@@ -72,7 +73,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         CreateDataStreamClusterStateUpdateRequest req =
             new CreateDataStreamClusterStateUpdateRequest(dataStreamName, TimeValue.ZERO, TimeValue.ZERO);
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+        ResourceAlreadyExistsException e = expectThrows(ResourceAlreadyExistsException.class,
             () -> MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req));
         assertThat(e.getMessage(), containsString("data_stream [" + dataStreamName + "] already exists"));
     }

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
@@ -124,17 +124,22 @@ setup:
 
   - do:
       indices.create_data_stream:
-        name: new-ds-1
+        name: simple-data-stream1
   - is_true: acknowledged
 
   - do:
       catch: bad_request
       indices.create_data_stream:
-        name: new-ds-1
+        name: simple-data-stream1
 
   - match: { status: 400 }
-  - match: { error.root_cause.0.type: "resource_already_exists" }
+  - match: { error.root_cause.0.type: "resource_already_exists_exception" }
   - match: { error.root_cause.0.reason: "data_stream [simple-data-stream1] already exists" }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
 
 ---
 "Get data stream":

--- a/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
+++ b/x-pack/plugin/data-streams/qa/rest/src/test/resources/rest-api-spec/test/data-streams/10_basic.yml
@@ -117,6 +117,26 @@ setup:
   - match: { error.root_cause.0.reason: "data_stream [invalid-data-stream#-name] must not contain '#'" }
 
 ---
+"Create existing data stream":
+  - skip:
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
+
+  - do:
+      indices.create_data_stream:
+        name: new-ds-1
+  - is_true: acknowledged
+
+  - do:
+      catch: bad_request
+      indices.create_data_stream:
+        name: new-ds-1
+
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "resource_already_exists" }
+  - match: { error.root_cause.0.reason: "data_stream [simple-data-stream1] already exists" }
+
+---
 "Get data stream":
   - skip:
       version: " - 7.8.99"


### PR DESCRIPTION
For consistency reasons (and reducing the overload of IllegalArgumentException)
this changes the exception thrown when trying to create a data stream
that already exists.

The response for attempting to create an existing data stream will be 
```
{"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"data_stream [testing] already exists"}],"type":"resource_already_exists_exception","reason":"data_stream [testing] already exists"},"status":400}
```
(note that the `reason` remains the same, it's the `type` that's changing from `illegal_argument_exception` to `resource_already_exists_exception`)