### PR TITLE
RabbitMQ action for X-Pack Watcher plug-in

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -40,6 +40,7 @@ commonscodec      = 1.11
 hamcrest          = 2.1
 securemock        = 1.2
 mocksocket        = 1.2
+rabbitmq          = 5.9.0
 
 # benchmark dependencies
 jmh               = 1.19

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
 
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
 
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
-  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
 
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
 
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -32,7 +32,8 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
-  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   api "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   api "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   api "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.elasticsearch:securemock:${versions.securemock}"
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
 }
 
 compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes,-unchecked'

--- a/x-pack/docs/en/watcher/actions/rabbitmq.asciidoc
+++ b/x-pack/docs/en/watcher/actions/rabbitmq.asciidoc
@@ -1,0 +1,73 @@
+[role="xpack"]
+[[actions-rabbitmq]]
+=== RabbitMQ action
+
+Use the `rabbitmq` action to send messages to a https://www.rabbitmq.com/[RabbitMQ message broker] instance.
+To create issues you need to <<configuring-rabbitmq, configure at least one RabbitMQ account>> in `elasticsearch.yml`.
+
+[[configuring-rabbitmq-actions]]
+==== Configuring RabbitMQ actions
+
+You configure RabbitMQ actions in the `actions` array. Action-specific attributes
+are specified using the `rabbitmq` keyword.
+
+The following snippet shows a simple rabbitmq action definition:
+
+[source,js]
+--------------------------------------------------
+"actions" : {
+  "create-rabbitmq-message" : {
+    "rabbitmq" : {
+      "account" : "rabbitmq-account", <1>
+      "vhost" : "test", <2>
+      "exchange" : "test", <3>      
+      "routingKey" : "test_key", <4> 
+      "headers" : { <5> 
+         "test_header" : "test_header_value"
+      },
+      "message" : "Found {{ctx.payload.hits.total}} logs" <6>
+    }
+  }
+}
+--------------------------------------------------
+// NOTCONSOLE
+<1> The name of a RabbitMQ account configured in `elasticsearch.yml`.
+<2> The virtual host to use (optional, default virtual host used if not specified) 
+<3> The exchange name for the notifications (optional, default exchange used if not specified)
+<4> The message routing key (optional) 
+<5> Message headers (optional) 
+<6> The message to send
+
+[[configuring-rabbitmq]]
+==== Configuring RabbitMQ accounts
+
+You configure the accounts {watcher} can use to communicate with RabbitMQ in the
+`xpack.notification.rabbitmq` namespace in `elasticsearch.yml`.
+
+To configure a RabbitMQ account you need to specify (see {ref}/secure-settings.html[secure settings]):
+
+[source,yaml]
+--------------------------------------------------
+bin/elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_url
+bin/elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_user
+bin/elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_password
+--------------------------------------------------
+
+[WARNING]
+======
+Storing sensitive data (`url`, `user` and `password`) in the configuration file or the cluster settings is insecure and has been deprecated. Please use {es}'s secure {ref}/secure-settings.html[keystore] method instead.
+======
+
+To avoid credentials that transit in clear text over the network, {watcher} will
+reject `url` settings like `http://internal-rabbitmq.elastic.co` that are based on
+plain text HTTP protocol. This default behavior can be disabled with the explicit
+ `allow_http` setting:
+
+[source,yaml]
+--------------------------------------------------
+xpack.notification.rabbitmq:
+  account:
+    monitoring:
+      allow_http: true
+--------------------------------------------------
+

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -31,7 +31,8 @@ dependencies {
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
-
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
@@ -46,8 +47,9 @@ dependencies {
 
   testImplementation 'org.elasticsearch:securemock:1.2'
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
-  testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-  testImplementation "org.slf4j:slf4j-api:${versions.slf4j}"
+  api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+  
+  api "org.slf4j:slf4j-api:${versions.slf4j}"
   testImplementation project(path: ':modules:reindex')
   testImplementation project(path: ':modules:parent-join')
   testImplementation project(path: ':modules:lang-mustache')

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -31,12 +31,14 @@ dependencies {
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
-  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
-
+  api("com.rabbitmq:amqp-client:${versions.rabbitmq}") {
+	  exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  
   // security deps
   api 'com.unboundid:unboundid-ldapsdk:4.0.8'
   api project(path: ':modules:transport-netty4')
@@ -44,7 +46,9 @@ dependencies {
     // TODO: core exclusion should not be necessary, since it is a transitive dep of all plugins
     exclude group: "org.elasticsearch", module: "elasticsearch-core"
   }
-
+  
+  api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+  api "org.slf4j:slf4j-api:${versions.slf4j}"
   testImplementation 'org.elasticsearch:securemock:1.2'
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
   testImplementation project(path: ':modules:reindex')

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
@@ -47,9 +47,6 @@ dependencies {
 
   testImplementation 'org.elasticsearch:securemock:1.2'
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
-  api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-  
-  api "org.slf4j:slf4j-api:${versions.slf4j}"
   testImplementation project(path: ':modules:reindex')
   testImplementation project(path: ':modules:parent-join')
   testImplementation project(path: ':modules:lang-mustache')

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
+  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   runtimeOnly 'com.google.guava:guava:19.0'
 
   // Dependencies for oidc

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -46,15 +46,14 @@ dependencies {
   api( "org.cryptacular:cryptacular:1.2.4") {
     exclude group: 'org.bouncycastle'
   }
-  api "org.slf4j:slf4j-api:${versions.slf4j}"
-  api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
-  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   runtimeOnly 'com.google.guava:guava:19.0'
+  api "org.slf4j:slf4j-api:${versions.slf4j}"
+  api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
 
   // Dependencies for oidc
   api "com.nimbusds:oauth2-oidc-sdk:7.0.2"

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   api "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
-  api "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  compile "com.rabbitmq:amqp-client:${versions.rabbitmq}"
   runtimeOnly 'com.google.guava:guava:19.0'
 
   // Dependencies for oidc

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -38,7 +38,8 @@ dependencies {
   api 'com.sun.activation:jakarta.activation:1.2.1'
   compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   compileOnly "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-
+  compileOnly "com.rabbitmq:amqp-client:${versions.rabbitmq}"
+  
   testImplementation 'org.subethamail:subethasmtp:3.1.7'
   // needed for subethasmtp, has @GuardedBy annotation
   testImplementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -38,8 +38,9 @@ dependencies {
   api 'com.sun.activation:jakarta.activation:1.2.1'
   compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   compileOnly "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+
   compileOnly "com.rabbitmq:amqp-client:${versions.rabbitmq}"
-  
+
   testImplementation 'org.subethamail:subethasmtp:3.1.7'
   // needed for subethasmtp, has @GuardedBy annotation
   testImplementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -38,9 +38,8 @@ dependencies {
   api 'com.sun.activation:jakarta.activation:1.2.1'
   compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   compileOnly "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-
   compileOnly "com.rabbitmq:amqp-client:${versions.rabbitmq}"
-
+  
   testImplementation 'org.subethamail:subethasmtp:3.1.7'
   // needed for subethasmtp, has @GuardedBy annotation
   testImplementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
@@ -42,9 +42,9 @@ public final class ActionBuilders {
         return JiraAction.builder(account, Map.copyOf(fields));
     }
 
-    public static RabbitMQAction.Builder rabbitmqAction(String account, String exchange, 
+    public static RabbitMQAction.Builder rabbitmqAction(String account, String vhost, String exchange, 
             String routingKey, Map<String, String> headers, String message) {
-        return RabbitMQAction.builder(account, exchange, routingKey, headers, message);
+        return RabbitMQAction.builder(account, vhost, exchange, routingKey, headers, message);
     }
     
     public static WebhookAction.Builder webhookAction(HttpRequestTemplate.Builder httpRequest) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
@@ -10,6 +10,7 @@ import org.elasticsearch.xpack.watcher.actions.index.IndexAction;
 import org.elasticsearch.xpack.watcher.actions.jira.JiraAction;
 import org.elasticsearch.xpack.watcher.actions.logging.LoggingAction;
 import org.elasticsearch.xpack.watcher.actions.pagerduty.PagerDutyAction;
+import org.elasticsearch.xpack.watcher.actions.rabbitmq.RabbitMQAction;
 import org.elasticsearch.xpack.watcher.actions.slack.SlackAction;
 import org.elasticsearch.xpack.watcher.actions.webhook.WebhookAction;
 import org.elasticsearch.xpack.watcher.common.http.HttpRequestTemplate;
@@ -41,6 +42,11 @@ public final class ActionBuilders {
         return JiraAction.builder(account, Map.copyOf(fields));
     }
 
+    public static RabbitMQAction.Builder rabbitmqAction(String account, String exchange, 
+            String routingKey, Map<String, String> headers, String message) {
+        return RabbitMQAction.builder(account, exchange, routingKey, headers, message);
+    }
+    
     public static WebhookAction.Builder webhookAction(HttpRequestTemplate.Builder httpRequest) {
         return webhookAction(httpRequest.build());
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQAction.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.xpack.core.watcher.actions.Action;
+import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
+import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
+import org.elasticsearch.xpack.core.watcher.watch.Payload;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplate;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQAccount;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQMessage;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQService;
+import org.elasticsearch.xpack.watcher.support.Variables;
+
+public class ExecutableRabbitMQAction extends ExecutableAction<RabbitMQAction> {
+    
+    private RabbitMQService rabbitMQService;
+
+    private TextTemplateEngine templateEngine;
+    
+    public ExecutableRabbitMQAction(RabbitMQAction action, 
+            RabbitMQService rabbitMQService, 
+            Logger logger, 
+            TextTemplateEngine templateEngine) {
+        super(action, logger);
+        this.templateEngine = templateEngine;
+        this.rabbitMQService = rabbitMQService;
+    }
+    
+    @Override
+    public Action.Result execute(final String actionId, WatchExecutionContext ctx, Payload payload) throws Exception {
+        RabbitMQAccount account = rabbitMQService.getAccount(action.account);
+        if (account == null) {
+            // the account associated with this action was deleted
+            throw new IllegalStateException("account [" + action.account + "] was not found. perhaps it was deleted");
+        }
+
+        Map<String, Object> model = Variables.createCtxParamsMap(ctx, payload);
+        
+        String exchange = "";
+        if(action.exchange != null) {
+            exchange = templateEngine.render(new TextTemplate(action.exchange), model);
+        }
+        
+        String routingKey = null;
+        if(action.routingKey != null) {
+            routingKey = templateEngine.render(new TextTemplate(action.routingKey), model);
+        }
+        
+        Map<String, Object> headers = new HashMap<>();
+        if(action.headers != null) {
+            for(Map.Entry<String, String> header : action.headers.entrySet()) {
+                headers.put(header.getKey(),  
+                        templateEngine.render(new TextTemplate(header.getValue()), model));
+            }
+        }
+        
+        String message = templateEngine.render(new TextTemplate(action.message), model);
+        
+        account.sendMessage(exchange, routingKey, headers, message.getBytes(StandardCharsets.UTF_8));
+        
+        RabbitMQMessage response = new RabbitMQMessage(action.account, exchange, routingKey, headers, message);
+
+        if (ctx.simulateAction(actionId)) {
+            return new RabbitMQAction.Result.Simulated(response);
+        }
+        
+        return new RabbitMQAction.Result.Success(response);
+    }
+    
+}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQAction.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.watcher.actions.Action;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQMessage;
+
+public class RabbitMQAction implements Action {
+
+    public static final String TYPE = "rabbitmq";
+    
+    final String account;
+    @Nullable final String exchange;
+    @Nullable final String routingKey;
+    @Nullable final Map<String, String> headers;
+    final String message;
+
+    public RabbitMQAction(String account,
+            @Nullable String exchange, 
+            @Nullable String routingKey, 
+            @Nullable Map<String, String> headers,
+            String message) {
+        this.account = account;
+        this.exchange = exchange != null ? exchange : "";
+        this.routingKey = routingKey;
+        this.headers = headers;
+        this.message = message;
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RabbitMQAction action = (RabbitMQAction) o;
+
+        return Objects.equals(account, action.account) &&
+                Objects.equals(exchange, action.exchange) &&
+                Objects.equals(routingKey, action.routingKey) &&
+                Objects.equals(headers, action.headers) && 
+                Objects.deepEquals(message, action.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(account, exchange, routingKey, headers, message);
+    }
+    
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        
+        if (account != null) {
+            builder.field(Field.ACCOUNT.getPreferredName(), account);
+        }
+        if (exchange != null) {
+            builder.field(Field.EXCHANGE.getPreferredName(), exchange);
+        }
+        if (routingKey != null) {
+            builder.field(Field.ROUTING_KEY.getPreferredName(), routingKey);
+        }
+        if (headers != null) {
+            builder.field(Field.HEADERS.getPreferredName(), headers);
+        }
+        if (message != null) {
+            builder.field(Field.MESSAGE.getPreferredName(), message);
+        }
+        
+        return builder.endObject();
+    }
+
+    public static RabbitMQAction parse(String watchId, String actionId, XContentParser parser) throws IOException {
+        String account = null;
+        String exchange = null;
+        String routingKey = null;
+        Map<String, String> headers = null;
+        String message = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (Field.ACCOUNT.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token == XContentParser.Token.VALUE_STRING) {
+                    account = parser.text();
+                } else {
+                    throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. expected [{}] to be of type string, but " +
+                            "found [{}] instead", TYPE, watchId, actionId, Field.ACCOUNT.getPreferredName(), token);
+                }
+            } else if (Field.EXCHANGE.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token == XContentParser.Token.VALUE_STRING) {
+                    exchange = parser.text();
+                } else {
+                    throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. expected [{}] to be of type string, but " +
+                            "found [{}] instead", TYPE, watchId, actionId, Field.EXCHANGE.getPreferredName(), token);
+                }
+            } else if (Field.ROUTING_KEY.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token == XContentParser.Token.VALUE_STRING) {
+                    routingKey = parser.text();
+                } else {
+                    throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. expected [{}] to be of type string, but " +
+                            "found [{}] instead", TYPE, watchId, actionId, Field.ROUTING_KEY.getPreferredName(), token);
+                }
+            } else if (Field.MESSAGE.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token == XContentParser.Token.VALUE_STRING) {
+                    message = parser.text();
+                } else {
+                    throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. expected [{}] to be of type string, but " +
+                            "found [{}] instead", TYPE, watchId, actionId, Field.MESSAGE.getPreferredName(), token);
+                }
+            } else if (Field.HEADERS.match(currentFieldName, parser.getDeprecationHandler())) {
+                try {
+                    headers = parser.mapStrings();
+                } catch (Exception e) {
+                    throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. failed to parse [{}] field", e, TYPE,
+                            watchId, actionId, Field.HEADERS.getPreferredName());
+                }
+            } else {
+                throw new ElasticsearchParseException("failed to parse [{}] action [{}/{}]. unexpected token [{}/{}]", TYPE, watchId,
+                        actionId, token, currentFieldName);
+            }
+        }
+        return new RabbitMQAction(account, exchange, routingKey, headers, message);
+    }
+
+    public static class Builder implements Action.Builder<RabbitMQAction> {
+
+        final RabbitMQAction action;
+
+        public Builder(RabbitMQAction action) {
+            this.action = action;
+        }
+
+        @Override
+        public RabbitMQAction build() {
+            return action;
+        }
+    }
+
+    public static Builder builder(String account,
+            String exchange, 
+            String routingKey, 
+            Map<String, String> headers,
+            String message) {
+        return new Builder(new RabbitMQAction(account, exchange, routingKey, headers, message));
+    }
+    
+    public interface Result {
+
+        class Success extends Action.Result implements Result {
+
+            private RabbitMQMessage message;
+            
+            public Success(RabbitMQMessage message) {
+                super(TYPE, Status.SUCCESS);
+                this.message = message;
+            }
+            
+            public RabbitMQMessage getMessage() {
+                return message;
+            }
+            
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                XContentBuilder result = builder.startObject(type)
+                        .field(Field.MESSAGE.getPreferredName(), message, params);
+                
+                return result.endObject();
+            }
+        }
+
+        class Simulated extends Action.Result implements Result {
+
+             private RabbitMQMessage message;
+             
+             public Simulated(RabbitMQMessage message) {
+                 super(TYPE, Status.SIMULATED);
+                 this.message = message;
+             }
+             
+             public RabbitMQMessage getMessage() {
+                return message;
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                XContentBuilder result = builder.startObject(type)
+                         .field(Field.MESSAGE.getPreferredName(), message, params);
+                 return result.endObject();
+            }
+        }
+    }
+    
+    public interface Field {
+        ParseField ACCOUNT = new ParseField("account");
+        ParseField EXCHANGE = new ParseField("exchange");
+        ParseField ROUTING_KEY = new ParseField("routingKey");
+        ParseField HEADERS = new ParseField("headers");
+        ParseField MESSAGE = new ParseField("message");
+    }
+    
+}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactory.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.watcher.actions.ActionFactory;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQService;
+
+public class RabbitMQActionFactory extends ActionFactory {
+
+    private final TextTemplateEngine templateEngine;
+
+    private RabbitMQService rabbitMQService;
+    
+    public RabbitMQActionFactory(TextTemplateEngine templateEngine, 
+            RabbitMQService rabbitMQService) {
+        super(LogManager.getLogger(ExecutableRabbitMQAction.class));
+        this.templateEngine = templateEngine;
+        this.rabbitMQService = rabbitMQService;
+    }
+    
+    @Override
+    public ExecutableRabbitMQAction parseExecutable(String watchId, String actionId, XContentParser parser) throws IOException {
+        RabbitMQAction action = RabbitMQAction.parse(watchId, actionId, parser);
+        return new ExecutableRabbitMQAction(action, rabbitMQService, actionLogger, templateEngine);
+    }
+}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccount.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccount.java
@@ -5,6 +5,14 @@
  */
 package org.elasticsearch.xpack.watcher.notification.jira;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.SecureSetting;
