### PR TITLE
Make `FetchPhase` logic more readable. 

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -161,11 +161,11 @@ public class FetchPhase implements SearchPhase {
                 int subDocId = docId - subReaderContext.docBase;
 
                 int rootDocId = findRootDocumentIfNested(context, subReaderContext, subDocId);
-                if (rootDocId != -1) {
-                    prepareNestedHitContext(hitContext, context, docId, subDocId, rootDocId,
+                if (rootDocId == -1) {
+                    prepareHitContext(hitContext, context, fieldsVisitor, docId, subDocId,
                         storedToRequestedFields, subReaderContext);
                 } else {
-                    prepareHitContext(hitContext, context, fieldsVisitor, docId, subDocId,
+                    prepareNestedHitContext(hitContext, context, docId, subDocId, rootDocId,
                         storedToRequestedFields, subReaderContext);
                 }
 


### PR DESCRIPTION
* Factor out `FieldsVisitor#postProcess` call.
* Swap logical order for normal and nested documents.
* Extract the method `createStoredFieldsVisitor`.