### PR TITLE
Increase information on SearchableSnapshotsIntegTests#assertRecoveryStats

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -703,7 +703,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
     private void assertRecoveryStats(String indexName, boolean preWarmEnabled) {
         int shardCount = getNumShards(indexName).totalNumShards;
         final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).get();
-        assertThat(recoveryResponse.shardRecoveryStates().get(indexName).size(), equalTo(shardCount));
+        assertThat(recoveryResponse.toString(), recoveryResponse.shardRecoveryStates().get(indexName).size(), equalTo(shardCount));
 
         for (List<RecoveryState> recoveryStates : recoveryResponse.shardRecoveryStates().values()) {
             for (RecoveryState recoveryState : recoveryStates) {


### PR DESCRIPTION
This would help diagnosing de cause of test failures such as https://gradle-enterprise.elastic.co/s/dzrw3ffl4j4cm/tests/:x-pack:plugin:searchable-snapshots:test/org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests/testCreateAndRestoreSearchableSnapshot#1