### PR TITLE
Search fix: query_string regex searches not working on wildcard fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -676,7 +676,8 @@ public class QueryStringQueryParser extends XQueryParser {
             if (currentFieldType == null) {
                 return newUnmappedFieldQuery(field);
             }            
-            if (forceAnalyzer != null) {
+            if (forceAnalyzer != null && 
+                (analyzeWildcard || currentFieldType.getTextSearchInfo().isTokenized())) {
                 setAnalyzer(forceAnalyzer);
                 return super.getWildcardQuery(currentFieldType.name(), termStr);
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -676,11 +676,11 @@ public class QueryStringQueryParser extends XQueryParser {
             if (currentFieldType == null) {
                 return newUnmappedFieldQuery(field);
             }            
-            // Possible BWC issue - we ignore any forceAnalyzer set here now that we delegate to fieldtype
-            // for query construction
-//            if (currentFieldType != null) {
-//                setAnalyzer(forceAnalyzer == null ? queryBuilder.context.getSearchAnalyzer(currentFieldType) : forceAnalyzer);
-//            }
+            if (forceAnalyzer != null) {
+                setAnalyzer(forceAnalyzer);
+                return super.getWildcardQuery(currentFieldType.name(), termStr);
+            }
+            
             return currentFieldType.wildcardQuery(termStr, getMultiTermRewriteMethod(), context);
         } catch (RuntimeException e) {
             if (lenient) {
@@ -726,9 +726,10 @@ public class QueryStringQueryParser extends XQueryParser {
             if (currentFieldType == null) {
                 return newUnmappedFieldQuery(field);
             }
-            // Possible BWC issue - we ignore any forceAnalyzer set here now that we delegate to fieldtype
-            // for query construction
-//            setAnalyzer(forceAnalyzer == null ? queryBuilder.context.getSearchAnalyzer(currentFieldType) : forceAnalyzer);
+            if (forceAnalyzer != null) {
+                setAnalyzer(forceAnalyzer);
+                return super.getRegexpQuery(field, termStr);
+            }            
             return currentFieldType.regexpQuery(termStr, RegExp.ALL, getMaxDeterminizedStates(), 
                 getMultiTermRewriteMethod(), context);
         } catch (RuntimeException e) {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -183,7 +183,7 @@ setup:
               default_field: "my_wildcard"
 
 
-  - match: {hits.total.value: 1}
+  - match: {hits.total.value: 101010101}
 
 ---
 "Term query on wildcard field":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -159,6 +159,33 @@ setup:
   - match: {hits.total.value: 1}
 
 ---
+"Query_string wildcard query":
+  - do:
+      search:
+        body:
+          track_total_hits: true
+          query:
+            query_string:
+              query: "hello*"
+              default_field: "my_wildcard"
+
+
+  - match: {hits.total.value: 1}
+---
+"Query_string regex query":
+  - do:
+      search:
+        body:
+          track_total_hits: true
+          query:
+            query_string:
+              query: "/hello.*/"
+              default_field: "my_wildcard"
+
+
+  - match: {hits.total.value: 1}
+
+---
 "Term query on wildcard field":
   - do:
       search:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -183,7 +183,7 @@ setup:
               default_field: "my_wildcard"
 
 
-  - match: {hits.total.value: 101010101}
+  - match: {hits.total.value: 1}
 
 ---
 "Term query on wildcard field":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -159,7 +159,7 @@ setup:
   - match: {hits.total.value: 1}
 
 ---
-"Query_string wildcard query":
+"Query_string prefix query":
   - do:
       search:
         body:
@@ -171,6 +171,19 @@ setup:
 
 
   - match: {hits.total.value: 1}
+---
+"Query_string wildcard query":
+  - do:
+      search:
+        body:
+          track_total_hits: true
+          query:
+            query_string:
+              query: "*orld"
+              default_field: "my_wildcard"
+
+
+  - match: {hits.total.value: 3}
 ---
 "Query_string regex query":
   - do:


### PR DESCRIPTION
Additional tests to follow - just checking this change doesn’t break existing tests here.
I have BWC concerns re forced user choices of analyzer.

Closes #60957