### PR TITLE
Handle nested arrays in field retrieval.

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
@@ -116,6 +116,35 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         assertThat(fields.size(), equalTo(2));
     }
 
+    public void testNestedArrays() throws IOException {
+        MapperService mapperService = createMapperService();
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .startArray("field")
+                .startArray().value("first").value("second").endArray()
+            .endArray()
+        .endObject();
+
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "field");
+        DocumentField field = fields.get("field");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(2));
+        assertThat(field.getValues(), hasItems("first", "second"));
+
+        source = XContentFactory.jsonBuilder().startObject()
+            .startArray("object")
+                .startObject().array("field", "first", "second").endObject()
+                .startObject().array("field", "third").endObject()
+                .startObject().field("field", "fourth").endObject()
+            .endArray()
+            .endObject();
+
+        fields = retrieveFields(mapperService, source, "object.field");
+        field = fields.get("object.field");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(4));
+        assertThat(field.getValues(), hasItems("first", "second", "third", "fourth"));
+    }
+
     public void testArrayValueMappers() throws IOException {
         MapperService mapperService = createMapperService();
 


### PR DESCRIPTION
We accept _source values with multiple levels of arrays, such as
`"field": [[[1, 2]]]`. This PR ensures that field retrieval can handle nested
arrays by unwrapping the arrays before parsing the values.

Fixes #60743.