@@ -18,21 +26,13 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xpack.watcher.common.http.BasicAuth;
 import org.elasticsearch.xpack.watcher.common.http.HttpClient;
 import org.elasticsearch.xpack.watcher.common.http.HttpMethod;
 import org.elasticsearch.xpack.watcher.common.http.HttpProxy;
 import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
 import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
 import org.elasticsearch.xpack.watcher.common.http.Scheme;
-import org.elasticsearch.xpack.watcher.common.http.BasicAuth;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.Map;
 
 public class JiraAccount {
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQAccount.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQAccount.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.notification.rabbitmq;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.xpack.watcher.common.http.Scheme;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+
+public class RabbitMQAccount {
+
+    private static final String DEFAULT_EXCHANGE = "";
+
+    static final String ISSUE_DEFAULTS_SETTING = "issue_defaults";
+    static final String ALLOW_HTTP_SETTING = "allow_http";
+
+    public static final Setting<SecureString> SECURE_USER_SETTING = SecureSetting.secureString("secure_user", null);
+    public static final Setting<SecureString> SECURE_PASSWORD_SETTING = SecureSetting.secureString("secure_password", null);
+    public static final Setting<SecureString> SECURE_URL_SETTING = SecureSetting.secureString("secure_url", null);
+
+    private final String name;
+    private final String user;
+    private final String password;
+    private final URI url;
+    private ConnectionFactory connectionFactory;
+    
+    public RabbitMQAccount(String name, Settings settings, ConnectionFactory connectionFactory) {
+        this.name = name;
+        String url = getSetting(name, settings, SECURE_URL_SETTING);
+        try {
+            URI uri = new URI(url);
+            if (uri.getScheme() == null) {
+                throw new URISyntaxException("null", "No scheme defined in url");
+            }
+            Scheme protocol = Scheme.parse(uri.getScheme());
+            if ((protocol == Scheme.HTTP) && (Booleans.isTrue(settings.get(ALLOW_HTTP_SETTING)) == false)) {
+                throw new SettingsException("invalid RabbitMQ [" + name + "] account settings. unsecure scheme [" + protocol + "]");
+            }
+            this.url = uri;
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new SettingsException(
+                "invalid RabbitMQ [" + name + "] account settings. invalid [" + SECURE_URL_SETTING.getKey() + "] setting", e);
+        }
+        this.user = getSetting(name, settings, SECURE_USER_SETTING);
+        this.password = getSetting(name, settings, SECURE_PASSWORD_SETTING);
+        this.connectionFactory = connectionFactory;
+    }
+
+    private static String getSetting(String accountName, Settings settings, Setting<SecureString> secureSetting) {
+        SecureString secureString = secureSetting.get(settings);
+        if (secureString == null || secureString.length() < 1) {
+            throw requiredSettingException(accountName, secureSetting.getKey());
+        }
+        return secureString.toString();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void sendMessage(String exchange, String routingKey, final Map<String, Object> headers, 
+            byte[] body) throws IOException, TimeoutException {
+        
+        connectionFactory.setUsername(user);
+        connectionFactory.setPassword(password);
+        connectionFactory.setHost(url.getHost());
+        connectionFactory.setPort(url.getPort());
+        
+        Connection connection = null;
+        Channel channel = null;
+        try {
+            connection = connectionFactory.newConnection();
+            channel = connection.createChannel();
+            if(!DEFAULT_EXCHANGE.equals(exchange)) {
+                channel.exchangeDeclare(exchange, "direct", false);
+            }
+            
+            channel.basicPublish(exchange, routingKey, new AMQP.BasicProperties.Builder()
+                    .headers(headers).build(), body);
+        } finally {
+            if(channel != null)  {
+                channel.close();
+            }
+            if(connection != null) {
+                connection.close();
+            }
+        }
+    }
+    
+    private static SettingsException requiredSettingException(String account, String setting) {
+        return new SettingsException("invalid RabbitMQ [" + account + "] account settings. missing required [" + setting + "] setting");
+    }
+}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQMessage.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQMessage.java
@@ -17,17 +17,20 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 public class RabbitMQMessage implements ToXContentObject {
     
     final String account;
+    @Nullable final String vhost;
     @Nullable final String exchange;
     @Nullable final String routingKey;
     @Nullable final Map<String, Object> headers;
     String message;
     
     public RabbitMQMessage(String account, 
+            String vhost, 
             String exchange, 
             String routingKey, 
             Map<String, Object> headers,
             String message) {
         this.account = account;
+        this.vhost = vhost;
         this.exchange = exchange;
         this.routingKey = routingKey;
         this.headers = headers;
@@ -36,6 +39,10 @@ public class RabbitMQMessage implements ToXContentObject {
     
     public String getAccount() {
         return account;
+    }
+
+    public String getVhost() {
+        return vhost;
     }
 
     public String getExchange() {
@@ -61,6 +68,7 @@ public class RabbitMQMessage implements ToXContentObject {
 
         RabbitMQMessage issue = (RabbitMQMessage) o;
         return Objects.equals(account, issue.account) &&
+                Objects.equals(vhost, issue.vhost) &&
                 Objects.equals(exchange, issue.exchange) &&
                 Objects.equals(routingKey, issue.routingKey) &&
                 Objects.equals(headers, issue.headers) && 
@@ -69,13 +77,16 @@ public class RabbitMQMessage implements ToXContentObject {
     
     @Override
     public int hashCode() {
-        return Objects.hash(account, exchange, routingKey, headers, message);
+        return Objects.hash(account, vhost, exchange, routingKey, headers, message);
     }
     
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(Field.ACCOUNT.getPreferredName(), account);
+        if (vhost != null) {
+            builder.field(Field.VHOST.getPreferredName(), vhost);
+        }
         if (exchange != null) {
             builder.field(Field.EXCHANGE.getPreferredName(), exchange);
         }
@@ -94,9 +105,10 @@ public class RabbitMQMessage implements ToXContentObject {
     
     private interface Field {
         ParseField ACCOUNT = new ParseField("account");
+        ParseField VHOST = new ParseField("vhost");
         ParseField EXCHANGE = new ParseField("exchange");
         ParseField ROUTING_KEY = new ParseField("routingKey");
         ParseField HEADERS = new ParseField("headers");
-        ParseField MESSAGE = new ParseField("headers");
+        ParseField MESSAGE = new ParseField("message");
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQMessage.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQMessage.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.notification.rabbitmq;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+public class RabbitMQMessage implements ToXContentObject {
+    
+    final String account;
+    @Nullable final String exchange;
+    @Nullable final String routingKey;
+    @Nullable final Map<String, Object> headers;
+    String message;
+    
+    public RabbitMQMessage(String account, 
+            String exchange, 
+            String routingKey, 
+            Map<String, Object> headers,
+            String message) {
+        this.account = account;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.headers = headers;
+        this.message = message;
+    }
+    
+    public String getAccount() {
+        return account;
+    }
+
+    public String getExchange() {
+        return exchange;
+    }
+    
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+    
+    public String getRoutingKey() {
+        return routingKey;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RabbitMQMessage issue = (RabbitMQMessage) o;
+        return Objects.equals(account, issue.account) &&
+                Objects.equals(exchange, issue.exchange) &&
+                Objects.equals(routingKey, issue.routingKey) &&
+                Objects.equals(headers, issue.headers) && 
+                Objects.equals(message, issue.message);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(account, exchange, routingKey, headers, message);
+    }
+    
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(Field.ACCOUNT.getPreferredName(), account);
+        if (exchange != null) {
+            builder.field(Field.EXCHANGE.getPreferredName(), exchange);
+        }
+        if (routingKey != null) {
+            builder.field(Field.ROUTING_KEY.getPreferredName(), routingKey);
+        }
+        if (headers != null) {
+            builder.field(Field.HEADERS.getPreferredName(), headers);
+        }
+        if (message != null) {
+            builder.field(Field.MESSAGE.getPreferredName(), message);
+        }
+
+        return builder.endObject();
+    }
+    
+    private interface Field {
+        ParseField ACCOUNT = new ParseField("account");
+        ParseField EXCHANGE = new ParseField("exchange");
+        ParseField ROUTING_KEY = new ParseField("routingKey");
+        ParseField HEADERS = new ParseField("headers");
+        ParseField MESSAGE = new ParseField("headers");
+    }
+}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/rabbitmq/RabbitMQService.java
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.watcher.notification.jira;
+package org.elasticsearch.xpack.watcher.notification.rabbitmq;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,68 +15,55 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.xpack.watcher.common.http.HttpClient;
 import org.elasticsearch.xpack.watcher.notification.NotificationService;
 
-/**
- * A component to store Atlassian's JIRA credentials.
- *
- * https://www.atlassian.com/software/jira
- */
-public class JiraService extends NotificationService<JiraAccount> {
+import com.rabbitmq.client.ConnectionFactory;
 
-    private static final Setting<String> SETTING_DEFAULT_ACCOUNT =
-            Setting.simpleString("xpack.notification.jira.default_account", Property.Dynamic, Property.NodeScope);
+public class RabbitMQService  extends NotificationService<RabbitMQAccount> {
+
 
     private static final Setting.AffixSetting<Boolean> SETTING_ALLOW_HTTP =
-            Setting.affixKeySetting("xpack.notification.jira.account.", "allow_http",
+            Setting.affixKeySetting("xpack.notification.rabbitmq.account.", "allow_http",
                     (key) -> Setting.boolSetting(key, false, Property.Dynamic, Property.NodeScope));
 
     private static final Setting.AffixSetting<SecureString> SETTING_SECURE_USER =
-            Setting.affixKeySetting("xpack.notification.jira.account.", "secure_user",
+            Setting.affixKeySetting("xpack.notification.rabbitmq.account.", "secure_user",
                     (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<SecureString> SETTING_SECURE_URL =
-            Setting.affixKeySetting("xpack.notification.jira.account.", "secure_url",
+            Setting.affixKeySetting("xpack.notification.rabbitmq.account.", "secure_url",
                     (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<SecureString> SETTING_SECURE_PASSWORD =
-            Setting.affixKeySetting("xpack.notification.jira.account.", "secure_password",
+            Setting.affixKeySetting("xpack.notification.rabbitmq.account.", "secure_password",
                     (key) -> SecureSetting.secureString(key, null));
+    
+    private ConnectionFactory connectionFactory;
 
-    private static final Setting.AffixSetting<Settings> SETTING_DEFAULTS =
-            Setting.affixKeySetting("xpack.notification.jira.account.", "issue_defaults",
-                    (key) -> Setting.groupSetting(key + ".", Property.Dynamic, Property.NodeScope));
-
-    private final HttpClient httpClient;
-
-    public JiraService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
-        super("jira", settings, clusterSettings, JiraService.getDynamicSettings(), JiraService.getSecureSettings());
-        this.httpClient = httpClient;
-        // ensure logging of setting changes
-        clusterSettings.addSettingsUpdateConsumer(SETTING_DEFAULT_ACCOUNT, (s) -> {});
+    public RabbitMQService(Settings settings, ConnectionFactory connectionFactory, ClusterSettings clusterSettings) {
+        super("rabbitmq", settings, clusterSettings, RabbitMQService.getDynamicSettings(), RabbitMQService.getSecureSettings());
+        this.connectionFactory = connectionFactory;
         clusterSettings.addAffixUpdateConsumer(SETTING_ALLOW_HTTP, (s, o) -> {}, (s, o) -> {});
-        clusterSettings.addAffixUpdateConsumer(SETTING_DEFAULTS, (s, o) -> {}, (s, o) -> {});
-        // do an initial load
         reload(settings);
     }
 
     @Override
-    protected JiraAccount createAccount(String name, Settings settings) {
-        return new JiraAccount(name, settings, httpClient);
+    protected RabbitMQAccount createAccount(String name, Settings settings) {
+        return new RabbitMQAccount(name, settings, connectionFactory);
     }
 
     private static List<Setting<?>> getDynamicSettings() {
-        return Arrays.asList(SETTING_DEFAULT_ACCOUNT, SETTING_ALLOW_HTTP, SETTING_DEFAULTS);
+        return Arrays.asList(SETTING_ALLOW_HTTP);
     }
 
     private static List<Setting<?>> getSecureSettings() {
         return Arrays.asList(SETTING_SECURE_USER, SETTING_SECURE_PASSWORD, SETTING_SECURE_URL);
     }
-
+    
     public static List<Setting<?>> getSettings() {
         List<Setting<?>> allSettings = new ArrayList<Setting<?>>(getDynamicSettings());
         allSettings.addAll(getSecureSettings());
         return allSettings;
     }
+    
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQActionTests.java
@@ -44,6 +44,8 @@ import com.rabbitmq.client.ConnectionFactory;
 
 public class ExecutableRabbitMQActionTests extends ESTestCase {
 
+    private final String TEST_VHOST = "test_vhost";
+    
     private final String TEST_EXCHANGE = "test_exchange";
     
     private final String TEST_ROUTING_KEY = "test_routing_key";
@@ -54,7 +56,7 @@ public class ExecutableRabbitMQActionTests extends ESTestCase {
         
         ConnectionFactory connectionFactory = createMockFactory();
         
-        RabbitMQAction action = new RabbitMQAction("account1", TEST_EXCHANGE, TEST_ROUTING_KEY, null, TEST_MESSAGE);
+        RabbitMQAction action = new RabbitMQAction("account1", TEST_VHOST, TEST_EXCHANGE, TEST_ROUTING_KEY, null, TEST_MESSAGE);
 
         final String host = randomFrom("localhost", "internal-rabbitmq.elastic.co");
         final int port = randomFrom(5672, 5673);
@@ -94,7 +96,8 @@ public class ExecutableRabbitMQActionTests extends ESTestCase {
         Map<String, String> headers = new HashMap<>();
         headers.put("test_header", "value");
         
-        RabbitMQAction.Result.Simulated result = simulateExecution(TEST_EXCHANGE, TEST_ROUTING_KEY,
+        RabbitMQAction.Result.Simulated result = simulateExecution(TEST_VHOST, TEST_EXCHANGE, 
+                TEST_ROUTING_KEY,
                 headers, TEST_MESSAGE, emptyMap());
         assertEquals(result.status(), Status.SIMULATED);
         RabbitMQMessage message = result.getMessage();
@@ -105,7 +108,7 @@ public class ExecutableRabbitMQActionTests extends ESTestCase {
         assertEquals(message.getHeaders().get("test_header"), "VALUE");
     }
     
-    private RabbitMQAction.Result.Simulated simulateExecution(String exchange, String routingKey, 
+    private RabbitMQAction.Result.Simulated simulateExecution(String vhost, String exchange, String routingKey, 
             Map<String, String> headers, String message, Map<String, String> accountFields
             ) throws Exception {
         final MockSecureSettings secureSettings = new MockSecureSettings();
@@ -122,7 +125,7 @@ public class ExecutableRabbitMQActionTests extends ESTestCase {
         RabbitMQService service = mock(RabbitMQService.class);
         when(service.getAccount(eq("account"))).thenReturn(account);
 
-        RabbitMQAction action = new RabbitMQAction("account", exchange, routingKey, headers, message);
+        RabbitMQAction action = new RabbitMQAction("account", vhost, exchange, routingKey, headers, message);
         ExecutableRabbitMQAction executable = new ExecutableRabbitMQAction(action, service, null, new UpperCaseTextTemplateEngine());
 
         WatchExecutionContext context = createWatchExecutionContext();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/ExecutableRabbitMQActionTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.xpack.watcher.test.WatcherTestUtils.mockExecutionContextBuilder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.watcher.actions.Action;
+import org.elasticsearch.xpack.core.watcher.actions.Action.Result.Status;
+import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
+import org.elasticsearch.xpack.core.watcher.execution.Wid;
+import org.elasticsearch.xpack.core.watcher.watch.Payload;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplate;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.jira.JiraAccount;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQAccount;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQMessage;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQService;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+
+public class ExecutableRabbitMQActionTests extends ESTestCase {
+
+    private final String TEST_EXCHANGE = "test_exchange";
+    
+    private final String TEST_ROUTING_KEY = "test_routing_key";
+    
+    private final String TEST_MESSAGE = "test message";
+    
+    public void testExecutableActionStatus() throws Exception {
+        
+        ConnectionFactory connectionFactory = createMockFactory();
+        
+        RabbitMQAction action = new RabbitMQAction("account1", TEST_EXCHANGE, TEST_ROUTING_KEY, null, TEST_MESSAGE);
+
+        final String host = randomFrom("localhost", "internal-rabbitmq.elastic.co");
+        final int port = randomFrom(5672, 5673);
+        final String url = "https://" + host + ":" + port;
+        final String user = randomAlphaOfLength(10);
+        final String password = randomAlphaOfLength(10);
+        
+        final MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(RabbitMQAccount.SECURE_URL_SETTING.getKey(), url);
+        secureSettings.setString(RabbitMQAccount.SECURE_USER_SETTING.getKey(), user);
+        secureSettings.setString(RabbitMQAccount.SECURE_PASSWORD_SETTING.getKey(), password);
+        Settings accountSettings = Settings.builder().setSecureSettings(secureSettings).build();
+
+        RabbitMQAccount account = new RabbitMQAccount("account1", accountSettings, connectionFactory);
+
+        RabbitMQService service = mock(RabbitMQService.class);
+        when(service.getAccount(eq("account1"))).thenReturn(account);
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        Wid wid = new Wid(randomAlphaOfLength(5), now);
+        WatchExecutionContext ctx = mockExecutionContextBuilder(wid.watchId())
+                .wid(wid)
+                .payload(new Payload.Simple())
+                .time(wid.watchId(), now)
+                .buildMock();
+
+        ExecutableRabbitMQAction executable = new ExecutableRabbitMQAction(action, service, logger, new UpperCaseTextTemplateEngine());
+        Action.Result result = executable.execute("foo", ctx, new Payload.Simple());
+        
+        assertThat(result.type(), is("rabbitmq"));
+        assertThat(result.status(), is(Status.SUCCESS));
+    }
+
+    public void testExecutionResult() throws Exception {
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put("test_header", "value");
+        
+        RabbitMQAction.Result.Simulated result = simulateExecution(TEST_EXCHANGE, TEST_ROUTING_KEY,
+                headers, TEST_MESSAGE, emptyMap());
+        assertEquals(result.status(), Status.SIMULATED);
+        RabbitMQMessage message = result.getMessage();
+        assertEquals(message.getExchange(), TEST_EXCHANGE.toUpperCase(Locale.ROOT));
+        assertEquals(message.getRoutingKey(), TEST_ROUTING_KEY.toUpperCase(Locale.ROOT));
+        assertEquals(message.getMessage(), TEST_MESSAGE.toUpperCase(Locale.ROOT));
+        assertEquals(message.getHeaders().size(), 1);
+        assertEquals(message.getHeaders().get("test_header"), "VALUE");
+    }
+    
+    private RabbitMQAction.Result.Simulated simulateExecution(String exchange, String routingKey, 
+            Map<String, String> headers, String message, Map<String, String> accountFields
+            ) throws Exception {
+        final MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(JiraAccount.SECURE_URL_SETTING.getKey(), "https://localhost:443");
+        secureSettings.setString(JiraAccount.SECURE_USER_SETTING.getKey(), "elastic");
+        secureSettings.setString(JiraAccount.SECURE_PASSWORD_SETTING.getKey(), "secret");
+        Settings.Builder settings = Settings.builder()
+                .setSecureSettings(secureSettings)
+                .putProperties(accountFields, s -> "message_defaults." + s);
+
+        RabbitMQAccount account = new RabbitMQAccount("account", settings.build(), 
+                createMockFactory());
+        
+        RabbitMQService service = mock(RabbitMQService.class);
+        when(service.getAccount(eq("account"))).thenReturn(account);
+
+        RabbitMQAction action = new RabbitMQAction("account", exchange, routingKey, headers, message);
+        ExecutableRabbitMQAction executable = new ExecutableRabbitMQAction(action, service, null, new UpperCaseTextTemplateEngine());
+
+        WatchExecutionContext context = createWatchExecutionContext();
+        when(context.simulateAction("test")).thenReturn(true);
+
+        Action.Result result = executable.execute("test", context, new Payload.Simple());
+        assertThat(result, instanceOf(RabbitMQAction.Result.class));
+        assertThat(result, instanceOf(RabbitMQAction.Result.Simulated.class));
+        return (RabbitMQAction.Result.Simulated) result;
+    }
+
+    private ConnectionFactory createMockFactory() throws IOException, TimeoutException {
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        Connection connection = mock(Connection.class);
+        Channel channel = mock(Channel.class);
+        when(connectionFactory.newConnection()).thenReturn(connection);
+        when(connection.createChannel()).thenReturn(channel);
+        return connectionFactory;
+    }
+
+    private WatchExecutionContext createWatchExecutionContext() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        Wid wid = new Wid(randomAlphaOfLength(5), now);
+        Map<String, Object> metadata = MapBuilder.<String, Object>newMapBuilder().put("_key", "_val").map();
+        return mockExecutionContextBuilder("watch1")
+                .wid(wid)
+                .payload(new Payload.Simple())
+                .time("watch1", now)
+                .metadata(metadata)
+                .buildMock();
+    }
+    
+    /**
+     * TextTemplateEngine that convert templates to uppercase
+     */
+    class UpperCaseTextTemplateEngine extends TextTemplateEngine {
+
+        UpperCaseTextTemplateEngine() {
+            super(mock(ScriptService.class));
+        }
+
+        @Override
+        public String render(TextTemplate textTemplate, Map<String, Object> model) {
+            return textTemplate.getTemplate().toUpperCase(Locale.ROOT);
+        }
+    }
+    
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactoryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactoryTests.java
@@ -31,7 +31,7 @@ public class RabbitMQActionFactoryTests extends ESTestCase {
         RabbitMQAccount account = mock(RabbitMQAccount.class);
         when(service.getAccount("_account1")).thenReturn(account);
 
-        RabbitMQAction action = rabbitmqAction("_account1","test_exchange", "test_queue", 
+        RabbitMQAction action = rabbitmqAction("_account1", "test_vhost", "test_exchange", "test_queue", 
                 null, "test message").build();
         XContentBuilder jsonBuilder = jsonBuilder().value(action);
         XContentParser parser = createParser(jsonBuilder);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactoryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionFactoryTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.watcher.actions.ActionBuilders.rabbitmqAction;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQAccount;
+import org.elasticsearch.xpack.watcher.notification.rabbitmq.RabbitMQService;
+import org.junit.Before;
+
+public class RabbitMQActionFactoryTests extends ESTestCase {
+
+    private RabbitMQService service;
+
+    @Before
+    public void init() throws Exception {
+        service = mock(RabbitMQService.class);
+    }
+    
+    public void testParseAction() throws Exception {
+        RabbitMQAccount account = mock(RabbitMQAccount.class);
+        when(service.getAccount("_account1")).thenReturn(account);
+
+        RabbitMQAction action = rabbitmqAction("_account1","test_exchange", "test_queue", 
+                null, "test message").build();
+        XContentBuilder jsonBuilder = jsonBuilder().value(action);
+        XContentParser parser = createParser(jsonBuilder);
+        parser.nextToken();
+
+        RabbitMQAction parsedAction = RabbitMQAction.parse("_w1", "_a1", parser);
+        assertThat(parsedAction, equalTo(action));
+    }
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher.actions.rabbitmq;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.cborBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.smileBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.yamlBuilder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplate;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+
+public class RabbitMQActionTests extends ESTestCase {
+    
+    private final String TEST_EXCHANGE = "test_exchange";
+    
+    private final String TEST_ROUTING_KEY = "test_routing_key";
+    
+    private final String TEST_MESSAGE = "test message";
+    
+    public void testParser() throws Exception {
+        final String accountName = randomAlphaOfLength(10);
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("test_header", "test_header_value");
+        
+        XContentBuilder builder = jsonBuilder().startObject()
+                    .field("account", accountName)
+                    .field("exchange", TEST_EXCHANGE)
+                    .field("routingKey", TEST_ROUTING_KEY)
+                    .field("headers", headers)
+                    .field("message", TEST_MESSAGE)
+                .endObject();
+        
+        BytesReference bytes = BytesReference.bytes(builder);
+        logger.info("rabbitmq action json [{}]", bytes.utf8ToString());
+
+        XContentParser parser = createParser(JsonXContent.jsonXContent, bytes);
+        parser.nextToken();
+
+        RabbitMQAction action = RabbitMQAction.parse("_watch", "_action", parser);
+
+        assertThat(action, notNullValue());
+        assertThat(action.account, is(accountName));
+        assertThat(action.exchange, is(TEST_EXCHANGE));
+        assertThat(action.routingKey, is(TEST_ROUTING_KEY));
+        assertThat(action.headers.size(), is(1));
+        assertThat(action.headers.get("test_header"), is("test_header_value"));
+    }
+    
+    public void testParserInvalid() throws Exception {
+        XContentBuilder builder = jsonBuilder().startObject().field("unknown_field", "value").endObject();
+        XContentParser parser = createParser(builder);
+        parser.nextToken();
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> RabbitMQAction.parse("_w", "_a", parser));
+        assertThat(e.getMessage(), is("failed to parse [rabbitmq] action [_w/_a]. unexpected token [VALUE_STRING/unknown_field]"));
+    }
+
+    public void testToXContent() throws Exception {
+        final RabbitMQAction action = randomRabbitMQAction();
+
+        try (XContentBuilder builder = randomFrom(jsonBuilder(), smileBuilder(), yamlBuilder(), cborBuilder())) {
+            action.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+            String parsedAccount = null;
+
+            String parsedExchange = null;
+            String parsedRoutingKey = null;
+            Map<String, String> parsedHeaders = null;
+            String parsedMessage = null;
+            String currentFieldName = null;
+
+            try (XContentParser parser = createParser(builder)) {
+                assertNull(parser.currentToken());
+                parser.nextToken();
+
+                XContentParser.Token token = parser.currentToken();
+                assertThat(token, is(XContentParser.Token.START_OBJECT));
+
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        currentFieldName = parser.currentName();
+                    } else if ("account".equals(currentFieldName)) {
+                        parsedAccount = parser.text();
+                    } else if ("exchange".equals(currentFieldName)) {
+                        parsedExchange = parser.text();
+                    } else if ("routingKey".equals(currentFieldName)) {
+                        parsedRoutingKey = parser.text();
+                    } else if ("headers".equals(currentFieldName)) {
+                        parsedHeaders = parser.mapStrings();
+                    } else if ("message".equals(currentFieldName)) {
+                        parsedMessage = parser.text();
+                    } else {
+                        fail("unknown field [" + currentFieldName + "]");
+                    }
+                }
+            }
+
+            assertThat(parsedAccount, equalTo(action.account));
+            assertThat(parsedExchange, equalTo(action.exchange));
+            assertThat(parsedRoutingKey, equalTo(action.routingKey));
+            assertThat(parsedHeaders.size(), equalTo(action.headers.size()));
+            if(parsedHeaders.size() > 0) {
+                Map.Entry<String, String> entry = parsedHeaders.entrySet().iterator().next();
+                Map.Entry<String, String> actionEntry = action.headers.entrySet().iterator().next();
+                
+                assertThat(entry.getKey(), equalTo(actionEntry.getKey()));
+                assertThat(entry.getValue(), equalTo(actionEntry.getValue()));
+            }
+            assertThat(parsedMessage, equalTo(action.message));
+        }
+    }
+    
+    private static RabbitMQAction randomRabbitMQAction() {
+        
+        String account = null;
+        if (randomBoolean()) {
+            account = randomAlphaOfLength(randomIntBetween(5, 10));
+        }
+        
+        String exchange = null;
+        if (randomBoolean()) {
+            exchange = randomFrom("first_exchange", "second_exchange", "third_exchange");
+        }
+        
+        String routingKey = null;
+        if (randomBoolean()) {
+            routingKey = randomFrom("first_key", "second_key", "third_key");
+        }
+        
+        Map<String, String> headers = new HashMap<>();
+        if (randomBoolean()) {
+            String key = randomFrom("key1", "key2", "key3");
+            String value = randomFrom("value1", "value2", "value3");
+            headers.put(key, value);
+        }
+
+        String message = null;
+        if (randomBoolean()) {
+            message = randomFrom("first_message", "second_message", "third_message");
+        }
+
+        return new RabbitMQAction(account, exchange, routingKey, headers, message);
+    }
+    
+    /**
+     * TextTemplateEngine that picks up templates from the model if exist,
+     * otherwise returns the template as it is.
+     */
+    class ModelTextTemplateEngine extends TextTemplateEngine {
+
+        private final Map<String, Object> model;
+
+        ModelTextTemplateEngine(Map<String, Object> model) {
+            super(mock(ScriptService.class));
+            this.model = model;
+        }
+
+        @Override
+        public String render(TextTemplate textTemplate, Map<String, Object> ignoredModel) {
+            String template = textTemplate.getTemplate();
+            if (model.containsKey(template)) {
+                return (String) model.get(template);
+            }
+            return template;
+        }
+    }
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/rabbitmq/RabbitMQActionTests.java
@@ -136,6 +136,11 @@ public class RabbitMQActionTests extends ESTestCase {
             account = randomAlphaOfLength(randomIntBetween(5, 10));
         }
         
+        String vhost = null;
+        if (randomBoolean()) {
+            vhost = randomFrom("/", "test_vhost1", "test_vhost2");
+        }
+        
         String exchange = null;
         if (randomBoolean()) {
             exchange = randomFrom("first_exchange", "second_exchange", "third_exchange");
@@ -158,7 +163,7 @@ public class RabbitMQActionTests extends ESTestCase {
             message = randomFrom("first_message", "second_message", "third_message");
         }
 
-        return new RabbitMQAction(account, exchange, routingKey, headers, message);
+        return new RabbitMQAction(account, vhost, exchange, routingKey, headers, message);
     }
     
     /**


### PR DESCRIPTION
The Elasticsearch Watcher plug-in extension provides a RabbitMQ action as a notification target. Similar to the watcher JIRA action it requires SSL connection to the RabbitMQ host. The action is of type 'rabbitmq' and accepts the following:

- vhost: RabbitMQ virtual host (if ommitted default vhost assumed)
- exchange: exchange for which to send the alerts (supports Mustache templates, if ommmited default exchange assumed)
- routingKey (optional): routing key for the RabbitMQ messages (supports Mustache templates)
- headers: list of header values to send for the message (supports Mustache templates)
- message: the message (supports Mustache templates)

Example:

```
 "actions" : {
    "rabbitmq_action" : {
      "rabbitmq" : {
            "vhost" : "test",
            "exchange" : "test",
            "routingKey" : "test_key",
             "headers" : {
			"test_header" : "test_header_value"
	     },
	     "message" : "Found {{ctx.payload.hits.total}} logs"
      }
    }
  }
```

The following configuration needs to be specified in order to identify the connection to the RabbitMQ host (URL, username and password, similar to the configuration of the JIRA action extension):

```
bin\elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_url
bin\elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_user
bin\elasticsearch-keystore add xpack.notification.rabbitmq.account.monitoring.secure_password
```
