### PR TITLE
Unmute the test failure: painless/71_context_api

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/71_context_api.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/71_context_api.yml
@@ -1,7 +1,4 @@
 "Action to list contexts":
-    - skip:
-        version: "all"
-        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/51939"
     - do:
         scripts_painless_context: {}
     - match: { contexts.0: aggregation_selector}
@@ -9,9 +6,6 @@
 ---
 
 "Action to get all API values for score context":
-    - skip:
-        version: "all"
-        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/51939"
     - do:
         scripts_painless_context:
             context: score


### PR DESCRIPTION
I was unable to reproduce this locally on either 7.6 (first introduced) and 7.x. This is already not muted on master and doesn't appear to have failures. There were some API changes at the time that could have affected this test, and I'm wondering with backports if this is now stable again. If this has more failures, I will continue to investigate further.

Relates to https://github.com/elastic/elasticsearch/issues/51939