### PR TITLE
[Backport 7.x] Only call listener once (SP template registration)

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndex.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndex.java
@@ -205,6 +205,7 @@ public class SamlServiceProviderIndex implements Closeable {
         final ClusterState state = clusterService.state();
         if (isTemplateUpToDate(state)) {
             listener.onResponse(false);
+            return;
         }
         final String template = TemplateUtils.loadTemplate(TEMPLATE_RESOURCE, Version.CURRENT.toString(), TEMPLATE_VERSION_SUBSTITUTE);
         final PutIndexTemplateRequest request = new PutIndexTemplateRequest(TEMPLATE_NAME).source(template, XContentType.JSON);

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.idp.saml.idp.SamlIdentityProviderBuilder.IDP_ENTITY_ID;
@@ -132,9 +133,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
     }
 
     public void testWritesViaAliasIfItExists() {
-        final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
-        serviceProviderIndex.installIndexTemplate(installTemplate);
-        assertTrue(installTemplate.actionGet());
+        assertTrue(installTemplate());
 
         // Create an index that will trigger the template, but isn't the standard index name
         final String customIndexName = SamlServiceProviderIndex.INDEX_NAME + "-test";
@@ -172,9 +171,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
         assertBusy(() -> assertThat("template should have been installed", templateMeta, notNullValue()));
 
-        final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
-        serviceProviderIndex.installIndexTemplate(installTemplate);
-        assertFalse("Template is already installed, should not install again", installTemplate.actionGet());
+        assertFalse("Template is already installed, should not install again", installTemplate());
     }
 
     public void testInstallTemplateAutomaticallyOnDocumentWrite() {
@@ -186,45 +183,44 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         IndexTemplateMetadata templateMeta = clusterService.state().metadata().templates().get(SamlServiceProviderIndex.TEMPLATE_NAME);
         assertThat("template should have been installed", templateMeta, notNullValue());
 
-        final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
-        serviceProviderIndex.installIndexTemplate(installTemplate);
-        assertFalse("Template is already installed, should not install again", installTemplate.actionGet());
+        assertFalse("Template is already installed, should not install again", installTemplate());
     }
 
     private boolean installTemplate() {
         final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
-        serviceProviderIndex.installIndexTemplate(installTemplate);
+        serviceProviderIndex.installIndexTemplate(assertListenerIsOnlyCalledOnce(installTemplate));
         return installTemplate.actionGet();
     }
 
     private Set<SamlServiceProviderDocument> getAllDocs() {
         final PlainActionFuture<Set<SamlServiceProviderDocument>> future = new PlainActionFuture<>();
-        serviceProviderIndex.findAll(ActionListener.wrap(
+        serviceProviderIndex.findAll(assertListenerIsOnlyCalledOnce(ActionListener.wrap(
             set -> future.onResponse(set.stream().map(doc -> doc.document.get())
                 .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet))),
             future::onFailure
-        ));
+        )));
         return future.actionGet();
     }
 
     private SamlServiceProviderDocument readDocument(String docId) {
         final PlainActionFuture<SamlServiceProviderIndex.DocumentSupplier> future = new PlainActionFuture<>();
-        serviceProviderIndex.readDocument(docId, future);
+        serviceProviderIndex.readDocument(docId, assertListenerIsOnlyCalledOnce(future));
         final SamlServiceProviderIndex.DocumentSupplier supplier = future.actionGet();
         return supplier == null ? null : supplier.getDocument();
     }
 
     private void writeDocument(SamlServiceProviderDocument doc) {
         final PlainActionFuture<DocWriteResponse> future = new PlainActionFuture<>();
-        serviceProviderIndex.writeDocument(doc, DocWriteRequest.OpType.INDEX, WriteRequest.RefreshPolicy.WAIT_UNTIL, future);
+        serviceProviderIndex.writeDocument(doc, DocWriteRequest.OpType.INDEX, WriteRequest.RefreshPolicy.WAIT_UNTIL,
+            assertListenerIsOnlyCalledOnce(future));
         doc.setDocId(future.actionGet().getId());
     }
 
     private DeleteResponse deleteDocument(SamlServiceProviderDocument doc) {
         final PlainActionFuture<DeleteResponse> future = new PlainActionFuture<>();
-        serviceProviderIndex.readDocument(doc.docId, ActionListener.wrap(
+        serviceProviderIndex.readDocument(doc.docId, assertListenerIsOnlyCalledOnce(ActionListener.wrap(
             info -> serviceProviderIndex.deleteDocument(info.version, WriteRequest.RefreshPolicy.IMMEDIATE, future),
-            future::onFailure));
+            future::onFailure)));
         return future.actionGet();
     }
 
