### PR TITLE
Add method to make random DateFormatter pattern

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
@@ -102,13 +102,17 @@ public enum FormatNames {
     STRICT_YEAR_MONTH("strict_year_month"),
     STRICT_YEAR_MONTH_DAY("strict_year_month_day");
 
-    private final String snakeCaseName;
+    private final String name;
 
-    FormatNames(String snakeCaseName) {
-        this.snakeCaseName = snakeCaseName;
+    FormatNames(String name) {
+        this.name = name;
     }
 
     public boolean matches(String format) {
-        return format.equals(snakeCaseName);
+        return format.equals(name);
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
@@ -740,87 +741,13 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         ZonedDateTime javaDate = ZonedDateTime.of(year, month, day, hour, minute, second, 0, ZoneOffset.UTC);
         DateTime jodaDate = new DateTime(year, month, day, hour, minute, second, DateTimeZone.UTC);
 
-        assertSamePrinterOutput("epoch_second", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_date", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_ordinal_date", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_ordinal_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_ordinal_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_time", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_t_time", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_t_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_week_date", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_week_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("basic_week_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("date", javaDate, jodaDate);
-        assertSamePrinterOutput("date_hour", javaDate, jodaDate);
-        assertSamePrinterOutput("date_hour_minute", javaDate, jodaDate);
-        assertSamePrinterOutput("date_hour_minute_second", javaDate, jodaDate);
-        assertSamePrinterOutput("date_hour_minute_second_fraction", javaDate, jodaDate);
-        assertSamePrinterOutput("date_hour_minute_second_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("date_optional_time", javaDate, jodaDate);
-        assertSamePrinterOutput("date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("hour", javaDate, jodaDate);
-        assertSamePrinterOutput("hour_minute", javaDate, jodaDate);
-        assertSamePrinterOutput("hour_minute_second", javaDate, jodaDate);
-        assertSamePrinterOutput("hour_minute_second_fraction", javaDate, jodaDate);
-        assertSamePrinterOutput("hour_minute_second_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinal_date", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinal_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinal_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("time", javaDate, jodaDate);
-        assertSamePrinterOutput("time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("t_time", javaDate, jodaDate);
-        assertSamePrinterOutput("t_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("week_date", javaDate, jodaDate);
-        assertSamePrinterOutput("week_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("week_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("week_year", javaDate, jodaDate);
-        assertSamePrinterOutput("weekyear_week", javaDate, jodaDate);
-        assertSamePrinterOutput("weekyear_week_day", javaDate, jodaDate);
-        assertSamePrinterOutput("year", javaDate, jodaDate);
-        assertSamePrinterOutput("year_month", javaDate, jodaDate);
-        assertSamePrinterOutput("year_month_day", javaDate, jodaDate);
-
-        assertSamePrinterOutput("epoch_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_basic_week_date", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_basic_week_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_basic_week_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_hour", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_hour_minute", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_hour_minute_second", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_hour_minute_second_fraction", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_hour_minute_second_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_optional_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_hour", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_hour_minute", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_hour_minute_second", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_hour_minute_second_fraction", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_hour_minute_second_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_ordinal_date", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_ordinal_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_ordinal_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_t_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_t_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_week_date", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_week_date_time", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_week_date_time_no_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_weekyear", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_weekyear_week", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_weekyear_week_day", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_year", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_year_month", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_year_month_day", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_optional_time", javaDate, jodaDate);
-        assertSamePrinterOutput("epoch_millis", javaDate, jodaDate);
+        for (FormatNames format : FormatNames.values()) {
+            if (format == FormatNames.ISO8601 || format == FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS) {
+                // Nanos aren't supported by joda
+                continue;
+            }
+            assertSamePrinterOutput(format.getName(), javaDate, jodaDate);
+        }
     }
 
     public void testSamePrinterOutputWithTimeZone() {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -70,6 +70,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
@@ -834,6 +835,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     private static String randomJodaAndJavaSupportedTimezone(List<String> zoneIds) {
         return randomValueOtherThanMany(id -> JODA_TIMEZONE_IDS.contains(id) == false,
             () -> randomFrom(zoneIds));
+    }
+
+    /**
+     * Generate a random valid date formatter pattern.
+     */
+    public static String randomDateFormatterPattern() {
+        return randomFrom(FormatNames.values()).getName();
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.test.test;
 import junit.framework.AssertionFailedError;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -40,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -198,5 +200,10 @@ public class ESTestCaseTests extends ESTestCase {
     public void testBasePortIDE() {
         assumeTrue("requires running tests without Gradle", System.getProperty("tests.gradle") == null);
         assertEquals(10300, ESTestCase.getBasePort());
+    }
+
+    public void testRandomDateFormatterPattern() {
+        DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern());
+        assertThat(formatter.parseMillis(formatter.formatMillis(0)), equalTo(0L));
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -529,8 +529,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
      */
     private Map<String, MappedFieldType> createFieldTypes(RollupJobConfig job) {
         Map<String, MappedFieldType> fieldTypes = new HashMap<>();
-        DateFormatter formatter
-            = DateFormatter.forPattern(randomFrom("basic_date", "date_optional_time", "epoch_second")).withLocale(Locale.ROOT);
+        DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(Locale.ROOT);
         MappedFieldType fieldType = new DateFieldMapper.DateFieldType(job.getGroupConfig().getDateHistogram().getField(), formatter);
         fieldTypes.put(fieldType.name(), fieldType);
 


### PR DESCRIPTION
Adds a method to make a random date `DateFormatter` pattern. We expect
this'll be useful for runtime fields to compate their formatting with
the standard date field.
