### PR TITLE
Handle empty input in AddStringKeyStoreCommand (#39490)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.settings;
 
 import java.io.BufferedReader;
+import java.io.CharArrayWriter;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -83,8 +84,17 @@ class AddStringKeyStoreCommand extends EnvironmentAwareCommand {
 
         final char[] value;
         if (options.has(stdinOption)) {
-            BufferedReader stdinReader = new BufferedReader(new InputStreamReader(getStdin(), StandardCharsets.UTF_8));
-            value = stdinReader.readLine().toCharArray();
+            try (BufferedReader stdinReader = new BufferedReader(new InputStreamReader(getStdin(), StandardCharsets.UTF_8));
+                 CharArrayWriter writer = new CharArrayWriter()) {
+                int charInt;
+                while ((charInt = stdinReader.read()) != -1) {
+                    if ((char) charInt == '\r' || (char) charInt == '\n') {
+                        break;
+                    }
+                    writer.write((char) charInt);
+                }
+                value = writer.toCharArray();
+            }
         } else {
             value = terminal.readSecret("Enter value for " + setting + ": ");
         }

--- a/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -134,6 +134,27 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         assertSecureString("foo", "secret value 2");
     }
 
+    public void testStdinNoInput() throws Exception {
+        KeyStoreWrapper.create().save(env.configFile(), new char[0]);
+        setInput("");
+        execute("-x", "foo");
+        assertSecureString("foo", "");
+    }
+
+    public void testStdinInputWithLineBreaks() throws Exception {
+        KeyStoreWrapper.create().save(env.configFile(), new char[0]);
+        setInput("Typedthisandhitenter\n");
+        execute("-x", "foo");
+        assertSecureString("foo", "Typedthisandhitenter");
+    }
+
+    public void testStdinInputWithCarriageReturn() throws Exception {
+        KeyStoreWrapper.create().save(env.configFile(), new char[0]);
+        setInput("Typedthisandhitenter\r");
+        execute("-x", "foo");
+        assertSecureString("foo", "Typedthisandhitenter");
+    }
+
     public void testMissingSettingName() throws Exception {
         createKeystore("");
         terminal.addTextInput("");


### PR DESCRIPTION
We should backport #39490 to 6.8. This will fix some test [failures](https://gradle-enterprise.elastic.co/s/ugjzuekrb4rlw) on 6.8.

This change ensures that we do not make assumptions about the length
of the input that we can read from the stdin. It still consumes only
one line, as the previous implementation
