### PR TITLE
[Transform] fix regression of date histogram optimization

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
@@ -565,7 +565,7 @@ public class CompositeBucketsChangeCollector implements ChangeCollector {
                             entry.getKey(),
                             entry.getValue().getMissingBucket(),
                             ((DateHistogramGroupSource) entry.getValue()).getRounding(),
-                            entry.getKey().equals(synchronizationField)
+                            entry.getValue().getField().equals(synchronizationField)
                         )
                     );
                     break;


### PR DESCRIPTION
**Important**: This PR originally should have made it into `7.9.0`, but did not, see #60590 for details. The regression _only_ applies to `7.9` releases.

fixes mix up of input and output field name for date histogram optimization.

minimal fix, more tests to be added with #60469

fixes #60590