### PR TITLE
[7.8] [DOCS] Cross-link `copy_to` and search speed docs (#60926)

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -36,6 +36,7 @@ queries hundreds of times slower. So if the same questions can be answered witho
 joins by denormalizing documents, significant speedups can be expected.
 
 [discrete]
+[[search-as-few-fields-as-possible]]
 === Search as few fields as possible
 
 The more fields a <<query-dsl-query-string-query,`query_string`>> or

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -3,7 +3,12 @@
 
 The `copy_to` parameter allows you to copy the values of multiple
 fields into a group field, which can then be queried as a single
-field. For instance, the `first_name` and `last_name` fields can be copied to
+field.
+
+TIP: If you often search multiple fields, you can improve search speeds by using
+`copy_to` to search fewer fields. See <<search-as-few-fields-as-possible>>.
+
+For example, the `first_name` and `last_name` fields can be copied to
 the `full_name` field as follows:
 
 [source,console]


### PR DESCRIPTION
7.8 backport of #60926