### PR TITLE
[7.x]Tests: don't fail if ILM executed the action already (#60916)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -83,7 +83,6 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60901")
     public void testSearchableSnapshotForceMergesIndexToOneSegment() throws Exception {
         String snapshotRepo = randomAlphaOfLengthBetween(4, 10);
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());
@@ -104,9 +103,16 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         updateIndexSettings(dataStream, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
         assertTrue(waitUntil(() -> {
             try {
-                return getNumberOfSegments(client(), backingIndexName) == 1;
-            } catch (IOException e) {
-                return false;
+                Integer numberOfSegments = getNumberOfSegments(client(), backingIndexName);
+                logger.info("index {} has {} segments", backingIndexName, numberOfSegments);
+                return numberOfSegments == 1;
+            } catch (Exception e) {
+                try {
+                    // if ILM executed the action already we don't have an index to assert on so we don't fail the test
+                    return indexExists(backingIndexName) == false;
+                } catch (IOException ex) {
+                    return false;
+                }
             }
         }, 60, TimeUnit.SECONDS));
 


### PR DESCRIPTION
(cherry picked from commit 8c970ad20f4f55a9c0d6a256aa643ea037281e75)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #60916 