### PR TITLE
[7.9] [DOCS] Update get data stream API

### DIFF
--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -76,9 +76,10 @@ GET /_data_stream/my-data-stream
 ==== {api-path-parms-title}
 
 `<data-stream>`::
-(Required, string)
-Name of the data stream to retrieve.
-Wildcard (`*`) expressions are supported.
+(Optional, string)
+Comma-separated list of data stream names used to limit the request. Wildcard
+(`*`) expressions are supported. If omitted, all data streams will be
+returned.
 
 [role="child_attributes"]
 [[get-data-stream-api-response-body]]


### PR DESCRIPTION
Changes docs to note that multiple names may be specified once #59095 is merged.

Relates to #53100

Backport of #59220
