### PR TITLE
First attempt at label bot rules

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -1,0 +1,14 @@
+issues:
+  - label: needs:type
+    comment: |
+      Please add a change type label if possible (these start with ">")
+pulls:
+  - label: needs:team
+    comment: |
+      Please add a team label, if possible (these start with ":")
+  - label: needs:type
+    comment: |
+      Please add a change type label (these start with ">")
+  - label: needs:version
+    comment: |
+      Please add any applicable version labels. This is usually the next major release and the latest minor release of the current major release.

--- a/.github/relabel.yml
+++ b/.github/relabel.yml
@@ -1,0 +1,10 @@
+issues:
+  - missingLabel: needs:type
+    regex: ^>.*
+pulls:
+  - missingLabel: needs:team
+    regex: ^:.*
+  - missingLabel: needs:type
+    regex: ^>.*
+  - missingLabel: needs:version
+    regex: ^v[0-9]+\..*


### PR DESCRIPTION
This PR adds configuration rules for our labelling bot. Note that the ES repo isn't yet enrolled with Infra - that's a separate thing.

@nkammah how do these look to you?

@elastic/es-core-infra I'd appreciate feedback on the rules and text here. The idea is to encourage everyone (both Elastic folks and external contributors) to label their PRs (and issues, but PRs are more important) more rigorously, as it's helpful for the release notes process.