### PR TITLE
Some progress on failing runtime fields tests (bring #61098 to master)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -695,6 +695,36 @@ setup:
 
   - match: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
 
+---
+"Global ordinals are loaded with the global_ordinals execution hint":
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 1
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 2
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 3
+        routing: 1
+        body: { "str": "bcd" }
+
+  - do:
+      indices.refresh: {}
+
   - do:
       search:
         index: test_1


### PR DESCRIPTION
This breaks apart the a test for the `terms` aggregation into one that
work for runtime fields and one that doesn't.
