### PR TITLE
BACKPORT Use the Index Access Control from the scroll search context

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.security.authz;
 
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.license.XPackLicenseState;
@@ -17,6 +18,8 @@ import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField;
+import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
 
@@ -51,6 +54,12 @@ public final class SecuritySearchOperationListener implements SearchOperationLis
     public void onNewScrollContext(SearchContext searchContext) {
         if (licenseState.isSecurityEnabled()) {
             searchContext.scrollContext().putInContext(AuthenticationField.AUTHENTICATION_KEY, securityContext.getAuthentication());
+            // store the DLS and FLS permissions of the initial search request that created the scroll
+            // this is then used to assert the DLS/FLS permission for the scroll search action
+            IndicesAccessControl indicesAccessControl =
+                    securityContext.getThreadContext().getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+            assert indicesAccessControl != null : "thread context does not contain index access control";
+            searchContext.scrollContext().putInContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY, indicesAccessControl);
         }
     }
 
@@ -68,6 +77,39 @@ public final class SecuritySearchOperationListener implements SearchOperationLis
                 final String action = threadContext.getTransient(ORIGINATING_ACTION_KEY);
                 ensureAuthenticatedUserIsSame(originalAuth, current, auditTrailService, searchContext.id(), action, request,
                         AuditUtil.extractRequestId(threadContext), threadContext.getTransient(AUTHORIZATION_INFO_KEY));
+                // piggyback on context validation to assert the DLS/FLS permissions on the thread context of the scroll search handler
+                if (null == securityContext.getThreadContext().getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY)) {
+                    // fill in the DLS and FLS permissions for the scroll search action from the scroll context
+                    IndicesAccessControl scrollIndicesAccessControl =
+                            searchContext.scrollContext().getFromContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+                    assert scrollIndicesAccessControl != null : "scroll does not contain index access control";
+                    securityContext.getThreadContext().putTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY,
+                            scrollIndicesAccessControl);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onPreFetchPhase(SearchContext searchContext) {
+        ensureIndicesAccessControlForScrollThreadContext(searchContext);
+    }
+
+    @Override
+    public void onPreQueryPhase(SearchContext searchContext) {
+        ensureIndicesAccessControlForScrollThreadContext(searchContext);
+    }
+
+    void ensureIndicesAccessControlForScrollThreadContext(SearchContext searchContext) {
+        if (licenseState.isSecurityEnabled() && searchContext.scrollContext() != null) {
+            IndicesAccessControl scrollIndicesAccessControl =
+                    searchContext.scrollContext().getFromContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+            IndicesAccessControl threadIndicesAccessControl =
+                    securityContext.getThreadContext().getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+            if (scrollIndicesAccessControl != threadIndicesAccessControl) {
+                throw new ElasticsearchSecurityException("[" + searchContext.id() + "] expected scroll indices access control [" +
+                        scrollIndicesAccessControl.toString() + "] but found [" + threadIndicesAccessControl.toString() + "] in thread " +
+                        "context");
             }
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.join.ParentJoinPlugin;
@@ -765,6 +766,114 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+        }
+    }
+
+    public void testScrollWithQueryCache() {
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
+                .setMapping("field1", "type=text", "field2", "type=text")
+        );
+
+        final int numDocs = scaledRandomIntBetween(2, 4);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex("test").setId(String.valueOf(i))
+                    .setSource("field1", "value1", "field2", "value2")
+                    .get();
+        }
+        refresh("test");
+
+        final QueryBuilder cacheableQueryBuilder = constantScoreQuery(termQuery("field1", "value1"));
+
+        SearchResponse user1SearchResponse = null;
+        SearchResponse user2SearchResponse = null;
+        int scrolledDocsUser1 = 0;
+        final int numScrollSearch = scaledRandomIntBetween(20, 30);
+
+        try {
+            for (int i = 0; i < numScrollSearch; i++) {
+                if (randomBoolean()) {
+                    if (user2SearchResponse == null) {
+                        user2SearchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(
+                                "user2", USERS_PASSWD)))
+                                .prepareSearch("test")
+                                .setQuery(cacheableQueryBuilder)
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .setSize(1)
+                                .setFetchSource(true)
+                                .get();
+                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getHits().length, is(0));
+                    } else {
+                        // make sure scroll is empty
+                        user2SearchResponse = client()
+                                .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2",
+                                        USERS_PASSWD)))
+                                .prepareSearchScroll(user2SearchResponse.getScrollId())
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .get();
+                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getHits().length, is(0));
+                        if (randomBoolean()) {
+                            // maybe reuse the scroll even if empty
+                            client().prepareClearScroll().addScrollId(user2SearchResponse.getScrollId()).get();
+                            user2SearchResponse = null;
+                        }
+                    }
+                } else {
+                    if (user1SearchResponse == null) {
+                        user1SearchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(
+                                "user1", USERS_PASSWD)))
+                                .prepareSearch("test")
+                                .setQuery(cacheableQueryBuilder)
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .setSize(1)
+                                .setFetchSource(true)
+                                .get();
+                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        assertThat(user1SearchResponse.getHits().getHits().length, is(1));
+                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
+                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                        scrolledDocsUser1++;
+                    } else {
+                        user1SearchResponse = client()
+                                .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                                .prepareSearchScroll(user1SearchResponse.getScrollId())
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .get();
+                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        if (scrolledDocsUser1 < numDocs) {
+                            assertThat(user1SearchResponse.getHits().getHits().length, is(1));
+                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
+                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                            scrolledDocsUser1++;
+                        } else {
+                            assertThat(user1SearchResponse.getHits().getHits().length, is(0));
+                            if (randomBoolean()) {
+                                // maybe reuse the scroll even if empty
+                                if (user1SearchResponse.getScrollId() != null) {
+                                    client().prepareClearScroll().addScrollId(user1SearchResponse.getScrollId()).get();
+                                }
+                                user1SearchResponse = null;
+                                scrolledDocsUser1 = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            if (user1SearchResponse != null) {
+                String scrollId = user1SearchResponse.getScrollId();
+                if (scrollId != null) {
+                    client().prepareClearScroll().addScrollId(scrollId).get();
+                }
+            }
+            if (user2SearchResponse != null) {
+                String scrollId = user2SearchResponse.getScrollId();
+                if (scrollId != null) {
+                    client().prepareClearScroll().addScrollId(scrollId).get();
+                }
+            }
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -772,12 +772,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     public void testScrollWithQueryCache() {
         assertAcked(client().admin().indices().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
-                .setMapping("field1", "type=text", "field2", "type=text")
+                .addMapping("type1", "field1", "type=text", "field2", "type=text")
         );
 
         final int numDocs = scaledRandomIntBetween(2, 4);
         for (int i = 0; i < numDocs; i++) {
-            client().prepareIndex("test").setId(String.valueOf(i))
+            client().prepareIndex("test", "type1", String.valueOf(i))
                     .setSource("field1", "value1", "field2", "value2")
                     .get();
         }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/60640

When the RBACEngine authorizes scroll searches it sets the index access control to the very limiting IndicesAccessControl.ALLOW_NO_INDICES value. This change will set it to the value for the index access control that was produced during the authorization of the initial search that created the scroll, which is now stored in the scroll context.