### PR TITLE
Ensure latch is counted down when assertion trips

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -177,7 +177,8 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
                     try {
                         assertThat(e, instanceOf(ElasticsearchException.class));
                         assertThat(e.getMessage(),
-                            containsString("Secure settings cannot be updated cluster wide when TLS for the transport layer is not enabled"));
+                            containsString("Secure settings cannot be updated cluster wide when TLS for the " +
+                                           "transport layer is not enabled"));
                     } finally {
                         latch.countDown();
                     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -174,10 +174,13 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    assertThat(e, instanceOf(ElasticsearchException.class));
-                    assertThat(e.getMessage(),
-                        containsString("Secure settings cannot be updated cluster wide when TLS for the transport layer is not enabled"));
-                    latch.countDown();
+                    try {
+                        assertThat(e, instanceOf(ElasticsearchException.class));
+                        assertThat(e.getMessage(),
+                            containsString("Secure settings cannot be updated cluster wide when TLS for the transport layer is not enabled"));
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
         latch.await();


### PR DESCRIPTION
The ReloadSecureSettingsIT uses latches to ensure coordination across
requests to the underlying in memory cluster. However, in the case of an
expected failure, if the assertion fails, the latch will never be
counted down, and will cause the test to hang indefinitely. This commit
ensures the latch is always counted down with a try/finally.

relates #51546