### PR TITLE
[DOCS] Fix metadata field refs

### DIFF
--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -1,7 +1,7 @@
 [[mapper-size]]
 === Mapper Size Plugin
 
-The mapper-size plugin provides the `_size` meta field which, when enabled,
+The mapper-size plugin provides the `_size` metadata field which, when enabled,
 indexes the size in bytes of the original
 {ref}/mapping-source-field.html[`_source`] field.
 

--- a/docs/plugins/mapper.asciidoc
+++ b/docs/plugins/mapper.asciidoc
@@ -10,7 +10,7 @@ The core mapper plugins are:
 
 <<mapper-size>>::
 
-The mapper-size plugin provides the `_size` meta field which, when enabled,
+The mapper-size plugin provides the `_size` metadata field which, when enabled,
 indexes the size in bytes of the original
 {ref}/mapping-source-field.html[`_source`] field.
 

--- a/docs/reference/ingest/processors/date-index-name.asciidoc
+++ b/docs/reference/ingest/processors/date-index-name.asciidoc
@@ -4,7 +4,7 @@
 The purpose of this processor is to point documents to the right time based index based
 on a date or timestamp field in a document by using the <<date-math-index-names, date math index name support>>.
 
-The processor sets the `_index` meta field with a date math index name expression based on the provided index name
+The processor sets the `_index` metadata field with a date math index name expression based on the provided index name
 prefix, a date or timestamp field in the documents being processed and the provided date rounding.
 
 First, this processor fetches the date or timestamp from a field in the document being processed. Optionally,

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -15,10 +15,10 @@ are stored and indexed. For instance, use mappings to define:
 
 A mapping definition has:
 
-<<mapping-fields,Meta-fields>>::
+<<mapping-fields,Metadata fields>>::
 
-Meta-fields are used to customize how a document's associated metadata is
-treated. Examples of meta-fields include the document's
+Metadata fields are used to customize how a document's associated metadata is
+treated. Examples of metadata fields include the document's
 <<mapping-index-field,`_index`>>, <<mapping-id-field,`_id`>>, and
 <<mapping-source-field,`_source`>> fields.
 

--- a/docs/reference/mapping/fields.asciidoc
+++ b/docs/reference/mapping/fields.asciidoc
@@ -1,12 +1,12 @@
 [[mapping-fields]]
-== Meta-Fields
+== Metadata fields
 
 Each document has metadata associated with it, such as the `_index`, mapping
-<<mapping-type-field,`_type`>>, and `_id` meta-fields.  The behaviour of some of these meta-fields
-can be customised when a mapping type is created.
+<<mapping-type-field,`_type`>>, and `_id` metadata fields.  The behavior of
+some of these metadata fields can be customized when a mapping type is created.
 
 [discrete]
-=== Identity meta-fields
+=== Identity metadata fields
 
 [horizontal]
 <<mapping-index-field,`_index`>>::
@@ -22,7 +22,7 @@ can be customised when a mapping type is created.
     The document's ID.
 
 [discrete]
-=== Document source meta-fields
+=== Document source metadata fields
 
 <<mapping-source-field,`_source`>>::
 
@@ -34,7 +34,7 @@ can be customised when a mapping type is created.
     {plugins}/mapper-size.html[`mapper-size` plugin].
 
 [discrete]
-=== Indexing meta-fields
+=== Indexing metadata fields
 
 <<mapping-field-names-field,`_field_names`>>::
 
@@ -46,14 +46,14 @@ can be customised when a mapping type is created.
     <<ignore-malformed,`ignore_malformed`>>.
 
 [discrete]
-=== Routing meta-field
+=== Routing metadata field
 
 <<mapping-routing-field,`_routing`>>::
 
     A custom routing value which routes a document to a particular shard.
 
 [discrete]
-=== Other meta-field
+=== Other metadata field
 
 <<mapping-meta-field,`_meta`>>::
 

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -51,7 +51,7 @@ blocks into a single level, or by switching to `copy_to` if appropriate.
 ====
 
 [[fieldnames-enabling]]
-.The `_field_names` meta-field's `enabled` parameter has been removed.
+.The `_field_names` metadata field's `enabled` parameter has been removed.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/query-dsl/query_filter_context.asciidoc
+++ b/docs/reference/query-dsl/query_filter_context.asciidoc
@@ -9,7 +9,7 @@ By default, Elasticsearch sorts matching search results by **relevance
 score**, which measures how well each document matches a query.
 
 The relevance score is a positive floating point number, returned in the
-`_score` meta-field of the <<search-request-body,search>> API. The higher the
+`_score` metadata field of the <<search-request-body,search>> API. The higher the
 `_score`, the more relevant the document. While each query type can calculate
 relevance scores differently, score calculation also depends on whether the
 query clause is run in a **query** or **filter** context.
@@ -20,7 +20,7 @@ query clause is run in a **query** or **filter** context.
 In the query context, a query clause answers the question ``__How well does this
 document match this query clause?__'' Besides deciding whether or not the
 document matches, the query clause also calculates a relevance score in the
-`_score` meta-field.
+`_score` metadata field.
 
 Query context is in effect whenever a query clause is passed to a `query`
 parameter, such as the `query` parameter in the

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -14,7 +14,7 @@ API will have access to the `ctx` variable which exposes:
 [horizontal]
 `ctx._source`::     Access to the document <<mapping-source-field,`_source` field>>.
 `ctx.op`::          The operation that should be applied to the document: `index` or `delete`.
-`ctx._index` etc::  Access to <<mapping-fields,document meta-fields>>, some of which may be read-only.
+`ctx._index` etc::  Access to <<mapping-fields,document metadata fields>>, some of which may be read-only.
 
 [discrete]
 == Search and aggregation scripts

--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -210,7 +210,7 @@ returns this response:
 // TESTRESPONSE[s/"took": 2,/"took": "$body.took",/]
 
 
-IMPORTANT: `_source` meta-field must be enabled, which is the default
+IMPORTANT: `_source` metadata field must be enabled, which is the default
 behavior, to enable returning `_source` with suggestions.
 
 The configured weight for a suggestion is returned as `_score`. The

--- a/x-pack/docs/en/security/authorization/field-level-security.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-level-security.asciidoc
@@ -30,9 +30,9 @@ POST /_security/role/test_role1
 }
 --------------------------------------------------
 
-Access to the following meta fields is always allowed: `_id`,
+Access to the following metadata fields is always allowed: `_id`,
 `_type`, `_parent`, `_routing`, `_timestamp`, `_ttl`, `_size` and `_index`. If
-you specify an empty list of fields, only these meta fields are accessible.
+you specify an empty list of fields, only these metadata fields are accessible.
 
 NOTE: Omitting the fields entry entirely disables field level security.
 


### PR DESCRIPTION
Standardizes `meta-field` and `meta field` references to `metadata field`.