### PR TITLE
Upload sysout/syserr if test jvm crashes

### DIFF
--- a/gradle/build-complete.gradle
+++ b/gradle/build-complete.gradle
@@ -17,6 +17,8 @@ if (buildNumber) {
             include("**/*.hprof")
             include("**/reaper.log")
             include("**/build/test-results/**/*.xml")
+            include("**/build/testrun/**/*.sysout")
+            include("**/build/testrun/**/*.syserr")
             include("**/build/testclusters/**")
             exclude("**/build/testclusters/**/data/**")
             exclude("**/build/testclusters/**/distro/**")


### PR DESCRIPTION
This commit adds the sysout and syserr files left behind when a test jvm
crashes. These files are deleted upon successful test execution, so they
will only exist when a failure occurred.