### PR TITLE
Ignore shutdown when retrying recoveries

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -160,14 +160,14 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     private void retryRecovery(final long recoveryId, final TimeValue retryAfter, final TimeValue activityTimeout) {
         RecoveryTarget newTarget = onGoingRecoveries.resetRecovery(recoveryId, activityTimeout);
         if (newTarget != null) {
-            threadPool.schedule(new RecoveryRunner(newTarget.recoveryId()), retryAfter, ThreadPool.Names.GENERIC);
+            threadPool.scheduleUnlessShuttingDown(retryAfter, ThreadPool.Names.GENERIC, new RecoveryRunner(newTarget.recoveryId()));
         }
     }
 
     protected void reestablishRecovery(final StartRecoveryRequest request, final String reason, TimeValue retryAfter) {
         final long recoveryId = request.recoveryId();
         logger.trace("will try to reestablish recovery with id [{}] in [{}] (reason [{}])", recoveryId, retryAfter, reason);
-        threadPool.schedule(new RecoveryRunner(recoveryId, request), retryAfter, ThreadPool.Names.GENERIC);
+        threadPool.scheduleUnlessShuttingDown(retryAfter, ThreadPool.Names.GENERIC, new RecoveryRunner(recoveryId, request));
     }
 
     private void doRecovery(final long recoveryId, final StartRecoveryRequest preExistingRequest) {


### PR DESCRIPTION
Avoids failures of the following kind:


```
[2020-08-03T14:46:22,256][INFO ][o.e.i.r.DanglingIndicesIT] [testDanglingIndexOverMultipleNodesCanBeDeleted] after test
Αυγ 03, 2020 2:46:22 ΜΜ com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_t0][generic][T#6],5,TGRP-DanglingIndicesIT]
org.elasticsearch.common.util.concurrent.EsRejectedExecutionException: rejected execution of java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@2a74d21a[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@208cb96a[Wrapped task = [threaded] org.elasticsearch.indices.recovery.PeerRecoveryTargetService$RecoveryRunner@2e4b530b]] on org.elasticsearch.threadpool.Scheduler$SafeScheduledThreadPoolExecutor@6f765930[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 12]
	at __randomizedtesting.SeedInfo.seed([DBD45D948E2921C2]:0)
	at org.elasticsearch.common.util.concurrent.EsAbortPolicy.rejectedExecution(EsAbortPolicy.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:825)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:562)
	at org.elasticsearch.threadpool.ThreadPool.schedule(ThreadPool.java:346)
	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.reestablishRecovery(PeerRecoveryTargetService.java:170)
	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService$RecoveryResponseHandler.onException(PeerRecoveryTargetService.java:639)
	at org.elasticsearch.indices.recovery.PeerRecoveryTargetService$RecoveryResponseHandler.handleException(PeerRecoveryTargetService.java:587)
	at org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1119)
	at org.elasticsearch.transport.TransportService$9.run(TransportService.java:981)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:647)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Found here: https://gradle-enterprise.elastic.co/s/xkwtqr4gcsdme/tests/:server:internalClusterTest/org.elasticsearch.indices.recovery.DanglingIndicesIT/testDanglingIndexOverMultipleNodesCanBeDeleted/0/output