### PR TITLE
Add ess marker to indexing_pressure.memory.limit

### DIFF
--- a/docs/reference/index-modules/indexing-pressure.asciidoc
+++ b/docs/reference/index-modules/indexing-pressure.asciidoc
@@ -66,7 +66,7 @@ retrieve indexing pressure metrics.
 [[indexing-pressure-settings]]
 === Indexing pressure settings
 
-`indexing_pressure.memory.limit`::
+`indexing_pressure.memory.limit` {ess-icon}::
   Number of outstanding bytes that may be consumed by indexing requests. When
   this limit is reached or exceeded, the node will reject new coordinating and
   primary operations. When replica operations consume 1.5x this limit, the node


### PR DESCRIPTION
Adds marker indicating this setting is supported on Cloud.