### PR TITLE
Speed up MockSinglePrioritizingExecutor (#61011)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/MockSinglePrioritizingExecutor.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/MockSinglePrioritizingExecutor.java
@@ -58,8 +58,9 @@ public class MockSinglePrioritizingExecutor extends PrioritizedEsThreadPoolExecu
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
         super.afterExecute(r, t);
-        // kill worker so that next one will be scheduled
-        throw new KillWorkerError();
+        // kill worker so that next one will be scheduled, using cached Error instance to not incur the cost of filling in the stack trace
+        // on every task
+        throw KillWorkerError.INSTANCE;
     }
 
     @Override
@@ -69,5 +70,6 @@ public class MockSinglePrioritizingExecutor extends PrioritizedEsThreadPoolExecu
     }
 
     private static final class KillWorkerError extends Error {
+        private static final KillWorkerError INSTANCE = new KillWorkerError();
     }
 }


### PR DESCRIPTION
Found this while checking if I can speed up SnapshotResiliencyTests
to get more coverage/time. Turns out throwing a new instance here on
every task was taking 9% of the CPU wall-time in those tests. With
this change it's 4% of the overall.

backport of #61011 