### PR TITLE
[DOCS] [7.x] Include reference to AWS VPC endpoints in s3 repository docs.

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -440,10 +440,12 @@ create the bucket then the repository registration will fail.
 
 AWS instances resolve S3 endpoints to a public IP. If the Elasticsearch
 instances reside in a private subnet in an AWS VPC then all traffic to S3 will
-go through that VPC's NAT instance. If your VPC's NAT instance is a smaller
-instance size (e.g. a t1.micro) or is handling a high volume of network traffic
+go through the VPC's NAT instance. If your VPC's NAT instance is a smaller
+instance size (e.g. a t2.micro) or is handling a high volume of network traffic
 your bandwidth to S3 may be limited by that NAT instance's networking bandwidth
-limitations.
+limitations. Instead we recommend creating a https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html[VPC endpoint]
+that enables connecting to S3 in instances that reside in a private subnet in an
+AWS VPC. This will eliminate any limitations imposed by the network bandwidth of your VPC's NAT instance. 
 
 Instances residing in a public subnet in an AWS VPC will connect to S3 via the
 VPC's internet gateway and not be bandwidth limited by the VPC's NAT instance.


### PR DESCRIPTION
Add VPC endpoint as the recommended way of connecting to s3 in private subnets

Backport of #60654

Co-authored-by: Bill Mitchell <vocatan@users.noreply.github.com>
Co-authored-by: David Turner <david.turner@elastic.co>