### PR TITLE
Fix mistake in notes around dynamic template validation.

### DIFF
--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -48,7 +48,7 @@ snippet may cause the update or validation of a dynamic template to fail under c
   is considered valid as string type, but if a field matching the dynamic template is indexed as a long, a validation 
   error is returned at index time.
 
-* If the `{{name}}` placeholder is used in the mapping snippet, validation is skipped when updating the dynamic 
+* If the `{name}` placeholder is used in the mapping snippet, validation is skipped when updating the dynamic
   template. This is because the field name is unknown at that time. Instead, validation occurs when the template is applied
   at index time.
 


### PR DESCRIPTION
The double bracket notation is incorrect.