### PR TITLE
[ML] Audit force stopping data frame analytics

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -61,6 +61,7 @@ public final class Messages {
     public static final String DATA_FRAME_ANALYTICS_AUDIT_UPDATED = "Updated analytics settings: {0}";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_STARTED = "Started analytics";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_STOPPED = "Stopped analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_FORCE_STOPPED = "Stopped analytics (forced)";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_DELETED = "Deleted analytics";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_UPDATED_STATE_WITH_REASON =
             "Updated analytics task state to [{0}] with reason [{1}]";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
@@ -217,6 +217,7 @@ public class TransportStopDataFrameAnalyticsAction
             if (analyticsTask != null) {
                 persistentTasksService.sendRemoveRequest(analyticsTask.getId(), ActionListener.wrap(
                     removedTask -> {
+                        auditor.info(analyticsId, Messages.DATA_FRAME_ANALYTICS_AUDIT_FORCE_STOPPED);
                         if (counter.incrementAndGet() == nonStoppedAnalytics.size()) {
                             sendResponseOrFailure(request.getId(), listener, failures);
                         }


### PR DESCRIPTION
Audits a message when a data frame analytics job is force stopped.
