### PR TITLE
Fix autoscaling policy test cleanup

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/put_autoscaling_policy.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/put_autoscaling_policy.yml
@@ -10,6 +10,11 @@
 
   - match: { "acknowledged": true }
 
+  # test cleanup
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: my_autoscaling_policy
+
 ---
 "Test put autoscaling policy with non-existent decider":
   - do:


### PR DESCRIPTION
Ensure that the put autoscaling policy rest test cleans up its policies
so that they do not interfere with subsequent tests.

Relates #59005
