### PR TITLE
BACKPORT Use the Index Access Control from the scroll search context (#60640)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -239,10 +239,15 @@ public class RBACEngine implements AuthorizationEngine {
                 if (SearchScrollAction.NAME.equals(action)) {
                     authorizeIndexActionName(action, authorizationInfo, null, listener);
                 } else {
-                    // we store the request as a transient in the ThreadContext in case of a authorization failure at the shard
-                    // level. If authorization fails we will audit a access_denied message and will use the request to retrieve
-                    // information such as the index and the incoming address of the request
-                    listener.onResponse(new IndexAuthorizationResult(true, IndicesAccessControl.ALLOW_NO_INDICES));
+                    // RBACEngine simply authorizes scroll related actions without filling in any DLS/FLS permissions.
+                    // Scroll related actions have special security logic, where the security context of the initial search
+                    // request is attached to the scroll context upon creation in {@code SecuritySearchOperationListener#onNewScrollContext}
+                    // and it is then verified, before every use of the scroll, in
+                    // {@code SecuritySearchOperationListener#validateSearchContext}.
+                    // The DLS/FLS permissions are used inside the {@code DirectoryReader} that {@code SecurityIndexReaderWrapper}
+                    // built while handling the initial search request. In addition, for consistency, the DLS/FLS permissions from
+                    // the originating search request are attached to the thread context upon validating the scroll.
+                    listener.onResponse(new IndexAuthorizationResult(true, null));
                 }
             } else {
                 assert false :

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListener.java
@@ -99,7 +99,7 @@ public final class SecuritySearchOperationListener implements SearchOperationLis
             IndicesAccessControl scrollIndicesAccessControl =
                     searchContext.scrollContext().getFromContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
             IndicesAccessControl threadIndicesAccessControl =
-                    threadContext().getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+                    threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
             if (scrollIndicesAccessControl != threadIndicesAccessControl) {
                 throw new ElasticsearchSecurityException("[" + searchContext.id() + "] expected scroll indices access control [" +
                         scrollIndicesAccessControl.toString() + "] but found [" + threadIndicesAccessControl.toString() + "] in thread " +

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -802,7 +802,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                                 .setSize(1)
                                 .setFetchSource(true)
                                 .get();
-                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getTotalHits(), is((long) 0));
                         assertThat(user2SearchResponse.getHits().getHits().length, is(0));
                     } else {
                         // make sure scroll is empty
@@ -812,7 +812,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                                 .prepareSearchScroll(user2SearchResponse.getScrollId())
                                 .setScroll(TimeValue.timeValueMinutes(10L))
                                 .get();
-                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getTotalHits(), is((long) 0));
                         assertThat(user2SearchResponse.getHits().getHits().length, is(0));
                         if (randomBoolean()) {
                             // maybe reuse the scroll even if empty
@@ -830,7 +830,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                                 .setSize(1)
                                 .setFetchSource(true)
                                 .get();
-                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        assertThat(user1SearchResponse.getHits().getTotalHits(), is((long) numDocs));
                         assertThat(user1SearchResponse.getHits().getHits().length, is(1));
                         assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
                         assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
@@ -841,7 +841,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                                 .prepareSearchScroll(user1SearchResponse.getScrollId())
                                 .setScroll(TimeValue.timeValueMinutes(10L))
                                 .get();
-                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        assertThat(user1SearchResponse.getHits().getTotalHits(), is((long) numDocs));
                         if (scrolledDocsUser1 < numDocs) {
                             assertThat(user1SearchResponse.getHits().getHits().length, is(1));
                             assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.join.ParentJoinPlugin;
@@ -765,6 +766,114 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
             assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+        }
+    }
+
+    public void testScrollWithQueryCache() {
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
+                .setMapping("field1", "type=text", "field2", "type=text")
+        );
+
+        final int numDocs = scaledRandomIntBetween(2, 4);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex("test").setId(String.valueOf(i))
+                    .setSource("field1", "value1", "field2", "value2")
+                    .get();
+        }
+        refresh("test");
+
+        final QueryBuilder cacheableQueryBuilder = constantScoreQuery(termQuery("field1", "value1"));
+
+        SearchResponse user1SearchResponse = null;
+        SearchResponse user2SearchResponse = null;
+        int scrolledDocsUser1 = 0;
+        final int numScrollSearch = scaledRandomIntBetween(20, 30);
+
+        try {
+            for (int i = 0; i < numScrollSearch; i++) {
+                if (randomBoolean()) {
+                    if (user2SearchResponse == null) {
+                        user2SearchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(
+                                "user2", USERS_PASSWD)))
+                                .prepareSearch("test")
+                                .setQuery(cacheableQueryBuilder)
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .setSize(1)
+                                .setFetchSource(true)
+                                .get();
+                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getHits().length, is(0));
+                    } else {
+                        // make sure scroll is empty
+                        user2SearchResponse = client()
+                                .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2",
+                                        USERS_PASSWD)))
+                                .prepareSearchScroll(user2SearchResponse.getScrollId())
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .get();
+                        assertThat(user2SearchResponse.getHits().getTotalHits().value, is((long) 0));
+                        assertThat(user2SearchResponse.getHits().getHits().length, is(0));
+                        if (randomBoolean()) {
+                            // maybe reuse the scroll even if empty
+                            client().prepareClearScroll().addScrollId(user2SearchResponse.getScrollId()).get();
+                            user2SearchResponse = null;
+                        }
+                    }
+                } else {
+                    if (user1SearchResponse == null) {
+                        user1SearchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(
+                                "user1", USERS_PASSWD)))
+                                .prepareSearch("test")
+                                .setQuery(cacheableQueryBuilder)
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .setSize(1)
+                                .setFetchSource(true)
+                                .get();
+                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        assertThat(user1SearchResponse.getHits().getHits().length, is(1));
+                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
+                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                        scrolledDocsUser1++;
+                    } else {
+                        user1SearchResponse = client()
+                                .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                                .prepareSearchScroll(user1SearchResponse.getScrollId())
+                                .setScroll(TimeValue.timeValueMinutes(10L))
+                                .get();
+                        assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
+                        if (scrolledDocsUser1 < numDocs) {
+                            assertThat(user1SearchResponse.getHits().getHits().length, is(1));
+                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
+                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                            scrolledDocsUser1++;
+                        } else {
+                            assertThat(user1SearchResponse.getHits().getHits().length, is(0));
+                            if (randomBoolean()) {
+                                // maybe reuse the scroll even if empty
+                                if (user1SearchResponse.getScrollId() != null) {
+                                    client().prepareClearScroll().addScrollId(user1SearchResponse.getScrollId()).get();
+                                }
+                                user1SearchResponse = null;
+                                scrolledDocsUser1 = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            if (user1SearchResponse != null) {
+                String scrollId = user1SearchResponse.getScrollId();
+                if (scrollId != null) {
+                    client().prepareClearScroll().addScrollId(scrollId).get();
+                }
+            }
+            if (user2SearchResponse != null) {
+                String scrollId = user2SearchResponse.getScrollId();
+                if (scrollId != null) {
+                    client().prepareClearScroll().addScrollId(scrollId).get();
+                }
+            }
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -772,12 +772,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     public void testScrollWithQueryCache() {
         assertAcked(client().admin().indices().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
-                .setMapping("field1", "type=text", "field2", "type=text")
+                .addMapping("type1", "field1", "type=text", "field2", "type=text")
         );
 
         final int numDocs = scaledRandomIntBetween(2, 4);
         for (int i = 0; i < numDocs; i++) {
-            client().prepareIndex("test").setId(String.valueOf(i))
+            client().prepareIndex("test", "type1", String.valueOf(i))
                     .setSource("field1", "value1", "field2", "value2")
                     .get();
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -22,9 +22,11 @@ import org.elasticsearch.transport.TransportRequest.Empty;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField;
+import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
-import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 
 import java.util.Collections;
 
@@ -34,6 +36,8 @@ import static org.elasticsearch.xpack.security.authz.AuthorizationService.AUTHOR
 import static org.elasticsearch.xpack.security.authz.AuthorizationService.ORIGINATING_ACTION_KEY;
 import static org.elasticsearch.xpack.security.authz.AuthorizationServiceTests.authzInfoRoles;
 import static org.elasticsearch.xpack.security.authz.SecuritySearchOperationListener.ensureAuthenticatedUserIsSame;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -69,6 +73,8 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
         AuditTrailService auditTrailService = mock(AuditTrailService.class);
         Authentication authentication = new Authentication(new User("test", "role"), new RealmRef("realm", "file", "node"), null);
         authentication.writeToContext(threadContext);
+        IndicesAccessControl indicesAccessControl = mock(IndicesAccessControl.class);
+        threadContext.putTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY, indicesAccessControl);
 
         SecuritySearchOperationListener listener = new SecuritySearchOperationListener(threadContext, licenseState, auditTrailService);
         listener.onNewScrollContext(testSearchContext);
@@ -76,6 +82,9 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
         Authentication contextAuth = testSearchContext.scrollContext().getFromContext(AuthenticationField.AUTHENTICATION_KEY);
         assertEquals(authentication, contextAuth);
         assertEquals(scroll, testSearchContext.scrollContext().scroll);
+
+        assertThat(testSearchContext.scrollContext().getFromContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY),
+                is(indicesAccessControl));
 
         verify(licenseState).isAuthAllowed();
         verifyZeroInteractions(auditTrailService);
@@ -86,6 +95,8 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
         testSearchContext.scrollContext(new ScrollContext());
         testSearchContext.scrollContext().putInContext(AuthenticationField.AUTHENTICATION_KEY,
                 new Authentication(new User("test", "role"), new RealmRef("realm", "file", "node"), null));
+        final IndicesAccessControl indicesAccessControl = mock(IndicesAccessControl.class);
+        testSearchContext.scrollContext().putInContext(AuthorizationServiceField.INDICES_PERMISSIONS_KEY, indicesAccessControl);
         testSearchContext.scrollContext().scroll = new Scroll(TimeValue.timeValueSeconds(2L));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isAuthAllowed()).thenReturn(true);
@@ -97,6 +108,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
             Authentication authentication = new Authentication(new User("test", "role"), new RealmRef("realm", "file", "node"), null);
             authentication.writeToContext(threadContext);
             listener.validateSearchContext(testSearchContext, Empty.INSTANCE);
+            assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
             verify(licenseState).isAuthAllowed();
             verifyZeroInteractions(auditTrailService);
         }
@@ -107,6 +119,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
             Authentication authentication = new Authentication(new User("test", "role"), new RealmRef(realmName, "file", nodeName), null);
             authentication.writeToContext(threadContext);
             listener.validateSearchContext(testSearchContext, Empty.INSTANCE);
+            assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
             verify(licenseState, times(2)).isAuthAllowed();
             verifyZeroInteractions(auditTrailService);
         }
