### PR TITLE
[DOCS] Fix chunking in query docs

### DIFF
--- a/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -263,6 +263,7 @@ POST /sales/_search?size=0
 --------------------------------------------------
 // NOTCONSOLE
 
+[[datehistogram-aggregation-notes]]
 ===== Notes
 
 In all cases, when the specified end time does not exist, the actual end time is

--- a/docs/reference/ingest/processors/circle.asciidoc
+++ b/docs/reference/ingest/processors/circle.asciidoc
@@ -139,7 +139,7 @@ The response from the above index request:
 --------------------------------------------------
 // TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term": 1/"_primary_term" : $body._primary_term/]
 
-
+[[circle-processor-notes]]
 ==== Notes on Accuracy
 
 Accuracy of the polygon that represents the circle is defined as `error_distance`. The smaller this

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -99,6 +99,7 @@ adjacent characters (ab → ba). Defaults to `true`.
 (Optional, string) Method used to rewrite the query. For valid values and more
 information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
+[[fuzzy-query-notes]]
 ==== Notes
 Fuzzy queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>
 is set to false.

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -272,6 +272,7 @@ supported:
 * `MULTIPOINT`
 * `MULTILINE`
 
+[[geo-shape-query-notes]]
 ==== Notes
 
 * Geo-shape queries on geo-shapes implemented with 

--- a/docs/reference/query-dsl/joining-queries.asciidoc
+++ b/docs/reference/query-dsl/joining-queries.asciidoc
@@ -21,6 +21,15 @@ Also see the <<query-dsl-terms-lookup,terms-lookup mechanism>> in the `terms`
 query, which allows you to build a `terms` query from values contained in
 another document.
 
+[discrete]
+[[joining-queries-notes]]
+==== Notes
+
+[discrete]
+===== Allow expensive queries
+Joining queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>
+is set to false.
+
 include::nested-query.asciidoc[]
 
 include::has-child-query.asciidoc[]
@@ -29,7 +38,4 @@ include::has-parent-query.asciidoc[]
 
 include::parent-id-query.asciidoc[]
 
-=== Notes
-==== Allow expensive queries
-Joining queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>
-is set to false.
+

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -687,8 +687,8 @@ allows for fields to be stored in a denser, more efficient way.
 - Percolate queries do not scale in the same way as other queries, so percolation performance may benefit from using
 a different index configuration, like the number of primary shards.
 
-[discrete]
-=== Notes
-==== Allow expensive queries
+[[percolate-query-notes]]
+==== Notes
+===== Allow expensive queries
 Percolate queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>
 is set to false.

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -548,7 +548,6 @@ The example above creates a boolean query:
 
 that matches documents with at least two of the three per-term blended queries.
 
-==== Notes
 ===== Allow expensive queries
 Query string query can be internally be transformed to a <<query-dsl-prefix-query, `prefix query`>> which means
 that if the prefix queries are disabled as explained <<prefix-query-allow-expensive-queries, here>> the query will not be

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -87,6 +87,7 @@ regular expressions.
 (Optional, string) Method used to rewrite the query. For valid values and more
 information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
+[[regexp-query-notes]]
 ==== Notes
 ===== Allow expensive queries
 Regexp queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -69,6 +69,7 @@ increases the relevance score.
 (Optional, string) Method used to rewrite the query. For valid values and more information, see the
 <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
+[[wildcard-query-notes]]
 ==== Notes
 ===== Allow expensive queries
 Wildcard queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1102,3 +1102,13 @@ See <<stored-fields>>.
 ==== Track total hits
 
 See <<track-total-hits>>.
+
+[role="exclude",id="_notes_3"]
+=== Joining queries notes
+
+See <<joining-queries-notes>>.
+
+[role="exclude",id="_notes_4"]
+=== Percolate query notes
+
+See <<percolate-query-notes>>.


### PR DESCRIPTION
Changes:
* Moves "Notes" sections for the joining queries and percolate query
  pages to the parent page
* Adds related redirects for the moved "Notes" pages
* Assigns explicit anchor IDs to other "Notes" headings. This was required for
  the redirects to work.