### PR TITLE
Add async search tests to runtime fields tests

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/rest/build.gradle
@@ -1,8 +1,13 @@
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 restResources {
+  restApi {
+    includeCore '*'
+    includeXpack 'async_search'
+  }
   restTests {
     includeCore '*'
+    includeXpack '*'
   }
 }
 
@@ -13,6 +18,7 @@ testClusters.yamlRestTest {
 yamlRestTest {
   systemProperty 'tests.rest.suite',
     [
+      'async_search',
       'search',
       'search.aggregation',
       'search.highlight',

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -6,6 +6,10 @@
         body:
           settings:
             number_of_shards: "2"
+          mappings:
+            properties:
+              max:
+                type: long
 
   - do:
       indices.create:
@@ -13,6 +17,10 @@
         body:
           settings:
             number_of_shards: "1"
+          mappings:
+            properties:
+              max:
+                type: long
 
   - do:
       indices.create:
@@ -20,6 +28,10 @@
         body:
           settings:
             number_of_shards: "3"
+          mappings:
+            properties:
+              max:
+                type: long
 
   - do:
       index:


### PR DESCRIPTION
This includes async search'es tests in the list of tests that runtime
fields runs.
\