### PR TITLE
Use explicit GID in 7.x when chrooting in Docker entrypoint

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ umask 0002
 run_as_other_user_if_needed() {
   if [[ "$(id -u)" == "0" ]]; then
     # If running as root, drop to specified UID and run command
-    exec chroot --userspec=1000 / "${@}"
+    exec chroot --userspec=1000:0 / "${@}"
   else
     # Either we are running in Openshift with random uid and are a member of the root group
     # or with a custom --user
@@ -30,8 +30,8 @@ if [[ "$1" != "eswrapper" ]]; then
     # Without this, user could specify `elasticsearch -E x.y=z` but
     # `bin/elasticsearch -E x.y=z` would not work.
     set -- "elasticsearch" "${@:2}"
-    # Use chroot to switch to UID 1000
-    exec chroot --userspec=1000 / "$@"
+    # Use chroot to switch to UID 1000 / GID 0
+    exec chroot --userspec=1000:0 / "$@"
   else
     # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
     exec "$@"

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -99,7 +99,6 @@ public class DockerTests extends PackagingTestCase {
     /**
      * Checks that the Docker image can be run, and that it passes various checks.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60853")
     public void test010Install() {
         verifyContainerInstallation(installation, distribution());
     }


### PR DESCRIPTION
Closes #60853.

After upgrading to CentOS 8 in #59019, the behaviour of `chroot` has subtly changed. Now we have to explicitly set the GID in order to get the previous behaviour of creating files with GID 0. This only applies to `7.x` because we don't `chroot` on `master`, but instead execute directly as `elasticsearch:root`. This is also why the issue wasn't caught before merging the backport, which is a lesson for the future.

I've labelled this PR as `>non-issue` because #59019 hasn't been released yet.