### PR TITLE
Runtime script field mapper to reject copy_to and fields

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
@@ -182,12 +182,19 @@ public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
                     "runtime_type [" + runtimeType.getValue() + "] not supported for " + CONTENT_TYPE + " field [" + name + "]"
                 );
             }
-            // TODO copy to and multi_fields should not be supported, parametrized field mapper needs to be adapted
+            MultiFields multiFields = multiFieldsBuilder.build(this, context);
+            if (multiFields.iterator().hasNext()) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field does not support [fields]");
+            }
+            CopyTo copyTo = this.copyTo.build();
+            if (copyTo.copyToFields().isEmpty() == false) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field does not support [copy_to]");
+            }
             return new RuntimeScriptFieldMapper(
                 name,
                 fieldTypeResolver.apply(this, context),
-                multiFieldsBuilder.build(this, context),
-                copyTo.build(),
+                MultiFields.empty(),
+                CopyTo.empty(),
                 runtimeType.getValue(),
                 script.getValue(),
                 scriptCompiler

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
@@ -84,6 +84,46 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals("Failed to parse mapping: script must be specified for runtime_script field [my_field]", exception.getMessage());
     }
 
+    public void testCopyToIsNotSupported() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .field("script", "keyword('test')")
+            .field("copy_to", "field")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createIndex("test", Settings.EMPTY, mapping));
+        assertEquals("Failed to parse mapping: runtime_script field does not support [copy_to]", exception.getMessage());
+    }
+
+    public void testMultiFieldsIsNotSupported() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .field("script", "keyword('test')")
+            .startObject("fields")
+            .startObject("test")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createIndex("test", Settings.EMPTY, mapping));
+        assertEquals("Failed to parse mapping: runtime_script field does not support [fields]", exception.getMessage());
+    }
+
     public void testStoredScriptsAreNotSupported() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()


### PR DESCRIPTION
Multi fields and copy_to are not supported by the runtime script field mapper. They are now rejected when provided.