### PR TITLE
Fix the REST FIPS tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchTestBasePlugin.java
@@ -92,10 +92,6 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                     test.systemProperty("java.locale.providers", "SPI,COMPAT");
                 }
             });
-            if (BuildParams.isInFipsJvm()) {
-                project.getDependencies().add("testRuntimeOnly", "org.bouncycastle:bc-fips:1.0.1");
-                project.getDependencies().add("testRuntimeOnly", "org.bouncycastle:bctls-fips:1.0.9");
-            }
             test.getJvmArgumentProviders().add(nonInputProperties);
             test.getExtensions().add("nonInputProperties", nonInputProperties);
 

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -14,22 +14,22 @@ if (BuildParams.inFipsJvm) {
     def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
     def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
 
-    project.afterEvaluate {
-      def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
-      // ensure that bouncycastle is on classpath for the all of test types, must happen in evaluateAfter since the rest tests explicitly
-      // set the class path to help maintain pure black box testing, and here we are adding to that classpath
-      tasks.withType(Test).configureEach { Test test ->
-        test.setClasspath(test.getClasspath().plus(extraFipsJars))
-      }
-    }
-
-    pluginManager.withPlugin('elasticsearch.java') {
+    pluginManager.withPlugin('java') {
       TaskProvider<ExportElasticsearchBuildResourcesTask> fipsResourcesTask = project.tasks.register('fipsResources', ExportElasticsearchBuildResourcesTask)
       fipsResourcesTask.configure {
         outputDir = fipsResourcesDir
         copy 'fips_java.security'
         copy 'fips_java.policy'
         copy 'cacerts.bcfks'
+      }
+
+      project.afterEvaluate {
+        def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
+        // ensure that bouncycastle is on classpath for the all of test types, must happen in evaluateAfter since the rest tests explicitly
+        // set the class path to help maintain pure black box testing, and here we are adding to that classpath
+        tasks.withType(Test).configureEach { Test test ->
+          test.setClasspath(test.getClasspath().plus(extraFipsJars))
+        }
       }
 
       pluginManager.withPlugin("elasticsearch.testclusters") {

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -21,19 +21,25 @@ if (BuildParams.inFipsJvm) {
         copy 'cacerts.bcfks'
       }
 
+      def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
+      def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
+
+      //ensure bouncycastle is on the test runtime classpath
+      project.getDependencies().add("testRuntimeOnly", bcFips);
+      project.getDependencies().add("testRuntimeOnly", bcTlsFips);
+
       pluginManager.withPlugin("elasticsearch.testclusters") {
         afterEvaluate {
           // This afterEvaluate hooks is required to avoid deprecated configuration resolution
           // This configuration can be removed once system modules are available
-          def extraFipsJars = configurations.detachedConfiguration(dependencies.create('org.bouncycastle:bc-fips:1.0.1'),
-            dependencies.create('org.bouncycastle:bctls-fips:1.0.9'),
-          )
+          def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
           testClusters.all {
             extraFipsJars.files.each {
               extraJarFile it
             }
           }
-          // ensure that bouncycastle is on classpath for the tests
+          // ensure that bouncycastle is on classpath for the REST tests, must happen in evaluateAfter since the rest tests explicitly
+          // set the class path to help maintain pure black box testing, and here we are adding to that classpath
           tasks.withType(RestIntegTestTask).configureEach { RestIntegTestTask restTest ->
             restTest.setClasspath(restTest.getClasspath().plus(extraFipsJars))
           }

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -2,7 +2,6 @@ import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
-import org.elasticsearch.gradle.test.RestIntegTestTask;
 
 // Common config when running with a FIPS-140 runtime JVM
 if (BuildParams.inFipsJvm) {
@@ -12,6 +11,17 @@ if (BuildParams.inFipsJvm) {
     File fipsSecurity = new File(fipsResourcesDir, 'fips_java.security')
     File fipsPolicy = new File(fipsResourcesDir, 'fips_java.policy')
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')
+    def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
+    def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
+
+    project.afterEvaluate {
+      def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
+      // ensure that bouncycastle is on classpath for the all of test types, must happen in evaluateAfter since the rest tests explicitly
+      // set the class path to help maintain pure black box testing, and here we are adding to that classpath
+      tasks.withType(Test).configureEach { Test test ->
+        test.setClasspath(test.getClasspath().plus(extraFipsJars))
+      }
+    }
     pluginManager.withPlugin('elasticsearch.java') {
       TaskProvider<ExportElasticsearchBuildResourcesTask> fipsResourcesTask = project.tasks.register('fipsResources', ExportElasticsearchBuildResourcesTask)
       fipsResourcesTask.configure {
@@ -21,10 +31,6 @@ if (BuildParams.inFipsJvm) {
         copy 'cacerts.bcfks'
       }
 
-      def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
-      def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
-
-      //ensure bouncycastle is on the test runtime classpath
       project.getDependencies().add("testRuntimeOnly", bcFips);
       project.getDependencies().add("testRuntimeOnly", bcTlsFips);
 
@@ -37,11 +43,6 @@ if (BuildParams.inFipsJvm) {
             extraFipsJars.files.each {
               extraJarFile it
             }
-          }
-          // ensure that bouncycastle is on classpath for the REST tests, must happen in evaluateAfter since the rest tests explicitly
-          // set the class path to help maintain pure black box testing, and here we are adding to that classpath
-          tasks.withType(RestIntegTestTask).configureEach { RestIntegTestTask restTest ->
-            restTest.setClasspath(restTest.getClasspath().plus(extraFipsJars))
           }
         }
         testClusters.all {

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -22,6 +22,7 @@ if (BuildParams.inFipsJvm) {
         test.setClasspath(test.getClasspath().plus(extraFipsJars))
       }
     }
+
     pluginManager.withPlugin('elasticsearch.java') {
       TaskProvider<ExportElasticsearchBuildResourcesTask> fipsResourcesTask = project.tasks.register('fipsResources', ExportElasticsearchBuildResourcesTask)
       fipsResourcesTask.configure {
@@ -30,9 +31,6 @@ if (BuildParams.inFipsJvm) {
         copy 'fips_java.policy'
         copy 'cacerts.bcfks'
       }
-
-      project.getDependencies().add("testRuntimeOnly", bcFips);
-      project.getDependencies().add("testRuntimeOnly", bcTlsFips);
 
       pluginManager.withPlugin("elasticsearch.testclusters") {
         afterEvaluate {

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -2,10 +2,10 @@ import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
+import org.elasticsearch.gradle.test.RestIntegTestTask;
 
 // Common config when running with a FIPS-140 runtime JVM
 if (BuildParams.inFipsJvm) {
-
 
   allprojects {
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
@@ -21,18 +21,21 @@ if (BuildParams.inFipsJvm) {
         copy 'cacerts.bcfks'
       }
 
-
       pluginManager.withPlugin("elasticsearch.testclusters") {
         afterEvaluate {
           // This afterEvaluate hooks is required to avoid deprecated configuration resolution
           // This configuration can be removed once system modules are available
           def extraFipsJars = configurations.detachedConfiguration(dependencies.create('org.bouncycastle:bc-fips:1.0.1'),
-                  dependencies.create('org.bouncycastle:bctls-fips:1.0.9'),
+            dependencies.create('org.bouncycastle:bctls-fips:1.0.9'),
           )
           testClusters.all {
             extraFipsJars.files.each {
               extraJarFile it
             }
+          }
+          // ensure that bouncycastle is on classpath for the tests
+          tasks.withType(RestIntegTestTask).configureEach { RestIntegTestTask restTest ->
+            restTest.setClasspath(restTest.getClasspath().plus(extraFipsJars))
           }
         }
         testClusters.all {

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -104,6 +104,6 @@ if (BuildParams.inFipsJvm) {
   // rather than provide a long list of exclusions, disable the check on FIPS.
   jarHell.enabled = false
   test.enabled = false
-  integTest.enabled = false;
+  yamlRestTest.enabled = false;
   testingConventions.enabled = false;
 }


### PR DESCRIPTION
When run with the `-Dtests.fips.enabled=true` most all of the REST tests fail. 
This fixes most (all?) of the REST test failures in FIPS mode.

Specifically:

* The bouncy castle library was no longer on the classpath for the tests for 
[yaml/java]RestTests since they explicitly set the classpath to only that of 
the test sourceset. The fix for this to ensure that bouncy castle is added to 
classpath for these (and all) types of tests when running with FIPS.  

* The elasticsearch.java plugin is not applied to every standalone test project. 
This mainly impacts the specialized tests that setup custom test clusters such as CCR.
The fix for this is to hook into the java plugin instead of the elasticsearch.java plugin.  

* One or more project would throw an error about could not change dependency after 
evaluation (it did so without any of the changes here). The fix for this was to move 
the FIPS config out of the TestBasePlugin and just use the classpath addition via 
gradle/fips.gradle.

* Ingest attachment was conditionally disabling integTest, now it conditionally
 disables yamlRestTest



fixes #60990 

