### PR TITLE
FullClusterRestartIT include_type_name for 6.7+

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1496,7 +1496,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // make sure .tasks index exists
         assertBusy(() -> {
             Request getTasksIndex = new Request("GET", "/.tasks");
-            if (getOldClusterVersion().onOrAfter(Version.V_6_8_0) && getOldClusterVersion().before(Version.V_7_0_0)) {
+            if (getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)) {
                 getTasksIndex.addParameter("include_type_name", "false");
             }
             assertThat(client().performRequest(getTasksIndex).getStatusLine().getStatusCode(), is(200));


### PR DESCRIPTION
#61059 changed this test to only pass include_type_name for 6.8+.
However, the parameter was introduced in 6.7 and should be specified in
6.7+.

Closes #61111