@@ -123,6 +136,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
             final InternalScrollSearchRequest request = new InternalScrollSearchRequest();
             SearchContextMissingException expected =
                     expectThrows(SearchContextMissingException.class, () -> listener.validateSearchContext(testSearchContext, request));
+            assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), nullValue());
             assertEquals(testSearchContext.id(), expected.id());
             verify(licenseState, times(3)).isAuthAllowed();
             verify(auditTrailService).accessDenied(eq(null), eq(authentication), eq("action"), eq(request),
@@ -141,6 +155,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
             threadContext.putTransient(ORIGINATING_ACTION_KEY, "action");
             final InternalScrollSearchRequest request = new InternalScrollSearchRequest();
             listener.validateSearchContext(testSearchContext, request);
+            assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
             verify(licenseState, times(4)).isAuthAllowed();
             verifyNoMoreInteractions(auditTrailService);
         }
@@ -159,6 +174,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
             final InternalScrollSearchRequest request = new InternalScrollSearchRequest();
             SearchContextMissingException expected =
                     expectThrows(SearchContextMissingException.class, () -> listener.validateSearchContext(testSearchContext, request));
+            assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), nullValue());
             assertEquals(testSearchContext.id(), expected.id());
             verify(licenseState, times(5)).isAuthAllowed();
             verify(auditTrailService).accessDenied(eq(null), eq(authentication), eq("action"), eq(request),


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/60640

When the RBACEngine authorizes scroll searches it sets the index access control
to the very limiting IndicesAccessControl.ALLOW_NO_INDICES value.
This change will set it to the value for the index access control that was produced
during the authorization of the initial search that created the scroll,
which is now stored in the scroll context.

