### PR TITLE
Fix get-license test failure by ensure cluster is ready (#60498)

### DIFF
--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -104,7 +104,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @Before
     public void waitForRequirements() throws Exception {
-        if (isCcrTest()) {
+        if (isCcrTest() || isGetLicenseTest()) {
             ESRestTestCase.waitForActiveLicense(adminClient());
         }
     }
@@ -173,6 +173,11 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     protected boolean isCcrTest() {
         String testName = getTestName();
         return testName != null && testName.contains("/ccr/");
+    }
+
+    protected boolean isGetLicenseTest() {
+        String testName = getTestName();
+        return testName != null && (testName.contains("/get-license/") || testName.contains("\\get-license\\"));
     }
 
     /**

--- a/x-pack/plugin/security/qa/basic-enable-security/src/test/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/basic-enable-security/src/test/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
@@ -97,10 +97,16 @@ public class EnableSecurityOnBasicLicenseIT extends ESRestTestCase {
         return EntityUtils.toString(response.getEntity());
     }
 
-    private void checkBasicLicenseType() throws IOException {
-        Map<String, Object> license = getAsMap("/_license");
-        assertThat(license, notNullValue());
-        assertThat(ObjectPath.evaluate(license, "license.type"), equalTo("basic"));
+    private void checkBasicLicenseType() throws Exception {
+        assertBusy(() -> {
+            try {
+                Map<String, Object> license = getAsMap("/_license");
+                assertThat(license, notNullValue());
+                assertThat(ObjectPath.evaluate(license, "license.type"), equalTo("basic"));
+            } catch (ResponseException e) {
+                throw new AssertionError(e);
+            }
+        });
     }
 
     private void checkSecurityStatus(boolean expectEnabled) throws IOException {

--- a/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -77,10 +77,12 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         client().performRequest(new Request("POST", "/_license/start_basic?acknowledge=true"));
     }
 
-    private void checkLicenseType(String type) throws IOException {
-        Map<String, Object> license = getAsMap("/_license");
-        assertThat(license, notNullValue());
-        assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+    private void checkLicenseType(String type) throws Exception {
+        assertBusy(() -> {
+            Map<String, Object> license = getAsMap("/_license");
+            assertThat(license, notNullValue());
+            assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+        });
     }
 
     private void checkSecurityEnabled(boolean allowAllRealms) throws IOException {

--- a/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -79,9 +79,13 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
 
     private void checkLicenseType(String type) throws Exception {
         assertBusy(() -> {
-            Map<String, Object> license = getAsMap("/_license");
-            assertThat(license, notNullValue());
-            assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            try {
+                Map<String, Object> license = getAsMap("/_license");
+                assertThat(license, notNullValue());
+                assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            } catch (ResponseException e) {
+                throw new AssertionError(e);
+            }
         });
     }
 

--- a/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -60,11 +61,9 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
     }
 
     public void testWithBasicLicense() throws Exception {
-        assertBusy(() -> {
-            checkLicenseType("basic");
-            checkSSLEnabled();
-            checkCertificateAPI();
-        });
+        checkLicenseType("basic");
+        checkSSLEnabled();
+        checkCertificateAPI();
     }
 
     public void testWithTrialLicense() throws Exception {
@@ -87,10 +86,17 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
         client().performRequest(new Request("POST", "/_license/start_basic?acknowledge=true"));
     }
 
-    private void checkLicenseType(String type) throws IOException {
-        Map<String, Object> license = getAsMap("/_license");
-        assertThat(license, notNullValue());
-        assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+    private void checkLicenseType(String type) throws Exception {
+        assertBusy(() -> {
+            try {
+                Map<String, Object> license = getAsMap("/_license");
+                assertThat(license, notNullValue());
+                assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            } catch (ResponseException e) {
+                throw new AssertionError(e);
+            }
+        });
+
     }
 
     private void checkSSLEnabled() throws IOException {

--- a/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
@@ -60,9 +60,11 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
     }
 
     public void testWithBasicLicense() throws Exception {
-        checkLicenseType("basic");
-        checkSSLEnabled();
-        checkCertificateAPI();
+        assertBusy(() -> {
+            checkLicenseType("basic");
+            checkSSLEnabled();
+            checkCertificateAPI();
+        });
     }
 
     public void testWithTrialLicense() throws Exception {


### PR DESCRIPTION
When a new cluster starts, the HTTP layer becomes ready to accept incoming 
requests while the basic license is still being populated in the background. 
When a get license request comes in before the license is ready, it can get 
404 error. This PR fixes it by either wrap the license check in assertBusy or 
ensure the license is ready before perform the check.