### PR TITLE
Highlight `cluster.initial_master_nodes` removal after cluster formation

### DIFF
--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -42,8 +42,12 @@ themselves. As this auto-bootstrapping is <<modules-discovery-quorums,inherently
 unsafe>>, when you start a brand new cluster in <<dev-vs-prod-mode,production
 mode>>, you must explicitly list the master-eligible nodes whose votes should be
 counted in the very first election. This list is set using the
-`cluster.initial_master_nodes` setting. You should not use this setting when
-restarting a cluster or adding a new node to an existing cluster.
+`cluster.initial_master_nodes` setting. 
+
+NOTE: For clusters running in <<dev-vs-prod-mode,production
+mode>>, you should remove `cluster.initial_master_nodes` setting from the nodes' configuration
+once the cluster has successfully formed for the first time. You should not use this setting when
+restarting a cluster or adding a new node to an existing cluster.  
 
 [source,yaml]
 --------------------------------------------------

--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -44,9 +44,8 @@ mode>>, you must explicitly list the master-eligible nodes whose votes should be
 counted in the very first election. This list is set using the
 `cluster.initial_master_nodes` setting. 
 
-NOTE: For clusters running in <<dev-vs-prod-mode,production
-mode>>, you should remove `cluster.initial_master_nodes` setting from the nodes' configuration
-once the cluster has successfully formed for the first time. You should not use this setting when
+NOTE: You should remove `cluster.initial_master_nodes` setting from the nodes' configuration
+*once the cluster has successfully formed for the first time*. Do not use this setting when
 restarting a cluster or adding a new node to an existing cluster.  
 
 [source,yaml]


### PR DESCRIPTION
Explicitly ask users to remove `cluster.initial_master_nodes` once the cluster has formed for the first time.

It will be helpful to back port this doc change to all 7.x versions.
