### PR TITLE
Mute FullClusterRestartIT.testSearch

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -98,6 +98,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         type = getOldClusterVersion().before(Version.V_6_7_0) ? "doc" : "_doc";
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/57245")
     public void testSearch() throws Exception {
         int count;
         if (isRunningAgainstOldCluster()) {


### PR DESCRIPTION
This test fails reliably on upgrades from 6.0.0 and 6.0.1. See #57245 for details.
