### PR TITLE
[DOCS] Replace `twitter` dataset in docs APIs

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -8,16 +8,16 @@ Deletes documents that match the specified query.
 
 [source,console]
 --------------------------------------------------
-POST /twitter/_delete_by_query
+POST /my-index-000001/_delete_by_query
 {
   "query": {
     "match": {
-      "message": "some message"
+      "user.id": "elkbee"
     }
   }
 }
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 ////
 
@@ -250,16 +250,16 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 [source,console]
 --------------------------------------------------
-POST /twitter/_delete_by_query
+POST /my-index-000001/_delete_by_query
 {
   "query": { <1>
     "match": {
-      "message": "some message"
+      "user.id": "elkbee"
     }
   }
 }
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 //////////////////////////
 
@@ -350,38 +350,38 @@ version conflicts.
 [[docs-delete-by-query-api-example]]
 ==== {api-examples-title}
 
-Delete all tweets from the `twitter` data stream or index:
+Delete all documents from the `my-index-000001` data stream or index:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_delete_by_query?conflicts=proceed
+POST my-index-000001/_delete_by_query?conflicts=proceed
 {
   "query": {
     "match_all": {}
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 Delete documents from multiple data streams or indices:
 
 [source,console]
 --------------------------------------------------
-POST /twitter,blog/_delete_by_query
+POST /my-index-000001,my-index-000002/_delete_by_query
 {
   "query": {
     "match_all": {}
   }
 }
 --------------------------------------------------
-// TEST[s/^/PUT twitter\nPUT blog\n/]
+// TEST[s/^/PUT my-index-000001\nPUT my-index-000002\n/]
 
 Limit the delete by query operation to shards that a particular routing
 value: 
 
 [source,console]
 --------------------------------------------------
-POST twitter/_delete_by_query?routing=1
+POST my-index-000001/_delete_by_query?routing=1
 {
   "query": {
     "range" : {
@@ -392,23 +392,23 @@ POST twitter/_delete_by_query?routing=1
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 By default `_delete_by_query` uses scroll batches of 1000. You can change the
 batch size with the `scroll_size` URL parameter:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_delete_by_query?scroll_size=5000
+POST my-index-000001/_delete_by_query?scroll_size=5000
 {
   "query": {
     "term": {
-      "user": "kimchy"
+      "user.id": "kimchy"
     }
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [discrete]
 [[docs-delete-by-query-manual-slice]]
@@ -419,7 +419,7 @@ slices:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_delete_by_query
+POST my-index-000001/_delete_by_query
 {
   "slice": {
     "id": 0,
@@ -427,13 +427,13 @@ POST twitter/_delete_by_query
   },
   "query": {
     "range": {
-      "likes": {
-        "lt": 10
+      "http.response.bytes": {
+        "lt": 2000000
       }
     }
   }
 }
-POST twitter/_delete_by_query
+POST my-index-000001/_delete_by_query
 {
   "slice": {
     "id": 1,
@@ -441,26 +441,26 @@ POST twitter/_delete_by_query
   },
   "query": {
     "range": {
-      "likes": {
-        "lt": 10
+      "http.response.bytes": {
+        "lt": 2000000
       }
     }
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 Which you can verify works with:
 
 [source,console]
 ----------------------------------------------------------------
 GET _refresh
-POST twitter/_search?size=0&filter_path=hits.total
+POST my-index-000001/_search?size=0&filter_path=hits.total
 {
   "query": {
     "range": {
-      "likes": {
-        "lt": 10
+      "http.response.bytes": {
+        "lt": 2000000
       }
     }
   }
@@ -492,29 +492,29 @@ the number of slices to use:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_delete_by_query?refresh&slices=5
+POST my-index-000001/_delete_by_query?refresh&slices=5
 {
   "query": {
     "range": {
-      "likes": {
-        "lt": 10
+      "http.response.bytes": {
+        "lt": 2000000
       }
     }
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 Which you also can verify works with:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_search?size=0&filter_path=hits.total
+POST my-index-000001/_search?size=0&filter_path=hits.total
 {
   "query": {
     "range": {
-      "likes": {
-        "lt": 10
+      "http.response.bytes": {
+        "lt": 2000000
       }
     }
   }

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -63,7 +63,7 @@ Example to delete with routing
 
 [source,console]
 --------------------------------------------------
-PUT /twitter/_doc/1?routing=kimchy
+PUT /my-index-000001/_doc/1?routing=kimchy
 {
   "test": "test"
 }
@@ -73,11 +73,11 @@ PUT /twitter/_doc/1?routing=kimchy
 
 [source,console]
 --------------------------------------------------
-DELETE /twitter/_doc/1?routing=kimchy
+DELETE /my-index-000001/_doc/1?routing=kimchy
 --------------------------------------------------
 // TEST[continued]
 
-This request deletes the tweet with id `1`, but it is routed based on the
+This request deletes the document with id `1`, but it is routed based on the
 user. The document is not deleted if the correct routing is not specified.
 
 [discrete]
@@ -129,9 +129,9 @@ to 5 minutes:
 
 [source,console]
 --------------------------------------------------
-DELETE /twitter/_doc/1?timeout=5m
+DELETE /my-index-000001/_doc/1?timeout=5m
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-delete-api-path-params]]
 ==== {api-path-parms-title}
@@ -166,13 +166,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 [[docs-delete-api-example]]
 ==== {api-examples-title}
 
-Delete the JSON document `1` from the `twitter` index:
+Delete the JSON document `1` from the `my-index-000001` index:
 
 [source,console]
 --------------------------------------------------
-DELETE /twitter/_doc/1
+DELETE /my-index-000001/_doc/1
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following result:
 
@@ -184,7 +184,7 @@ The API returns the following result:
     "failed": 0,
     "successful": 2
   },
-  "_index": "twitter",
+  "_index": "my-index-000001",
   "_id": "1",
   "_version": 2,
   "_primary_term": 1,

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -8,9 +8,9 @@ Retrieves the specified JSON document from an index.
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/0
+GET my-index-000001/_doc/0
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-get-api-request]]
 ==== {api-request-title}
@@ -51,9 +51,9 @@ You can turn off `_source` retrieval by using the `_source` parameter:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/0?_source=false
+GET my-index-000001/_doc/0?_source=false
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 If you only need one or two fields from the `_source`, use the `_source_includes`
 or `_source_excludes` parameters to include or filter out particular fields.
@@ -63,17 +63,17 @@ of fields or wildcard expressions. Example:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/0?_source_includes=*.id&_source_excludes=entities
+GET my-index-000001/_doc/0?_source_includes=*.id&_source_excludes=entities
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 If you only want to specify includes, you can use a shorter notation:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/0?_source=*.id,retweeted
+GET my-index-000001/_doc/0?_source=*.id
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [discrete]
 [[get-routing]]
@@ -84,11 +84,11 @@ specified to retrieve a document. For example:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/2?routing=user1
+GET my-index-000001/_doc/2?routing=user1
 --------------------------------------------------
 // TEST[continued]
 
-This request gets the tweet with id `2`, but it is routed based on the
+This request gets the document with id `2`, but it is routed based on the
 user. The document is not fetched if the correct routing is not specified.
 
 [discrete]
@@ -218,33 +218,43 @@ If the `stored_fields` parameter is set to `true` and `found` is
 [[docs-get-api-example]]
 ==== {api-examples-title}
 
-Retrieve the JSON document with the `_id` 0 from the `twitter` index:
+Retrieve the JSON document with the `_id` 0 from the `my-index-000001` index:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/0
+GET my-index-000001/_doc/0
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following result:
 
 [source,console-result]
 --------------------------------------------------
 {
-  "_index": "twitter",
+  "_index": "my-index-000001",
   "_id": "0",
   "_version": 1,
-  "_seq_no": 10,
+  "_seq_no": 0,
   "_primary_term": 1,
   "found": true,
   "_source": {
-    "user": "kimchy",
-    "date": "2009-11-15T14:12:12",
-    "likes": 0,
-    "message": "trying out Elasticsearch",
-    "location": {
-      "city": "Amsterdam",
-      "country": "Netherlands"
+    "@timestamp": "2099-11-15T14:12:12",
+    "http": {
+      "request": {
+        "method": "get"
+      },
+      "response": {
+        "status_code": 200,
+        "bytes": 1070000
+      },
+      "version": "1.1"
+    },
+    "source": {
+      "ip": "127.0.0.1"
+    },
+    "message": "GET /search HTTP/1.1 200 1070000",
+    "user": {
+      "id": "kimchy"
     }
   }
 }
@@ -255,9 +265,9 @@ Check to see if a document with the `_id` 0 exists:
 
 [source,console]
 --------------------------------------------------
-HEAD twitter/_doc/0
+HEAD my-index-000001/_doc/0
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 {es} returns a status code of `200 - OK` if the document exists, or
 `404 - Not Found` if it doesn't.
@@ -271,7 +281,7 @@ just the `_source` field of a document. For example:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_source/1
+GET my-index-000001/_source/1
 --------------------------------------------------
 // TEST[continued]
 
@@ -280,7 +290,7 @@ You can use the source filtering parameters to control which parts of the
 
 [source,console]
 --------------------------------------------------
-GET twitter/_source/1/?_source_includes=*.id&_source_excludes=entities
+GET my-index-000001/_source/1/?_source_includes=*.id&_source_excludes=entities
 --------------------------------------------------
 // TEST[continued]
 
@@ -290,7 +300,7 @@ available if it is disabled in the <<mapping-source-field,mapping>>.
 
 [source,console]
 --------------------------------------------------
-HEAD twitter/_source/1
+HEAD my-index-000001/_source/1
 --------------------------------------------------
 // TEST[continued]
 
@@ -304,7 +314,7 @@ Consider for instance the following mapping:
 
 [source,console]
 --------------------------------------------------
-PUT twitter
+PUT my-index-000001
 {
    "mappings": {
        "properties": {
@@ -325,10 +335,10 @@ Now we can add a document:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/1
+PUT my-index-000001/_doc/1
 {
   "counter": 1,
-  "tags": [ "red" ]
+  "tags": [ "production" ]
 }
 --------------------------------------------------
 // TEST[continued]
@@ -337,7 +347,7 @@ And then try to retrieve it:
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/1?stored_fields=tags,counter
+GET my-index-000001/_doc/1?stored_fields=tags,counter
 --------------------------------------------------
 // TEST[continued]
 
@@ -346,7 +356,7 @@ The API returns the following result:
 [source,console-result]
 --------------------------------------------------
 {
-   "_index": "twitter",
+   "_index": "my-index-000001",
    "_id": "1",
    "_version": 1,
    "_seq_no" : 22,
@@ -354,7 +364,7 @@ The API returns the following result:
    "found": true,
    "fields": {
       "tags": [
-         "red"
+         "production"
       ]
    }
 }
@@ -368,17 +378,17 @@ You can also retrieve metadata fields like the `_routing` field:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/2?routing=user1
+PUT my-index-000001/_doc/2?routing=user1
 {
   "counter" : 1,
-  "tags" : ["white"]
+  "tags" : ["env2"]
 }
 --------------------------------------------------
 // TEST[continued]
 
 [source,console]
 --------------------------------------------------
-GET twitter/_doc/2?routing=user1&stored_fields=tags,counter
+GET my-index-000001/_doc/2?routing=user1&stored_fields=tags,counter
 --------------------------------------------------
 // TEST[continued]
 
@@ -387,7 +397,7 @@ The API returns the following result:
 [source,console-result]
 --------------------------------------------------
 {
-   "_index": "twitter",
+   "_index": "my-index-000001",
    "_id": "2",
    "_version": 1,
    "_seq_no" : 13,
@@ -396,7 +406,7 @@ The API returns the following result:
    "found": true,
    "fields": {
       "tags": [
-         "white"
+         "env2"
       ]
    }
 }

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -191,7 +191,7 @@ creation of indices. It does not affect the creation of data streams.
 PUT _cluster/settings
 {
   "persistent": {
-    "action.auto_create_index": "twitter,index10,-index1*,+ind*" <1>
+    "action.auto_create_index": "my-index-000001,index10,-index1*,+ind*" <1>
   }
 }
 
@@ -210,7 +210,7 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 
-<1> Allow auto-creation of indices called `twitter` or `index10`, block the
+<1> Allow auto-creation of indices called `my-index-000001` or `index10`, block the
 creation of indices that match the pattern `index1*`, and allow creation of
 any other indices that match the `ind*` pattern. Patterns are matched in
 the order specified.
@@ -238,11 +238,13 @@ the document.
 
 [source,console]
 --------------------------------------------------
-POST twitter/_doc/
+POST my-index-000001/_doc/
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------
 
@@ -256,7 +258,7 @@ The API returns the following result:
     "failed": 0,
     "successful": 2
   },
-  "_index": "twitter",
+  "_index": "my-index-000001",
   "_id": "W0tpsmIBdwcYyG50zbta",
   "_version": 1,
   "_seq_no": 0,
@@ -287,11 +289,13 @@ on a per-operation basis using the `routing` parameter. For example:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_doc?routing=kimchy
+POST my-index-000001/_doc?routing=kimchy
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------
 
@@ -412,11 +416,13 @@ to 5 minutes:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/1?timeout=5m
+PUT my-index-000001/_doc/1?timeout=5m
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------
 
@@ -441,9 +447,11 @@ conflict will occur and the index operation will fail. For example:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/1?version=2&version_type=external
+PUT my-index-000001/_doc/1?version=2&version_type=external
 {
-  "message" : "elasticsearch now has versioning support, double cool!"
+  "user": {
+    "id": "elkbee"
+  }
 }
 --------------------------------------------------
 // TEST[continued]
@@ -495,15 +503,17 @@ primary and replica shards to diverge.
 [[docs-index-api-example]]
 ==== {api-examples-title}
 
-Insert a JSON document into the `twitter` index with an `_id` of 1:
+Insert a JSON document into the `my-index-000001` index with an `_id` of 1:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/1
+PUT my-index-000001/_doc/1
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------
 
@@ -517,7 +527,7 @@ The API returns the following result:
     "failed": 0,
     "successful": 2
   },
-  "_index": "twitter",
+  "_index": "my-index-000001",
   "_id": "1",
   "_version": 1,
   "_seq_no": 0,
@@ -527,28 +537,32 @@ The API returns the following result:
 --------------------------------------------------
 // TESTRESPONSE[s/"successful": 2/"successful": 1/]
 
-Use the `_create` resource to index a document into the `twitter` index if
+Use the `_create` resource to index a document into the `my-index-000001` index if
 no document with that ID exists:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_create/1
+PUT my-index-000001/_create/1
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------
 
-Set the `op_type` parameter to _create_ to index a document into the `twitter`
+Set the `op_type` parameter to _create_ to index a document into the `my-index-000001`
 index if no document with that ID exists:
 
 [source,console]
 --------------------------------------------------
-PUT twitter/_doc/1?op_type=create
+PUT my-index-000001/_doc/1?op_type=create
 {
-  "user" : "kimchy",
-  "post_date" : "2009-11-15T14:12:12",
-  "message" : "trying out Elasticsearch"
+  "@timestamp": "2099-11-15T13:12:00",
+  "message": "GET /search HTTP/1.1 200 1070000",
+  "user": {
+    "id": "kimchy"
+  }
 }
 --------------------------------------------------

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -12,17 +12,17 @@ GET /_mget
 {
   "docs": [
     {
-      "_index": "twitter",
+      "_index": "my-index-000001",
       "_id": "1"
     },
     {
-      "_index": "twitter",
+      "_index": "my-index-000001",
       "_id": "2"
     }
   ]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-multi-get-api-request]]
 ==== {api-request-title}
@@ -128,7 +128,7 @@ If you specify an index in the request URI, only the document IDs are required i
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_mget
+GET /my-index-000001/_mget
 {
   "docs": [
     {
@@ -140,18 +140,18 @@ GET /twitter/_mget
   ]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 You can use the `ids` element to simplify the request:
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_mget
+GET /my-index-000001/_mget
 {
   "ids" : ["1", "2"]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[mget-source-filtering]]
 ===== Filter source fields

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -12,12 +12,12 @@ POST /_mtermvectors
 {
    "docs": [
       {
-         "_index": "twitter",
+         "_index": "my-index-000001",
          "_id": "2",
          "term_statistics": true
       },
       {
-         "_index": "twitter",
+         "_index": "my-index-000001",
          "_id": "1",
          "fields": [
             "message"
@@ -26,7 +26,7 @@ POST /_mtermvectors
    ]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-multi-termvectors-api-request]]
 ==== {api-request-title}
@@ -89,7 +89,7 @@ in the request body:
 
 [source,console]
 --------------------------------------------------
-POST /twitter/_mtermvectors
+POST /my-index-000001/_mtermvectors
 {
    "docs": [
       {
@@ -105,14 +105,14 @@ POST /twitter/_mtermvectors
    ]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 If all requested documents are in same index and the parameters are the same, you can use the
 following simplified syntax:
 
 [source,console]
 --------------------------------------------------
-POST /twitter/_mtermvectors
+POST /my-index-000001/_mtermvectors
 {
   "ids": [ "1", "2" ],
   "parameters": {
@@ -123,7 +123,7 @@ POST /twitter/_mtermvectors
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-multi-termvectors-artificial-doc]]
 ===== Artificial documents
@@ -137,20 +137,18 @@ POST /_mtermvectors
 {
    "docs": [
       {
-         "_index": "twitter",
+         "_index": "my-index-000001",
          "doc" : {
-            "user" : "John Doe",
-            "message" : "twitter test test test"
+            "message" : "test test test"
          }
       },
       {
-         "_index": "twitter",
+         "_index": "my-index-000001",
          "doc" : {
-           "user" : "Jane Doe",
-           "message" : "Another twitter test ..."
+           "message" : "Another test ..."
          }
       }
    ]
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -26,14 +26,14 @@ Mappings, shard counts, replicas, and so on must be configured ahead of time.
 POST _reindex
 {
   "source": {
-    "index": "twitter"
+    "index": "my-index-000001"
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 ////
 
@@ -205,38 +205,38 @@ slices to each request:
 POST _reindex
 {
   "source": {
-    "index": "twitter",
+    "index": "my-index-000001",
     "slice": {
       "id": 0,
       "max": 2
     }
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 POST _reindex
 {
   "source": {
-    "index": "twitter",
+    "index": "my-index-000001",
     "slice": {
       "id": 1,
       "max": 2
     }
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 You can verify this works by:
 
 [source,console]
 ----------------------------------------------------------------
 GET _refresh
-POST new_twitter/_search?size=0&filter_path=hits.total
+POST my-new-index-000001/_search?size=0&filter_path=hits.total
 ----------------------------------------------------------------
 // TEST[continued]
 
@@ -265,20 +265,20 @@ slice on `_id`. Use `slices` to specify the number of slices to use:
 POST _reindex?slices=5&refresh
 {
   "source": {
-    "index": "twitter"
+    "index": "my-index-000001"
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 You can also this verify works by:
 
 [source,console]
 ----------------------------------------------------------------
-POST new_twitter/_search?size=0&filter_path=hits.total
+POST my-new-index-000001/_search?size=0&filter_path=hits.total
 ----------------------------------------------------------------
 // TEST[continued]
 
@@ -603,33 +603,33 @@ the `conflicts` option to prevent reindex from aborting on version conflicts.
 ===== Reindex select documents with a query
 
 You can limit the documents by adding a query to the `source`.
-For example, the following request only copies tweets made by `kimchy` into `new_twitter`:
+For example, the following request only copies documents with a `user.id` of `kimchy` into `my-new-index-000001`:
 
 [source,console]
 --------------------------------------------------
 POST _reindex
 {
   "source": {
-    "index": "twitter",
+    "index": "my-index-000001",
     "query": {
       "term": {
-        "user": "kimchy"
+        "user.id": "kimchy"
       }
     }
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-reindex-select-max-docs]]
 ===== Reindex select documents with `max_docs`
 
 You can limit the number of processed documents by setting `max_docs`.
-For example, this request copies a single document from `twitter` to
-`new_twitter`:
+For example, this request copies a single document from `my-index-000001` to
+`my-new-index-000001`:
 
 [source,console]
 --------------------------------------------------
@@ -637,36 +637,36 @@ POST _reindex
 {
   "max_docs": 1,
   "source": {
-    "index": "twitter"
+    "index": "my-index-000001"
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-reindex-multiple-sources]]
 ===== Reindex from multiple sources
 
 The `index` attribute in `source` can be a list, allowing you to copy from lots
 of sources in one request. This will copy documents from the
-`twitter` and `blog` indices:
+`my-index-000001` and `my-index-000002` indices:
 
 [source,console]
 --------------------------------------------------
 POST _reindex
 {
   "source": {
-    "index": ["twitter", "blog"]
+    "index": ["my-index-000001", "my-index-000002"]
   },
   "dest": {
-    "index": "all_together"
+    "index": "my-new-index-000002"
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
-// TEST[s/^/PUT blog\/_doc\/post1?refresh\n{"test": "foo"}\n/]
+// TEST[setup:my_index]
+// TEST[s/^/PUT my-index-000002\/_doc\/post1?refresh\n{"test": "foo"}\n/]
 
 NOTE: The Reindex API makes no effort to handle ID collisions so the last
 document written will "win" but the order isn't usually predictable so it is
@@ -677,22 +677,22 @@ using a script.
 ===== Reindex select fields with a source filter
 
 You can use source filtering to reindex a subset of the fields in the original documents.
-For example, the following request only reindexes the `user` and `_doc` fields of each document:
+For example, the following request only reindexes the `user.id` and `_doc` fields of each document:
 
 [source,console]
 --------------------------------------------------
 POST _reindex
 {
   "source": {
-    "index": "twitter",
-    "_source": ["user", "_doc"]
+    "index": "my-index-000001",
+    "_source": ["user.id", "_doc"]
   },
   "dest": {
-    "index": "new_twitter"
+    "index": "my-new-index-000001"
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-reindex-change-name]]
 ===== Reindex to change the name of a field
@@ -702,7 +702,7 @@ create an index containing documents that look like this:
 
 [source,console]
 --------------------------------------------------
-POST test/_doc/1?refresh
+POST my-index-000001/_doc/1?refresh
 {
   "text": "words words",
   "flag": "foo"
@@ -717,10 +717,10 @@ but you don't like the name `flag` and want to replace it with `tag`.
 POST _reindex
 {
   "source": {
-    "index": "test"
+    "index": "my-index-000001"
   },
   "dest": {
-    "index": "test2"
+    "index": "my-new-index-000001"
   },
   "script": {
     "source": "ctx._source.tag = ctx._source.remove(\"flag\")"
@@ -733,7 +733,7 @@ Now you can get the new document:
 
 [source,console]
 --------------------------------------------------
-GET test2/_doc/1
+GET my-new-index-000001/_doc/1
 --------------------------------------------------
 // TEST[continued]
 
@@ -744,7 +744,7 @@ which will return:
 {
   "found": true,
   "_id": "1",
-  "_index": "test2",
+  "_index": "my-new-index-000001",
   "_version": 1,
   "_seq_no": 44,
   "_primary_term": 1,
@@ -821,7 +821,7 @@ POST _reindex
 {
   "max_docs": 10,
   "source": {
-    "index": "twitter",
+    "index": "my-index-000001",
     "query": {
       "function_score" : {
         "random_score" : {},
@@ -830,11 +830,11 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "random_twitter"
+    "index": "my-new-index-000001"
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 <1> You may need to adjust the `min_score` depending on the relative amount of
 data extracted from source.
@@ -851,10 +851,10 @@ document's metadata. This example bumps the version of the source document:
 POST _reindex
 {
   "source": {
-    "index": "twitter"
+    "index": "my-index-000001"
   },
   "dest": {
-    "index": "new_twitter",
+    "index": "my-new-index-000001",
     "version_type": "external"
   },
   "script": {
@@ -863,7 +863,7 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 Just as in `_update_by_query`, you can set `ctx.op` to change the
 operation that is executed on the destination:
@@ -911,7 +911,7 @@ POST _reindex
       "username": "user",
       "password": "pass"
     },
-    "index": "source",
+    "index": "my-index-000001",
     "query": {
       "match": {
         "test": "data"
@@ -919,12 +919,12 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "dest"
+    "index": "my-new-index-000001"
   }
 }
 --------------------------------------------------
 // TEST[setup:host]
-// TEST[s/^/PUT source\n/]
+// TEST[s/^/PUT my-index-000001\n/]
 // TEST[s/otherhost:9200",/\${host}"/]
 // TEST[s/"username": "user",//]
 // TEST[s/"password": "pass"//]

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -8,9 +8,9 @@ Retrieves information and statistics for terms in the fields of a particular doc
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors/1
+GET /my-index-000001/_termvectors/1
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-termvectors-api-request]]
 ==== {api-request-title}
@@ -28,9 +28,9 @@ or by adding the fields to the request body.
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors/1?fields=message
+GET /my-index-000001/_termvectors/1?fields=message
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 Fields can be specified using wildcards, similar to the <<query-dsl-multi-match-query,multi match query>>.
 
@@ -169,7 +169,7 @@ First, we create an index that stores term vectors, payloads etc. :
 
 [source,console]
 --------------------------------------------------
-PUT /twitter
+PUT /my-index-000001
 { "mappings": {
     "properties": {
       "text": {
@@ -210,16 +210,16 @@ Second, we add some documents:
 
 [source,console]
 --------------------------------------------------
-PUT /twitter/_doc/1
+PUT /my-index-000001/_doc/1
 {
   "fullname" : "John Doe",
-  "text" : "twitter test test test "
+  "text" : "test test test "
 }
 
-PUT /twitter/_doc/2?refresh=wait_for
+PUT /my-index-000001/_doc/2?refresh=wait_for
 {
   "fullname" : "Jane Doe",
-  "text" : "Another twitter test ..."
+  "text" : "Another test ..."
 }
 --------------------------------------------------
 // TEST[continued]
@@ -229,7 +229,7 @@ The following request returns all information and statistics for field
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors/1
+GET /my-index-000001/_termvectors/1
 {
   "fields" : ["text"],
   "offsets" : true,
@@ -246,56 +246,43 @@ Response:
 [source,console-result]
 --------------------------------------------------
 {
+  "_index": "my-index-000001",
   "_id": "1",
-  "_index": "twitter",
   "_version": 1,
   "found": true,
   "took": 6,
   "term_vectors": {
     "text": {
       "field_statistics": {
+        "sum_doc_freq": 4,
         "doc_count": 2,
-        "sum_doc_freq": 6,
-        "sum_ttf": 8
+        "sum_ttf": 6
       },
       "terms": {
         "test": {
           "doc_freq": 2,
+          "ttf": 4,
           "term_freq": 3,
           "tokens": [
             {
-              "end_offset": 12,
-              "payload": "d29yZA==",
-              "position": 1,
-              "start_offset": 8
-            },
-            {
-              "end_offset": 17,
-              "payload": "d29yZA==",
-              "position": 2,
-              "start_offset": 13
-            },
-            {
-              "end_offset": 22,
-              "payload": "d29yZA==",
-              "position": 3,
-              "start_offset": 18
-            }
-          ],
-          "ttf": 4
-        },
-        "twitter": {
-          "doc_freq": 2,
-          "term_freq": 1,
-          "tokens": [
-            {
-              "end_offset": 7,
-              "payload": "d29yZA==",
               "position": 0,
-              "start_offset": 0
+              "start_offset": 0,
+              "end_offset": 4,
+              "payload": "d29yZA=="
+            },
+            {
+              "position": 1,
+              "start_offset": 5,
+              "end_offset": 9,
+              "payload": "d29yZA=="
+            },
+            {
+              "position": 2,
+              "start_offset": 10,
+              "end_offset": 14,
+              "payload": "d29yZA=="
             }
-          ],
-          "ttf": 2
+          ]
         }
       }
     }
@@ -315,7 +302,7 @@ Note that for the field `text`, the terms are not re-generated.
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors/1
+GET /my-index-000001/_termvectors/1
 {
   "fields" : ["text", "some_field_without_term_vectors"],
   "offsets" : true,
@@ -338,11 +325,11 @@ mapping will be dynamically created.*
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors
+GET /my-index-000001/_termvectors
 {
   "doc" : {
     "fullname" : "John Doe",
-    "text" : "twitter test test test"
+    "text" : "test test test"
   }
 }
 --------------------------------------------------
@@ -359,11 +346,11 @@ vectors, the term vectors will be re-generated.
 
 [source,console]
 --------------------------------------------------
-GET /twitter/_termvectors
+GET /my-index-000001/_termvectors
 {
   "doc" : {
     "fullname" : "John Doe",
-    "text" : "twitter test test test"
+    "text" : "test test test"
   },
   "fields": ["fullname"],
   "per_field_analyzer" : {
@@ -378,7 +365,7 @@ Response:
 [source,console-result]
 --------------------------------------------------
 {
-  "_index": "twitter",
+  "_index": "my-index-000001",
   "_version": 0,
   "found": true,
   "took": 6,

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -10,9 +10,9 @@ modifying the source, which is useful for picking up mapping changes.
 
 [source,console]
 --------------------------------------------------
-POST twitter/_update_by_query?conflicts=proceed
+POST my-index-000001/_update_by_query?conflicts=proceed
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 ////
 
@@ -305,16 +305,16 @@ To update selected documents, specify a query in the request body:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_update_by_query?conflicts=proceed
+POST my-index-000001/_update_by_query?conflicts=proceed
 {
   "query": { <1>
     "term": {
-      "user": "kimchy"
+      "user.id": "kimchy"
     }
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 <1> The query must be passed as a value to the `query` key, in the same
 way as the <<search-search,Search API>>. You can also use the `q`
@@ -324,49 +324,63 @@ Update documents in multiple data streams or indices:
 
 [source,console]
 --------------------------------------------------
-POST twitter,blog/_update_by_query
+POST my-index-000001,my-index-000002/_update_by_query
 --------------------------------------------------
-// TEST[s/^/PUT twitter\nPUT blog\n/]
+// TEST[s/^/PUT my-index-000001\nPUT my-index-000002\n/]
 
 Limit the update by query operation to shards that a particular routing value:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_update_by_query?routing=1
+POST my-index-000001/_update_by_query?routing=1
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 By default update by query uses scroll batches of 1000. 
 You can change the batch size with the `scroll_size` parameter:
 
 [source,console]
 --------------------------------------------------
-POST twitter/_update_by_query?scroll_size=100
+POST my-index-000001/_update_by_query?scroll_size=100
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 [[docs-update-by-query-api-source]]
 ===== Update the document source
 
 Update by query supports scripts to update the document source. 
-For example, the following request increments the likes field for all of kimchy’s tweets:
+For example, the following request increments the `count` field for all
+documents with a `user.id` of `kimchy` in `my-index-000001`:
+
+////
+[source,console]
+----
+PUT my-index-000001/_create/1
+{
+  "user": {
+    "id": "kimchy"
+  },
+  "count": 1
+}
+----
+////
 
 [source,console]
 --------------------------------------------------
-POST twitter/_update_by_query
+POST my-index-000001/_update_by_query
 {
   "script": {
-    "source": "ctx._source.likes++",
+    "source": "ctx._source.count++",
     "lang": "painless"
   },
   "query": {
     "term": {
-      "user": "kimchy"
+      "user.id": "kimchy"
     }
   }
 }
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[continued]
 
 Note that `conflicts=proceed` is not specified in this example. In this case, a
 version conflict should halt the process so you can handle the failure.
@@ -404,9 +418,9 @@ PUT _ingest/pipeline/set-foo
       }
   } ]
 }
-POST twitter/_update_by_query?pipeline=set-foo
+POST my-index-000001/_update_by_query?pipeline=set-foo
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 
 [discrete]
@@ -535,7 +549,7 @@ slices to each request:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_update_by_query
+POST my-index-000001/_update_by_query
 {
   "slice": {
     "id": 0,
@@ -545,7 +559,7 @@ POST twitter/_update_by_query
     "source": "ctx._source['extra'] = 'test'"
   }
 }
-POST twitter/_update_by_query
+POST my-index-000001/_update_by_query
 {
   "slice": {
     "id": 1,
@@ -556,14 +570,14 @@ POST twitter/_update_by_query
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 Which you can verify works with:
 
 [source,console]
 ----------------------------------------------------------------
 GET _refresh
-POST twitter/_search?size=0&q=extra:test&filter_path=hits.total
+POST my-index-000001/_search?size=0&q=extra:test&filter_path=hits.total
 ----------------------------------------------------------------
 // TEST[continued]
 
@@ -591,20 +605,20 @@ slices to use:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_update_by_query?refresh&slices=5
+POST my-index-000001/_update_by_query?refresh&slices=5
 {
   "script": {
     "source": "ctx._source['extra'] = 'test'"
   }
 }
 ----------------------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 Which you also can verify works with:
 
 [source,console]
 ----------------------------------------------------------------
-POST twitter/_search?size=0&q=extra:test&filter_path=hits.total
+POST my-index-000001/_search?size=0&q=extra:test&filter_path=hits.total
 ----------------------------------------------------------------
 // TEST[continued]
 

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -325,7 +325,7 @@ POST /_aliases
       "add": {
         "index": "test1",
         "alias": "alias2",
-        "filter": { "term": { "user": "kimchy" } }
+        "filter": { "term": { "user.id": "kimchy" } }
       }
     }
   ]
@@ -392,7 +392,7 @@ routing value:
 
 [source,console]
 --------------------------------------------------
-GET /alias2/_search?q=user:kimchy&routing=2,3
+GET /alias2/_search?q=user.id:kimchy&routing=2,3
 --------------------------------------------------
 // TEST[continued]
 

--- a/docs/reference/indices/component-templates.asciidoc
+++ b/docs/reference/indices/component-templates.asciidoc
@@ -139,7 +139,7 @@ PUT _component_template/template_1
         "alias1" : {},
         "alias2" : {
             "filter" : {
-                "term" : {"user" : "kimchy" }
+                "term" : {"user.id" : "kimchy" }
             },
             "routing" : "kimchy"
         },

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -147,7 +147,7 @@ PUT /test
     "alias_1": {},
     "alias_2": {
       "filter": {
-        "term": { "user": "kimchy" }
+        "term": { "user.id": "kimchy" }
       },
       "routing": "kimchy"
     }

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -136,7 +136,7 @@ PUT _component_template/template_1
         "alias1" : {},
         "alias2" : {
             "filter" : {
-                "term" : {"user" : "kimchy" }
+                "term" : {"user.id" : "kimchy" }
             },
             "routing" : "kimchy"
         },

--- a/docs/reference/indices/put-index-template-v1.asciidoc
+++ b/docs/reference/indices/put-index-template-v1.asciidoc
@@ -150,7 +150,7 @@ PUT _template/template_1
     "alias1" : {},
     "alias2" : {
       "filter" : {
-        "term" : {"user" : "kimchy" }
+        "term" : {"user.id" : "kimchy" }
       },
       "routing" : "kimchy"
     },

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -153,7 +153,7 @@ PUT _index_template/template_1
         "alias1" : {},
         "alias2" : {
             "filter" : {
-                "term" : {"user" : "kimchy" }
+                "term" : {"user.id" : "kimchy" }
             },
             "routing" : "kimchy"
         },


### PR DESCRIPTION
Updates the docs API docs to use `my-index-*`
in place of the twitter dataset.