### PR TITLE
Use native Gradle support for --release flag

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/ElasticsearchJavaPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/ElasticsearchJavaPluginFuncTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+
+class ElasticsearchJavaPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "compatibility options are resolved from from build params minimum runtime version"() {
+        when:
+        buildFile.text = """
+        plugins {
+          id 'elasticsearch.global-build-info'
+        }
+        import org.elasticsearch.gradle.Architecture
+        import org.elasticsearch.gradle.info.BuildParams
+        BuildParams.init { it.setMinimumRuntimeVersion(JavaVersion.VERSION_1_10) }
+
+        apply plugin:'elasticsearch.java'
+
+        assert compileJava.sourceCompatibility == JavaVersion.VERSION_1_10.toString()     
+        assert compileJava.targetCompatibility == JavaVersion.VERSION_1_10.toString()           
+        """
+
+        then:
+        gradleRunner("help").build()
+    }
+
+    def "compile option --release is configured from targetCompatibility"() {
+        when:
+        buildFile.text = """
+            plugins {
+             id 'elasticsearch.java'
+            }
+            
+            compileJava.targetCompatibility = "1.10"
+            afterEvaluate {
+                assert compileJava.options.release.get() == 10
+            }
+        """
+        then:
+        gradleRunner("help").build()
+    }
+
+    private File someJavaSource() {
+        file("src/main/java/org/acme/SomeClass.java") << """
+        package org.acme;
+        public class SomeClass {}
+        """
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -170,7 +170,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
                 // TODO: this probably shouldn't apply to groovy at all?
-                compileTask.setSourceCompatibility(compileTask.getSourceCompatibility());
                 compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
         });

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -173,21 +173,14 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 compileOptions.setEncoding("UTF-8");
                 compileOptions.setIncremental(true);
 
-                // TODO: use native Gradle support for --release when available (cf. https://github.com/gradle/gradle/issues/2510)
                 final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
-                compilerArgs.add("--release");
-                compilerArgs.add(targetCompatibilityVersion.getMajorVersion());
-
+                compileOptions.getRelease().set(Integer.parseInt(targetCompatibilityVersion.getMajorVersion()));
             });
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
-
                 // TODO: this probably shouldn't apply to groovy at all?
-                // TODO: use native Gradle support for --release when available (cf. https://github.com/gradle/gradle/issues/2510)
                 final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
-                final List<String> compilerArgs = compileTask.getOptions().getCompilerArgs();
-                compilerArgs.add("--release");
-                compilerArgs.add(targetCompatibilityVersion.getMajorVersion());
+                compileTask.getOptions().getRelease().set(Integer.parseInt(targetCompatibilityVersion.getMajorVersion()));
             });
         });
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -148,7 +148,8 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                  * -serial because we don't use java serialization.
                  */
                 // don't even think about passing args with -J-xxx, oracle will ask you to submit a bug report :)
-                // fail on all javac warnings
+                // fail on all javac warnings.
+                // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
                 List<String> compilerArgs = compileOptions.getCompilerArgs();
                 compilerArgs.add("-Werror");
                 compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try");
@@ -163,6 +164,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
                 compileOptions.setEncoding("UTF-8");
                 compileOptions.setIncremental(true);
+                // TODO Discuss this required workaround with the Gradle team
                 compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
                 compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
                 compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -47,6 +47,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.CoreJavadocOptions;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.process.CommandLineArgumentProvider;
 
 import java.io.File;
 import java.util.List;
@@ -155,7 +156,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try");
                 compilerArgs.add("-Xdoclint:all");
                 compilerArgs.add("-Xdoclint:-missing");
-
                 // either disable annotation processor completely (default) or allow to enable them if an annotation processor is explicitly
                 // defined
                 if (compilerArgs.contains("-processor") == false) {
@@ -164,7 +164,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
                 compileOptions.setEncoding("UTF-8");
                 compileOptions.setIncremental(true);
-                // TODO Discuss this required workaround with the Gradle team
+                // workaround for https://github.com/gradle/gradle/issues/14141
                 compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
                 compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
                 compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -170,10 +170,14 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
             // also apply release flag to groovy, which is used in build-tools
-            project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
-                // TODO: this probably shouldn't apply to groovy at all?
-                compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
-            });
+            project.getTasks()
+                .withType(GroovyCompile.class)
+                .configureEach(
+                    compileTask -> {
+                        // TODO: this probably shouldn't apply to groovy at all?
+                        compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+                    }
+                );
         });
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -47,7 +47,6 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.CoreJavadocOptions;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
-import org.gradle.process.CommandLineArgumentProvider;
 
 import java.io.File;
 import java.util.List;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -25,7 +25,6 @@ import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.util.Util;
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -38,8 +37,10 @@ import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -48,11 +49,9 @@ import org.gradle.external.javadoc.CoreJavadocOptions;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.elasticsearch.gradle.util.Util.toStringable;
 
@@ -140,14 +139,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
         java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
 
-        Function<File, String> canonicalPath = file -> {
-            try {
-                return file.getCanonicalPath();
-            } catch (IOException e) {
-                throw new GradleException("Failed to get canonical path for " + file, e);
-            }
-        };
-
         project.afterEvaluate(p -> {
             project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
                 CompileOptions compileOptions = compileTask.getOptions();
@@ -172,16 +163,23 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
                 compileOptions.setEncoding("UTF-8");
                 compileOptions.setIncremental(true);
-
-                final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
-                compileOptions.getRelease().set(Integer.parseInt(targetCompatibilityVersion.getMajorVersion()));
+                compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
+                compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
+                compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
                 // TODO: this probably shouldn't apply to groovy at all?
-                final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
-                compileTask.getOptions().getRelease().set(Integer.parseInt(targetCompatibilityVersion.getMajorVersion()));
+                compileTask.setSourceCompatibility(compileTask.getSourceCompatibility());
+                compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
+        });
+    }
+
+    private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {
+        return project.provider(() -> {
+            JavaVersion javaVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
+            return Integer.parseInt(javaVersion.getMajorVersion());
         });
     }
 


### PR DESCRIPTION
- With Gradle 6.6 we can use the native support for the --release compile options