### PR TITLE
Adding a painless API to generate hash values for strings

### DIFF
--- a/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/index.asciidoc
@@ -421,6 +421,8 @@ The following classes are available grouped by their respective packages. Click 
 
 * <<painless-api-reference-shared-Debug, Debug>>
 
+* <<painless-api-reference-shared-Hash, Hash>>
+
 ==== org.elasticsearch.script
 <<painless-api-reference-shared-org-elasticsearch-script, Expand details for org.elasticsearch.script>>
 

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
@@ -8509,6 +8509,12 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 === Shared API for package org.elasticsearch.script
 See the <<painless-api-reference-shared, Shared API>> for a high-level overview of all packages and classes.
 
+[[painless-api-reference-shared-Hash]]
+==== Hash
+*  static def md5(String)
+*  static def sha1(String)
+*  static def sha2(String)
+
 [[painless-api-reference-shared-JodaCompatibleZonedDateTime]]
 ==== JodaCompatibleZonedDateTime
 * int {java11-javadoc}/java.base/java/time/chrono/ChronoZonedDateTime.html#compareTo(java.time.chrono.ChronoZonedDateTime)[compareTo](ChronoZonedDateTime)

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
@@ -8511,9 +8511,8 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 
 [[painless-api-reference-shared-Hash]]
 ==== Hash
-*  static def md5(String)
-*  static def sha1(String)
-*  static def sha2(String)
+The method parameter can take any of the algorithms defined in the https://docs.oracle.com/javase/specs/jls/se8/html/index.html[Java Security Standard Algorithm Names spec].
+*  static def hash(String inputString, String method)
 
 [[painless-api-reference-shared-JodaCompatibleZonedDateTime]]
 ==== JodaCompatibleZonedDateTime

--- a/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
+++ b/docs/painless/painless-api-reference/painless-api-reference-shared/packages.asciidoc
@@ -8511,7 +8511,7 @@ See the <<painless-api-reference-shared, Shared API>> for a high-level overview 
 
 [[painless-api-reference-shared-Hash]]
 ==== Hash
-The method parameter can take any of the algorithms defined in the https://docs.oracle.com/javase/specs/jls/se8/html/index.html[Java Security Standard Algorithm Names spec].
+The method parameter can take any of the algorithms defined in the https://docs.oracle.com/javase/9/docs/specs/security/standard-names.html#messagedigest-algorithms [Java Security Standard Algorithm Names spec].
 *  static def hash(String inputString, String method)
 
 [[painless-api-reference-shared-JodaCompatibleZonedDateTime]]

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Hash.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Hash.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.api;
+
+import java.math.BigInteger; 
+import java.security.MessageDigest; 
+import java.security.NoSuchAlgorithmException;
+
+public class Hash {
+
+    public static String hash(String input, String method) throws NoSuchAlgorithmException {
+        try { 
+  
+            // Accepts all message digest algorithms supported by java.security.MessageDigest
+            MessageDigest md = MessageDigest.getInstance(method); 
+            byte[] messageDigest = md.digest(input.getBytes()); 
+            BigInteger no = new BigInteger(1, messageDigest); 
+  
+            // Convert message digest into hex value 
+            String hashtext = no.toString(16); 
+            while (hashtext.length() < 32) { 
+                hashtext = "0" + hashtext; 
+            } 
+            return hashtext; 
+        }  
+  
+        // For specifying wrong message digest algorithms 
+        catch (NoSuchAlgorithmException e) { 
+            throw new RuntimeException(e); 
+        } 
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Hash.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Hash.java
@@ -19,31 +19,24 @@
 
 package org.elasticsearch.painless.api;
 
-import java.math.BigInteger; 
-import java.security.MessageDigest; 
+import java.math.BigInteger;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Hash {
 
     public static String hash(String input, String method) throws NoSuchAlgorithmException {
-        try { 
-  
-            // Accepts all message digest algorithms supported by java.security.MessageDigest
-            MessageDigest md = MessageDigest.getInstance(method); 
-            byte[] messageDigest = md.digest(input.getBytes()); 
-            BigInteger no = new BigInteger(1, messageDigest); 
-  
-            // Convert message digest into hex value 
-            String hashtext = no.toString(16); 
-            while (hashtext.length() < 32) { 
-                hashtext = "0" + hashtext; 
-            } 
-            return hashtext; 
-        }  
-  
-        // For specifying wrong message digest algorithms 
-        catch (NoSuchAlgorithmException e) { 
-            throw new RuntimeException(e); 
-        } 
+        // Accepts all message digest algorithms supported by
+        // java.security.MessageDigest
+        MessageDigest md = MessageDigest.getInstance(method);
+        byte[] messageDigest = md.digest(input.getBytes());
+        BigInteger mdNum = new BigInteger(1, messageDigest);
+
+        // Convert message digest into hex value
+        String hashString = mdNum.toString(16);
+        while (hashString.length() < 32) {
+            hashString = "0" + hashString;
+        }
+        return hashString;
     }
 }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -57,6 +57,12 @@ class org.elasticsearch.painless.api.Debug {
   void explain(Object)
 }
 
+#### Painless Hash API
+
+class org.elasticsearch.painless.api.Hash {
+  String hash(String, String)
+}
+
 #### ES Scripting API
 
 class org.elasticsearch.common.geo.GeoPoint {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+import static java.util.Collections.singletonMap;
+
+public class HashTests extends ScriptTestCase {
+    public void testMD2() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'MD2')", singletonMap("data", input), true);
+        assertEquals("f0625c48c038fbf6ae121a339dd48cff", output);
+    }
+
+    public void testMD5() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'MD5')", singletonMap("data", input), true);
+        assertEquals("5eed650258ee02f6a77c87b748b764ec", output);
+    }
+
+    public void testSHA1() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'SHA-1')", singletonMap("data", input), true);
+        assertEquals("49883b34e5a0f48224dd6230f471e9dc1bdbeaf5", output);
+    }
+
+    public void testSHA256() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'SHA-256')", singletonMap("data", input), true);
+        assertEquals("9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae", output);
+    }
+
+    public void testSHA384() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'SHA-384')", singletonMap("data", input), true);
+        assertEquals("1d8e2db6723d79d7cb2d2d9df903c206c6381120263ef0bec9db076b4204f73ff931658276ae7e19f245963815ae7eed", output);
+    }
+
+    public void test512() {
+        String input = "test input";
+        Object output = exec("Hash.hash(params.data, 'SHA-512')", singletonMap("data", input), true);
+        assertEquals("40aa1b203c9d8ee150b21c3c7cda8261492e5420c5f2b9f7380700e094c303b48e62f319c1da0e32eb40d113c5f1749cc61aeb499167890ab82f2cc9bb706971", output);
+    }
+
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
@@ -52,7 +52,7 @@ public class HashTests extends ScriptTestCase {
         assertEquals("1d8e2db6723d79d7cb2d2d9df903c206c6381120263ef0bec9db076b4204f73ff931658276ae7e19f245963815ae7eed", output);
     }
 
