### PR TITLE
[7.9] [DOCS] Update Amazon Linux AMI link in EC2 docs (#60589)

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -314,7 +314,7 @@ achieve the same benefits using {es} directly.
 
 ===== Choice of AMI
 
-Prefer the https://aws.amazon.com/amazon-linux-ami/[Amazon Linux AMIs] as these
+Prefer the https://aws.amazon.com/amazon-linux-2/[Amazon Linux 2 AMIs] as these
 allow you to benefit from the lightweight nature, support, and EC2-specific
 performance enhancements that these images offer.
 


### PR DESCRIPTION
7.9 backport of #60589