### PR TITLE
[DOCS] Adds inference phase to get DFA job stats

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -502,7 +502,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 * `coarse_parameter_search` (for {regression} and {classification} only),
 * `fine_tuning_parameters` (for {regression} and {classification} only),
 * `final_training` (for {regression} and {classification} only),
-* `writing_results`.
+* `writing_results`,
+* `inference` (for {regression} and {classification} only).
 +
 To learn more about the different phases, refer to
 {ml-docs}/ml-dfa-phases.html[How a {dfanalytics} job works].


### PR DESCRIPTION
## Overview

This PR adds the `inference` phase to the list of the DFA job phases in the GET DFA job stats API docs. Applies to 7.9 and above.

### Preview

[GET DFA job stats](https://elasticsearch_60737.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html)