### PR TITLE
Canonicalize client name in krb5kdc-fixture

### DIFF
--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
@@ -29,6 +29,7 @@
     permitted_enctypes = rc4-hmac
     # udp_preference_limit = 1
     kdc_timeout = 3000
+    canonicalize = true
 
 [realms]
     ${REALM_NAME} = {


### PR DESCRIPTION
This commit changes the value for client name canonicalization to true
in the krb5.conf template file. This is done as a means to workaround
JDK-8246193 which has made it into some builds of JDK8.

Closes #61050