### PR TITLE
Update the `Handling Failures in Pipelines` in the ingest doc to match ECS field names

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -702,7 +702,7 @@ Elasticsearch.
         "on_failure" : [
           {
             "set" : {
-              "field" : "error",
+              "field" : "error.message",
               "value" : "field \"foo\" does not exist, cannot rename to \"bar\""
             }
           }
@@ -785,7 +785,7 @@ metadata field to provide the error message.
         "on_failure" : [
           {
             "set" : {
-              "field" : "error",
+              "field" : "error.message",
               "value" : "{{ _ingest.on_failure_message }}"
             }
           }


### PR DESCRIPTION
This may not actually be an issue but I figured it may be worth considering this update.

The Elastic Common Schema (ECS) has `error` as an object and [`error.message`](https://www.elastic.co/guide/en/ecs/current/ecs-error.html#_error_field_details) as a field.  The examples for error handling in ingest pipelines currently would conflict with ECS mapped data.  The example should be updated to prevent people from copying and pasting the code bits into an ingest pipelines and not realizing they created a conflict with Beats generated or other ECS mapped data.