### PR TITLE
Rename `datastream` to `data_stream`.

### DIFF
--- a/x-pack/plugin/core/src/main/resources/logs-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/logs-mappings.json
@@ -31,7 +31,7 @@
             }
           }
         },
-        "datastream": {
+        "data_stream": {
           "properties": {
             "type": {
               "type": "constant_keyword",

--- a/x-pack/plugin/core/src/main/resources/metrics-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/metrics-mappings.json
@@ -31,7 +31,7 @@
             }
           }
         },
-        "datastream": {
+        "data_stream": {
           "properties": {
             "type": {
               "type": "constant_keyword",


### PR DESCRIPTION
The name of the feature having a space: "data stream", the key should
have an underscore.

Backport of #60658