### PR TITLE
Allow running the Docker image with a non-default group

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -89,7 +89,10 @@ ENV PATH /usr/share/elasticsearch/bin:\$PATH
 
 COPY bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-RUN chmod g=u /etc/passwd && \\
+# The JDK's directories' permissions don't allow `java` to be executed under a different
+# group to the default. Fix this.
+RUN find /usr/share/elasticsearch/jdk -type d -exec chmod 0755 '{}' \\; && \\
+    chmod g=u /etc/passwd && \\
     chmod 0775 /usr/local/bin/docker-entrypoint.sh
 
 # Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -235,6 +235,10 @@ public class DockerTests extends PackagingTestCase {
         copyFromContainer(installation.config("jvm.options"), tempEsConfigDir);
         copyFromContainer(installation.config("log4j2.properties"), tempEsConfigDir);
 
+        chownWithPrivilegeEscalation(tempEsConfigDir, "501:501");
+        chownWithPrivilegeEscalation(tempEsDataDir, "501:501");
+        chownWithPrivilegeEscalation(tempEsLogsDir, "501:501");
+
         // Define the bind mounts
         final Map<Path, Path> volumes = new HashMap<>();
         volumes.put(tempEsDataDir.toAbsolutePath(), installation.data);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -438,12 +438,30 @@ public class Docker {
      */
     public static void rmDirWithPrivilegeEscalation(Path localPath) {
         final Path containerBasePath = Paths.get("/mount");
-        final Path containerPath = containerBasePath.resolve(Paths.get("/").relativize(localPath));
+        final Path containerPath = containerBasePath.resolve(localPath.getParent().getFileName());
         final List<String> args = new ArrayList<>();
 
         args.add("cd " + containerBasePath.toAbsolutePath());
         args.add("&&");
-        args.add("rm -rf " + localPath.getFileName());
+        args.add("rm -r " + localPath.getFileName());
+        final String command = String.join(" ", args);
+        executePrivilegeEscalatedShellCmd(command, localPath, containerPath);
+    }
+
+    /**
+     * Change the ownership of a path using Docker backed privilege escalation.
+     * @param localPath The path to the file or directory to change.
+     * @param ownership the ownership to apply. Can either be just the user, or the user and group, separated by a colon (":"),
+     *                  or just the group if prefixed with a colon.
+     */
+    public static void chownWithPrivilegeEscalation(Path localPath, String ownership) {
+        final Path containerBasePath = Paths.get("/mount");
+        final Path containerPath = containerBasePath.resolve(localPath.getParent().getFileName());
+        final List<String> args = new ArrayList<>();
+
+        args.add("cd " + containerBasePath.toAbsolutePath());
+        args.add("&&");
+        args.add("chown " + ownership + " " + localPath.getFileName());
         final String command = String.join(" ", args);
         executePrivilegeEscalatedShellCmd(command, localPath, containerPath);
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -104,7 +104,26 @@ public class Docker {
      * @param envVars environment variables to set when running the container, or null
      */
     public static Installation runContainer(Distribution distribution, Map<Path, Path> volumes, Map<String, String> envVars) {
-        executeDockerRun(distribution, volumes, envVars);
+        return runContainer(distribution, volumes, envVars, null, null);
+    }
+
+    /**
+     * Runs an Elasticsearch Docker container, with options for overriding the config directory
+     * through a bind mount, and passing additional environment variables.
+     * @param distribution details about the docker image being tested.
+     * @param volumes a map that declares any volume mappings to apply, or null
+     * @param envVars environment variables to set when running the container, or null
+     * @param uid optional UID to run the container under
+     * @param gid optional GID to run the container under
+     */
+    public static Installation runContainer(
+        Distribution distribution,
+        Map<Path, Path> volumes,
+        Map<String, String> envVars,
+        Integer uid,
+        Integer gid
+    ) {
+        executeDockerRun(distribution, volumes, envVars, uid, gid);
 
         waitForElasticsearchToStart();
 
@@ -125,14 +144,20 @@ public class Docker {
         Map<Path, Path> volumes,
         Map<String, String> envVars
     ) {
-        executeDockerRun(distribution, volumes, envVars);
+        executeDockerRun(distribution, volumes, envVars, null, null);
 
         waitForElasticsearchToExit();
 
         return getContainerLogs();
     }
 
-    private static void executeDockerRun(Distribution distribution, Map<Path, Path> volumes, Map<String, String> envVars) {
+    private static void executeDockerRun(
+        Distribution distribution,
+        Map<Path, Path> volumes,
+        Map<String, String> envVars,
+        Integer uid,
+        Integer gid
+    ) {
         removeContainer();
 
         final List<String> args = new ArrayList<>();
@@ -165,6 +190,19 @@ public class Docker {
                 }
                 args.add("--volume \"" + localPath + ":" + containerPath + "\"");
             });
+        }
+
+        if (uid == null) {
+            if (gid != null) {
+                throw new IllegalArgumentException("Cannot override GID without also overriding UID");
+            }
+        } else {
+            args.add("--user");
+            if (gid != null) {
+                args.add(uid + ":" + gid);
+            } else {
+                args.add(uid.toString());
+            }
         }
 
         // Image name


### PR DESCRIPTION
Closes #60864. Tweak the JDK directories' permissions in the ES Docker image so that ES can run under a different user and group.

These changes assume that the image is being run with bind-mounted config, data and logs directories, and reads and writes to these locations will still fail when both the UID and GID are not the default. Everything should be OK when running with the default GID of zero, however.