### PR TITLE
Remove content type required setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/http.asciidoc
+++ b/docs/reference/migration/migrate_8_0/http.asciidoc
@@ -8,6 +8,21 @@
 
 // end::notable-breaking-changes[]
 
+.The `http.content_type.required` setting has been removed.
+[%collapsible]
+====
+*Details* +
+The `http.content_type.required` setting was deprecated in Elasticsearch 6.0
+and has been removed in Elasticsearch 8.0. The setting was introduced in
+Elasticsearch 5.3 to prepare users for Elasticsearch 6.0, where content type
+auto detection was removed for HTTP requests.
+
+*Impact* +
+Discontinue use of the `http.content_type.required` system property.
+Specifying this property in `elasticsearch.yml` will result in an error on
+startup.
+====
+
 .The `http.tcp_no_delay` setting has been replaced by `http.tcp.no_delay`.
 [%collapsible]
 ====

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -35,7 +35,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       numberOfNodes = 2
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '60m'
-      setting 'http.content_type.required', 'true'
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     }
   }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -49,7 +49,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      setting 'http.content_type.required', 'true'
     }
   }
 

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -32,7 +32,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
   testClusters {
     "${baseName}" {
       version = bwcVersion.toString()
-      setting 'http.content_type.required', 'true'
     }
   }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -264,7 +264,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
             HttpTransportSettings.SETTING_CORS_ALLOW_METHODS,
             HttpTransportSettings.SETTING_CORS_ALLOW_HEADERS,
             HttpTransportSettings.SETTING_HTTP_DETAILED_ERRORS_ENABLED,
-            HttpTransportSettings.SETTING_HTTP_CONTENT_TYPE_REQUIRED,
             HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH,
             HttpTransportSettings.SETTING_HTTP_MAX_CHUNK_SIZE,
             HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE,

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.http;
 
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -72,15 +71,6 @@ public final class HttpTransportSettings {
         intSetting("http.publish_port", -1, -1, Property.NodeScope);
     public static final Setting<Boolean> SETTING_HTTP_DETAILED_ERRORS_ENABLED =
         Setting.boolSetting("http.detailed_errors.enabled", true, Property.NodeScope);
-    public static final Setting<Boolean> SETTING_HTTP_CONTENT_TYPE_REQUIRED =
-        new Setting<>("http.content_type.required", (s) -> Boolean.toString(true), (s) -> {
-            final boolean value = Booleans.parseBoolean(s);
-            if (value == false) {
-                throw new IllegalArgumentException("http.content_type.required cannot be set to false. It exists only to make a rolling" +
-                    " upgrade easier");
-            }
-            return true;
-        }, Property.NodeScope, Property.Deprecated);
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CONTENT_LENGTH =
         Setting.byteSizeSetting(
                 "http.max_content_length",

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -42,7 +42,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      setting 'http.content_type.required', 'true'
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.security.transport.ssl.enabled', 'true'


### PR DESCRIPTION
This change removes the HTTP content type required setting, which was
deprecated in 6.0 and only existed for users upgrading from 5.x so that
they did not need to remove the setting immediately. The setting has no
effect on behavior.