### PR TITLE
[7.8] [DOCS] Note refresh requests are synchronous (#60540)

### DIFF
--- a/docs/reference/indices/refresh.asciidoc
+++ b/docs/reference/indices/refresh.asciidoc
@@ -40,6 +40,9 @@ indices that have received one search request or more in the last 30 seconds.
 You can change this default interval
 using the <<index-refresh-interval-setting,`index.refresh_interval`>> setting.
 
+Refresh requests are synchronous and do not return a response until the
+refresh operation completes.
+
 [IMPORTANT]
 ====
 Refreshes are resource-intensive.


### PR DESCRIPTION
7.8 backport of #60540