### PR TITLE
[DOCS] Fixes reusability of highlights and breaking changes

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -114,13 +114,14 @@ you dynamically update the index mapping based on the template's mapping configu
 [%collapsible]
 ====
 *Details* +
-Automatically importing <<dangling-indices,dangling indices>> into the cluster
+Automatically importing
+{ref}/modules-gateway.html#dangling-indices[dangling indices] into the cluster
 is unsafe and is now disabled by default. This feature will be removed entirely
 in {es} 8.0.0.
 
 *Impact* +
-Use the <<dangling-indices-api,Dangling indices API>> to list, delete or import
-any dangling indices manually.
+Use the {ref}/indices.html#dangling-indices-api[dangling indices API] to list,
+delete or import any dangling indices manually.
 
 Alternatively you can enable automatic imports of dangling indices, recovering
 the unsafe behaviour of earlier versions, by setting

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -53,7 +53,7 @@ Consider using EQL if you:
 
 A good intro on EQL and its purpose is available
 https://www.elastic.co/blog/introducing-event-query-language[in this blog
-post]. See the <<eql,EQL in Elasticsearch>> documentaton for an in-depth
+post]. See the {ref}/eql.html[EQL in Elasticsearch] documentaton for an in-depth
 explanation, and also the
 https://eql.readthedocs.io/en/latest/query-guide/index.html[language
 reference].
@@ -75,7 +75,7 @@ A _data stream_ is a convenient, scalable way to ingest, search, and manage
 continuously generated time series data. They provide a simpler way to split
 data across multiple indices and still query it via a single named resource.
 
-See the <<data-streams,Data streams documentation>> to get started.
+See the {ref}/data-streams.html[Data streams documentation] to get started.
 // end::notable-highlights[]
 
 
@@ -200,7 +200,7 @@ for wildcard grep-like queries. While such queries are possible with other
 field types, they suffer from constraints that limit their usefulness.
 
 This field type is especially well suited for running grep-like queries on
-log lines. See the <<wildcard,wildcard datatype>> documentation for more
+log lines. See the {ref}/wildcard.html[wildcard datatype] documentation for more
 information.
 // end::notable-highlights[]
 


### PR DESCRIPTION
This PR updates links within the 7.9.0 highlights and breaking changes to external links, so that they can be successfully re-used within the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/7.9/elasticsearch-breaking-changes.html).

Related to https://github.com/elastic/elasticsearch/pull/59961