### PR TITLE
[DOCS] Add manual redirects.

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -977,7 +977,7 @@ For more information, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-apis.html[7.x docs].
 
 [role="exclude",id="ilm-searchable-snapshot"]
-=== SSearchable snapshots coming soon
+=== Searchable snapshots coming soon
 
 Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
 For more information, see the 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -969,6 +969,49 @@ See <<run-an-es-search>>.
 
 See <<how-es-highlighters-work-internally>>.
 
+[role="exclude",id="searchable-snapshots-apis"]
+=== Searchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-apis.html[7.x docs].
+
+[role="exclude",id="ilm-searchable-snapshot"]
+=== SSearchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ilm-searchable-snapshot.html[7.x docs].
+
+[role="exclude",id="searchable-snapshots-api-stats"]
+=== Searchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-api-stats.html[7.x docs].
+
+[role="exclude",id="searchable-snapshots-api-mount-snapshot"]
+=== Searchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-api-mount-snapshot.html[7.x docs].
+
+[role="exclude",id="searchable-snapshots-api-clear-cache"]
+=== Searchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-api-clear-cache.html[7.x docs].
+
+[role="exclude",id="searchable-snapshots-repository-stats"]
+=== Searchable snapshots coming soon
+
+Searchable snapshots are not supported in 7.8, but will be part of an upcoming release.
+For more information, see the 
+https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-repository-stats.html[7.x docs].
+
+
 ////
 [role="exclude",id="search-request-body"]
 === Request body search


### PR DESCRIPTION
The website redirects are causing confusion because it's easy to miss that you're actually looking at the 7.x docs. Reverting the web redirects & adding these so links from the search results don't 404.