### PR TITLE
Borrow more tests for runtime fields

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
@@ -60,7 +60,12 @@ public class ClientYamlTestSection implements Comparable<ClientYamlTestSection> 
     private final SkipSection skipSection;
     private final List<ExecutableSection> executableSections;
 
-    ClientYamlTestSection(XContentLocation location, String name, SkipSection skipSection, List<ExecutableSection> executableSections) {
+    public ClientYamlTestSection(
+        XContentLocation location,
+        String name,
+        SkipSection skipSection,
+        List<ExecutableSection> executableSections
+    ) {
         this.location = location;
         this.name = name;
         this.skipSection = Objects.requireNonNull(skipSection, "skip section cannot be null");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -111,7 +111,7 @@ public class ClientYamlTestSuite {
     private final TeardownSection teardownSection;
     private final List<ClientYamlTestSection> testSections;
 
-    ClientYamlTestSuite(String api, String name, SetupSection setupSection, TeardownSection teardownSection,
+    public ClientYamlTestSuite(String api, String name, SetupSection setupSection, TeardownSection teardownSection,
                         List<ClientYamlTestSection> testSections) {
         this.api = api;
         this.name = name;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
@@ -70,7 +70,7 @@ public class SetupSection {
     private final SkipSection skipSection;
     private final List<ExecutableSection> executableSections;
 
-    SetupSection(SkipSection skipSection, List<ExecutableSection> executableSections) {
+    public SetupSection(SkipSection skipSection, List<ExecutableSection> executableSections) {
         this.skipSection = Objects.requireNonNull(skipSection, "skip section cannot be null");
         this.executableSections = Collections.unmodifiableList(executableSections);
     }

--- a/x-pack/plugin/runtime-fields/qa/rest/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/rest/build.gradle
@@ -30,6 +30,9 @@ yamlRestTest {
       'search/115_multiple_field_collapsing/two levels fields collapsing', // Broken. Gotta fix.
       'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
       'search.aggregation/10_histogram/*', // runtime_script doesn't support sub-fields. Maybe it should?
+      'search/10_source_filtering/docvalue_fields with explicit format',
+      'search.aggregation/200_top_hits_metric/top_hits aggregation with sequence numbers',
+      'search.aggregation/200_top_hits_metric/top_hits aggregation with nested documents',
       /////// TO FIX ///////
 
       /////// NOT SUPPORTED ///////


### PR DESCRIPTION
This "borrows" 150 more tests from core for runtime fields, extending
the work done in #60931. More precisely, it adds a template to every
test that forces dynamic mapping updates to build runtime fields where
possible. In particular, `long` and `double` field are created as
runtime fields. `string`-typed fields are mimick the out of the box
behavior and create a top level `text` field with a `.keyword`
multi-field, but this `keyword` multi-field executes a script and loads
from source.
