### PR TITLE
[7.x] Fix typo in DataHistogramGroupByIT name (#60880)

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -39,14 +39,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60781")
-public class DataHistogramGroupByIT extends ContinuousTestCase {
+public class DateHistogramGroupByIT extends ContinuousTestCase {
     private static final String NAME = "continuous-date-histogram-pivot-test";
     private static final String MISSING_BUCKET_KEY = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
         .format(Instant.ofEpochMilli(42));
 
     private final boolean missing;
 
-    public DataHistogramGroupByIT() {
+    public DateHistogramGroupByIT() {
         missing = randomBoolean();
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -124,7 +124,7 @@ public class TransformContinuousIT extends ESRestTestCase {
     @Before
     public void registerTestCases() {
         addTestCaseIfNotDisabled(new TermsGroupByIT());
-        addTestCaseIfNotDisabled(new DataHistogramGroupByIT());
+        addTestCaseIfNotDisabled(new DateHistogramGroupByIT());
     }
 
     @Before


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo in DataHistogramGroupByIT name (#60880)