### PR TITLE
[DOCS] Replace `twitter` dataset in cat API docs

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -70,7 +70,7 @@ node | n | node name
 // TESTRESPONSE[s/[|]/[|]/ non_json]
 
 NOTE: `help` is not supported if any optional url parameter is used.
-For example `GET _cat/shards/twitter?help` or `GET _cat/indices/twi*?help`
+For example `GET _cat/shards/my-index-000001?help` or `GET _cat/indices/my-index-*?help`
 results in an error. Use `GET _cat/shards?help` or `GET _cat/indices?help`
 instead.
 
@@ -121,16 +121,16 @@ by shard storage in descending order.
 --------------------------------------------------
 GET /_cat/indices?bytes=b&s=store.size:desc&v
 --------------------------------------------------
-// TEST[setup:huge_twitter]
-// TEST[s/^/PUT twitter2\n{"settings": {"number_of_replicas": 0}}\n/]
+// TEST[setup:my_index]
+// TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]
 
 The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
-health status index    uuid                   pri rep docs.count docs.deleted store.size pri.store.size
-yellow open   twitter  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0      72171         72171
-green  open   twitter2 nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0        230          230
+health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0      72171         72171
+green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0        230          230
 --------------------------------------------------
 // TESTRESPONSE[s/72171|230/\\d+/]
 // TESTRESPONSE[s/u8FNjxh8Rfy_awN11oDKYQ|nYFWZEO7TUiOjLQXBaYJpA/.+/ non_json]
@@ -152,7 +152,7 @@ If you want to change the <<byte-units,byte units>>, use `bytes` parameter.
     "pri.store.size": "650b",
     "health": "yellow",
     "status": "open",
-    "index": "twitter",
+    "index": "my-index-000001",
     "pri": "5",
     "rep": "1",
     "docs.count": "0",
@@ -182,7 +182,7 @@ For example:
     "pri.store.size": "650b",
     "health": "yellow",
     "status": "open",
-    "index": "twitter",
+    "index": "my-index-000001",
     "pri": "5",
     "rep": "1",
     "docs.count": "0",

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -121,7 +121,7 @@ by shard storage in descending order.
 --------------------------------------------------
 GET /_cat/indices?bytes=b&s=store.size:desc&v
 --------------------------------------------------
-// TEST[setup:my_index]
+// TEST[setup:my_index_huge]
 // TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]
 
 The API returns the following response:

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -55,7 +55,7 @@ PUT test1
     "alias2": {
       "filter": {
         "match": {
-          "user": "kimchy"
+          "user.id": "kimchy"
         }
       }
     },

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -51,13 +51,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 ===== Example with an individual data stream or index
 
 The following `count` API request retrieves the document count for the 
-`twitter` data stream or index.
+`my-index-000001` data stream or index.
 
 [source,console,id=cat-count-individual-example]
 --------------------------------------------------
-GET /_cat/count/twitter?v
+GET /_cat/count/my-index-000001?v
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 
 
 The API returns the following response:
@@ -79,7 +79,7 @@ streams and indices in the cluster.
 --------------------------------------------------
 GET /_cat/count?v
 --------------------------------------------------
-// TEST[setup:big_twitter]
+// TEST[setup:my_index_big]
 // TEST[s/^/POST test\/_doc\?refresh\n{"test": "test"}\n/]
 
 The API returns the following response:

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -69,7 +69,7 @@ https://en.wikipedia.org/wiki/Unix_time[Unix `epoch`] timestamps. For example:
 --------------------------------------------------
 GET /_cat/health?v
 --------------------------------------------------
-// TEST[s/^/PUT twitter\n{"settings":{"number_of_replicas": 0}}\n/]
+// TEST[s/^/PUT my-index-000001\n{"settings":{"number_of_replicas": 0}}\n/]
 
 The API returns the following response:
 
@@ -89,7 +89,7 @@ You can use the `ts` (timestamps) parameter to disable timestamps. For example:
 --------------------------------------------------
 GET /_cat/health?v&ts=false
 --------------------------------------------------
-// TEST[s/^/PUT twitter\n{"settings":{"number_of_replicas": 0}}\n/]
+// TEST[s/^/PUT my-index-000001\n{"settings":{"number_of_replicas": 0}}\n/]
 
 The API returns the following response:
 

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -98,18 +98,18 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 [[examples]]
 [source,console]
 --------------------------------------------------
-GET /_cat/indices/twi*?v&s=index
+GET /_cat/indices/my-index-*?v&s=index
 --------------------------------------------------
-// TEST[setup:huge_twitter]
-// TEST[s/^/PUT twitter2\n{"settings": {"number_of_replicas": 0}}\n/]
+// TEST[setup:my_index_huge]
+// TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]
 
 The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
-health status index    uuid                   pri rep docs.count docs.deleted store.size pri.store.size
-yellow open   twitter  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0     88.1kb         88.1kb
-green  open   twitter2 nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0       260b           260b
+health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0     88.1kb         88.1kb
+green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0       260b           260b
 --------------------------------------------------
 // TESTRESPONSE[s/\d+(\.\d+)?[tgmk]?b/\\d+(\\.\\d+)?[tgmk]?b/]
 // TESTRESPONSE[s/u8FNjxh8Rfy_awN11oDKYQ|nYFWZEO7TUiOjLQXBaYJpA/.+/ non_json]

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -75,14 +75,14 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 ----------------------------------------------------------------------------
 GET _cat/recovery?v
 ----------------------------------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-index   shard time type  stage source_host source_node target_host target_node repository snapshot files files_recovered files_percent files_total bytes bytes_recovered bytes_percent bytes_total translog_ops translog_ops_recovered translog_ops_percent