@@ -236,17 +232,17 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     private Set<SamlServiceProviderDocument> findAllByEntityId(String entityId) {
         final PlainActionFuture<Set<SamlServiceProviderDocument>> future = new PlainActionFuture<>();
-        serviceProviderIndex.findByEntityId(entityId, ActionListener.wrap(
+        serviceProviderIndex.findByEntityId(entityId, assertListenerIsOnlyCalledOnce(ActionListener.wrap(
             set -> future.onResponse(set.stream().map(doc -> doc.document.get())
                 .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet))),
             future::onFailure
-        ));
+        )));
         return future.actionGet();
     }
 
     private void refresh() {
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        serviceProviderIndex.refresh(future);
+        serviceProviderIndex.refresh(assertListenerIsOnlyCalledOnce(future));
         future.actionGet();
     }
 
@@ -301,6 +297,15 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
     private static String randomUri(String scheme) {
         return scheme + "://" + randomAlphaOfLengthBetween(2, 6) + "."
             + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(2, 4) + "/";
+    }
+
+    private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {
+        final AtomicInteger callCount = new AtomicInteger(0);
+        return ActionListener.runBefore(delegate, () -> {
+            if (callCount.incrementAndGet() != 1) {
+                fail("Listener was called twice");
+            }
+        });
     }
 
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.core.security.authc.TokenMetadata;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.client.SecurityClient;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 
@@ -216,7 +217,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
             .actionGet();
         assertThat(invalidateAccessTokenResponse.getResult().getInvalidatedTokens().size(), equalTo(0));
         assertThat(invalidateAccessTokenResponse.getResult().getPreviouslyInvalidatedTokens().size(), equalTo(0));
-        assertThat(invalidateAccessTokenResponse.getResult().getErrors().size(), equalTo(0));
+        assertThat(/*invalidateAccessTokenResponse.getResult().getErrors()*/ Collections.singletonList("x"), Matchers.empty());
         InvalidateTokenResponse invalidateRefreshTokenResponse = securityClient.prepareInvalidateToken(refreshToken)
             .setType(InvalidateTokenRequest.Type.REFRESH_TOKEN)
             .execute()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.xpack.core.security.authc.TokenMetadata;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.client.SecurityClient;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 
@@ -217,7 +216,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
             .actionGet();
         assertThat(invalidateAccessTokenResponse.getResult().getInvalidatedTokens().size(), equalTo(0));
         assertThat(invalidateAccessTokenResponse.getResult().getPreviouslyInvalidatedTokens().size(), equalTo(0));
-        assertThat(/*invalidateAccessTokenResponse.getResult().getErrors()*/ Collections.singletonList("x"), Matchers.empty());
+        assertThat(invalidateAccessTokenResponse.getResult().getErrors().size(), equalTo(0));
         InvalidateTokenResponse invalidateRefreshTokenResponse = securityClient.prepareInvalidateToken(refreshToken)
             .setType(InvalidateTokenRequest.Type.REFRESH_TOKEN)
             .execute()


### PR DESCRIPTION
This fixes a bug in the IdP's template registration that would
sometimes call the listener twice.

Resolves: #54285
Resolves: #54423

Backport of: #60497

