### PR TITLE
Fix CompressibleBytesOutputStreamTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 
 public class CompressibleBytesOutputStreamTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60814")
     public void testStreamWithoutCompression() throws IOException {
         BytesStream bStream = new ZeroOutOnCloseStream();
         CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bStream, false);
@@ -115,8 +114,10 @@ public class CompressibleBytesOutputStreamTests extends ESTestCase {
 
         @Override
         public void close() {
-            int size = (int) bytes.size();
-            bytes.set(0, new byte[size], 0, size);
+            if (bytes != null) {
+                int size = (int) bytes.size();
+                bytes.set(0, new byte[size], 0, size);
+            }
         }
     }
 }


### PR DESCRIPTION
Since #60730 the `bytes` field can be `null`. This adds the missing `null` check to the test
override.

Closes #60814
