### PR TITLE
[DOCS] Add ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,3 +1,17 @@
+[[release-notes-6.8.12]]
+== {es} version 6.8.12
+
+coming::[6.8.12]
+
+Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
+
+[float]
+[[bug-6.8.12]]
+=== Bug fixes
+
+Machine Learning::
+* Fix restoration of change detectors after seasonality change {ml-pull}1391[#1391]
+
 [[release-notes-6.8.11]]
 == {es} version 6.8.11
 


### PR DESCRIPTION
This PR adds the content from https://raw.githubusercontent.com/elastic/ml-cpp/6.8/docs/CHANGELOG.asciidoc to the Elasticsearch release notes.

### Preview

https://elasticsearch_60839.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.12.html