### PR TITLE
Prevent loading 'fields' with stored fields disabled.

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
@@ -126,7 +126,7 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             assertNotNull(rootCause);
             assertThat(rootCause.getClass(), equalTo(SearchException.class));
             assertThat(rootCause.getMessage(),
-                equalTo("`stored_fields` cannot be disabled if _source is requested"));
+                equalTo("[stored_fields] cannot be disabled if [_source] is requested"));
         }
         {
             SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
@@ -135,7 +135,16 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             assertNotNull(rootCause);
             assertThat(rootCause.getClass(), equalTo(SearchException.class));
             assertThat(rootCause.getMessage(),
-                equalTo("`stored_fields` cannot be disabled if version is requested"));
+                equalTo("[stored_fields] cannot be disabled if [version] is requested"));
+        }
+        {
+            SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
+                () -> client().prepareSearch("test").storedFields("_none_").addFetchField("field").get());
+            Throwable rootCause = ExceptionsHelper.unwrap(exc, SearchException.class);
+            assertNotNull(rootCause);
+            assertThat(rootCause.getClass(), equalTo(SearchException.class));
+            assertThat(rootCause.getMessage(),
+                equalTo("[stored_fields] cannot be disabled when using the [fields] option"));
         }
         {
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -994,10 +994,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (source.storedFields() != null) {
             if (source.storedFields().fetchFields() == false) {
                 if (context.version()) {
-                    throw new SearchException(shardTarget, "`stored_fields` cannot be disabled if version is requested");
+                    throw new SearchException(shardTarget, "[stored_fields] cannot be disabled if [version] is requested");
                 }
                 if (context.sourceRequested()) {
-                    throw new SearchException(shardTarget, "`stored_fields` cannot be disabled if _source is requested");
+                    throw new SearchException(shardTarget, "[stored_fields] cannot be disabled if [_source] is requested");
+                }
+                if (context.fetchFieldsContext() != null) {
+                    throw new SearchException(shardTarget, "[stored_fields] cannot be disabled when using the [fields] option");
                 }
             }
             context.storedFieldsContext(source.storedFields());


### PR DESCRIPTION
Because the 'fields' option loads from _source (which is a stored field), it is
not possible to retrieve 'fields' when stored_fields are disabled.

This also fixes #60912, where setting `stored_fields: _none_` prevented the
`_ignored` fields from being loaded and caused a parsing exception.