-twitter 0     13ms store done  n/a         n/a         127.0.0.1   node-0      n/a        n/a      0     0               100%          13          0b    0b              100%          9928b       0            0                      100.0%
+index             shard time type  stage source_host source_node target_host target_node repository snapshot files files_recovered files_percent files_total bytes bytes_recovered bytes_percent bytes_total translog_ops translog_ops_recovered translog_ops_percent
+my-index-000001   0     13ms store done  n/a         n/a         127.0.0.1   node-0      n/a        n/a      0     0               100%          13          0b    0b              100%          9928b       0            0                      100.0%
 ---------------------------------------------------------------------------
 // TESTRESPONSE[s/store/empty_store/]
 // TESTRESPONSE[s/100%/0.0%/]
@@ -104,14 +104,14 @@ host the replicas, you can retrieve information about an ongoing recovery.
 ----------------------------------------------------------------------------
 GET _cat/recovery?v&h=i,s,t,ty,st,shost,thost,f,fp,b,bp
 ----------------------------------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following response:
 
 [source,txt]
 ----------------------------------------------------------------------------
-i       s t      ty   st    shost       thost       f     fp      b  bp
-twitter 0 1252ms peer done  192.168.1.1 192.168.1.2 0     100.0%  0b 100.0%
+i               s t      ty   st    shost       thost       f     fp      b  bp
+my-index-000001 0 1252ms peer done  192.168.1.1 192.168.1.2 0     100.0%  0b 100.0%
 ----------------------------------------------------------------------------
 // TESTRESPONSE[s/peer/empty_store/]
 // TESTRESPONSE[s/192.168.1.2/127.0.0.1/]
@@ -140,7 +140,7 @@ The API returns the following response with a recovery type of `snapshot`:
 
 [source,txt]
 --------------------------------------------------------------------------------
-i       s t      ty       st    rep     snap   f  fp   b     bp
-twitter 0 1978ms snapshot done  twitter snap_1 79 8.0% 12086 9.0%
+i               s t      ty       st    rep     snap   f  fp   b     bp
+my-index-000001 0 1978ms snapshot done  my-repo snap-1 79 8.0% 12086 9.0%
 --------------------------------------------------------------------------------
 // TESTRESPONSE[non_json]

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -47,7 +47,7 @@ columns, it only returns the specified columns.
 Valid columns are:
 
 `index`, `i`, `idx`::
-(Default) Name of the index, such as `twitter`.
+(Default) Name of the index.
 
 `shard`, `s`, `sh`::
 (Default) Name of the shard.

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -48,7 +48,7 @@ columns, it only returns the specified columns.
 Valid columns are:
 
 `index`, `i`, `idx`::
-(Default) Name of the index, such as `twitter`.
+(Default) Name of the index.
 
 `shard`, `s`, `sh`::
 (Default) Name of the shard.
@@ -294,13 +294,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 ---------------------------------------------------------------------------
 GET _cat/shards
 ---------------------------------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-twitter 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA
+my-index-000001 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA
 ---------------------------------------------------------------------------
 // TESTRESPONSE[s/3014/\\d+/]
 // TESTRESPONSE[s/31.1mb/\\d+(\.\\d+)?[kmg]?b/]
@@ -318,15 +318,15 @@ beginning with `twitt`.
 
 [source,console]
 ---------------------------------------------------------------------------
-GET _cat/shards/twitt*
+GET _cat/shards/my-index-*
 ---------------------------------------------------------------------------
-// TEST[setup:twitter]
+// TEST[setup:my_index]
 
 The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-twitter 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA
+my-index-000001 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA
 ---------------------------------------------------------------------------
 // TESTRESPONSE[s/3014/\\d+/]
 // TESTRESPONSE[s/31.1mb/\\d+(\.\\d+)?[kmg]?b/]
@@ -347,7 +347,7 @@ The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-twitter 0 p RELOCATING 3014 31.1mb 192.168.56.10 H5dfFeA -> -> 192.168.56.30 bGG90GE
+my-index-000001 0 p RELOCATING 3014 31.1mb 192.168.56.10 H5dfFeA -> -> 192.168.56.30 bGG90GE
 ---------------------------------------------------------------------------
 // TESTRESPONSE[non_json]
 
@@ -370,8 +370,8 @@ The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-twitter 0 p STARTED      3014 31.1mb 192.168.56.10 H5dfFeA
-twitter 0 r INITIALIZING    0 14.3mb 192.168.56.30 bGG90GE
+my-index-000001 0 p STARTED      3014 31.1mb 192.168.56.10 H5dfFeA
+my-index-000001 0 r INITIALIZING    0 14.3mb 192.168.56.30 bGG90GE
 ---------------------------------------------------------------------------
 // TESTRESPONSE[non_json]
 
@@ -391,9 +391,9 @@ The API returns the following response:
 
 [source,txt]
 ---------------------------------------------------------------------------
-twitter 0 p STARTED    3014 31.1mb 192.168.56.10 H5dfFeA
-twitter 0 r STARTED    3014 31.1mb 192.168.56.30 bGG90GE
-twitter 0 r STARTED    3014 31.1mb 192.168.56.20 I8hydUG
-twitter 0 r UNASSIGNED ALLOCATION_FAILED
+my-index-000001 0 p STARTED    3014 31.1mb 192.168.56.10 H5dfFeA
+my-index-000001 0 r STARTED    3014 31.1mb 192.168.56.30 bGG90GE
+my-index-000001 0 r STARTED    3014 31.1mb 192.168.56.20 I8hydUG
+my-index-000001 0 r UNASSIGNED ALLOCATION_FAILED
 ---------------------------------------------------------------------------
 // TESTRESPONSE[non_json]


### PR DESCRIPTION
Updates the cat API docs to use my-index-*
in place of the twitter dataset.