### PR TITLE
Fix deperacation log backward compatibility issue.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -144,7 +144,7 @@ public class DeprecationLogger {
     private static final String WARNING_PREFIX =
             String.format(
                     Locale.ROOT,
-                    "299 Elasticsearch-%s%s-%s",
+                    "299 Elasticsearch-%s%s-%s \"\"",
                     Version.CURRENT.toString(),
                     Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
                     Build.CURRENT.shortHash());

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -179,17 +179,18 @@ public class DeprecationLogger {
          * We know the exact format of the warning header, so to extract the warning value we can skip forward from the front to the first
          * quote and we know the last quote is at the end of the string
          *
-         *   299 Elasticsearch-6.0.0 "warning value"
-         *                           ^             ^
-         *                           firstQuote    lastQuote
+         *   299 Elasticsearch-6.0.0 "warning value" "Thu, 01 Jan 1970 00:00:00 GMT"
+         *                           ^               ^                             ^
+         *                           firstQuote      penultimateQuote              lastQuote
          *
          * We parse this manually rather than using the capturing regular expression because the regular expression involves a lot of
          * backtracking and carries a performance penalty. However, when assertions are enabled, we still use the regular expression to
          * verify that we are maintaining the warning header format.
          */
         final int firstQuote = s.indexOf('\"');
-        final int lastQuote = s.length() - 1;
-        final String warningValue = s.substring(firstQuote + 1, lastQuote);
+        final int lastQuote = s.lastIndexOf('\"');
+        final int penultimateQuote = s.lastIndexOf('\"', lastQuote - 1);
+        final String warningValue = s.substring(firstQuote + 1, penultimateQuote - 2);
         assert assertWarningValue(s, warningValue);
         return warningValue;
     }
@@ -251,7 +252,7 @@ public class DeprecationLogger {
      * @return a warning value formatted according to RFC 7234
      */
     public static String formatWarning(final String s) {
-        return WARNING_PREFIX + " " + "\"" + escapeAndEncode(s) + "\"";
+        return WARNING_PREFIX + " " + "\"" + escapeAndEncode(s) + "\"" + " \"Thu, 01 Jan 1970 00:00:00 GMT\"";
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -144,7 +144,7 @@ public class DeprecationLogger {
     private static final String WARNING_PREFIX =
             String.format(
                     Locale.ROOT,
-                    "299 Elasticsearch-%s%s-%s \"\"",
+                    "299 Elasticsearch-%s%s-%s",
                     Version.CURRENT.toString(),
                     Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
                     Build.CURRENT.shortHash());


### PR DESCRIPTION
# Issue
In our production environment, we try to rolling restart nodes to update from 6.4.3 to 6.8.2, after upgrading one node to 6.8.2, we found lots of follow query fetch exceptions on this upgraded node:

```
[2020-07-31T15:18:12,101][DEBUG][o.e.a.s.TransportSearchAction] [1566368687200189609] [187102244] Failed to execute fetch phase
org.elasticsearch.transport.RemoteTransportException: [1566368687200189509][9.33.214.172:9300][indices:data/read/search[phase/fetch/id]]
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -3
        at java.lang.String.substring(Unknown Source) ~[?:1.8.0_181]
        at org.elasticsearch.common.logging.DeprecationLogger.extractWarningValueFromWarningHeader(DeprecationLogger.java:271) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at java.util.stream.ReferencePipeline$3$1.accept(Unknown Source) ~[?:1.8.0_181]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[?:1.8.0_181]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[?:1.8.0_181]
        at java.util.stream.ReferencePipeline.collect(Unknown Source) ~[?:1.8.0_181]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ThreadContextStruct.putResponse(ThreadContext.java:491) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ThreadContextStruct.access$1100(ThreadContext.java:366) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.ThreadContext.addResponseHeader(ThreadContext.java:294) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.logging.DeprecationLogger.deprecated(DeprecationLogger.java:313) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.logging.DeprecationLogger.deprecated(DeprecationLogger.java:298) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.logging.DeprecationLogger.deprecated(DeprecationLogger.java:128) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.search.fetch.subphase.DocValueFieldsFetchSubPhase.hitsExecute(DocValueFieldsFetchSubPhase.java:84) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.search.fetch.FetchPhase.execute(FetchPhase.java:225) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.search.SearchService.executeFetchPhase(SearchService.java:550) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.action.search.SearchTransportService$11.messageReceived(SearchTransportService.java:439) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.action.search.SearchTransportService$11.messageReceived(SearchTransportService.java:436) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:66) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1605) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:723) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:41) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-6.8.2.jar:6.8.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:1.8.0_181]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:1.8.0_181]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]

```

We also could see several above exceptions on other data node, but not that much as this upgraded node.

# Analysis
After try catch the `StringIndexOutOfBoundsException` exception string on **6.4.3** nodes, we found the exception string is:
`299 Elasticsearch-6.8.2-bf84795 "'y' year should be replaced with 'u'. Use 'y' for year-of-era. Prefix your date format with '8' to use the new specifier."`

The above string is generated on 6.8.2 node, it's because we used joda date formatter string "yyyy-MM-dd HH:mm:ss" in query request body. The deprecation log will be sent to target data node in query phase response header:
https://github.com/elastic/elasticsearch/blob/dfd91e088420b8c6e6f4a73e0efc0fbebb025c5e/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java#L234

However, 6.4.3 version expect double strings in warning formatter, it has date formatter in the end:
https://github.com/elastic/elasticsearch/blob/fe40335c1e4fa7db9e38001fa99d19526f3bc5ce/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java#L165

This caused 6.4.3 cannot parse the incoming 6.8.2 deprecation log, `penultimateQuote` and `firstQuote` are equal:
https://github.com/elastic/elasticsearch/blob/fe40335c1e4fa7db9e38001fa99d19526f3bc5ce/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java#L271

This will cause all the queries/fetches with depercation logging failed on 6.4.3 data nodes that received the 6.8.2 depercation log. As the `responseHeaders` of `ThreadContext` is common in threadpool, and `extractWarningValueFromWarningHeader` method always be called before 6.8.2 version.

# Solution
To avoid date format performance issue in https://github.com/elastic/elasticsearch/pull/37622, add fake date time string at the end of warning headers to bwc with versions before 6.8.

