### PR TITLE
[DOCS] Fix index boost snippet

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -376,20 +376,6 @@ buildRestTests.doFirst {
     buildRestTests.setups['bank'].replace('#bank_data#', accounts)
 }
 
-// Used by index boost doc
-buildRestTests.setups['index_boost'] = '''
-  - do:
-      indices.create:
-          index:  index1
-  - do:
-      indices.create:
-          index:  index2
-
-  - do:
-      indices.put_alias:
-        index: index1
-        name: alias1
-'''
 // Used by sampler and diversified-sampler aggregation docs
 buildRestTests.setups['stackoverflow'] = '''
   - do:

--- a/docs/reference/search/request/index-boost.asciidoc
+++ b/docs/reference/search/request/index-boost.asciidoc
@@ -10,13 +10,13 @@ coming from one index matter more than hits coming from another index.
 --------------------------------------------------
 GET /_search
 {
-  "indices_boost" : [
-    { "index1" : 1.4 },
-    { "index2" : 1.3 }
+  "indices_boost": [
+    { "my-index-000001": 1.4 },
+    { "my-index-000002": 1.3 }
   ]
 }
 --------------------------------------------------
-// TEST[setup:index_boost]
+// TEST[s/^/PUT my-index-000001\nPUT my-index-000002\n/]
 
 Index aliases and wildcard expressions can also be used:
 
@@ -24,13 +24,13 @@ Index aliases and wildcard expressions can also be used:
 --------------------------------------------------
 GET /_search
 {
-  "indices_boost" : [
-    { "alias1" : 1.4 },
-    { "index*" : 1.3 }
+  "indices_boost": [
+    { "my-alias":  1.4 },
+    { "my-index*": 1.3 }
   ]
 }
 --------------------------------------------------
-// TEST[continued]
+// TEST[s/^/PUT my-index-000001\nPUT my-index-000001\/_alias\/my-alias\n/]
 
 If multiple matches are found, the first match will be used. For example, if an
 index is included in both `alias1` and `index*`, boost value of `1.4` is applied.


### PR DESCRIPTION
Updates the `indices_boost` snippet to use the `my-index-000001` index.

Removes a related REST test.