### PR TITLE
[DOCS] Document query support for metadata fields

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -31,7 +31,7 @@ GET /_search
 [[exists-query-top-level-params]]
 ==== Top-level parameters for `exists`
 `field`::
-(Required, string) Name of the field you wish to search. Supports
+(Required, string) Name of the field you wish to search. Accepts
 the <<mapping-routing-field,`_routing`>> metadata field.
 +
 While a field is deemed non-existent if the JSON value is `null` or `[]`, these

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -32,7 +32,7 @@ GET /_search
 ==== Top-level parameters for `exists`
 `field`::
 (Required, string) Name of the field you wish to search. Supports
-<<mapping-fields,metadata fields>>.
+the <<mapping-routing-field,`_routing`>> metadata field.
 +
 While a field is deemed non-existent if the JSON value is `null` or `[]`, these
 values will indicate the field does exist:

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -31,7 +31,8 @@ GET /_search
 [[exists-query-top-level-params]]
 ==== Top-level parameters for `exists`
 `field`::
-(Required, string) Name of the field you wish to search.
+(Required, string) Name of the field you wish to search. Supports
+<<mapping-fields,metadata fields>>.
 +
 While a field is deemed non-existent if the JSON value is `null` or `[]`, these
 values will indicate the field does exist:

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -64,7 +64,7 @@ GET /_search
 [[fuzzy-query-top-level-params]]
 ==== Top-level parameters for `fuzzy`
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-routing-field,`_routing`>> metadata field.
 
 [[fuzzy-query-field-params]]

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -64,8 +64,8 @@ GET /_search
 [[fuzzy-query-top-level-params]]
 ==== Top-level parameters for `fuzzy`
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-routing-field,`_routing`>> metadata field.
 
 [[fuzzy-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -64,7 +64,8 @@ GET /_search
 [[fuzzy-query-top-level-params]]
 ==== Top-level parameters for `fuzzy`
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[fuzzy-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -33,7 +33,8 @@ GET /_search
 ==== Top-level parameters for `match`
 
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 
 [[match-field-params]]

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -33,7 +33,7 @@ GET /_search
 ==== Top-level parameters for `match`
 
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
 fields.
 

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -33,9 +33,9 @@ GET /_search
 ==== Top-level parameters for `match`
 
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
-
+(Required, object) Field you wish to search. Supports the
+<<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
+fields.
 
 [[match-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -70,7 +70,7 @@ WARNING: There is a limit on the number of fields that can be queried
 at once. It is defined by the `indices.query.bool.max_clause_count` <<search-settings>>
 which defaults to 1024.
 
-The `fields` parameter supports the <<mapping-id-field,`_id`>> and
+The `fields` parameter accepts the <<mapping-id-field,`_id`>> and
 <<mapping-routing-field,`_routing`>> metadata fields.
 
 [[multi-match-types]]

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -70,6 +70,9 @@ WARNING: There is a limit on the number of fields that can be queried
 at once. It is defined by the `indices.query.bool.max_clause_count` <<search-settings>>
 which defaults to 1024.
 
+The `fields` parameter supports <<mapping-fields,metadata fields>>, such as
+`_routing`.
+
 [[multi-match-types]]
 [discrete]
 ==== Types of `multi_match` query:

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -70,8 +70,8 @@ WARNING: There is a limit on the number of fields that can be queried
 at once. It is defined by the `indices.query.bool.max_clause_count` <<search-settings>>
 which defaults to 1024.
 
-The `fields` parameter supports <<mapping-fields,metadata fields>>, such as
-`_routing`.
+The `fields` parameter supports the <<mapping-id-field,`_id`>> and
+<<mapping-routing-field,`_routing`>> metadata fields.
 
 [[multi-match-types]]
 [discrete]

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -29,7 +29,7 @@ GET /_search
 [[prefix-query-top-level-params]]
 ==== Top-level parameters for `prefix`
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-routing-field,`_routing`>> metadata field.
 
 [[prefix-query-field-params]]

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -29,7 +29,8 @@ GET /_search
 [[prefix-query-top-level-params]]
 ==== Top-level parameters for `prefix`
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[prefix-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -29,8 +29,8 @@ GET /_search
 [[prefix-query-top-level-params]]
 ==== Top-level parameters for `prefix`
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-routing-field,`_routing`>> metadata field.
 
 [[prefix-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -61,7 +61,7 @@ GET /_search
 +
 --
 (Optional, string) Default field you wish to search if no field is provided in
-the query string. Supports the <<mapping-id-field,`_id`>> and
+the query string. Accepts the <<mapping-id-field,`_id`>> and
 <<mapping-routing-field,`_routing`>> metadata fields.
 
 Defaults to the `index.query.default_field` index setting, which has a default

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -61,7 +61,8 @@ GET /_search
 +
 --
 (Optional, string) Default field you wish to search if no field is provided in
-the query string. Supports <<mapping-fields,metadata fields>>.
+the query string. Supports the <<mapping-id-field,`_id`>> and
+<<mapping-routing-field,`_routing`>> metadata fields.
 
 Defaults to the `index.query.default_field` index setting, which has a default
 value of `*`. The `*` value extracts all fields that are eligible for term

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -61,7 +61,7 @@ GET /_search
 +
 --
 (Optional, string) Default field you wish to search if no field is provided in
-the query string.
+the query string. Supports <<mapping-fields,metadata fields>>.
 
 Defaults to the `index.query.default_field` index setting, which has a default
 value of `*`. The `*` value extracts all fields that are eligible for term

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -16,8 +16,9 @@ explained below.
 
 ====== Field names
 
-You can specify fields to search in the query syntax. <<mapping-fields,Metadata
-fields>>, such as `_routing`, are supported. For example:
+You can specify fields to search in the query syntax. The
+<<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
+fields are supported. For example:
 
 * where the `status` field contains `active`
 

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -16,7 +16,8 @@ explained below.
 
 ====== Field names
 
-You can specify fields to search in the query syntax:
+You can specify fields to search in the query syntax. <<mapping-fields,Metadata
+fields>>, such as `_routing`, are supported. For example:
 
 * where the `status` field contains `active`
 
@@ -43,6 +44,10 @@ You can specify fields to search in the query syntax:
 * where the field `title` has any non-null value:
 
     _exists_:title
+
+* where the `_routing` metadata field contains `shard-1:
+
+    _routing:shard-1
 
 [[query-string-wildcard]]
 ====== Wildcards

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -16,9 +16,9 @@ explained below.
 
 ====== Field names
 
-You can specify fields to search in the query syntax. The
+You can specify fields to search in the query syntax, which also accepts the
 <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
-fields are supported. For example:
+fields. For example:
 
 * where the `status` field contains `active`
 

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -40,8 +40,8 @@ GET /_search
 [[regexp-top-level-params]]
 ==== Top-level parameters for `regexp`
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-routing-field,`_routing`>> metadata field.
 
 [[regexp-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -40,7 +40,8 @@ GET /_search
 [[regexp-top-level-params]]
 ==== Top-level parameters for `regexp`
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[regexp-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -45,6 +45,7 @@ GET /_search
 +
 --
 (Optional, array of strings) Array of fields you wish to search.
+Supports <<mapping-fields,metadata fields>>.
 
 This field accepts wildcard expressions. You also can boost relevance scores for
 matches to particular fields using a caret (`^`) notation. See

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -45,7 +45,7 @@ GET /_search
 +
 --
 (Optional, array of strings) Array of fields you wish to search.
-Supports the <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>>
+Accepts the <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>>
 metadata fields.
 
 This field accepts wildcard expressions. You also can boost relevance scores for

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -45,7 +45,8 @@ GET /_search
 +
 --
 (Optional, array of strings) Array of fields you wish to search.
-Supports <<mapping-fields,metadata fields>>.
+Supports the <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>>
+metadata fields.
 
 This field accepts wildcard expressions. You also can boost relevance scores for
 matches to particular fields using a caret (`^`) notation. See

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -42,7 +42,7 @@ GET /_search
 [[term-top-level-params]]
 ==== Top-level parameters for `term`
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
 fields.
 

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -42,8 +42,9 @@ GET /_search
 [[term-top-level-params]]
 ==== Top-level parameters for `term`
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
+fields.
 
 [[term-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -42,7 +42,8 @@ GET /_search
 [[term-top-level-params]]
 ==== Top-level parameters for `term`
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[term-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -33,7 +33,8 @@ GET /_search
 `<field>`::
 +
 --
-(Optional, object) Field you wish to search.
+(Optional, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 The value of this parameter is an array of terms you wish to find in the
 provided field. To return a document, one or more terms must exactly match a

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -33,8 +33,9 @@ GET /_search
 `<field>`::
 +
 --
-(Optional, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Optional, object) Field you wish to search. Supports the
+<<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
+fields.
 
 The value of this parameter is an array of terms you wish to find in the
 provided field. To return a document, one or more terms must exactly match a

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -33,7 +33,7 @@ GET /_search
 `<field>`::
 +
 --
-(Optional, object) Field you wish to search. Supports the
+(Optional, object) Field you wish to search. Accepts the
 <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
 fields.
 

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -151,8 +151,9 @@ GET /job-candidates/_search
 ==== Top-level parameters for `terms_set`
 
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
+fields.
 
 [[terms-set-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -151,7 +151,8 @@ GET /job-candidates/_search
 ==== Top-level parameters for `terms_set`
 
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[terms-set-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -151,7 +151,7 @@ GET /job-candidates/_search
 ==== Top-level parameters for `terms_set`
 
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-id-field,`_id`>> and <<mapping-routing-field,`_routing`>> metadata
 fields.
 

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -36,8 +36,8 @@ GET /_search
 [[wildcard-top-level-params]]
 ==== Top-level parameters for `wildcard`
 `<field>`::
-(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
-fields>>.
+(Required, object) Field you wish to search. Supports the
+<<mapping-routing-field,`_routing`>> metadata field.
 
 [[wildcard-query-field-params]]
 ==== Parameters for `<field>`

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -36,7 +36,7 @@ GET /_search
 [[wildcard-top-level-params]]
 ==== Top-level parameters for `wildcard`
 `<field>`::
-(Required, object) Field you wish to search. Supports the
+(Required, object) Field you wish to search. Accepts the
 <<mapping-routing-field,`_routing`>> metadata field.
 
 [[wildcard-query-field-params]]

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -36,7 +36,8 @@ GET /_search
 [[wildcard-top-level-params]]
 ==== Top-level parameters for `wildcard`
 `<field>`::
-(Required, object) Field you wish to search.
+(Required, object) Field you wish to search. Supports <<mapping-fields,metadata
+fields>>.
 
 [[wildcard-query-field-params]]
 ==== Parameters for `<field>`


### PR DESCRIPTION
Documents queries that support metadata field searches, such as `_id` and `_routing`.

Closes #60553.