### PR TITLE
Adjust hlrc data streams integration test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1590,6 +1590,9 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         IndicesClient indices = highLevelClient().indices();
         response = execute(createDataStreamRequest, indices::createDataStream, indices::createDataStreamAsync);
         assertThat(response.isAcknowledged(), equalTo(true));
+        ensureHealth(dataStreamName, (request -> {
+            request.addParameter("wait_for_status", "yellow");
+        }));
 
         GetDataStreamRequest getDataStreamRequest = new GetDataStreamRequest(dataStreamName);
         GetDataStreamResponse getDataStreamResponse = execute(getDataStreamRequest, indices::getDataStream, indices::getDataStreamAsync);


### PR DESCRIPTION
to wait for at least a single shard to be allocated for a backing index of a data stream,
so that total store size is larger than zero (which is what the tests expects).

Closes #60461