### PR TITLE
Some progress on failing runtime fields tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -695,6 +695,36 @@ setup:
 
   - match: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
 
+---
+"Global ordinals are loaded with the global_ordinals execution hint":
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 1
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 2
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 3
+        routing: 1
+        body: { "str": "bcd" }
+
+  - do:
+      indices.refresh: {}
+
   - do:
       search:
         index: test_1

--- a/x-pack/plugin/runtime-fields/qa/rest/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/rest/build.gradle
@@ -26,17 +26,17 @@ yamlRestTest {
     [
       /////// TO FIX ///////
       'search/330_fetch_fields/*', // The whole API is not yet supported
-      'search.aggregation/20_terms/Global ordinals are not loaded with the map execution hint', // Broken. Gotta fix.
-      'search.highlight/40_keyword_ignore/Plain Highligher should skip highlighting ignored keyword values', // Broken. Gotta fix.
+      'search.highlight/40_keyword_ignore/Plain Highligher should skip highlighting ignored keyword values', // The plain highlighter is incompatible with runtime fields. Worth fixing?
       'search/115_multiple_field_collapsing/two levels fields collapsing', // Broken. Gotta fix.
-      'search/140_pre_filter_search_shards/pre_filter_shard_size with shards that have no hit', // Broken. Gotta fix.
       'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
       'search.aggregation/10_histogram/*', // runtime_script doesn't support sub-fields. Maybe it should?
       /////// TO FIX ///////
 
       /////// NOT SUPPORTED ///////
       'search.aggregation/280_rare_terms/*', // Requires an index and we won't have it
-      'search.aggregation/20_terms/string profiler via global ordinals', // Runtime fields don't have global ords
+      // Runtime fields don't have global ords
+      'search.aggregation/20_terms/string profiler via global ordinals',
+      'search.aggregation/20_terms/Global ordinals are loaded with the global_ordinals execution hint',
       /////// NOT SUPPORTED ///////
     ].join(',')
 }


### PR DESCRIPTION
This breaks apart the a test for the `terms` aggregation into one that
work for runtime fields and one that doesn't.
