### PR TITLE
Add assert message for multiple lines in osprobe

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -233,7 +233,7 @@ public class OsProbe {
      */
     private String readSingleLine(final Path path) throws IOException {
         final List<String> lines = Files.readAllLines(path);
-        assert lines != null && lines.size() == 1;
+        assert lines.size() == 1 : String.join("\n", lines);
         return lines.get(0);
     }
 


### PR DESCRIPTION
Several /proc files are expected to contain a single line. We assert on
this in tests, but the contents of the file are lost and the assertion
therefore lacks important information to debug why the file appeared to
have multiple lines. This commit dumps the contents of the file on
assertion failure.

relates #59284