### PR TITLE
Doc: Max field expansions is not a hard limit

### DIFF
--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -150,8 +150,8 @@ for a particular index with the index setting `index.max_regex_length`.
 Executing queries that use automatic expansion of fields (e.g. `query_string`, `simple_query_string`
 or `multi_match`) can have performance issues for indices with a large numbers of fields.
 To safeguard against this, a default limit of 1024 fields has been introduced for
-queries using the "all fields" mode ("default_field": "*") or other fieldname
-expansions (e.g. "foo*"). If needed, you can change this limit using the
+queries using the "all fields" mode (`"default_field": "*"`) or other fieldname
+expansions (e.g. `"foo*"`). If needed, you can change this limit using the
 <<indices-query-bool-max-clause-count,`indices.query.bool.max_clause_count`>>
 dynamic cluster setting.
 

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -149,9 +149,11 @@ for a particular index with the index setting `index.max_regex_length`.
 
 Executing queries that use automatic expansion of fields (e.g. `query_string`, `simple_query_string`
 or `multi_match`) can have performance issues for indices with a large numbers of fields.
-To safeguard against this, a soft limit of 1024 fields has been introduced for queries
-using the "all fields" mode ("default_field": "*") or other fieldname expansions (e.g. "foo*").
-This default maximum can be changed with the dynamic cluster setting `indices.query.bool.max_clause_count`.
+To safeguard against this, a default limit of 1024 fields has been introduced for
+queries using the "all fields" mode ("default_field": "*") or other fieldname
+expansions (e.g. "foo*"). If needed, you can change this limit using the
+<<indices-query-bool-max-clause-count,`indices.query.bool.max_clause_count`>>
+dynamic cluster setting.
 
 [discrete]
 [[invalid-search-request-body]]

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -149,8 +149,9 @@ for a particular index with the index setting `index.max_regex_length`.
 
 Executing queries that use automatic expansion of fields (e.g. `query_string`, `simple_query_string`
 or `multi_match`) can have performance issues for indices with a large numbers of fields.
-To safeguard against this, a hard limit of 1024 fields has been introduced for queries
+To safeguard against this, a soft limit of 1024 fields has been introduced for queries
 using the "all fields" mode ("default_field": "*") or other fieldname expansions (e.g. "foo*").
+This default maximum can be changed with the dynamic cluster setting `indices.query.bool.max_clause_count`.
 
 [discrete]
 [[invalid-search-request-body]]


### PR DESCRIPTION
>Limiting the number of auto-expanded fieldsedit
Executing queries that use automatic expansion of fields (e.g. query_string, simple_query_string or multi_match) can have performance issues for indices with a large numbers of fields. To safeguard against this, a hard limit of 1024 fields has been introduced for queries using the "all fields" mode ("default_field": "") or other fieldname expansions (e.g. "foo").

Per https://github.com/elastic/elasticsearch/pull/35284, we changed this from a hard limit to a soft limit by leveraging `indices.query.bool.max_clause_count` in 7.0 beta1.   It looks like we might have missed the doc change in the breaking changes guide.  We will want to backport this to all 7.x versions.
