### PR TITLE
Ensure hotthreads do not produce node failures

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -42,6 +42,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 public class HotThreadsIT extends ESIntegTestCase {
 
@@ -88,6 +89,7 @@ public class HotThreadsIT extends ESIntegTestCase {
                     try {
                         assertThat(nodeHotThreads, notNullValue());
                         Map<String, NodeHotThreads> nodesMap = nodeHotThreads.getNodesMap();
+                        assertThat(nodeHotThreads.failures(), empty());
                         assertThat(nodesMap.size(), equalTo(cluster().size()));
                         for (NodeHotThreads ht : nodeHotThreads.getNodes()) {
                             assertNotNull(ht.getHotThreads());


### PR DESCRIPTION
This commit adds an assertion that no sub-nodes requests within
hot threads failed.

relates #58842