### PR TITLE
Delegate getRecoveryStateFactory to delegates on LocalStateCompositeXPackPlugin

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -503,6 +503,13 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin implements Scrip
         return factories;
     }
 
+    @Override
+    public Map<String, RecoveryStateFactory> getRecoveryStateFactories() {
+        final Map<String, RecoveryStateFactory> factories = new HashMap<>();
+        filterPlugins(IndexStorePlugin.class).stream().forEach(p -> factories.putAll(p.getRecoveryStateFactories()));
+        return factories;
+    }
+
     private <T> List<T> filterPlugins(Class<T> type) {
         return plugins.stream().filter(x -> type.isAssignableFrom(x.getClass())).map(p -> ((T)p))
                 .collect(Collectors.toList());


### PR DESCRIPTION
This should fix the CI failures related to Searchable Snapshots