### PR TITLE
[DOCS] Fix query docs formatting

### DIFF
--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -31,7 +31,7 @@ GET /_search
 {
   "query": {
     "fuzzy": {
-      "user": {
+      "user.id": {
         "value": "ki"
       }
     }
@@ -48,7 +48,7 @@ GET /_search
 {
   "query": {
     "fuzzy": {
-      "user": {
+      "user.id": {
         "value": "ki",
         "fuzziness": "AUTO",
         "max_expansions": 50,

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -687,6 +687,7 @@ allows for fields to be stored in a denser, more efficient way.
 - Percolate queries do not scale in the same way as other queries, so percolation performance may benefit from using
 a different index configuration, like the number of primary shards.
 
+[discrete]
 === Notes
 ==== Allow expensive queries
 Percolate queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>

--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -15,7 +15,7 @@ GET /_search
   "query": {
     "span_multi": {
       "match": {
-        "prefix": { "user": { "value": "ki" } }
+        "prefix": { "user.id": { "value": "ki" } }
       }
     }
   }
@@ -31,7 +31,7 @@ GET /_search
   "query": {
     "span_multi": {
       "match": {
-        "prefix": { "user": { "value": "ki", "boost": 1.08 } }
+        "prefix": { "user.id": { "value": "ki", "boost": 1.08 } }
       }
     }
   }


### PR DESCRIPTION
Changes:

* Adds a `[discrete]` tag to the percolate query docs
* Updates snippets for the `fuzzy` and `span mult-term` queries to use `user.id`.
  This better aligns with the `my-index` dataset. 