### PR TITLE
Fix CCSRemoteClusterClientRoleIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSRemoteClusterClientRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSRemoteClusterClientRoleIT.java
@@ -59,9 +59,7 @@ public class CCSRemoteClusterClientRoleIT extends AbstractMultiClustersTestCase 
         final int demoDocs = indexDocs(client(LOCAL_CLUSTER), "demo");
         final int prodDocs = indexDocs(client("cluster_a"), "prod");
         final InternalTestCluster localCluster = cluster(LOCAL_CLUSTER);
-        if (randomBoolean()) {
-            localCluster.startDataOnlyNode();
-        }
+        final String pureDataNode = randomBoolean() ? localCluster.startDataOnlyNode() : null;
         final String nodeWithoutRemoteClusterClientRole = localCluster.startNode(NodeRoles.onlyRole(DiscoveryNodeRole.DATA_ROLE));
         ElasticsearchAssertions.assertFutureThrows(
             localCluster.client(nodeWithoutRemoteClusterClientRole)
@@ -79,6 +77,7 @@ public class CCSRemoteClusterClientRoleIT extends AbstractMultiClustersTestCase 
             StreamSupport.stream(localCluster.clusterService().state().nodes().spliterator(), false)
                 .map(DiscoveryNode::getName)
                 .filter(nodeName -> nodeWithoutRemoteClusterClientRole.equals(nodeName) == false)
+                .filter(nodeName -> nodeName.equals(pureDataNode) == false)
                 .collect(Collectors.toList()));
 
         final SearchResponse resp = localCluster.client(nodeWithRemoteClusterClientRole)


### PR DESCRIPTION
Test would sometimes use a node without the remote cluster client role.

Related to #60351

Following failed reliably:

```
./gradlew ':server:internalClusterTest' --tests "org.elasticsearch.search.ccs.CCSRemoteClusterClientRoleIT.testRemoteClusterClientRole"   -Dtests.seed=C47608096D4EB8A9   -Dtests.security.manager=true   -Dtests.locale=en-AU   -Dtests.timezone=W-SU   -Druntime.java=11
```

[build scan](https://gradle-enterprise.elastic.co/s/fqzr4o6puthry/tests/:server:internalClusterTest/org.elasticsearch.search.ccs.CCSRemoteClusterClientRoleIT/testRemoteClusterClientRole#1)