### PR TITLE
Deprecate allow_no_jobs and allow_no_datafeeds in favor of allow_no_match

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -120,8 +120,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        if (getJobRequest.getAllowNoJobs() != null) {
-            params.putParam("allow_no_jobs", Boolean.toString(getJobRequest.getAllowNoJobs()));
+        if (getJobRequest.getAllowNoMatch() != null) {
+            params.putParam("allow_no_match", Boolean.toString(getJobRequest.getAllowNoMatch()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -137,8 +137,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        if (getJobStatsRequest.getAllowNoJobs() != null) {
-            params.putParam("allow_no_jobs", Boolean.toString(getJobStatsRequest.getAllowNoJobs()));
+        if (getJobStatsRequest.getAllowNoMatch() != null) {
+            params.putParam("allow_no_match", Boolean.toString(getJobStatsRequest.getAllowNoMatch()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -266,9 +266,9 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        if (getDatafeedRequest.getAllowNoDatafeeds() != null) {
-            params.putParam(GetDatafeedRequest.ALLOW_NO_DATAFEEDS.getPreferredName(),
-                    Boolean.toString(getDatafeedRequest.getAllowNoDatafeeds()));
+        if (getDatafeedRequest.getAllowNoMatch() != null) {
+            params.putParam(GetDatafeedRequest.ALLOW_NO_MATCH.getPreferredName(),
+                    Boolean.toString(getDatafeedRequest.getAllowNoMatch()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -323,8 +323,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        if (getDatafeedStatsRequest.getAllowNoDatafeeds() != null) {
-            params.putParam("allow_no_datafeeds", Boolean.toString(getDatafeedStatsRequest.getAllowNoDatafeeds()));
+        if (getDatafeedStatsRequest.getAllowNoMatch() != null) {
+            params.putParam("allow_no_match", Boolean.toString(getDatafeedStatsRequest.getAllowNoMatch()));
         }
         request.addParameters(params.asMap());
         return request;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobRequest.java
@@ -42,7 +42,7 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
     public static final ParseField JOB_ID = new ParseField("job_id");
     public static final ParseField TIMEOUT = new ParseField("timeout");
     public static final ParseField FORCE = new ParseField("force");
-    public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<CloseJobRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -55,7 +55,7 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
             JOB_ID, ObjectParser.ValueType.STRING_ARRAY);
         PARSER.declareString((obj, val) -> obj.setTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
         PARSER.declareBoolean(CloseJobRequest::setForce, FORCE);
-        PARSER.declareBoolean(CloseJobRequest::setAllowNoJobs, ALLOW_NO_JOBS);
+        PARSER.declareBoolean(CloseJobRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     private static final String ALL_JOBS = "_all";
@@ -63,7 +63,7 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
     private final List<String> jobIds;
     private TimeValue timeout;
     private Boolean force;
-    private Boolean allowNoJobs;
+    private Boolean allowNoMatch;
 
     /**
      * Explicitly close all jobs
@@ -128,8 +128,8 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
         this.force = force;
     }
 
-    public Boolean getAllowNoJobs() {
-        return this.allowNoJobs;
+    public Boolean getAllowNoMatch() {
+        return this.allowNoMatch;
     }
 
     /**
@@ -137,15 +137,15 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
      *
      * This includes {@code _all} string or when no jobs have been specified
      *
-     * @param allowNoJobs When {@code true} ignore if wildcard or {@code _all} matches no jobs. Defaults to {@code true}
+     * @param allowNoMatch When {@code true} ignore if wildcard or {@code _all} matches no jobs. Defaults to {@code true}
      */
-    public void setAllowNoJobs(boolean allowNoJobs) {
-        this.allowNoJobs = allowNoJobs;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, timeout, force, allowNoJobs);
+        return Objects.hash(jobIds, timeout, force, allowNoMatch);
     }
 
     @Override
@@ -162,7 +162,7 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
         return Objects.equals(jobIds, that.jobIds) &&
             Objects.equals(timeout, that.timeout) &&
             Objects.equals(force, that.force) &&
-            Objects.equals(allowNoJobs, that.allowNoJobs);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
@@ -175,8 +175,8 @@ public class CloseJobRequest implements ToXContentObject, Validatable {
         if (force != null) {
             builder.field(FORCE.getPreferredName(), force);
         }
-        if (allowNoJobs != null) {
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
@@ -40,11 +40,11 @@ import java.util.Objects;
 public class GetDatafeedRequest implements Validatable, ToXContentObject {
 
     public static final ParseField DATAFEED_IDS = new ParseField("datafeed_ids");
-    public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     private static final String ALL_DATAFEEDS = "_all";
     private final List<String> datafeedIds;
-    private Boolean allowNoDatafeeds;
+    private Boolean allowNoMatch;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetDatafeedRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -53,7 +53,7 @@ public class GetDatafeedRequest implements Validatable, ToXContentObject {
 
     static {
         PARSER.declareStringArray(ConstructingObjectParser.optionalConstructorArg(), DATAFEED_IDS);
-        PARSER.declareBoolean(GetDatafeedRequest::setAllowNoDatafeeds, ALLOW_NO_DATAFEEDS);
+        PARSER.declareBoolean(GetDatafeedRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     /**
@@ -89,20 +89,20 @@ public class GetDatafeedRequest implements Validatable, ToXContentObject {
     /**
      * Whether to ignore if a wildcard expression matches no datafeeds.
      *
-     * @param allowNoDatafeeds If this is {@code false}, then an error is returned when a wildcard (or {@code _all})
+     * @param allowNoMatch If this is {@code false}, then an error is returned when a wildcard (or {@code _all})
      *                        does not match any datafeeds
      */
-    public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-        this.allowNoDatafeeds = allowNoDatafeeds;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
-    public Boolean getAllowNoDatafeeds() {
-        return allowNoDatafeeds;
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedIds, allowNoDatafeeds);
+        return Objects.hash(datafeedIds, allowNoMatch);
     }
 
     @Override
@@ -117,7 +117,7 @@ public class GetDatafeedRequest implements Validatable, ToXContentObject {
 
         GetDatafeedRequest that = (GetDatafeedRequest) other;
         return Objects.equals(datafeedIds, that.datafeedIds) &&
-            Objects.equals(allowNoDatafeeds, that.allowNoDatafeeds);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
@@ -128,8 +128,8 @@ public class GetDatafeedRequest implements Validatable, ToXContentObject {
             builder.field(DATAFEED_IDS.getPreferredName(), datafeedIds);
         }
 
-        if (allowNoDatafeeds != null) {
-            builder.field(ALLOW_NO_DATAFEEDS.getPreferredName(), allowNoDatafeeds);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
 
         builder.endObject();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedStatsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedStatsRequest.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  */
 public class GetDatafeedStatsRequest implements Validatable, ToXContentObject {
 
-    public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetDatafeedStatsRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -52,13 +52,13 @@ public class GetDatafeedStatsRequest implements Validatable, ToXContentObject {
         PARSER.declareField(ConstructingObjectParser.constructorArg(),
             p -> Arrays.asList(Strings.commaDelimitedListToStringArray(p.text())),
             DatafeedConfig.ID, ObjectParser.ValueType.STRING_ARRAY);
-        PARSER.declareBoolean(GetDatafeedStatsRequest::setAllowNoDatafeeds, ALLOW_NO_DATAFEEDS);
+        PARSER.declareBoolean(GetDatafeedStatsRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     private static final String ALL_DATAFEEDS = "_all";
 
     private final List<String> datafeedIds;
-    private Boolean allowNoDatafeeds;
+    private Boolean allowNoMatch;
 
     /**
      * Explicitly gets all datafeeds statistics
@@ -92,8 +92,8 @@ public class GetDatafeedStatsRequest implements Validatable, ToXContentObject {
         return datafeedIds;
     }
 
-    public Boolean getAllowNoDatafeeds() {
-        return this.allowNoDatafeeds;
+    public Boolean getAllowNoMatch() {
+        return this.allowNoMatch;
     }
 
     /**
@@ -101,15 +101,15 @@ public class GetDatafeedStatsRequest implements Validatable, ToXContentObject {
      *
      * This includes {@code _all} string or when no datafeeds have been specified
      *
-     * @param allowNoDatafeeds When {@code true} ignore if wildcard or {@code _all} matches no datafeeds. Defaults to {@code true}
+     * @param allowNoMatch When {@code true} ignore if wildcard or {@code _all} matches no datafeeds. Defaults to {@code true}
      */
-    public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-        this.allowNoDatafeeds = allowNoDatafeeds;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedIds, allowNoDatafeeds);
+        return Objects.hash(datafeedIds, allowNoMatch);
     }
 
     @Override
@@ -124,15 +124,15 @@ public class GetDatafeedStatsRequest implements Validatable, ToXContentObject {
 
         GetDatafeedStatsRequest that = (GetDatafeedStatsRequest) other;
         return Objects.equals(datafeedIds, that.datafeedIds) &&
-            Objects.equals(allowNoDatafeeds, that.allowNoDatafeeds);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
         builder.field(DatafeedConfig.ID.getPreferredName(), Strings.collectionToCommaDelimitedString(datafeedIds));
-        if (allowNoDatafeeds != null) {
-            builder.field(ALLOW_NO_DATAFEEDS.getPreferredName(), allowNoDatafeeds);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
@@ -41,11 +41,11 @@ import java.util.Objects;
 public class GetJobRequest implements Validatable, ToXContentObject {
 
     public static final ParseField JOB_IDS = new ParseField("job_ids");
-    public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     private static final String ALL_JOBS = "_all";
     private final List<String> jobIds;
-    private Boolean allowNoJobs;
+    private Boolean allowNoMatch;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetJobRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -54,7 +54,7 @@ public class GetJobRequest implements Validatable, ToXContentObject {
 
     static {
         PARSER.declareStringArray(ConstructingObjectParser.optionalConstructorArg(), JOB_IDS);
-        PARSER.declareBoolean(GetJobRequest::setAllowNoJobs, ALLOW_NO_JOBS);
+        PARSER.declareBoolean(GetJobRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     /**
@@ -90,19 +90,19 @@ public class GetJobRequest implements Validatable, ToXContentObject {
     /**
      * Whether to ignore if a wildcard expression matches no jobs.
      *
-     * @param allowNoJobs If this is {@code false}, then an error is returned when a wildcard (or {@code _all}) does not match any jobs
+     * @param allowNoMatch If this is {@code false}, then an error is returned when a wildcard (or {@code _all}) does not match any jobs
      */
-    public void setAllowNoJobs(boolean allowNoJobs) {
-        this.allowNoJobs = allowNoJobs;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
-    public Boolean getAllowNoJobs() {
-        return allowNoJobs;
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, allowNoJobs);
+        return Objects.hash(jobIds, allowNoMatch);
     }
 
     @Override
@@ -117,7 +117,7 @@ public class GetJobRequest implements Validatable, ToXContentObject {
 
         GetJobRequest that = (GetJobRequest) other;
         return Objects.equals(jobIds, that.jobIds) &&
-            Objects.equals(allowNoJobs, that.allowNoJobs);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
@@ -128,8 +128,8 @@ public class GetJobRequest implements Validatable, ToXContentObject {
             builder.field(JOB_IDS.getPreferredName(), jobIds);
         }
 
-        if (allowNoJobs != null) {
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
 
         builder.endObject();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobStatsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobStatsRequest.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  */
 public class GetJobStatsRequest implements Validatable, ToXContentObject {
 
-    public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetJobStatsRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -52,13 +52,13 @@ public class GetJobStatsRequest implements Validatable, ToXContentObject {
         PARSER.declareField(ConstructingObjectParser.constructorArg(),
             p -> Arrays.asList(Strings.commaDelimitedListToStringArray(p.text())),
             Job.ID, ObjectParser.ValueType.STRING_ARRAY);
-        PARSER.declareBoolean(GetJobStatsRequest::setAllowNoJobs, ALLOW_NO_JOBS);
+        PARSER.declareBoolean(GetJobStatsRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     private static final String ALL_JOBS = "_all";
 
     private final List<String> jobIds;
-    private Boolean allowNoJobs;
+    private Boolean allowNoMatch;
 
     /**
      * Explicitly gets all jobs statistics
@@ -92,8 +92,8 @@ public class GetJobStatsRequest implements Validatable, ToXContentObject {
         return jobIds;
     }
 
-    public Boolean getAllowNoJobs() {
-        return this.allowNoJobs;
+    public Boolean getAllowNoMatch() {
+        return this.allowNoMatch;
     }
 
     /**
@@ -101,15 +101,15 @@ public class GetJobStatsRequest implements Validatable, ToXContentObject {
      *
      * This includes {@code _all} string or when no jobs have been specified
      *
-     * @param allowNoJobs When {@code true} ignore if wildcard or {@code _all} matches no jobs. Defaults to {@code true}
+     * @param allowNoMatch When {@code true} ignore if wildcard or {@code _all} matches no jobs. Defaults to {@code true}
      */
-    public void setAllowNoJobs(boolean allowNoJobs) {
-        this.allowNoJobs = allowNoJobs;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, allowNoJobs);
+        return Objects.hash(jobIds, allowNoMatch);
     }
 
     @Override
@@ -124,15 +124,15 @@ public class GetJobStatsRequest implements Validatable, ToXContentObject {
 
         GetJobStatsRequest that = (GetJobStatsRequest) other;
         return Objects.equals(jobIds, that.jobIds) &&
-            Objects.equals(allowNoJobs, that.allowNoJobs);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(Job.ID.getPreferredName(), Strings.collectionToCommaDelimitedString(jobIds));
-        if (allowNoJobs != null) {
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetOverallBucketsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetOverallBucketsRequest.java
@@ -44,7 +44,7 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
     public static final ParseField EXCLUDE_INTERIM = new ParseField("exclude_interim");
     public static final ParseField START = new ParseField("start");
     public static final ParseField END = new ParseField("end");
-    public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     private static final String ALL_JOBS = "_all";
 
@@ -60,7 +60,7 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
         PARSER.declareDouble(GetOverallBucketsRequest::setOverallScore, OVERALL_SCORE);
         PARSER.declareStringOrNull(GetOverallBucketsRequest::setStart, START);
         PARSER.declareStringOrNull(GetOverallBucketsRequest::setEnd, END);
-        PARSER.declareBoolean(GetOverallBucketsRequest::setAllowNoJobs, ALLOW_NO_JOBS);
+        PARSER.declareBoolean(GetOverallBucketsRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     private final List<String> jobIds;
@@ -70,7 +70,7 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
     private Double overallScore;
     private String start;
     private String end;
-    private Boolean allowNoJobs;
+    private Boolean allowNoMatch;
 
     private GetOverallBucketsRequest(String jobId) {
         this(Strings.tokenizeToStringArray(jobId, ","));
@@ -186,11 +186,11 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
     }
 
     /**
-     * See {@link GetJobRequest#getAllowNoJobs()}
-     * @param allowNoJobs value of "allow_no_jobs".
+     * See {@link GetJobRequest#getAllowNoMatch()}
+     * @param allowNoMatch value of "allow_no_match".
      */
-    public void setAllowNoJobs(boolean allowNoJobs) {
-        this.allowNoJobs = allowNoJobs;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
     /**
@@ -198,8 +198,8 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
      *
      * If this is {@code false}, then an error is returned when a wildcard (or {@code _all}) does not match any jobs
      */
-    public Boolean getAllowNoJobs() {
-        return allowNoJobs;
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
     }
 
     @Override
@@ -227,8 +227,8 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
         if (overallScore != null) {
             builder.field(OVERALL_SCORE.getPreferredName(), overallScore);
         }
-        if (allowNoJobs != null) {
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
         builder.endObject();
         return builder;
@@ -236,7 +236,7 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, topN, bucketSpan, excludeInterim, overallScore, start, end, allowNoJobs);
+        return Objects.hash(jobIds, topN, bucketSpan, excludeInterim, overallScore, start, end, allowNoMatch);
     }
 
     @Override
@@ -255,6 +255,6 @@ public class GetOverallBucketsRequest implements Validatable, ToXContentObject {
                 Objects.equals(overallScore, other.overallScore) &&
                 Objects.equals(start, other.start) &&
                 Objects.equals(end, other.end) &&
-                Objects.equals(allowNoJobs, other.allowNoJobs);
+                Objects.equals(allowNoMatch, other.allowNoMatch);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedRequest.java
@@ -42,7 +42,7 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
 
     public static final ParseField TIMEOUT = new ParseField("timeout");
     public static final ParseField FORCE = new ParseField("force");
-    public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<StopDatafeedRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -55,7 +55,7 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
             DatafeedConfig.ID, ObjectParser.ValueType.STRING_ARRAY);
         PARSER.declareString((obj, val) -> obj.setTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
         PARSER.declareBoolean(StopDatafeedRequest::setForce, FORCE);
-        PARSER.declareBoolean(StopDatafeedRequest::setAllowNoDatafeeds, ALLOW_NO_DATAFEEDS);
+        PARSER.declareBoolean(StopDatafeedRequest::setAllowNoMatch, ALLOW_NO_MATCH);
     }
 
     private static final String ALL_DATAFEEDS = "_all";
@@ -63,7 +63,7 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
     private final List<String> datafeedIds;
     private TimeValue timeout;
     private Boolean force;
-    private Boolean allowNoDatafeeds;
+    private Boolean allowNoMatch;
 
     /**
      * Explicitly stop all datafeeds
@@ -128,8 +128,8 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
         this.force = force;
     }
 
-    public Boolean getAllowNoDatafeeds() {
-        return this.allowNoDatafeeds;
+    public Boolean getAllowNoMatch() {
+        return this.allowNoMatch;
     }
 
     /**
@@ -137,15 +137,15 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
      *
      * This includes {@code _all} string.
      *
-     * @param allowNoDatafeeds When {@code true} ignore if wildcard or {@code _all} matches no datafeeds. Defaults to {@code true}
+     * @param allowNoMatch When {@code true} ignore if wildcard or {@code _all} matches no datafeeds. Defaults to {@code true}
      */
-    public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-        this.allowNoDatafeeds = allowNoDatafeeds;
+    public void setAllowNoMatch(boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedIds, timeout, force, allowNoDatafeeds);
+        return Objects.hash(datafeedIds, timeout, force, allowNoMatch);
     }
 
     @Override
@@ -162,7 +162,7 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
         return Objects.equals(datafeedIds, that.datafeedIds) &&
             Objects.equals(timeout, that.timeout) &&
             Objects.equals(force, that.force) &&
-            Objects.equals(allowNoDatafeeds, that.allowNoDatafeeds);
+            Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 
     @Override
@@ -175,8 +175,8 @@ public class StopDatafeedRequest implements Validatable, ToXContentObject {
         if (force != null) {
             builder.field(FORCE.getPreferredName(), force);
         }
-        if (allowNoDatafeeds != null) {
-            builder.field(ALLOW_NO_DATAFEEDS.getPreferredName(), allowNoDatafeeds);
+        if (allowNoMatch != null) {
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
@@ -159,14 +159,14 @@ public class MLRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/anomaly_detectors", request.getEndpoint());
-        assertFalse(request.getParameters().containsKey("allow_no_jobs"));
+        assertFalse(request.getParameters().containsKey("allow_no_match"));
 
         getJobRequest = new GetJobRequest("job1", "jobs*");
-        getJobRequest.setAllowNoJobs(true);
+        getJobRequest.setAllowNoMatch(true);
         request = MLRequestConverters.getJob(getJobRequest);
 
         assertEquals("/_ml/anomaly_detectors/job1,jobs*", request.getEndpoint());
-        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_jobs"));
+        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_match"));
     }
 
     public void testGetJobStats() {
@@ -176,14 +176,14 @@ public class MLRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/anomaly_detectors/_stats", request.getEndpoint());
-        assertFalse(request.getParameters().containsKey("allow_no_jobs"));
+        assertFalse(request.getParameters().containsKey("allow_no_match"));
 
         getJobStatsRequestRequest = new GetJobStatsRequest("job1", "jobs*");
-        getJobStatsRequestRequest.setAllowNoJobs(true);
+        getJobStatsRequestRequest.setAllowNoMatch(true);
         request = MLRequestConverters.getJobStats(getJobStatsRequestRequest);
 
         assertEquals("/_ml/anomaly_detectors/job1,jobs*/_stats", request.getEndpoint());
-        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_jobs"));
+        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_match"));
     }
 
     public void testOpenJob() throws Exception {
@@ -208,12 +208,12 @@ public class MLRequestConvertersTests extends ESTestCase {
 
         closeJobRequest = new CloseJobRequest(jobId, "otherjobs*");
         closeJobRequest.setForce(true);
-        closeJobRequest.setAllowNoJobs(false);
+        closeJobRequest.setAllowNoMatch(false);
         closeJobRequest.setTimeout(TimeValue.timeValueMinutes(10));
         request = MLRequestConverters.closeJob(closeJobRequest);
 
         assertEquals("/_ml/anomaly_detectors/" + jobId + ",otherjobs*/_close", request.getEndpoint());
-        assertEquals("{\"job_id\":\"somejobid,otherjobs*\",\"timeout\":\"10m\",\"force\":true,\"allow_no_jobs\":false}",
+        assertEquals("{\"job_id\":\"somejobid,otherjobs*\",\"timeout\":\"10m\",\"force\":true,\"allow_no_match\":false}",
             requestEntityToString(request));
     }
 
@@ -330,14 +330,14 @@ public class MLRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/datafeeds", request.getEndpoint());
-        assertFalse(request.getParameters().containsKey("allow_no_datafeeds"));
+        assertFalse(request.getParameters().containsKey("allow_no_match"));
 
         getDatafeedRequest = new GetDatafeedRequest("feed-1", "feed-*");
-        getDatafeedRequest.setAllowNoDatafeeds(true);
+        getDatafeedRequest.setAllowNoMatch(true);
         request = MLRequestConverters.getDatafeed(getDatafeedRequest);
 
         assertEquals("/_ml/datafeeds/feed-1,feed-*", request.getEndpoint());
-        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_datafeeds"));
+        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_match"));
     }
 
     public void testDeleteDatafeed() {
@@ -371,7 +371,7 @@ public class MLRequestConvertersTests extends ESTestCase {
         StopDatafeedRequest datafeedRequest = new StopDatafeedRequest("datafeed_1", "datafeed_2");
         datafeedRequest.setForce(true);
         datafeedRequest.setTimeout(TimeValue.timeValueMinutes(10));
-        datafeedRequest.setAllowNoDatafeeds(true);
+        datafeedRequest.setAllowNoMatch(true);
         Request request = MLRequestConverters.stopDatafeed(datafeedRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/datafeeds/" +
@@ -390,14 +390,14 @@ public class MLRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/datafeeds/_stats", request.getEndpoint());
-        assertFalse(request.getParameters().containsKey("allow_no_datafeeds"));
+        assertFalse(request.getParameters().containsKey("allow_no_match"));
 
         getDatafeedStatsRequestRequest = new GetDatafeedStatsRequest("datafeed1", "datafeeds*");
-        getDatafeedStatsRequestRequest.setAllowNoDatafeeds(true);
+        getDatafeedStatsRequestRequest.setAllowNoMatch(true);
         request = MLRequestConverters.getDatafeedStats(getDatafeedStatsRequestRequest);
 
         assertEquals("/_ml/datafeeds/datafeed1,datafeeds*/_stats", request.getEndpoint());
-        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_datafeeds"));
+        assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_match"));
     }
 
     public void testPreviewDatafeed() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -389,9 +389,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertTrue(response.jobStats().size() >= 2L);
         assertThat(response.jobStats().stream().map(JobStats::getJobId).collect(Collectors.toList()), hasItems(jobId1, jobId2));
 
-        // Test when allow_no_jobs is false
+        // Test when allow_no_match is false
         final GetJobStatsRequest erroredRequest = new GetJobStatsRequest("jobs-that-do-not-exist*");
-        erroredRequest.setAllowNoJobs(false);
+        erroredRequest.setAllowNoMatch(false);
         ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class,
             () -> execute(erroredRequest, machineLearningClient::getJobStats, machineLearningClient::getJobStatsAsync));
         assertThat(exception.status().getStatus(), equalTo(404));
@@ -563,7 +563,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
                     hasItems(datafeedId1, datafeedId2));
         }
 
-        // Test get missing pattern with allow_no_datafeeds set to true
+        // Test get missing pattern with allow_no_match set to true
         {
             GetDatafeedRequest request = new GetDatafeedRequest("missing-*");
 
@@ -572,10 +572,10 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             assertThat(response.count(), equalTo(0L));
         }
 
-        // Test get missing pattern with allow_no_datafeeds set to false
+        // Test get missing pattern with allow_no_match set to false
         {
             GetDatafeedRequest request = new GetDatafeedRequest("missing-*");
-            request.setAllowNoDatafeeds(false);
+            request.setAllowNoMatch(false);
 
             ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
                     () -> execute(request, machineLearningClient::getDatafeed, machineLearningClient::getDatafeedAsync));
@@ -703,7 +703,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         {
             StopDatafeedRequest request = new StopDatafeedRequest(datafeedId1);
-            request.setAllowNoDatafeeds(false);
+            request.setAllowNoMatch(false);
             StopDatafeedResponse stopDatafeedResponse = execute(request,
                 machineLearningClient::stopDatafeed,
                 machineLearningClient::stopDatafeedAsync);
@@ -711,7 +711,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         }
         {
             StopDatafeedRequest request = new StopDatafeedRequest(datafeedId2, datafeedId3);
-            request.setAllowNoDatafeeds(false);
+            request.setAllowNoMatch(false);
             StopDatafeedResponse stopDatafeedResponse = execute(request,
                 machineLearningClient::stopDatafeed,
                 machineLearningClient::stopDatafeedAsync);
@@ -725,7 +725,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         }
         {
             StopDatafeedRequest request = new StopDatafeedRequest("datafeed_that_doesnot_exist*");
-            request.setAllowNoDatafeeds(false);
+            request.setAllowNoMatch(false);
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class,
                 () -> execute(request, machineLearningClient::stopDatafeed, machineLearningClient::stopDatafeedAsync));
             assertThat(exception.status().getStatus(), equalTo(404));
@@ -792,9 +792,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(response.datafeedStats().stream().map(DatafeedStats::getDatafeedId).collect(Collectors.toList()),
             hasItems(datafeedId1, datafeedId2));
 
-        // Test when allow_no_jobs is false
+        // Test when allow_no_match is false
         final GetDatafeedStatsRequest erroredRequest = new GetDatafeedStatsRequest("datafeeds-that-do-not-exist*");
-        erroredRequest.setAllowNoDatafeeds(false);
+        erroredRequest.setAllowNoMatch(false);
         ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class,
             () -> execute(erroredRequest, machineLearningClient::getDatafeedStats, machineLearningClient::getDatafeedStatsAsync));
         assertThat(exception.status().getStatus(), equalTo(404));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -337,7 +337,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-job-request
             GetJobRequest request = new GetJobRequest("get-machine-learning-job1", "get-machine-learning-job*"); // <1>
-            request.setAllowNoJobs(true); // <2>
+            request.setAllowNoMatch(true); // <2>
             // end::get-job-request
 
             // tag::get-job-execute
@@ -510,7 +510,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::close-job-request
             CloseJobRequest closeJobRequest = new CloseJobRequest("closing-my-first-machine-learning-job", "otherjobs*"); // <1>
             closeJobRequest.setForce(false); // <2>
-            closeJobRequest.setAllowNoJobs(true); // <3>
+            closeJobRequest.setAllowNoMatch(true); // <3>
             closeJobRequest.setTimeout(TimeValue.timeValueMinutes(10)); // <4>
             // end::close-job-request
 
@@ -833,7 +833,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-datafeed-request
             GetDatafeedRequest request = new GetDatafeedRequest(datafeedId); // <1>
-            request.setAllowNoDatafeeds(true); // <2>
+            request.setAllowNoMatch(true); // <2>
             // end::get-datafeed-request
 
             // tag::get-datafeed-execute
@@ -1068,7 +1068,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             request = StopDatafeedRequest.stopAllDatafeedsRequest();
 
             // tag::stop-datafeed-request-options
-            request.setAllowNoDatafeeds(true); // <1>
+            request.setAllowNoMatch(true); // <1>
             request.setForce(true); // <2>
             request.setTimeout(TimeValue.timeValueMinutes(10)); // <3>
             // end::stop-datafeed-request-options
@@ -1137,7 +1137,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             //tag::get-datafeed-stats-request
             GetDatafeedStatsRequest request =
                 new GetDatafeedStatsRequest("get-machine-learning-datafeed-stats1-feed", "get-machine-learning-datafeed*"); // <1>
-            request.setAllowNoDatafeeds(true); // <2>
+            request.setAllowNoMatch(true); // <2>
             //end::get-datafeed-stats-request
 
             //tag::get-datafeed-stats-execute
@@ -1437,7 +1437,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-job-stats-request
             GetJobStatsRequest request = new GetJobStatsRequest("get-machine-learning-job-stats1", "get-machine-learning-job-*"); // <1>
-            request.setAllowNoJobs(true); // <2>
+            request.setAllowNoMatch(true); // <2>
             // end::get-job-stats-request
 
             // tag::get-job-stats-execute

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/CloseJobRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/CloseJobRequestTests.java
@@ -55,7 +55,7 @@ public class CloseJobRequestTests extends AbstractXContentTestCase<CloseJobReque
         CloseJobRequest request = new CloseJobRequest(jobIds.toArray(new String[0]));
 
         if (randomBoolean()) {
-            request.setAllowNoJobs(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetDatafeedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetDatafeedRequestTests.java
@@ -52,7 +52,7 @@ public class GetDatafeedRequestTests extends AbstractXContentTestCase<GetDatafee
         GetDatafeedRequest request = new GetDatafeedRequest(datafeedIds);
 
         if (randomBoolean()) {
-            request.setAllowNoDatafeeds(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         return request;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetDatafeedStatsRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetDatafeedStatsRequestTests.java
@@ -51,7 +51,7 @@ public class GetDatafeedStatsRequestTests extends AbstractXContentTestCase<GetDa
         GetDatafeedStatsRequest request = new GetDatafeedStatsRequest(datafeedIds);
 
         if (randomBoolean()) {
-            request.setAllowNoDatafeeds(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         return request;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetJobRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetJobRequestTests.java
@@ -51,7 +51,7 @@ public class GetJobRequestTests extends AbstractXContentTestCase<GetJobRequest> 
         GetJobRequest request = new GetJobRequest(jobIds);
 
         if (randomBoolean()) {
-            request.setAllowNoJobs(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         return request;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetJobStatsRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/GetJobStatsRequestTests.java
@@ -51,7 +51,7 @@ public class GetJobStatsRequestTests extends AbstractXContentTestCase<GetJobStat
         GetJobStatsRequest request = new GetJobStatsRequest(jobIds);
 
         if (randomBoolean()) {
-            request.setAllowNoJobs(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         return request;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StopDatafeedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StopDatafeedRequestTests.java
@@ -55,7 +55,7 @@ public class StopDatafeedRequestTests extends AbstractXContentTestCase<StopDataf
         StopDatafeedRequest request = new StopDatafeedRequest(datafeedIds.toArray(new String[0]));
 
         if (randomBoolean()) {
-            request.setAllowNoDatafeeds(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
 
         if (randomBoolean()) {

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -40,7 +40,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 [[cat-anomaly-detectors-query-params]]
 ==== {api-query-parms-title}
 
-`allow_no_jobs`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -41,7 +41,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 [[cat-datafeeds-query-params]]
 ==== {api-query-parms-title}
 
-`allow_no_datafeeds`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -66,7 +66,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildca
 [[ml-close-job-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_jobs`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
@@ -82,7 +82,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  If `allow_no_match` is `false`, this code indicates that there are no 
   resources that match the request or only partial matches for the request.
 
 [[ml-close-job-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -56,7 +56,7 @@ all {dfeeds}.
 [[ml-get-datafeed-stats-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_datafeeds`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
@@ -143,7 +143,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-time]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  If `allow_no_match` is `false`, this code indicates that there are no
   resources that match the request or only partial matches for the request. 
 
 [[ml-get-datafeed-stats-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -53,7 +53,7 @@ all {dfeeds}.
 [[ml-get-datafeed-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_datafeeds`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
@@ -67,7 +67,7 @@ see <<ml-put-datafeed-request-body,create {dfeeds} API>>.
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  If `allow_no_match` is `false`, this code indicates that there are no
   resources that match the request or only partial matches for the request.
 
 [[ml-get-datafeed-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -46,7 +46,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 [[ml-get-job-stats-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_jobs`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
@@ -360,7 +360,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  If `allow_no_match` is `false`, this code indicates that there are no 
   resources that match the request or only partial matches for the request.
 
 [[ml-get-job-stats-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -46,7 +46,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 [[ml-get-job-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_jobs`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
@@ -80,7 +80,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-snapshot-id]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  If `allow_no_match` is `false`, this code indicates that there are no 
   resources that match the request or only partial matches for the request.
 
 [[ml-get-job-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -62,7 +62,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildca
 [[ml-get-overall-buckets-request-body]]
 == {api-request-body-title}
 
-`allow_no_jobs`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -46,7 +46,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 [[ml-stop-datafeed-query-parms]]
 == {api-query-parms-title}
 
-`allow_no_datafeeds`::
+`allow_no_match`::
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
@@ -64,7 +64,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  If `allow_no_match` is `false`, this code indicates that there are no
   resources that match the request or only partial matches for the request.
 
 [[ml-stop-datafeed-example]]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -78,8 +78,8 @@ public class MlMetadata implements Metadata.Custom {
         return jobs;
     }
 
-    public Set<String> expandJobIds(String expression, boolean allowNoJobs) {
-        return groupOrJobLookup.expandJobIds(expression, allowNoJobs);
+    public Set<String> expandJobIds(String expression, boolean allowNoMatch) {
+        return groupOrJobLookup.expandJobIds(expression, allowNoMatch);
     }
 
     public SortedMap<String, DatafeedConfig> getDatafeeds() {
@@ -94,9 +94,9 @@ public class MlMetadata implements Metadata.Custom {
         return datafeeds.values().stream().filter(s -> s.getJobId().equals(jobId)).findFirst();
     }
 
-    public Set<String> expandDatafeedIds(String expression, boolean allowNoDatafeeds) {
+    public Set<String> expandDatafeedIds(String expression, boolean allowNoMatch) {
         return NameResolver.newUnaliased(datafeeds.keySet(), ExceptionsHelper::missingDatafeedException)
-                .expand(expression, allowNoDatafeeds);
+                .expand(expression, allowNoMatch);
     }
 
     public boolean isUpgradeMode() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
@@ -37,7 +37,9 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
 
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField FORCE = new ParseField("force");
-        public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+        @Deprecated
+        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
+        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match", ALLOW_NO_JOBS);
         public static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
         static {
@@ -45,7 +47,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             PARSER.declareString((request, val) ->
                     request.setCloseTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
             PARSER.declareBoolean(Request::setForce, FORCE);
-            PARSER.declareBoolean(Request::setAllowNoJobs, ALLOW_NO_JOBS);
+            PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
         }
 
         public static Request parseRequest(String jobId, XContentParser parser) {
@@ -58,7 +60,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
 
         private String jobId;
         private boolean force = false;
-        private boolean allowNoJobs = true;
+        private boolean allowNoMatch = true;
         // A big state can take a while to persist.  For symmetry with the _open endpoint any
         // changes here should be reflected there too.
         private TimeValue timeout = MachineLearningField.STATE_PERSIST_RESTORE_TIMEOUT;
@@ -78,7 +80,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             force = in.readBoolean();
             openJobIds = in.readStringArray();
             local = in.readBoolean();
-            allowNoJobs = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         @Override
@@ -89,7 +91,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             out.writeBoolean(force);
             out.writeStringArray(openJobIds);
             out.writeBoolean(local);
-            out.writeBoolean(allowNoJobs);
+            out.writeBoolean(allowNoMatch);
         }
 
         public Request(String jobId) {
@@ -121,12 +123,12 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             this.force = force;
         }
 
-        public boolean allowNoJobs() {
-            return allowNoJobs;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
-        public void setAllowNoJobs(boolean allowNoJobs) {
-            this.allowNoJobs = allowNoJobs;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         public boolean isLocal() { return local; }
@@ -158,7 +160,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             builder.field(Job.ID.getPreferredName(), jobId);
             builder.field(TIMEOUT.getPreferredName(), timeout.getStringRep());
             builder.field(FORCE.getPreferredName(), force);
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
             builder.endObject();
             return builder;
         }
@@ -166,7 +168,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
         @Override
         public int hashCode() {
             // openJobIds are excluded
-            return Objects.hash(jobId, timeout, force, allowNoJobs);
+            return Objects.hash(jobId, timeout, force, allowNoMatch);
         }
 
         @Override
@@ -182,7 +184,7 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
             return Objects.equals(jobId, other.jobId) &&
                     Objects.equals(timeout, other.timeout) &&
                     Objects.equals(force, other.force) &&
-                    Objects.equals(allowNoJobs, other.allowNoJobs);
+                    Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -33,10 +32,12 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+        @Deprecated
+        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
+        public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String datafeedId;
-        private boolean allowNoDatafeeds = true;
+        private boolean allowNoMatch = true;
 
         public Request(String datafeedId) {
             this();
@@ -50,26 +51,26 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();
-            allowNoDatafeeds = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(datafeedId);
-            out.writeBoolean(allowNoDatafeeds);
+            out.writeBoolean(allowNoMatch);
         }
 
         public String getDatafeedId() {
             return datafeedId;
         }
 
-        public boolean allowNoDatafeeds() {
-            return allowNoDatafeeds;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
-        public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-            this.allowNoDatafeeds = allowNoDatafeeds;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         @Override
@@ -79,7 +80,7 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
 
         @Override
         public int hashCode() {
-            return Objects.hash(datafeedId, allowNoDatafeeds);
+            return Objects.hash(datafeedId, allowNoMatch);
         }
 
         @Override
@@ -91,7 +92,7 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(datafeedId, other.datafeedId) && Objects.equals(allowNoDatafeeds, other.allowNoDatafeeds);
+            return Objects.equals(datafeedId, other.datafeedId) && Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -46,10 +45,12 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+        @Deprecated
+        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
+        public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String datafeedId;
-        private boolean allowNoDatafeeds = true;
+        private boolean allowNoMatch = true;
 
         public Request(String datafeedId) {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
@@ -58,26 +59,26 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();
-            allowNoDatafeeds = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(datafeedId);
-            out.writeBoolean(allowNoDatafeeds);
+            out.writeBoolean(allowNoMatch);
         }
 
         public String getDatafeedId() {
             return datafeedId;
         }
 
-        public boolean allowNoDatafeeds() {
-            return allowNoDatafeeds;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
-        public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-            this.allowNoDatafeeds = allowNoDatafeeds;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         @Override
@@ -87,7 +88,7 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
 
         @Override
         public int hashCode() {
-            return Objects.hash(datafeedId, allowNoDatafeeds);
+            return Objects.hash(datafeedId, allowNoMatch);
         }
 
         @Override
@@ -99,7 +100,7 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(datafeedId, other.datafeedId) && Objects.equals(allowNoDatafeeds, other.allowNoDatafeeds);
+            return Objects.equals(datafeedId, other.datafeedId) && Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,10 +30,12 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
 
     public static class Request extends MasterNodeReadRequest<Request> {
 
-        public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+        @Deprecated
+        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
+        public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String jobId;
-        private boolean allowNoJobs = true;
+        private boolean allowNoMatch = true;
 
         public Request(String jobId) {
             this();
@@ -48,26 +49,26 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();
-            allowNoJobs = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(jobId);
-            out.writeBoolean(allowNoJobs);
+            out.writeBoolean(allowNoMatch);
         }
 
-        public void setAllowNoJobs(boolean allowNoJobs) {
-            this.allowNoJobs = allowNoJobs;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         public String getJobId() {
             return jobId;
         }
 
-        public boolean allowNoJobs() {
-            return allowNoJobs;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
         @Override
@@ -77,7 +78,7 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(jobId, allowNoJobs);
+            return Objects.hash(jobId, allowNoMatch);
         }
 
         @Override
@@ -89,7 +90,7 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(jobId, other.jobId) && Objects.equals(allowNoJobs, other.allowNoJobs);
+            return Objects.equals(jobId, other.jobId) && Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
@@ -6,14 +6,13 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -58,10 +57,12 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
 
     public static class Request extends BaseTasksRequest<Request> {
 
-        public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+        @Deprecated
+        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
+        public static final String ALLOW_NO_MATCH = "allow_no_match";
 
         private String jobId;
-        private boolean allowNoJobs = true;
+        private boolean allowNoMatch = true;
 
         // used internally to expand _all jobid to encapsulate all jobs in cluster:
         private List<String> expandedJobsIds;
@@ -75,7 +76,7 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
             super(in);
             jobId = in.readString();
             expandedJobsIds = in.readStringList();
-            allowNoJobs = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         @Override
@@ -83,23 +84,23 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
             super.writeTo(out);
             out.writeString(jobId);
             out.writeStringCollection(expandedJobsIds);
-            out.writeBoolean(allowNoJobs);
+            out.writeBoolean(allowNoMatch);
         }
 
         public List<String> getExpandedJobsIds() { return expandedJobsIds; }
 
         public void setExpandedJobsIds(List<String> expandedJobsIds) { this.expandedJobsIds = expandedJobsIds; }
 
-        public void setAllowNoJobs(boolean allowNoJobs) {
-            this.allowNoJobs = allowNoJobs;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         public String getJobId() {
             return jobId;
         }
 
-        public boolean allowNoJobs() {
-            return allowNoJobs;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
         @Override
@@ -114,7 +115,7 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
 
         @Override
         public int hashCode() {
-            return Objects.hash(jobId, allowNoJobs);
+            return Objects.hash(jobId, allowNoMatch);
         }
 
         @Override
@@ -126,7 +127,7 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(jobId, other.jobId) && Objects.equals(allowNoJobs, other.allowNoJobs);
+            return Objects.equals(jobId, other.jobId) && Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
@@ -61,7 +61,9 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
         public static final ParseField EXCLUDE_INTERIM = new ParseField("exclude_interim");
         public static final ParseField START = new ParseField("start");
         public static final ParseField END = new ParseField("end");
-        public static final ParseField ALLOW_NO_JOBS = new ParseField("allow_no_jobs");
+        @Deprecated
+        public static final String ALLOW_NO_JOBS = "allow_no_jobs";
+        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match", ALLOW_NO_JOBS);
 
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
@@ -75,7 +77,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
                     startTime, START, System::currentTimeMillis)), START);
             PARSER.declareString((request, endTime) -> request.setEnd(parseDateOrThrow(
                     endTime, END, System::currentTimeMillis)), END);
-            PARSER.declareBoolean(Request::setAllowNoJobs, ALLOW_NO_JOBS);
+            PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
         }
 
         static long parseDateOrThrow(String date, ParseField paramName, LongSupplier now) {
@@ -104,7 +106,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
         private boolean excludeInterim = false;
         private Long start;
         private Long end;
-        private boolean allowNoJobs = true;
+        private boolean allowNoMatch = true;
 
         public Request() {
         }
@@ -118,7 +120,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
             excludeInterim = in.readBoolean();
             start = in.readOptionalLong();
             end = in.readOptionalLong();
-            allowNoJobs = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         public Request(String jobId) {
@@ -192,12 +194,12 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
             setEnd(parseDateOrThrow(end, END, System::currentTimeMillis));
         }
 
-        public boolean allowNoJobs() {
-            return allowNoJobs;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
-        public void setAllowNoJobs(boolean allowNoJobs) {
-            this.allowNoJobs = allowNoJobs;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         @Override
@@ -215,7 +217,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
             out.writeBoolean(excludeInterim);
             out.writeOptionalLong(start);
             out.writeOptionalLong(end);
-            out.writeBoolean(allowNoJobs);
+            out.writeBoolean(allowNoMatch);
         }
 
         @Override
@@ -234,14 +236,14 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
             if (end != null) {
                 builder.field(END.getPreferredName(), String.valueOf(end));
             }
-            builder.field(ALLOW_NO_JOBS.getPreferredName(), allowNoJobs);
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
             builder.endObject();
             return builder;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(jobId, topN, bucketSpan, overallScore, excludeInterim, start, end, allowNoJobs);
+            return Objects.hash(jobId, topN, bucketSpan, overallScore, excludeInterim, start, end, allowNoMatch);
         }
 
         @Override
@@ -260,7 +262,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
                     this.overallScore == that.overallScore &&
                     Objects.equals(start, that.start) &&
                     Objects.equals(end, that.end) &&
-                    this.allowNoJobs == that.allowNoJobs;
+                    this.allowNoMatch == that.allowNoMatch;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -40,7 +40,9 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
 
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField FORCE = new ParseField("force");
-        public static final ParseField ALLOW_NO_DATAFEEDS = new ParseField("allow_no_datafeeds");
+        @Deprecated
+        public static final String ALLOW_NO_DATAFEEDS = "allow_no_datafeeds";
+        public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match", ALLOW_NO_DATAFEEDS);
 
         public static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
         static {
@@ -48,7 +50,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             PARSER.declareString((request, val) ->
                     request.setStopTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
             PARSER.declareBoolean(Request::setForce, FORCE);
-            PARSER.declareBoolean(Request::setAllowNoDatafeeds, ALLOW_NO_DATAFEEDS);
+            PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
         }
 
         public static Request fromXContent(XContentParser parser) {
@@ -67,7 +69,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
         private String[] resolvedStartedDatafeedIds = new String[] {};
         private TimeValue stopTimeout = DEFAULT_TIMEOUT;
         private boolean force = false;
-        private boolean allowNoDatafeeds = true;
+        private boolean allowNoMatch = true;
 
         public Request(String datafeedId) {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
@@ -82,7 +84,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             resolvedStartedDatafeedIds = in.readStringArray();
             stopTimeout = in.readTimeValue();
             force = in.readBoolean();
-            allowNoDatafeeds = in.readBoolean();
+            allowNoMatch = in.readBoolean();
         }
 
         public String getDatafeedId() {
@@ -113,12 +115,12 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             this.force = force;
         }
 
-        public boolean allowNoDatafeeds() {
-            return allowNoDatafeeds;
+        public boolean allowNoMatch() {
+            return allowNoMatch;
         }
 
-        public void setAllowNoDatafeeds(boolean allowNoDatafeeds) {
-            this.allowNoDatafeeds = allowNoDatafeeds;
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
         }
 
         @Override
@@ -144,12 +146,12 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             out.writeStringArray(resolvedStartedDatafeedIds);
             out.writeTimeValue(stopTimeout);
             out.writeBoolean(force);
-            out.writeBoolean(allowNoDatafeeds);
+            out.writeBoolean(allowNoMatch);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(datafeedId, stopTimeout, force, allowNoDatafeeds);
+            return Objects.hash(datafeedId, stopTimeout, force, allowNoMatch);
         }
 
         @Override
@@ -158,7 +160,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
             builder.field(TIMEOUT.getPreferredName(), stopTimeout.getStringRep());
             builder.field(FORCE.getPreferredName(), force);
-            builder.field(ALLOW_NO_DATAFEEDS.getPreferredName(), allowNoDatafeeds);
+            builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
             builder.endObject();
             return builder;
         }
@@ -175,7 +177,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             return Objects.equals(datafeedId, other.datafeedId) &&
                     Objects.equals(stopTimeout, other.stopTimeout) &&
                     Objects.equals(force, other.force) &&
-                    Objects.equals(allowNoDatafeeds, other.allowNoDatafeeds);
+                    Objects.equals(allowNoMatch, other.allowNoMatch);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
@@ -55,8 +55,8 @@ public class GroupOrJobLookup {
         }
     }
 
-    public Set<String> expandJobIds(String expression, boolean allowNoJobs) {
-        return new GroupOrJobResolver().expand(expression, allowNoJobs);
+    public Set<String> expandJobIds(String expression, boolean allowNoMatch) {
+        return new GroupOrJobResolver().expand(expression, allowNoMatch);
     }
 
     public boolean isGroupOrJob(String id) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CloseJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CloseJobActionRequestTests.java
@@ -23,7 +23,7 @@ public class CloseJobActionRequestTests extends AbstractSerializingTestCase<Requ
             request.setForce(randomBoolean());
         }
         if (randomBoolean()) {
-            request.setAllowNoJobs(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
         return request;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionRequestTests.java
@@ -15,7 +15,7 @@ public class GetDatafeedStatsActionRequestTests extends AbstractWireSerializingT
     @Override
     protected Request createTestInstance() {
         Request request = new Request(randomBoolean() ? Metadata.ALL : randomAlphaOfLengthBetween(1, 20));
-        request.setAllowNoDatafeeds(randomBoolean());
+        request.setAllowNoMatch(randomBoolean());
         return request;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsActionRequestTests.java
@@ -15,7 +15,7 @@ public class GetDatafeedsActionRequestTests extends AbstractWireSerializingTestC
     @Override
     protected Request createTestInstance() {
         Request request = new Request(randomBoolean() ? Metadata.ALL : randomAlphaOfLengthBetween(1, 20));
-        request.setAllowNoDatafeeds(randomBoolean());
+        request.setAllowNoMatch(randomBoolean());
         return request;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobStatsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobStatsActionRequestTests.java
@@ -19,7 +19,7 @@ public class GetJobStatsActionRequestTests extends AbstractWireSerializingTestCa
     @Override
     protected Request createTestInstance() {
         Request request = new Request(randomBoolean() ? Metadata.ALL : randomAlphaOfLengthBetween(1, 20));
-        request.setAllowNoJobs(randomBoolean());
+        request.setAllowNoMatch(randomBoolean());
         return request;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobsActionRequestTests.java
@@ -15,7 +15,7 @@ public class GetJobsActionRequestTests extends AbstractWireSerializingTestCase<R
     @Override
     protected Request createTestInstance() {
         Request request = new Request(randomBoolean() ? Metadata.ALL : randomAlphaOfLengthBetween(1, 20));
-        request.setAllowNoJobs(randomBoolean());
+        request.setAllowNoMatch(randomBoolean());
         return request;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionRequestTests.java
@@ -35,7 +35,7 @@ public class GetOverallBucketsActionRequestTests extends AbstractSerializingTest
         if (randomBoolean()) {
             request.setEnd(randomNonNegativeLong());
         }
-        request.setAllowNoJobs(randomBoolean());
+        request.setAllowNoMatch(randomBoolean());
         return request;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
@@ -23,7 +23,7 @@ public class StopDatafeedActionRequestTests extends AbstractSerializingTestCase<
             request.setForce(randomBoolean());
         }
         if (randomBoolean()) {
-            request.setAllowNoDatafeeds(randomBoolean());
+            request.setAllowNoMatch(randomBoolean());
         }
         if (randomBoolean()) {
             request.setResolvedStartedDatafeedIds(generateRandomStringArray(4, 8, false));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 public class GroupOrJobLookupTests extends ESTestCase {
 
-    public void testEmptyLookup_GivenAllowNoJobs() {
+    public void testEmptyLookup_GivenAllowNoMatch() {
         GroupOrJobLookup lookup = new GroupOrJobLookup(Collections.emptyList());
 
         assertThat(lookup.expandJobIds("_all", true).isEmpty(), is(true));
@@ -33,7 +33,7 @@ public class GroupOrJobLookupTests extends ESTestCase {
         expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("foo", true));
     }
 
-    public void testEmptyLookup_GivenNotAllowNoJobs() {
+    public void testEmptyLookup_GivenNotAllowNoMatch() {
         GroupOrJobLookup lookup = new GroupOrJobLookup(Collections.emptyList());
 
         expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("_all", false));

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -167,7 +167,7 @@ integTest {
     'ml/jobs_get_result_categories/Test with invalid param combinations',
     'ml/jobs_get_result_categories/Test with invalid param combinations via body',
     'ml/jobs_get_result_overall_buckets/Test overall buckets given missing job',
-    'ml/jobs_get_result_overall_buckets/Test overall buckets given non-matching expression and not allow_no_jobs',
+    'ml/jobs_get_result_overall_buckets/Test overall buckets given non-matching expression and not allow_no_match',
     'ml/jobs_get_result_overall_buckets/Test overall buckets given top_n is 0',
     'ml/jobs_get_result_overall_buckets/Test overall buckets given top_n is negative',
     'ml/jobs_get_result_overall_buckets/Test overall buckets given invalid start param',

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
@@ -47,7 +47,7 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
 
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> {
             CloseJobAction.Request request = new CloseJobAction.Request(jobId);
-            request.setAllowNoJobs(false);
+            request.setAllowNoMatch(false);
             client().execute(CloseJobAction.INSTANCE, request).actionGet();
         });
         assertThat(ex.getMessage(), equalTo("No known job with id 'job-with-missing-config'"));
@@ -87,7 +87,7 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
 
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> {
             StopDatafeedAction.Request request = new StopDatafeedAction.Request(datafeedConfig.getId());
-            request.setAllowNoDatafeeds(false);
+            request.setAllowNoMatch(false);
             client().execute(StopDatafeedAction.INSTANCE, request).actionGet();
         });
         assertThat(ex.getMessage(), equalTo("No datafeed with id [job-with-missing-datafeed-with-config-datafeed] exists"));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -208,7 +208,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
 
     }
 
-    public void testAllowNoDatafeeds() throws InterruptedException {
+    public void testAllowNoMatch() throws InterruptedException {
         AtomicReference<SortedSet<String>> datafeedIdsHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -257,7 +257,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(exceptionHolder.get().getMessage(), containsString("I don't like this update"));
     }
 
-    public void testAllowNoJobs() throws InterruptedException {
+    public void testAllowNoMatch() throws InterruptedException {
         AtomicReference<SortedSet<String>> jobIdsHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -108,7 +108,7 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
 
             PersistentTasksCustomMetadata tasksMetadata = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             jobConfigProvider.expandJobsIds(request.getJobId(),
-                request.allowNoJobs(),
+                request.allowNoMatch(),
                 true,
                 tasksMetadata,
                 request.isForce(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -71,9 +71,9 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         logger.debug("Get datafeed '{}'", request.getDatafeedId());
 
         Map<String, DatafeedConfig> clusterStateConfigs =
-                expandClusterStateDatafeeds(request.getDatafeedId(), request.allowNoDatafeeds(), state);
+                expandClusterStateDatafeeds(request.getDatafeedId(), request.allowNoMatch(), state);
 
-        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
+        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoMatch(), ActionListener.wrap(
                 datafeedBuilders -> {
                     // Check for duplicate datafeeds
                     for (DatafeedConfig.Builder datafeed : datafeedBuilders) {
@@ -99,13 +99,12 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         ));
     }
 
-    Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, boolean allowNoDatafeeds,
-                                                            ClusterState clusterState) {
+    Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, boolean allowNoMatch, ClusterState clusterState) {
 
         Map<String, DatafeedConfig> configById = new HashMap<>();
         try {
             MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
-            Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression, allowNoDatafeeds);
+            Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression, allowNoMatch);
 
             for (String expandedDatafeedId : expandedDatafeedIds) {
                 configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -121,7 +121,7 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
 
         // This might also include datafeed tasks that exist but no longer have a config
         datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(),
-            request.allowNoDatafeeds(),
+            request.allowNoMatch(),
             tasksInProgress,
             true,
             expandIdsListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -55,7 +55,7 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
     protected void masterOperation(Task task, GetJobsAction.Request request, ClusterState state,
                                    ActionListener<GetJobsAction.Response> listener) {
         logger.debug("Get job '{}'", request.getJobId());
-        jobManager.expandJobs(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
+        jobManager.expandJobs(request.getJobId(), request.allowNoMatch(), ActionListener.wrap(
                 jobs -> {
                     listener.onResponse(new GetJobsAction.Response(jobs));
                 },

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -78,7 +78,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
         ClusterState state = clusterService.state();
         PersistentTasksCustomMetadata tasks = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         // If there are deleted configs, but the task is still around, we probably want to return the tasks in the stats call
-        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, tasks, true, ActionListener.wrap(
+        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoMatch(), true, tasks, true, ActionListener.wrap(
                 expandedIds -> {
                     request.setExpandedJobsIds(new ArrayList<>(expandedIds));
                     ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -79,7 +79,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
     @Override
     protected void doExecute(Task task, GetOverallBucketsAction.Request request,
                              ActionListener<GetOverallBucketsAction.Response> listener) {
-        jobManager.expandJobs(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
+        jobManager.expandJobs(request.getJobId(), request.allowNoMatch(), ActionListener.wrap(
                 jobPage -> {
                     if (jobPage.count() == 0) {
                         listener.onResponse(new GetOverallBucketsAction.Response(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -132,7 +132,7 @@ public class TransportStopDatafeedAction extends TransportTasksAction<TransportS
         } else {
             PersistentTasksCustomMetadata tasks = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(),
-                request.allowNoDatafeeds(),
+                request.allowNoMatch(),
                 tasks,
                 request.isForce(),
                 ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -347,7 +347,7 @@ public class DatafeedConfigProvider {
      * </ul>
      *
      * @param expression the expression to resolve
-     * @param allowNoDatafeeds if {@code false}, an error is thrown when no name matches the {@code expression}.
+     * @param allowNoMatch if {@code false}, an error is thrown when no name matches the {@code expression}.
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
      * @param tasks The current tasks meta-data. For expanding IDs when datafeeds might have missing configurations
@@ -355,7 +355,7 @@ public class DatafeedConfigProvider {
      * @param listener The expanded datafeed IDs listener
      */
     public void expandDatafeedIds(String expression,
-                                  boolean allowNoDatafeeds,
+                                  boolean allowNoMatch,
                                   PersistentTasksCustomMetadata tasks,
                                   boolean allowMissingConfigs,
                                   ActionListener<SortedSet<String>> listener) {
@@ -371,7 +371,7 @@ public class DatafeedConfigProvider {
                 .setSize(AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
                 .request();
 
-        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoDatafeeds);
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoMatch);
         Collection<String> matchingStartedDatafeedIds = matchingDatafeedIdsWithTasks(tokens, tasks);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
@@ -407,12 +407,12 @@ public class DatafeedConfigProvider {
      * See {@link #expandDatafeedIds(String, boolean, PersistentTasksCustomMetadata, boolean, ActionListener)}
      *
      * @param expression the expression to resolve
-     * @param allowNoDatafeeds if {@code false}, an error is thrown when no name matches the {@code expression}.
+     * @param allowNoMatch if {@code false}, an error is thrown when no name matches the {@code expression}.
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
      * @param listener The expanded datafeed config listener
      */
-    public void expandDatafeedConfigs(String expression, boolean allowNoDatafeeds, ActionListener<List<DatafeedConfig.Builder>> listener) {
+    public void expandDatafeedConfigs(String expression, boolean allowNoMatch, ActionListener<List<DatafeedConfig.Builder>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedIdQuery(tokens));
         sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
@@ -423,7 +423,7 @@ public class DatafeedConfigProvider {
                 .setSize(AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
                 .request();
 
-        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoDatafeeds);
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoMatch);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
                 ActionListener.<SearchResponse>wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -172,13 +172,13 @@ public class JobManager {
      * Note that when the {@code jobId} is {@link Metadata#ALL} all jobs are returned.
      *
      * @param expression   the jobId or an expression matching jobIds
-     * @param allowNoJobs  if {@code false}, an error is thrown when no job matches the {@code jobId}
+     * @param allowNoMatch if {@code false}, an error is thrown when no job matches the {@code jobId}
      * @param jobsListener The jobs listener
      */
-    public void expandJobs(String expression, boolean allowNoJobs, ActionListener<QueryPage<Job>> jobsListener) {
-        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, allowNoJobs, clusterService.state());
+    public void expandJobs(String expression, boolean allowNoMatch, ActionListener<QueryPage<Job>> jobsListener) {
+        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, allowNoMatch, clusterService.state());
 
-        jobConfigProvider.expandJobs(expression, allowNoJobs, false, ActionListener.wrap(
+        jobConfigProvider.expandJobs(expression, allowNoMatch, false, ActionListener.wrap(
                 jobBuilders -> {
                     // Check for duplicate jobs
                     for (Job.Builder jb : jobBuilders) {
@@ -203,10 +203,10 @@ public class JobManager {
         ));
     }
 
-    private Map<String, Job> expandJobsFromClusterState(String expression, boolean allowNoJobs, ClusterState clusterState) {
+    private Map<String, Job> expandJobsFromClusterState(String expression, boolean allowNoMatch, ClusterState clusterState) {
         Map<String, Job> jobIdToJob = new HashMap<>();
         try {
-            Set<String> expandedJobIds = MlMetadata.getMlMetadata(clusterState).expandJobIds(expression, allowNoJobs);
+            Set<String> expandedJobIds = MlMetadata.getMlMetadata(clusterState).expandJobIds(expression, allowNoMatch);
             MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
             for (String expandedJobId : expandedJobIds) {
                 jobIdToJob.put(expandedJobId, mlMetadata.getJobs().get(expandedJobId));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -496,7 +496,7 @@ public class JobConfigProvider {
      * </ul>
      *
      * @param expression the expression to resolve
-     * @param allowNoJobs if {@code false}, an error is thrown when no name matches the {@code expression}.
+     * @param allowNoMatch if {@code false}, an error is thrown when no name matches the {@code expression}.
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
      * @param excludeDeleting If true exclude jobs marked as deleting
@@ -506,7 +506,7 @@ public class JobConfigProvider {
      * @param listener The expanded job Ids listener
      */
     public void expandJobsIds(String expression,
-                              boolean allowNoJobs,
+                              boolean allowNoMatch,
                               boolean excludeDeleting,
                               @Nullable PersistentTasksCustomMetadata tasksCustomMetadata,
                               boolean allowMissingConfigs,
@@ -524,7 +524,7 @@ public class JobConfigProvider {
                 .setSize(AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
                 .request();
 
-        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoJobs);
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoMatch);
         Collection<String> openMatchingJobs = matchingJobIdsWithTasks(tokens, tasksCustomMetadata);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
@@ -565,13 +565,13 @@ public class JobConfigProvider {
      * See {@link #expandJobsIds(String, boolean, boolean, PersistentTasksCustomMetadata, boolean, ActionListener)}
      *
      * @param expression the expression to resolve
-     * @param allowNoJobs if {@code false}, an error is thrown when no name matches the {@code expression}.
+     * @param allowNoMatch if {@code false}, an error is thrown when no name matches the {@code expression}.
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
      * @param excludeDeleting If true exclude jobs marked as deleting
      * @param listener The expanded jobs listener
      */
-    public void expandJobs(String expression, boolean allowNoJobs, boolean excludeDeleting, ActionListener<List<Job.Builder>> listener) {
+    public void expandJobs(String expression, boolean allowNoMatch, boolean excludeDeleting, ActionListener<List<Job.Builder>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildJobWildcardQuery(tokens, excludeDeleting));
         sourceBuilder.sort(Job.ID.getPreferredName());
@@ -582,7 +582,7 @@ public class JobConfigProvider {
                 .setSize(AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
                 .request();
 
-        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoJobs);
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoMatch);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
                 ActionListener.<SearchResponse>wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatDatafeedsAction.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.xpack.core.common.table.TableColumnAttributeBuilder;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestRequest;
@@ -17,6 +18,8 @@ import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 import org.elasticsearch.rest.action.cat.RestTable;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction.Request;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction.Response;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 
@@ -44,14 +47,17 @@ public class RestCatDatafeedsAction extends AbstractCatAction {
         if (Strings.isNullOrEmpty(datafeedId)) {
             datafeedId = GetDatafeedsStatsAction.ALL;
         }
-        GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
+        Request request = new Request(datafeedId);
+        if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetDatafeedsStatsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsStatsAction.INSTANCE, request, new RestResponseListener<>(channel) {
             @Override
-            public RestResponse buildResponse(GetDatafeedsStatsAction.Response getDatafeedsStatsRespons) throws Exception {
+            public RestResponse buildResponse(Response getDatafeedsStatsRespons) throws Exception {
                 return RestTable.buildResponse(buildTable(restRequest, getDatafeedsStatsRespons), channel);
             }
         });
@@ -124,7 +130,7 @@ public class RestCatDatafeedsAction extends AbstractCatAction {
         return table;
     }
 
-    private Table buildTable(RestRequest request, GetDatafeedsStatsAction.Response dfStats) {
+    private Table buildTable(RestRequest request, Response dfStats) {
         Table table = getTableWithHeader(request);
         dfStats.getResponse().results().forEach(df -> {
             table.startRow();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatDatafeedsAction.java
@@ -45,8 +45,10 @@ public class RestCatDatafeedsAction extends AbstractCatAction {
             datafeedId = GetDatafeedsStatsAction.ALL;
         }
         GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
-        request.setAllowNoDatafeeds(restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS.getPreferredName(),
-            request.allowNoDatafeeds()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetDatafeedsStatsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsStatsAction.INSTANCE, request, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(GetDatafeedsStatsAction.Response getDatafeedsStatsRespons) throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
@@ -50,8 +50,10 @@ public class RestCatJobsAction extends AbstractCatAction {
             jobId = Metadata.ALL;
         }
         GetJobsStatsAction.Request request = new GetJobsStatsAction.Request(jobId);
-        request.setAllowNoJobs(restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS.getPreferredName(),
-            request.allowNoJobs()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetJobsStatsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsStatsAction.INSTANCE, request, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(GetJobsStatsAction.Response getJobStatsResponse) throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.xpack.core.common.table.TableColumnAttributeBuilder;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -19,6 +20,8 @@ import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 import org.elasticsearch.rest.action.cat.RestTable;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction.Request;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction.Response;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
@@ -49,14 +52,17 @@ public class RestCatJobsAction extends AbstractCatAction {
         if (Strings.isNullOrEmpty(jobId)) {
             jobId = Metadata.ALL;
         }
-        GetJobsStatsAction.Request request = new GetJobsStatsAction.Request(jobId);
+        Request request = new Request(jobId);
+        if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetJobsStatsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsStatsAction.INSTANCE, request, new RestResponseListener<>(channel) {
             @Override
-            public RestResponse buildResponse(GetJobsStatsAction.Response getJobStatsResponse) throws Exception {
+            public RestResponse buildResponse(Response getJobStatsResponse) throws Exception {
                 return RestTable.buildResponse(buildTable(restRequest, getJobStatsResponse), channel);
             }
         });
@@ -324,7 +330,7 @@ public class RestCatJobsAction extends AbstractCatAction {
         return table;
     }
 
-    private Table buildTable(RestRequest request, GetJobsStatsAction.Response jobStats) {
+    private Table buildTable(RestRequest request, Response jobStats) {
         Table table = getTableWithHeader(request);
         jobStats.getResponse().results().forEach(job -> {
             table.startRow();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
@@ -7,10 +7,12 @@ package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction.Request;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
@@ -40,11 +42,14 @@ public class RestGetDatafeedStatsAction extends BaseRestHandler {
         if (Strings.isNullOrEmpty(datafeedId)) {
             datafeedId = GetDatafeedsStatsAction.ALL;
         }
-        GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
+        Request request = new Request(datafeedId);
+        if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetDatafeedsStatsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedStatsAction.java
@@ -41,8 +41,10 @@ public class RestGetDatafeedStatsAction extends BaseRestHandler {
             datafeedId = GetDatafeedsStatsAction.ALL;
         }
         GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
-        request.setAllowNoDatafeeds(restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS.getPreferredName(),
-                request.allowNoDatafeeds()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetDatafeedsStatsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetDatafeedsStatsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
@@ -6,10 +6,12 @@
 package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction.Request;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
@@ -39,11 +41,14 @@ public class RestGetDatafeedsAction extends BaseRestHandler {
         if (datafeedId == null) {
             datafeedId = GetDatafeedsAction.ALL;
         }
-        GetDatafeedsAction.Request request = new GetDatafeedsAction.Request(datafeedId);
+        Request request = new Request(datafeedId);
+        if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetDatafeedsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetDatafeedsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
@@ -40,8 +40,10 @@ public class RestGetDatafeedsAction extends BaseRestHandler {
             datafeedId = GetDatafeedsAction.ALL;
         }
         GetDatafeedsAction.Request request = new GetDatafeedsAction.Request(datafeedId);
-        request.setAllowNoDatafeeds(restRequest.paramAsBoolean(GetDatafeedsAction.Request.ALLOW_NO_DATAFEEDS.getPreferredName(),
-                request.allowNoDatafeeds()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetDatafeedsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetDatafeedsAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
@@ -57,10 +57,10 @@ public class RestStopDatafeedAction extends BaseRestHandler {
             if (restRequest.hasParam(StopDatafeedAction.Request.FORCE.getPreferredName())) {
                 request.setForce(restRequest.paramAsBoolean(StopDatafeedAction.Request.FORCE.getPreferredName(), request.isForce()));
             }
-            if (restRequest.hasParam(StopDatafeedAction.Request.ALLOW_NO_DATAFEEDS.getPreferredName())) {
-                request.setAllowNoDatafeeds(restRequest.paramAsBoolean(StopDatafeedAction.Request.ALLOW_NO_DATAFEEDS.getPreferredName(),
-                        request.allowNoDatafeeds()));
-            }
+            request.setAllowNoMatch(
+                restRequest.paramAsBoolean(
+                    StopDatafeedAction.Request.ALLOW_NO_MATCH.getPreferredName(),
+                    restRequest.paramAsBoolean(StopDatafeedAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         }
         return channel -> client.execute(StopDatafeedAction.INSTANCE, request, new RestBuilderListener<Response>(channel) {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStopDatafeedAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.rest.datafeeds;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -16,6 +17,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction.Request;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction.Response;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -43,24 +45,27 @@ public class RestStopDatafeedAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String datafeedId = restRequest.param(DatafeedConfig.ID.getPreferredName());
-        StopDatafeedAction.Request request;
+        Request request;
         if (restRequest.hasContentOrSourceParam()) {
             XContentParser parser = restRequest.contentOrSourceParamParser();
-            request = StopDatafeedAction.Request.parseRequest(datafeedId, parser);
+            request = Request.parseRequest(datafeedId, parser);
         } else {
-            request = new StopDatafeedAction.Request(datafeedId);
-            if (restRequest.hasParam(StopDatafeedAction.Request.TIMEOUT.getPreferredName())) {
-                TimeValue stopTimeout = restRequest.paramAsTime(
-                        StopDatafeedAction.Request.TIMEOUT.getPreferredName(), StopDatafeedAction.DEFAULT_TIMEOUT);
+            request = new Request(datafeedId);
+            if (restRequest.hasParam(Request.TIMEOUT.getPreferredName())) {
+                TimeValue stopTimeout = restRequest.paramAsTime(Request.TIMEOUT.getPreferredName(), StopDatafeedAction.DEFAULT_TIMEOUT);
                 request.setStopTimeout(stopTimeout);
             }
-            if (restRequest.hasParam(StopDatafeedAction.Request.FORCE.getPreferredName())) {
-                request.setForce(restRequest.paramAsBoolean(StopDatafeedAction.Request.FORCE.getPreferredName(), request.isForce()));
+            if (restRequest.hasParam(Request.FORCE.getPreferredName())) {
+                request.setForce(restRequest.paramAsBoolean(Request.FORCE.getPreferredName(), request.isForce()));
+            }
+            if (restRequest.hasParam(Request.ALLOW_NO_DATAFEEDS)) {
+                LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(
+                    null, () -> null, Request.ALLOW_NO_DATAFEEDS, Request.ALLOW_NO_MATCH.getPreferredName());
             }
             request.setAllowNoMatch(
                 restRequest.paramAsBoolean(
-                    StopDatafeedAction.Request.ALLOW_NO_MATCH.getPreferredName(),
-                    restRequest.paramAsBoolean(StopDatafeedAction.Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
+                    Request.ALLOW_NO_MATCH.getPreferredName(),
+                    restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         }
         return channel -> client.execute(StopDatafeedAction.INSTANCE, request, new RestBuilderListener<Response>(channel) {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
@@ -49,9 +49,10 @@ public class RestCloseJobAction extends BaseRestHandler {
             if (restRequest.hasParam(Request.FORCE.getPreferredName())) {
                 request.setForce(restRequest.paramAsBoolean(Request.FORCE.getPreferredName(), request.isForce()));
             }
-            if (restRequest.hasParam(Request.ALLOW_NO_JOBS.getPreferredName())) {
-                request.setAllowNoJobs(restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS.getPreferredName(), request.allowNoJobs()));
-            }
+            request.setAllowNoMatch(
+                restRequest.paramAsBoolean(
+                    Request.ALLOW_NO_MATCH.getPreferredName(),
+                    restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         }
         return channel -> client.execute(CloseJobAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestCloseJobAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.rest.job;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -48,6 +49,10 @@ public class RestCloseJobAction extends BaseRestHandler {
             }
             if (restRequest.hasParam(Request.FORCE.getPreferredName())) {
                 request.setForce(restRequest.paramAsBoolean(Request.FORCE.getPreferredName(), request.isForce()));
+            }
+            if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
+                LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(
+                    null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH.getPreferredName());
             }
             request.setAllowNoMatch(
                 restRequest.paramAsBoolean(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
@@ -8,10 +8,12 @@ package org.elasticsearch.xpack.ml.rest.job;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction.Request;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
@@ -41,11 +43,14 @@ public class RestGetJobStatsAction extends BaseRestHandler {
         if (Strings.isNullOrEmpty(jobId)) {
             jobId = Metadata.ALL;
         }
-        GetJobsStatsAction.Request request = new GetJobsStatsAction.Request(jobId);
+        Request request = new Request(jobId);
+        if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetJobsStatsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobStatsAction.java
@@ -42,8 +42,10 @@ public class RestGetJobStatsAction extends BaseRestHandler {
             jobId = Metadata.ALL;
         }
         GetJobsStatsAction.Request request = new GetJobsStatsAction.Request(jobId);
-        request.setAllowNoJobs(restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS.getPreferredName(),
-                request.allowNoJobs()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetJobsStatsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetJobsStatsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
@@ -42,7 +42,10 @@ public class RestGetJobsAction extends BaseRestHandler {
             jobId = Metadata.ALL;
         }
         GetJobsAction.Request request = new GetJobsAction.Request(jobId);
-        request.setAllowNoJobs(restRequest.paramAsBoolean(GetJobsAction.Request.ALLOW_NO_JOBS.getPreferredName(), request.allowNoJobs()));
+        request.setAllowNoMatch(
+            restRequest.paramAsBoolean(
+                GetJobsAction.Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(GetJobsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
@@ -8,10 +8,12 @@ package org.elasticsearch.xpack.ml.rest.job;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsAction.Request;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
@@ -41,11 +43,14 @@ public class RestGetJobsAction extends BaseRestHandler {
         if (Strings.isNullOrEmpty(jobId)) {
             jobId = Metadata.ALL;
         }
-        GetJobsAction.Request request = new GetJobsAction.Request(jobId);
+        Request request = new Request(jobId);
+        if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
+            LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH);
+        }
         request.setAllowNoMatch(
             restRequest.paramAsBoolean(
-                GetJobsAction.Request.ALLOW_NO_MATCH,
-                restRequest.paramAsBoolean(GetJobsAction.Request.ALLOW_NO_JOBS, request.allowNoMatch())));
+                Request.ALLOW_NO_MATCH,
+                restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
@@ -59,7 +59,10 @@ public class RestGetOverallBucketsAction extends BaseRestHandler {
             if (restRequest.hasParam(Request.END.getPreferredName())) {
                 request.setEnd(restRequest.param(Request.END.getPreferredName()));
             }
-            request.setAllowNoJobs(restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS.getPreferredName(), request.allowNoJobs()));
+            request.setAllowNoMatch(
+                restRequest.paramAsBoolean(
+                    Request.ALLOW_NO_MATCH.getPreferredName(),
+                    restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         }
 
         return channel -> client.execute(GetOverallBucketsAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetOverallBucketsAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.rest.results;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -58,6 +59,10 @@ public class RestGetOverallBucketsAction extends BaseRestHandler {
             }
             if (restRequest.hasParam(Request.END.getPreferredName())) {
                 request.setEnd(restRequest.param(Request.END.getPreferredName()));
+            }
+            if (restRequest.hasParam(Request.ALLOW_NO_JOBS)) {
+                LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(
+                    null, () -> null, Request.ALLOW_NO_JOBS, Request.ALLOW_NO_MATCH.getPreferredName());
             }
             request.setAllowNoMatch(
                 restRequest.paramAsBoolean(

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -33,6 +33,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
+      "allow_no_datafeeds":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+        "deprecated":true
+      },
       "format":{
         "type":"string",
         "description":"a short version of the Accept header, e.g. json, yaml"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -33,11 +33,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
-      },
       "format":{
         "type":"string",
         "description":"a short version of the Accept header, e.g. json, yaml"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -28,6 +28,11 @@
       ]
     },
     "params":{
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
       "allow_no_datafeeds":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -33,6 +33,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
+      "allow_no_jobs":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
+        "deprecated":true
+      },
       "bytes":{
         "type":"enum",
         "description":"The unit in which to display byte values",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -28,11 +28,6 @@
       ]
     },
     "params":{
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
       "allow_no_match":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -33,6 +33,11 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
       "bytes":{
         "type":"enum",
         "description":"The unit in which to display byte values",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -22,11 +22,6 @@
       ]
     },
     "params":{
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
       "allow_no_match":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -27,6 +27,11 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
       "force":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -27,6 +27,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
+      "allow_no_jobs":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
+        "deprecated":true
+      },
       "force":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -28,6 +28,11 @@
       ]
     },
     "params":{
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
       "allow_no_datafeeds":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -32,6 +32,12 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
+      "allow_no_datafeeds":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+        "deprecated":true
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -32,11 +32,6 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
-      },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -28,6 +28,11 @@
       ]
     },
     "params":{
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
       "allow_no_datafeeds":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -32,6 +32,12 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
+      "allow_no_datafeeds":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+        "deprecated":true
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -32,11 +32,6 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
-      },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -32,6 +32,11 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -32,6 +32,12 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_jobs":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
+        "deprecated":true
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -28,11 +28,6 @@
       ]
     },
     "params":{
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
       "allow_no_match":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -32,6 +32,11 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -32,6 +32,12 @@
         "type":"boolean",
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_jobs":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
+        "deprecated":true
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -28,11 +28,6 @@
       ]
     },
     "params":{
-      "allow_no_jobs":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
       "allow_no_match":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -50,6 +50,10 @@
       "allow_no_jobs":{
         "type":"boolean",
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     },
     "body":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -47,10 +47,6 @@
         "type":"string",
         "description":"Returns overall buckets with timestamps earlier than this time"
       },
-      "allow_no_jobs":{
-        "type":"boolean",
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
       "allow_no_match":{
         "type":"boolean",
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -50,6 +50,11 @@
       "allow_no_match":{
         "type":"boolean",
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+      },
+      "allow_no_jobs":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
+        "deprecated":true
       }
     },
     "body":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -27,6 +27,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
+      "allow_no_datafeeds":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+        "deprecated":true
+      },
       "force":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -27,11 +27,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
-      },
       "force":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -22,6 +22,11 @@
       ]
     },
     "params":{
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+      },
       "allow_no_datafeeds":{
         "type":"boolean",
         "required":false,
@@ -37,6 +42,10 @@
         "required":false,
         "description":"Controls the time to wait until a datafeed has stopped. Default to 20 seconds"
       }
+    },
+    "body":{
+      "description":"The URL params optionally sent in the body",
+      "required":false
     }
   }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -53,7 +53,14 @@ setup:
   - match: { datafeeds: [] }
 
 ---
-"Test get datafeed with expression that does not match and allow_no_datafeeds":
+"Test get datafeed with expression that does not match and allow_no_match":
+
+  - do:
+      ml.get_datafeeds:
+        datafeed_id: "missing-*"
+        allow_no_match: true
+  - match: { count: 0 }
+  - match: { datafeeds: [] }
 
   - do:
       ml.get_datafeeds:
@@ -63,7 +70,13 @@ setup:
   - match: { datafeeds: [] }
 
 ---
-"Test get datafeed with expression that does not match and not allow_no_datafeeds":
+"Test get datafeed with expression that does not match and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.get_datafeeds:
+        datafeed_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -54,6 +54,9 @@ setup:
 
 ---
 "Test get datafeed with expression that does not match and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.get_datafeeds:
@@ -63,6 +66,8 @@ setup:
   - match: { datafeeds: [] }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       ml.get_datafeeds:
         datafeed_id: "missing-*"
         allow_no_datafeeds: true
@@ -71,6 +76,9 @@ setup:
 
 ---
 "Test get datafeed with expression that does not match and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -79,6 +87,8 @@ setup:
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_datafeeds:
         datafeed_id: "missing-*"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -103,6 +103,9 @@ setup:
 
 ---
 "Test get datafeed stats with expression that does not match and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.get_datafeed_stats:
@@ -112,6 +115,8 @@ setup:
   - match: { datafeeds: [] }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       ml.get_datafeed_stats:
         datafeed_id: "missing-*"
         allow_no_datafeeds: true
@@ -120,6 +125,9 @@ setup:
 
 ---
 "Test get datafeed stats with expression that does not match and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -128,6 +136,8 @@ setup:
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_datafeed_stats:
         datafeed_id: "missing-*"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -102,7 +102,14 @@ setup:
         datafeed_id: missing-datafeed
 
 ---
-"Test get datafeed stats with expression that does not match and allow_no_datafeeds":
+"Test get datafeed stats with expression that does not match and allow_no_match":
+
+  - do:
+      ml.get_datafeed_stats:
+        datafeed_id: "missing-*"
+        allow_no_match: true
+  - match: { count: 0 }
+  - match: { datafeeds: [] }
 
   - do:
       ml.get_datafeed_stats:
@@ -112,7 +119,13 @@ setup:
   - match: { datafeeds: [] }
 
 ---
-"Test get datafeed stats with expression that does not match and not allow_no_datafeeds":
+"Test get datafeed stats with expression that does not match and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.get_datafeed_stats:
+        datafeed_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -15,6 +15,9 @@
 
 ---
 "Test get jobs with expression that does not match and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.get_jobs:
@@ -24,6 +27,8 @@
   - match: { jobs: [] }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       ml.get_jobs:
         job_id: "missing-*"
         allow_no_jobs: true
@@ -32,6 +37,9 @@
 
 ---
 "Test get jobs with expression that does not match and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -40,6 +48,8 @@
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_jobs:
         job_id: "missing-*"
@@ -863,6 +873,9 @@
 
 ---
 "Test close jobs with expression that does not match and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.close_job:
@@ -871,6 +884,8 @@
   - match: { closed: true }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       ml.close_job:
         job_id: "missing-*"
         allow_no_jobs: true
@@ -878,6 +893,9 @@
 
 ---
 "Test close jobs with expression that does not match and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -886,6 +904,8 @@
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       catch: missing
       ml.close_job:
         job_id: "missing-*"
@@ -1581,7 +1601,6 @@
   - skip:
       features:
        - "warnings"
-       - "allowed_warnings"
 
   - do:
       catch: missing

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -14,7 +14,14 @@
   - match: { jobs: [] }
 
 ---
-"Test get jobs with expression that does not match and allow_no_jobs":
+"Test get jobs with expression that does not match and allow_no_match":
+
+  - do:
+      ml.get_jobs:
+        job_id: "missing-*"
+        allow_no_match: true
+  - match: { count: 0 }
+  - match: { jobs: [] }
 
   - do:
       ml.get_jobs:
@@ -24,7 +31,13 @@
   - match: { jobs: [] }
 
 ---
-"Test get jobs with expression that does not match and not allow_no_jobs":
+"Test get jobs with expression that does not match and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.get_jobs:
+        job_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing
@@ -849,7 +862,13 @@
   - match: { jobs.0.state: opened }
 
 ---
-"Test close jobs with expression that does not match and allow_no_jobs":
+"Test close jobs with expression that does not match and allow_no_match":
+
+  - do:
+      ml.close_job:
+        job_id: "missing-*"
+        allow_no_match: true
+  - match: { closed: true }
 
   - do:
       ml.close_job:
@@ -858,7 +877,13 @@
   - match: { closed: true }
 
 ---
-"Test close jobs with expression that does not match and not allow_no_jobs":
+"Test close jobs with expression that does not match and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.close_job:
+        job_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing
@@ -1553,7 +1578,31 @@
 
 ---
 "Test close job with body params":
+  - skip:
+      features:
+       - "warnings"
+       - "allowed_warnings"
+
   - do:
+      catch: missing
+      ml.close_job:
+        job_id: job-that-doesnot-exist*
+        body:  >
+          {
+            "allow_no_match" : false
+          }
+
+  - do:
+      ml.close_job:
+        job_id: job-that-doesnot-exist*
+        body:  >
+          {
+            "allow_no_match" : true
+          }
+
+  - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       catch: missing
       ml.close_job:
         job_id: job-that-doesnot-exist*
@@ -1563,6 +1612,8 @@
           }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       ml.close_job:
         job_id: job-that-doesnot-exist*
         body:  >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -232,14 +232,21 @@ setup:
         job_id: "missing-job"
 
 ---
-"Test overall buckets given non-matching expression and allow_no_jobs":
+"Test overall buckets given non-matching expression and allow_no_match":
   - do:
       ml.get_overall_buckets:
         job_id: "none-matching-*"
   - match: { count: 0 }
 
 ---
-"Test overall buckets given non-matching expression and not allow_no_jobs":
+"Test overall buckets given non-matching expression and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.get_overall_buckets:
+        job_id: "none-matching-*"
+        allow_no_match: false
+
   - do:
       catch: missing
       ml.get_overall_buckets:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -240,6 +240,9 @@ setup:
 
 ---
 "Test overall buckets given non-matching expression and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -248,6 +251,8 @@ setup:
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_overall_buckets:
         job_id: "none-matching-*"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -206,7 +206,13 @@ setup:
         job_id: unknown-job
 
 ---
-"Test get job stats given pattern and allow_no_jobs":
+"Test get job stats given pattern and allow_no_match":
+
+  - do:
+      ml.get_job_stats:
+        job_id: "missing-*"
+        allow_no_match: true
+  - match: { count: 0 }
 
   - do:
       ml.get_job_stats:
@@ -215,7 +221,13 @@ setup:
   - match: { count: 0 }
 
 ---
-"Test get job stats given pattern and not allow_no_jobs":
+"Test get job stats given pattern and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.get_job_stats:
+        job_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -207,6 +207,9 @@ setup:
 
 ---
 "Test get job stats given pattern and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.get_job_stats:
@@ -215,6 +218,8 @@ setup:
   - match: { count: 0 }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       ml.get_job_stats:
         job_id: "missing-*"
         allow_no_jobs: true
@@ -222,6 +227,9 @@ setup:
 
 ---
 "Test get job stats given pattern and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -230,6 +238,8 @@ setup:
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_jobs] used, expected [allow_no_match] instead'
       catch: missing
       ml.get_job_stats:
         job_id: "missing-*"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
@@ -240,7 +240,13 @@ setup:
           datafeed_id: "non-existing-datafeed"
 
 ---
-"Test stop with expression that does not match and allow_no_datafeeds":
+"Test stop with expression that does not match and allow_no_match":
+
+  - do:
+      ml.stop_datafeed:
+        datafeed_id: "missing-*"
+        allow_no_match: true
+  - match: { stopped: true }
 
   - do:
       ml.stop_datafeed:
@@ -249,13 +255,64 @@ setup:
   - match: { stopped: true }
 
 ---
-"Test stop with expression that does not match and not allow_no_datafeeds":
+"Test stop with expression that does not match and not allow_no_match":
+
+  - do:
+      catch: missing
+      ml.stop_datafeed:
+        datafeed_id: "missing-*"
+        allow_no_match: false
 
   - do:
       catch: missing
       ml.stop_datafeed:
         datafeed_id: "missing-*"
         allow_no_datafeeds: false
+
+---
+"Test stop with body params":
+  - skip:
+      features:
+        - "warnings"
+        - "allowed_warnings"
+
+  - do:
+      catch: missing
+      ml.stop_datafeed:
+        datafeed_id: missing-*
+        body:  >
+          {
+            "allow_no_match" : false
+          }
+
+  - do:
+      ml.stop_datafeed:
+        datafeed_id: missing-*
+        body:  >
+          {
+            "allow_no_match" : true
+          }
+
+  - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+      catch: missing
+      ml.stop_datafeed:
+        datafeed_id: missing-*
+        body:  >
+          {
+            "allow_no_datafeeds" : false
+          }
+
+  - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
+      ml.stop_datafeed:
+        datafeed_id: missing-*
+        body:  >
+          {
+            "allow_no_datafeeds" : true
+          }
 
 ---
 "Test stop already stopped datafeed job is not an error":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
@@ -241,6 +241,9 @@ setup:
 
 ---
 "Test stop with expression that does not match and allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       ml.stop_datafeed:
@@ -249,6 +252,8 @@ setup:
   - match: { stopped: true }
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       ml.stop_datafeed:
         datafeed_id: "missing-*"
         allow_no_datafeeds: true
@@ -256,6 +261,9 @@ setup:
 
 ---
 "Test stop with expression that does not match and not allow_no_match":
+  - skip:
+      features:
+        - "warnings"
 
   - do:
       catch: missing
@@ -264,6 +272,8 @@ setup:
         allow_no_match: false
 
   - do:
+      warnings:
+        - 'Deprecated field [allow_no_datafeeds] used, expected [allow_no_match] instead'
       catch: missing
       ml.stop_datafeed:
         datafeed_id: "missing-*"
@@ -274,7 +284,6 @@ setup:
   - skip:
       features:
         - "warnings"
-        - "allowed_warnings"
 
   - do:
       catch: missing


### PR DESCRIPTION
This PR deprecates `allow_no_jobs` and `allow_no_datafeeds` API parameters in favor of `allow_no_match`.
The old parameters are still accepted by the APIs but the deprecation warning is emitted if the old parameter name is used in the request body or as a request param.

High-level REST client classes will now send the new `allow_no_match` parameter to the backend.

Closes #60642