-    public void test512() {
+    public void testSHA512() {
         String input = "test input";
         Object output = exec("Hash.hash(params.data, 'SHA-512')", singletonMap("data", input), true);
         assertEquals("40aa1b203c9d8ee150b21c3c7cda8261492e5420c5f2b9f7380700e094c303b48e62f319c1da0e32eb40d113c5f1749cc61aeb499167890ab82f2cc9bb706971", output);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/HashTests.java
@@ -49,13 +49,15 @@ public class HashTests extends ScriptTestCase {
     public void testSHA384() {
         String input = "test input";
         Object output = exec("Hash.hash(params.data, 'SHA-384')", singletonMap("data", input), true);
-        assertEquals("1d8e2db6723d79d7cb2d2d9df903c206c6381120263ef0bec9db076b4204f73ff931658276ae7e19f245963815ae7eed", output);
+        assertEquals("1d8e2db6723d79d7cb2d2d9df903c206c6381120263ef0bec9db076b4204f73ff931658276ae7e19f245963815ae7eed",
+                output);
     }
 
     public void testSHA512() {
         String input = "test input";
         Object output = exec("Hash.hash(params.data, 'SHA-512')", singletonMap("data", input), true);
-        assertEquals("40aa1b203c9d8ee150b21c3c7cda8261492e5420c5f2b9f7380700e094c303b48e62f319c1da0e32eb40d113c5f1749cc61aeb499167890ab82f2cc9bb706971", output);
+        assertEquals(
+                "40aa1b203c9d8ee150b21c3c7cda8261492e5420c5f2b9f7380700e094c303b48e62f319c1da0e32eb40d113c5f1749cc61aeb499167890ab82f2cc9bb706971",
+                output);
     }
-
 }


### PR DESCRIPTION
This PR adds a painless API called `Hash` to allow the generation of hash strings from string values. 

All algorithms defined as part of [Java security standard algorithm names spec](https://docs.oracle.com/javase/9/docs/specs/security/standard-names.html#messagedigest-algorithms) are supported.


Example:

```
def hashstr = Hash.hash(doc['field_1'] + doc['field_2'], "SHA-256");
def hashstr2 = Hash.hash("some string", "MD5");

// use hash string in new documents 
doc["_id"] = hashstr;
```