### PR TITLE
[DOCS] Add admon for built-in index templates

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -102,7 +102,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "mappings": {
       "properties": {
@@ -185,7 +185,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "mappings": {
       "properties": {
@@ -290,7 +290,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "settings": {
       "index.refresh_interval": "30s"             <1>
@@ -344,7 +344,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "settings": {
       "sort.field": [ "@timestamp"],             <1>
@@ -446,7 +446,7 @@ PUT /_index_template/new-data-stream-template
 {
   "index_patterns": [ "new-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -102,6 +102,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "mappings": {
       "properties": {
@@ -184,6 +185,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "mappings": {
       "properties": {
@@ -288,6 +290,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "settings": {
       "index.refresh_interval": "30s"             <1>
@@ -341,6 +344,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "settings": {
       "sort.field": [ "@timestamp"],             <1>
@@ -442,6 +446,7 @@ PUT /_index_template/new-data-stream-template
 {
   "index_patterns": [ "new-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -113,7 +113,7 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
 non-overlapping index pattern, or assign your templates a `priority` greater
-than `100`.
+or lower than `100`.
 
 Every document indexed to a data stream must have a `@timestamp` field. This
 field can be mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -155,7 +155,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "settings": {
       "index.lifecycle.name": "my-data-stream-policy"
@@ -173,7 +173,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 10,
+  "priority": 200,
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -112,8 +112,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+non-overlapping index pattern, or assign your templates a `priority` less 
+than `100`.
 
 Every document indexed to a data stream must have a `@timestamp` field. This
 field can be mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -108,12 +108,18 @@ template for a data stream must specify:
 
 * A priority for the template.
 
-IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
-`logs-*-*` index patterns.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
-create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+[IMPORTANT]
+====
+{es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
+patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
+templates to create data streams. If you use {agent}, assign your index
+templates a priority lower than `100` to avoid an override of the built-in
+templates.
+
+Otherwise, to avoid accidentally applying the built-in templates, use a
+non-overlapping index pattern, or assign your templates a `priority` higher or
+lower than `100`.
+====
 
 Every document indexed to a data stream must have a `@timestamp` field. This
 field can be mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -112,8 +112,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` less 
-than `100`.
+non-overlapping index pattern, or assign your templates a `priority` greater
+or lower than `100`.
 
 Every document indexed to a data stream must have a `@timestamp` field. This
 field can be mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -106,6 +106,15 @@ template for a data stream must specify:
 
 * That the template is used exclusively for data streams.
 
+* A priority for the template.
+
+IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
+`logs-*-*` index patterns.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. To avoid accidentally applying these templates, use a
+non-overlapping index pattern, or assign your templates a `priority` greater
+than `100`.
+
 Every document indexed to a data stream must have a `@timestamp` field. This
 field can be mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field
 data type by the stream's index template. This mapping can include other
@@ -146,6 +155,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "settings": {
       "index.lifecycle.name": "my-data-stream-policy"
@@ -163,6 +173,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
+  "priority": 10,
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -169,12 +169,18 @@ If the target doesn't exist and doesn't match a data stream template,
 the operation automatically creates the index and applies any matching
 <<indices-templates,index templates>>.
 
-IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
-`logs-*-*` index patterns.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
-create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+[IMPORTANT]
+====
+{es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
+patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
+templates to create data streams. If you use {agent}, assign your index
+templates a priority lower than `100` to avoid an override of the built-in
+templates.
+
+Otherwise, to avoid accidentally applying the built-in templates, use a
+non-overlapping index pattern, or assign your templates a `priority` higher or
+lower than `100`.
+====
 
 If no mapping exists, the index operation
 creates a dynamic mapping. By default, new fields and objects are

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -169,6 +169,13 @@ If the target doesn't exist and doesn't match a data stream template,
 the operation automatically creates the index and applies any matching
 <<indices-templates,index templates>>.
 
+IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
+`logs-*-*` index patterns.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. To avoid accidentally applying these templates, use a
+non-overlapping index pattern, or assign your templates a `priority` greater
+or lower than `100`.
+
 If no mapping exists, the index operation
 creates a dynamic mapping. By default, new fields and objects are
 automatically added to the mapping if needed. For more information about field

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -87,7 +87,7 @@ PUT _index_template/template_1
       "mydata": { }
     }
   },
-  "priority": 10,
+  "priority": 200,
   "composed_of": ["component_template1", "other_component_template"],
   "version": 3,
   "_meta": {

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -24,8 +24,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+non-overlapping index pattern, or assign your templates a `priority` less
+than `100`.
 
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -20,6 +20,13 @@ specify settings, mappings, and aliases.
 
 If a new data stream or index matches more than one index template, the index template with the highest priority is used.
 
+IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
+`logs-*-*` index patterns.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. To avoid accidentally applying these templates, use a
+non-overlapping index pattern, or assign your templates a `priority` greater
+than `100`.
+
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy
 template may still match and be applied.

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -25,7 +25,7 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
 non-overlapping index pattern, or assign your templates a `priority` greater
-than `100`.
+or lower than `100`.
 
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -20,12 +20,18 @@ specify settings, mappings, and aliases.
 
 If a new data stream or index matches more than one index template, the index template with the highest priority is used.
 
-IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
-`logs-*-*` index patterns.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
-create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+[IMPORTANT]
+====
+{es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
+patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
+templates to create data streams. If you use {agent}, assign your index
+templates a priority lower than `100` to avoid an override of the built-in
+templates.
+
+Otherwise, to avoid accidentally applying the built-in templates, use a
+non-overlapping index pattern, or assign your templates a `priority` higher or
+lower than `100`.
+====
 
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -24,8 +24,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` less
-than `100`.
+non-overlapping index pattern, or assign your templates a `priority` greater
+or lower than `100`.
 
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -84,12 +84,18 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Array of wildcard (`*`) expressions
 used to match the names of data streams and indices during creation.
 +
-IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
-`logs-*-*` index patterns.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
-create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+[IMPORTANT]
+====
+{es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
+patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
+templates to create data streams. If you use {agent}, assign your index
+templates a priority lower than `100` to avoid an override of the built-in
+templates.
+
+Otherwise, to avoid accidentally applying the built-in templates, use a
+non-overlapping index pattern, or assign your templates a `priority` higher or
+lower than `100`.
+====
 
 [xpack]#`data_stream`#::
 (Optional, object)

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -88,8 +88,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` greater
-or lower than `100`.
+non-overlapping index pattern, or assign your templates a `priority` less
+than `100`.
 
 [xpack]#`data_stream`#::
 (Optional, object)

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -88,8 +88,8 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 `logs-*-*` index patterns.
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
-non-overlapping index pattern, or assign your templates a `priority` less
-than `100`.
+non-overlapping index pattern, or assign your templates a `priority` greater
+or lower than `100`.
 
 [xpack]#`data_stream`#::
 (Optional, object)

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -83,6 +83,13 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 (Required, array of strings)
 Array of wildcard (`*`) expressions
 used to match the names of data streams and indices during creation.
++
+IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
+`logs-*-*` index patterns.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. To avoid accidentally applying these templates, use a
+non-overlapping index pattern, or assign your templates a `priority` greater
+than `100`.
 
 [xpack]#`data_stream`#::
 (Optional, object)

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -89,7 +89,7 @@ IMPORTANT: {es} comes with built-in index templates for the `metrics-*-*` and
 {ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. To avoid accidentally applying these templates, use a
 non-overlapping index pattern, or assign your templates a `priority` greater
-than `100`.
+or lower than `100`.
 
 [xpack]#`data_stream`#::
 (Optional, object)


### PR DESCRIPTION
Adds an important admonition for the built-in `metrics-*-*` and `logs-*-*` index
templates.

Updates several put index template snippets to include a priority.