### PR TITLE
[Transform] remove wrong test

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
@@ -48,10 +48,4 @@ public class TermsGroupSourceTests extends AbstractSerializingTestCase<TermsGrou
         return TermsGroupSource::new;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60794")
-    public void testSupportsIncrementalBucketUpdate() {
-        TermsGroupSource terms = randomTermsGroupSource();
-        assertEquals(terms.getScriptConfig() == null, terms.supportsIncrementalBucketUpdate());
-    }
-
 }


### PR DESCRIPTION
remove test, scripts are excluded in the change collector, the test is a leftover from a previous
solution of #57332, which has been discarded

relates #60724
fixes #60794