### PR TITLE
Fix serialization of AllFieldMapper

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
@@ -18,13 +18,11 @@
  */
 package org.elasticsearch.upgrades;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60986")
 public class MappingIT extends AbstractRollingTestCase {
     /**
      * Create a mapping that explicitly disables the _all field (possible in 6x, see #37429)

--- a/server/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
@@ -77,7 +77,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
     }
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(
-        c -> new AllFieldMapper(new Explicit<>(true, false)),
+        c -> new AllFieldMapper(new Explicit<>(false, false)),
         c -> new Builder()
     );
 
@@ -128,4 +128,8 @@ public class AllFieldMapper extends MetadataFieldMapper {
         return CONTENT_TYPE;
     }
 
+    @Override
+    public ParametrizedFieldMapper.Builder getMergeBuilder() {
+        return new Builder().init(this);
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
@@ -54,6 +54,8 @@ public class AllFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
             );
             indexService.mapperService().merge("_doc", new CompressedXContent(mappingDisabled), MergeReason.MAPPING_UPDATE);
+            assertEquals("{\"_doc\":{\"_all\":{\"enabled\":false}}}",
+                Strings.toString(indexService.mapperService().documentMapper()));
 
             String mappingEnabled = Strings.toString(XContentFactory.jsonBuilder().startObject()
                 .startObject("_all")


### PR DESCRIPTION
Converting `AllFieldMapper` to parametrized form ended up not being run through BWC
testing, resulting in an incorrect implementation being committed.  This commit fixes
the serialization, and adds unit tests as well as unmuting the BWC test that uncovered
the bug.

Fixes #60986 