### PR TITLE
Remove body from indices.create_data_stream REST spec

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.create_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.create_data_stream.json
@@ -2,7 +2,7 @@
   "indices.create_data_stream":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
-      "description":"Creates or updates a data stream"
+      "description":"Creates a data stream"
     },
     "stability":"stable",
     "url":{
@@ -22,9 +22,6 @@
       ]
     },
     "params":{
-    },
-    "body":{
-      "description":"The data stream definition"
     }
   }
 }


### PR DESCRIPTION
This commit removes the body property from the
indices.create_data_stream.json REST API spec
as the API does not support sending a body.

Update the description of the API to remove
that a data stream can be updated with the
API - data streams can only be created with
this API and attempting to update yields a
`resource_already_exists_exception`.

Closes #60704