### PR TITLE
Fix Slow Int Read from CompositeBytesReferencec

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/server/src/main/java/org/elasticsearch/common/Numbers.java
@@ -36,11 +36,7 @@ public final class Numbers {
     }
 
     public static long bytesToLong(BytesRef bytes) {
-        int high = (bytes.bytes[bytes.offset + 0] << 24) | ((bytes.bytes[bytes.offset + 1] & 0xff) << 16) |
-            ((bytes.bytes[bytes.offset + 2] & 0xff) << 8) | (bytes.bytes[bytes.offset + 3] & 0xff);
-        int low = (bytes.bytes[bytes.offset + 4] << 24) | ((bytes.bytes[bytes.offset + 5] & 0xff) << 16) |
-            ((bytes.bytes[bytes.offset + 6] & 0xff) << 8) | (bytes.bytes[bytes.offset + 7] & 0xff);
-        return (((long) high) << 32) | (low & 0x0ffffffffL);
+        return (((long) toInt(bytes.offset, bytes.bytes)) << 32) | (toInt(bytes.offset + 4, bytes.bytes) & 0x0ffffffffL);
     }
 
     public static byte[] intToBytes(int val) {
@@ -187,5 +183,16 @@ public final class Numbers {
             throw new ArithmeticException("byte overflow: " + l);
         }
         return (byte) l;
+    }
+
+    /**
+     * Reads an int from the given offset in the byte array.
+     *
+     * @param offset offset to read from
+     * @param bytes  byte array to read from
+     */
+    public static int toInt(int offset, byte[] bytes) {
+        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8)
+                | (bytes[offset + 3] & 0xFF);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Numbers;
 
 import java.util.Objects;
 
@@ -60,6 +61,11 @@ public final class BytesArray extends AbstractBytesReference {
     @Override
     public byte get(int index) {
         return bytes[offset + index];
+    }
+
+    @Override
+    public int getInt(int index) {
+        return Numbers.toInt(offset + index, bytes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.translog;
 
 import org.apache.lucene.store.BufferedChecksum;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.io.stream.FilterStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 
@@ -83,7 +84,7 @@ public final class BufferedChecksumStreamInput extends FilterStreamInput {
     public int readInt() throws IOException {
         final byte[] buf = buffer.get();
         readBytes(buf, 0, 4);
-        return ((buf[0] & 0xFF) << 24) | ((buf[1] & 0xFF) << 16) | ((buf[2] & 0xFF) << 8) | (buf[3] & 0xFF);
+        return Numbers.toInt(0, buf);
     }
 
     @Override


### PR DESCRIPTION
We were searching the offset 4 times when reading an `int` from an `CompositeBytesReference`,
needlessly burning lots of cycles for larger transport messages where there's a few offsets to go through while practically we'll close to always just read the `int` from a single array.
