### PR TITLE
Ensure assertion error is throw for tests in case of null license response 

### DIFF
--- a/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -79,9 +79,13 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
 
     private void checkLicenseType(String type) throws Exception {
         assertBusy(() -> {
-            Map<String, Object> license = getAsMap("/_license");
-            assertThat(license, notNullValue());
-            assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            try {
+                Map<String, Object> license = getAsMap("/_license");
+                assertThat(license, notNullValue());
+                assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            } catch (ResponseException e) {
+                throw new AssertionError(e);
+            }
         });
     }
 

--- a/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -60,11 +61,9 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
     }
 
     public void testWithBasicLicense() throws Exception {
-        assertBusy(() -> {
-            checkLicenseType("basic");
-            checkSSLEnabled();
-            checkCertificateAPI();
-        });
+        checkLicenseType("basic");
+        checkSSLEnabled();
+        checkCertificateAPI();
     }
 
     public void testWithTrialLicense() throws Exception {
@@ -87,10 +86,17 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
         client().performRequest(new Request("POST", "/_license/start_basic?acknowledge=true"));
     }
 
-    private void checkLicenseType(String type) throws IOException {
-        Map<String, Object> license = getAsMap("/_license");
-        assertThat(license, notNullValue());
-        assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+    private void checkLicenseType(String type) throws Exception {
+        assertBusy(() -> {
+            try {
+                Map<String, Object> license = getAsMap("/_license");
+                assertThat(license, notNullValue());
+                assertThat(ObjectPath.evaluate(license, "license.type"), equalTo(type));
+            } catch (ResponseException e) {
+                throw new AssertionError(e);
+            }
+        });
+
     }
 
     private void checkSSLEnabled() throws IOException {


### PR DESCRIPTION
This is a follow up for #60498 to ensure an AssertionError is throw when the license is ready. 
The client throws a ResponseException for 404 status code. It needs to be converted to an AssertionError to correctly work with assertBusy.