### PR TITLE
Rename dataset to datastream

### DIFF
--- a/x-pack/plugin/core/src/main/resources/logs-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/logs-mappings.json
@@ -31,6 +31,20 @@
             }
           }
         },
+        "datastream": {
+          "properties": {
+            "type": {
+              "type": "constant_keyword",
+              "value": "logs"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            },
+            "namespace": {
+              "type": "constant_keyword"
+            }
+          }
+        },
         "ecs": {
           "properties": {
             "version": {

--- a/x-pack/plugin/core/src/main/resources/metrics-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/metrics-mappings.json
@@ -31,6 +31,20 @@
             }
           }
         },
+        "datastream": {
+          "properties": {
+            "type": {
+              "type": "constant_keyword",
+              "value": "logs"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            },
+            "namespace": {
+              "type": "constant_keyword"
+            }
+          }
+        },
         "ecs": {
           "properties": {
             "version": {

--- a/x-pack/plugin/core/src/main/resources/metrics-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/metrics-mappings.json
@@ -35,7 +35,7 @@
           "properties": {
             "type": {
               "type": "constant_keyword",
-              "value": "logs"
+              "value": "metrics"
             },
             "dataset": {
               "type": "constant_keyword"


### PR DESCRIPTION
The current Elastic Agent ships data to `dataset.*`. We plant to rename this field to `datastream.type`, `datastream.dataset`, `datastream.namespace` instead. To make the template forward compatible, we add these fields to 7.9 and newer.

This is #60592 adapted for master.