### PR TITLE
[DOCS] Move post filter/rescore content to new page

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -97,7 +97,7 @@ See <<named-queries>>.
 
 [role="exclude",id="search-request-post-filter"]
 === Post filter parameter for request body search API
-See <<request-body-search-post-filter>>.
+See <<post-filter>>.
 
 [role="exclude",id="search-request-preference"]
 === Preference parameter for request body search API
@@ -1028,6 +1028,16 @@ See <<search-api-min-score>>.
 === Named queries
 
 See <<named-queries>.
+
+[role="exclude",id="request-body-search-post-filter"]
+=== Post filter
+
+See <<post-filter>>.
+
+[role="exclude",id="request-body-search-rescore"]
+=== Rescoring
+
+See <<rescore>>.
 
 [role="exclude",id="request-body-search-script-fields"]
 ==== Script fields

--- a/docs/reference/search/filter-search-results.asciidoc
+++ b/docs/reference/search/filter-search-results.asciidoc
@@ -3,12 +3,14 @@
 
 You can use two methods to filter search results:
 
-* Use a boolean query with a `filter` query clause. Search requests apply
-<<query-dsl-bool-query,boolean filters>> to both search hits and <<search-aggregations,aggregations>>.
+* Use a boolean query with a `filter` clause. Search requests apply
+<<query-dsl-bool-query,boolean filters>> to both search hits and
+<<search-aggregations,aggregations>>.
 
-
-* Use the search API's `post_filter` parameter. Search requests apply 
-<<post-filter,post filters>> only to search hits, not aggregations.
+* Use the search API's `post_filter` parameter. Search requests apply
+<<post-filter,post filters>> only to search hits, not aggregations. You can use
+a post filter to calculate aggregations based on a broader result set, and then
+further narrow the results.
 +
 You can also <<rescore,rescore>> hits after the post filter to
 improve relevance and reorder results.

--- a/docs/reference/search/filter-search-results.asciidoc
+++ b/docs/reference/search/filter-search-results.asciidoc
@@ -1,0 +1,18 @@
+[[filter-search-results]]
+== Filter search results
+
+You can use two methods to filter search results:
+
+* Use a boolean query with a `filter` query clause. Search requests apply
+boolean filters to both search hits and <<search-aggregations,aggregations>>.
+See <<query-dsl-bool-query,boolean query>>.
+
+* Use the search API's `post_filter` parameter. Search requests apply post
+filters only to search hits, not aggregations. See <<post-filter>>.
++
+If wanted, you can also <<rescore,rescore>> hits after the post filter to
+improve relevance and reorder results. See <<rescore>>.
+
+include::request/post-filter.asciidoc[]
+
+include::request/rescore.asciidoc[]

--- a/docs/reference/search/filter-search-results.asciidoc
+++ b/docs/reference/search/filter-search-results.asciidoc
@@ -10,8 +10,8 @@ You can use two methods to filter search results:
 * Use the search API's `post_filter` parameter. Search requests apply post
 filters only to search hits, not aggregations. See <<post-filter>>.
 +
-If wanted, you can also <<rescore,rescore>> hits after the post filter to
-improve relevance and reorder results. See <<rescore>>.
+You can also <<rescore,rescore>> hits after the post filter to
+improve relevance and reorder results.
 
 include::request/post-filter.asciidoc[]
 

--- a/docs/reference/search/filter-search-results.asciidoc
+++ b/docs/reference/search/filter-search-results.asciidoc
@@ -7,8 +7,8 @@ You can use two methods to filter search results:
 <<query-dsl-bool-query,boolean filters>> to both search hits and <<search-aggregations,aggregations>>.
 
 
-* Use the search API's `post_filter` parameter. Search requests apply post
-filters only to search hits, not aggregations. See <<post-filter>>.
+* Use the search API's `post_filter` parameter. Search requests apply 
+<<post-filter,post filters>> only to search hits, not aggregations.
 +
 You can also <<rescore,rescore>> hits after the post filter to
 improve relevance and reorder results.

--- a/docs/reference/search/filter-search-results.asciidoc
+++ b/docs/reference/search/filter-search-results.asciidoc
@@ -4,8 +4,8 @@
 You can use two methods to filter search results:
 
 * Use a boolean query with a `filter` query clause. Search requests apply
