### PR TITLE
[DOCS] Replaces ml.node with node.roles: [ ml ] in ML settings

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -28,17 +28,16 @@ file.
 [[general-ml-settings]]
 ==== General machine learning settings
 
-`node.ml`::
-deprecated:[7.9.0,"Use <<modules-node,node.roles>> instead."]
-Set to `true` (default) to identify the node as a _machine learning node_. +
+`node.roles: [ ml ]`::
+Set `node.roles` to contain `ml` to identify the node as a _{ml} node_. +
 +
-If set to `false` in `elasticsearch.yml`, the node cannot run jobs. If set to
-`true` but `xpack.ml.enabled` is set to `false`, the `node.ml` setting is
-ignored and the node cannot run jobs. If you want to run jobs, there must be at
-least one machine learning node in your cluster. +
+If a node does not have the `ml` role in `elasticsearch.yml`, or it has the role 
+but `xpack.ml.enabled` is set to `false`, the node cannot run jobs. If you want 
+to run jobs, there must be at least one {ml} node in your cluster. +
 +
-IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, disable
-the `node.ml` role.
+IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, do not set
+the `ml` role.
+
 
 `xpack.ml.enabled`::
 Set to `true` (default) to enable {ml} on the node.
@@ -51,10 +50,10 @@ from clients (including {kib}) also fail. For more information about disabling
 {kibana-ref}/ml-settings-kb.html[{kib} {ml} settings].
 +
 IMPORTANT: If you want to use {ml-features} in your cluster, it is recommended
-that you set `xpack.ml.enabled` to `true` on all nodes. This is the
-default behavior. At a minimum, it must be enabled on all master-eligible nodes.
-If you want to use {ml-features} in clients or {kib}, it must also be enabled on
-all coordinating nodes.
+that you set `xpack.ml.enabled` to `true` on all nodes. This is the default 
+behavior. At a minimum, it must be enabled on all master-eligible nodes. If you 
+want to use {ml-features} in clients or {kib}, it must also be enabled on all 
+coordinating nodes.
 
 `xpack.ml.inference_model.cache_size`::
 The maximum inference cache size allowed. The inference cache exists in the JVM

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -17,10 +17,8 @@ to `false`).
 
 All of these settings can be added to the `elasticsearch.yml` configuration file.
 The dynamic settings can also be updated across a cluster with the
-<<cluster-update-settings,cluster update settings API>>.
-
-TIP: Dynamic settings take precedence over settings in the `elasticsearch.yml`
-file.
+<<cluster-update-settings,cluster update settings API>>. Dynamic settings take 
+precedence over settings in the `elasticsearch.yml` file.
 
 // end::ml-settings-description-tag[]
 
@@ -29,18 +27,20 @@ file.
 ==== General machine learning settings
 
 `node.roles: [ ml ]`::
-Set `node.roles` to contain `ml` to identify the node as a _{ml} node_. +
+Set `node.roles` to contain `ml` to identify the node as a _{ml} node_ that is 
+capable of running jobs. +
 +
-If a node does not have the `ml` role in `elasticsearch.yml`, or it has the role 
-but `xpack.ml.enabled` is set to `false`, the node cannot run jobs. If you want 
-to run jobs, there must be at least one {ml} node in your cluster. +
+If you use the `node.roles` setting, then all required roles must be explicitly  
+set. The absence of `node.roles` means {ml} enabled by default. However, setting 
+`node.roles:[]` configures a dedicated coordinating node. Consult 
+<<modules-node>> to learn more.
 +
 IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, do not set
 the `ml` role.
 
 
 `xpack.ml.enabled`::
-Set to `true` (default) to enable {ml} on the node.
+Set to `true` (default) to enable {ml} APIs on the node.
 +
 If set to `false`, the {ml} APIs are disabled on the node. Therefore the node
 cannot open jobs, start {dfeeds}, or receive transport (internal) communication

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -15,8 +15,8 @@ CPUs https://en.wikipedia.org/wiki/SSE4#Supporting_CPUs[support] SSE4.2. If you
 run {es} on older hardware you must disable {ml} (by setting `xpack.ml.enabled`
 to `false`).
 
-All of these settings can be added to the `elasticsearch.yml` configuration file.
-The dynamic settings can also be updated across a cluster with the
+All of these settings can be added to the `elasticsearch.yml` configuration 
+file. The dynamic settings can also be updated across a cluster with the
 <<cluster-update-settings,cluster update settings API>>. Dynamic settings take 
 precedence over settings in the `elasticsearch.yml` file.
 
@@ -28,12 +28,10 @@ precedence over settings in the `elasticsearch.yml` file.
 
 `node.roles: [ ml ]`::
 Set `node.roles` to contain `ml` to identify the node as a _{ml} node_ that is 
-capable of running jobs. +
+capable of running jobs. Every node is a {ml} node by default.+
 +
 If you use the `node.roles` setting, then all required roles must be explicitly  
-set. The absence of `node.roles` means {ml} enabled by default. However, setting 
-`node.roles:[]` configures a dedicated coordinating node. Consult 
-<<modules-node>> to learn more.
+set. Consult <<modules-node>> to learn more.
 +
 IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, do not set
 the `ml` role.


### PR DESCRIPTION
## Overview

This PR replaces `ml.node` setting with `node.roles: [ ml ]` on the `Machine learning settings in Elasticsearch` page as `ml.node` will be depricated from 7.9.0.

### Preview

[Machine learning settings in Elasticsearch](https://elasticsearch_61017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html#general-ml-settings)