### PR TITLE
Apply new REST base plugin for the javaRestTest plugin

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.test.rest;
 
 import org.elasticsearch.gradle.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.test.RestIntegTestTask;
+import org.elasticsearch.gradle.test.RestTestBasePlugin;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
@@ -44,6 +45,7 @@ public class JavaRestTestPlugin implements Plugin<Project> {
     public void apply(Project project) {
 
         project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
+        project.getPluginManager().apply(RestTestBasePlugin.class);
         project.getPluginManager().apply(TestClustersPlugin.class);
 
         // create source set


### PR DESCRIPTION
This commit applies the new base REST plugin for javaRestTest plugin.

related: #60261

