### PR TITLE
Ensure license is ready for xpack info doc tests

### DIFF
--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -104,7 +104,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @Before
     public void waitForRequirements() throws Exception {
-        if (isCcrTest() || isGetLicenseTest()) {
+        if (isCcrTest() || isGetLicenseTest() || isXpackInfoTest()) {
             ESRestTestCase.waitForActiveLicense(adminClient());
         }
     }
@@ -178,6 +178,11 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     protected boolean isGetLicenseTest() {
         String testName = getTestName();
         return testName != null && (testName.contains("/get-license/") || testName.contains("\\get-license\\"));
+    }
+
+    protected boolean isXpackInfoTest() {
+        String testName = getTestName();
+        return testName != null && (testName.contains("/info/") || testName.contains("\\info\\"));
     }
 
     /**


### PR DESCRIPTION
Fix another variant of missing license test failure similar to the cases fixed by #60498.

Resolves: #56106