-boolean filters to both search hits and <<search-aggregations,aggregations>>.
-See <<query-dsl-bool-query,boolean query>>.
+<<query-dsl-bool-query,boolean filters>> to both search hits and <<search-aggregations,aggregations>>.
+
 
 * Use the search API's `post_filter` parameter. Search requests apply post
 filters only to search hits, not aggregations. See <<post-filter>>.

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -140,14 +140,20 @@ See <<search-api-min-score>>.
 
 See <<named-queries>>.
 
-include::request/post-filter.asciidoc[]
+[[request-body-search-post-filter]]
+==== Post filter
+
+See <<post-filter>>.
 
 include::request/preference.asciidoc[]
 
-include::request/rescore.asciidoc[]
+[[request-body-search-rescore]]
+==== Rescoring
+
+See <<rescore>>.
 
 [[request-body-search-script-fields]]
-==== Script Fields
+==== Script fields
 
 See <<script-fields>>.
 

--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -1,8 +1,9 @@
-[[request-body-search-post-filter]]
-==== Post filter
+[discrete]
+[[post-filter]]
+=== Post filter
 
-The `post_filter` is applied to the search `hits` at the very end of a search
-request,  after aggregations have already been calculated. Its purpose is
+The `post_filter` parameter is applied to the search `hits` at the very end of a search
+request, after aggregations have already been calculated. Its purpose is
 best explained by example:
 
 Imagine that you are selling shirts that have the following properties:

--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -2,11 +2,11 @@
 [[post-filter]]
 === Post filter
 
-The `post_filter` parameter is applied to the search `hits` at the very end of a search
-request, after aggregations have already been calculated. Its purpose is
-best explained by example:
+When you use the `post_filter` parameter to filter search results, the search
+hits are filtered after the aggregations are calculated. A post filter has no
+impact on the aggregation results.
 
-Imagine that you are selling shirts that have the following properties:
+For example, you are selling shirts that have the following properties:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -1,10 +1,11 @@
-[[request-body-search-rescore]]
-==== Rescoring
+[discrete]
+[[rescore]]
+=== Rescore filtered search results
 
 Rescoring can help to improve precision by reordering just the top (eg
 100 - 500) documents returned by the
 <<request-body-search-query,`query`>> and
-<<request-body-search-post-filter,`post_filter`>> phases, using a
+<<post-filter,`post_filter`>> phases, using a
 secondary (usually more costly) algorithm, instead of applying the
 costly algorithm to all documents in the index.
 
@@ -23,11 +24,13 @@ NOTE: when exposing pagination to your users, you should not change
 `from` values) since that can alter the top hits causing results to
 confusingly shift as the user steps through pages.
 
-===== Query rescorer
+[discrete]
+[[query-rescorer]]
+==== Query rescorer
 
 The query rescorer executes a second query only on the Top-K results
 returned by the <<request-body-search-query,`query`>> and
-<<request-body-search-post-filter,`post_filter`>> phases. The
+<<post-filter,`post_filter`>> phases. The
 number of docs which will be examined on each shard can be controlled by
 the `window_size` parameter, which defaults to 10.
 
@@ -82,7 +85,9 @@ for <<query-dsl-function-score-query,`function query`>> rescores.
 |`min`      |Take the min of the original score and the rescore query score.
 |=======================================================================
 
-===== Multiple Rescores
+[discrete]
+[[multiple-rescores]]
+==== Multiple rescores
 
 It is also possible to execute multiple rescores in sequence:
 

--- a/docs/reference/search/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data.asciidoc
@@ -228,6 +228,7 @@ GET /*/_search
 // TEST[setup:my_index]
 
 include::request/collapse.asciidoc[]
+include::filter-search-results.asciidoc[]
 include::request/highlighting.asciidoc[]
 include::{es-repo-dir}/async-search.asciidoc[]
 include::{es-repo-dir}/search/near-real-time.asciidoc[]


### PR DESCRIPTION
Moves post filter and rescored search content to a new `Filter search
results` page from the deprecated request body search page.

Adds related redirects and adjusts headings.