### PR TITLE
[Transform] disable optimizations when using scripts in group_by

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
@@ -28,6 +28,11 @@ public class TermsGroupSourceTests extends AbstractSerializingTestCase<TermsGrou
         return new TermsGroupSource(field, scriptConfig, missingBucket);
     }
 
+    public static TermsGroupSource randomTermsGroupSourceNoScript() {
+        String field = randomAlphaOfLengthBetween(1, 20);
+        return new TermsGroupSource(field, null, randomBoolean());
+    }
+
     @Override
     protected TermsGroupSource doParseInstance(XContentParser parser) throws IOException {
         return TermsGroupSource.fromXContent(parser, false);
@@ -41,6 +46,11 @@ public class TermsGroupSourceTests extends AbstractSerializingTestCase<TermsGrou
     @Override
     protected Reader<TermsGroupSource> instanceReader() {
         return TermsGroupSource::new;
+    }
+
+    public void testSupportsIncrementalBucketUpdate() {
+        TermsGroupSource terms = randomTermsGroupSource();
+        assertEquals(terms.getScriptConfig() == null, terms.supportsIncrementalBucketUpdate());
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
@@ -536,6 +536,11 @@ public class CompositeBucketsChangeCollector implements ChangeCollector {
         Map<String, FieldCollector> fieldCollectors = new HashMap<>();
 
         for (Entry<String, SingleGroupSource> entry : groups.entrySet()) {
+            // skip any fields that use scripts
+            if (entry.getValue().getScriptConfig() != null) {
+                continue;
+            }
+
             switch (entry.getValue().getType()) {
                 case TERMS:
                     fieldCollectors.put(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.core.transform.transforms.pivot.GeoTileGroupSourc
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.HistogramGroupSourceTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.ScriptConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.TermsGroupSourceTests;
@@ -80,7 +81,7 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
         assertEquals(10, getCompositeAggregationBuilder(collector.buildChangesQuery(new SearchSourceBuilder(), null, 10)).size());
 
         // a terms group_by is limited by terms query
-        SingleGroupSource termsGroupBy = TermsGroupSourceTests.randomTermsGroupSource();
+        SingleGroupSource termsGroupBy = TermsGroupSourceTests.randomTermsGroupSourceNoScript();
         groups.put("terms", termsGroupBy);
 
         collector = CompositeBucketsChangeCollector.buildChangeCollector(getCompositeAggregation(groups), groups, null);
@@ -194,6 +195,24 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         queryBuilder = collector.buildFilterQuery(66_666, 200_222);
         assertNull(queryBuilder);
+    }
+
+    public void testNoTermsFieldCollectorForScripts() throws IOException {
+        Map<String, SingleGroupSource> groups = new LinkedHashMap<>();
+
+        // terms with value script
+        SingleGroupSource termsGroupBy = new TermsGroupSource("id", ScriptConfigTests.randomScriptConfig(), false);
+        groups.put("id", termsGroupBy);
+
+        Map<String, FieldCollector> fieldCollectors = CompositeBucketsChangeCollector.createFieldCollectors(groups, null);
+        assertTrue(fieldCollectors.isEmpty());
+
+        // terms with only a script
+        termsGroupBy = new TermsGroupSource(null, ScriptConfigTests.randomScriptConfig(), false);
+        groups.put("id", termsGroupBy);
+
+        fieldCollectors = CompositeBucketsChangeCollector.createFieldCollectors(groups, null);
+        assertTrue(fieldCollectors.isEmpty());
     }
 
     private static CompositeAggregationBuilder getCompositeAggregation(Map<String, SingleGroupSource> groups) throws IOException {


### PR DESCRIPTION
disable optimizations when using scripts in group_by, when scripts using scripts we can not predict the
outcome and we have no query counterpart. Other optimizations for other group_by's are not affected.

fixes #57332

Note: if no group_by is optimized, a warning is created (introduced in #59591)