### PR TITLE
Optimize CS Persistence Stream Use (#60643)

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -814,6 +814,12 @@ public class PersistedClusterStateService {
             final ReleasableBytesStreamOutput releasableBytesStreamOutput = new ReleasableBytesStreamOutput(bigArrays);
             try {
                 final FilterOutputStream outputStream = new FilterOutputStream(releasableBytesStreamOutput) {
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                    }
+
                     @Override
                     public void close() {
                         // closing the XContentBuilder should not release the bytes yet


### PR DESCRIPTION
In the metadata persistence logic we failed to override the bulk write
method on the FilterOutputStream resulting in all the writes to it
running byte-by-byte in a loop adding a large number of bounds checks
needlessly.

backport of #60643 