### PR TITLE
[DOCS] Move named query content to bool query

### DIFF
--- a/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
@@ -19,7 +19,7 @@ The top_hits aggregation returns regular search hits, because of this many per h
 
 * <<highlighting,Highlighting>>
 * <<request-body-search-explain,Explain>>
-* <<request-body-search-queries-and-filters,Named filters and queries>>
+* <<named-queries,Named queries>>
 * <<source-filtering,Source filtering>>
 * <<request-body-search-stored-fields,Stored fields>>
 * <<request-body-search-script-fields,Script fields>>

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -146,9 +146,8 @@ GET _search
 ==== Named queries
 
 Each query accepts a `_name` in its top level definition. You can use named
-queries to track which queries matched documents returned by a search. If named
-queries are used, the response includes a `matched_queries` property for each
-hit.
+queries to track which queries matched returned documents. If named queries are
+used, the response includes a `matched_queries` property for each hit.
 
 [source,console]
 ----

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -142,9 +142,31 @@ GET _search
 }
 ---------------------------------
 
-==== Using named queries to see which clauses matched
+[[named-queries]]
+==== Named queries
 
-If you need to know which of the clauses in the bool query matched the documents
-returned from the query, you can use
-<<request-body-search-queries-and-filters,named queries>> to assign a name to
-each clause.
+Each query accepts a `_name` in its top level definition. You can use named
+queries to track which queries matched documents returned by a search. If named
+queries are used, the response includes a `matched_queries` property for each
+hit.
+
+[source,console]
+----
+GET /_search
+{
+  "query": {
+    "bool": {
+      "should": [
+        { "match": { "name.first": { "query": "shay", "_name": "first" } } },
+        { "match": { "name.last": { "query": "banon", "_name": "last" } } }
+      ],
+      "filter": {
+        "terms": {
+          "name.last": [ "banon", "kimchy" ],
+          "_name": "test"
+        }
+      }
+    }
+  }
+}
+----

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -981,11 +981,6 @@ See <<eql-syntax-limitations>>.
 
 See <<eql-required-fields>>.
 
-[role="exclude",id="request-body-search-queries-and-filters"]
-=== Named queries
-
-See <<named-queries>.
-
 ////
 [role="exclude",id="search-request-body"]
 === Request body search
@@ -1018,6 +1013,11 @@ See <<highlighting>>.
 
 [role="exclude",id="highlighter-internal-work"]
 ==== How highlighters work internally
+
+[role="exclude",id="request-body-search-queries-and-filters"]
+=== Named queries
+
+See <<named-queries>.
 
 See <<how-es-highlighters-work-internally>>.
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -93,7 +93,7 @@ See <<request-body-search-min-score>>.
 
 [role="exclude",id="search-request-named-queries-and-filters"]
 === Named query parameter for request body search API
-See <<request-body-search-queries-and-filters>>.
+See <<named-queries>>.
 
 [role="exclude",id="search-request-post-filter"]
 === Post filter parameter for request body search API
@@ -980,6 +980,11 @@ See <<eql-syntax-limitations>>.
 === EQL requirements
 
 See <<eql-required-fields>>.
+
+[role="exclude",id="request-body-search-queries-and-filters"]
+=== Named queries
+
+See <<named-queries>.
 
 ////
 [role="exclude",id="search-request-body"]

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -129,7 +129,10 @@ include::request/inner-hits.asciidoc[]
 
 include::request/min-score.asciidoc[]
 
-include::request/named-queries-and-filters.asciidoc[]
+[[request-body-search-queries-and-filters]]
+==== Named queries
+
+See <<named-queries>>.
 
 include::request/post-filter.asciidoc[]
 

--- a/docs/reference/search/request/named-queries-and-filters.asciidoc
+++ b/docs/reference/search/request/named-queries-and-filters.asciidoc
@@ -1,29 +1,4 @@
 [[request-body-search-queries-and-filters]]
-==== Named Queries
+==== Named queries
 
-Each filter and query can accept a `_name` in its top level definition.
-
-[source,console]
---------------------------------------------------
-GET /_search
-{
-  "query": {
-    "bool": {
-      "should": [
-        { "match": { "name.first": { "query": "shay", "_name": "first" } } },
-        { "match": { "name.last": { "query": "banon", "_name": "last" } } }
-      ],
-      "filter": {
-        "terms": {
-          "name.last": [ "banon", "kimchy" ],
-          "_name": "test"
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
-
-The search response will include for each hit the `matched_queries` it matched on. The tagging of queries and filters
-only make sense for the `bool` query.
-
+See <<named-queries>>.

--- a/docs/reference/search/request/named-queries-and-filters.asciidoc
+++ b/docs/reference/search/request/named-queries-and-filters.asciidoc
@@ -1,4 +1,0 @@
-[[request-body-search-queries-and-filters]]
-==== Named queries
-
-See <<named-queries>>.


### PR DESCRIPTION
Moves content for named queries from the deprecated 'Request Body Search'
chapter to the bool query page.