### PR TITLE
Test: fix check for specifying include_type_name

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1496,7 +1496,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // make sure .tasks index exists
         assertBusy(() -> {
             Request getTasksIndex = new Request("GET", "/.tasks");
-            if (isRunningAgainstAncientCluster()) {
+            if (getOldClusterVersion().onOrAfter(Version.V_6_8_0) && getOldClusterVersion().before(Version.V_7_0_0)) {
                 getTasksIndex.addParameter("include_type_name", "false");
             }
             assertThat(client().performRequest(getTasksIndex).getStatusLine().getStatusCode(), is(200));


### PR DESCRIPTION
This commit fixes the version check for when to specify the
include_type_name request parameter in the FullClusterRestartIT test
that forces the creation of a system index in the old cluster.