### PR TITLE
[DOCS] Adds clarification to node roles

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -1,8 +1,8 @@
 [[modules-node]]
 === Node
 
-Any time that you start an instance of Elasticsearch, you are starting a _node_.
-A collection of connected nodes is called a <<modules-cluster,cluster>>. If you
+Any time that you start an instance of {es}, you are starting a _node_. A 
+collection of connected nodes is called a <<modules-cluster,cluster>>. If you
 are running a single node of {es}, then you have a cluster of one node.
 
 Every node in the cluster can handle <<modules-http,HTTP>> and
@@ -21,6 +21,17 @@ and (if available) machine learning. All data nodes are also transform nodes.
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.
+
+[[node-roles]]
+==== Nore roles
+
+You can define the roles of a node by setting `node.roles`. If you don't 
+configure this setting, then the node has the following roles by default: 
+`master`, `data`, ingest, `transform`, `ml`.
+
+If you use the `node.roles` setting, then all required roles must be explicitly 
+set as the values that you provide for `node.roles` overwrite the default 
+behavior.
 
 <<master-node,Master-eligible node>>::
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -27,7 +27,7 @@ dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 You can define the roles of a node by setting `node.roles`. If you don't 
 configure this setting, then the node has the following roles by default: 
-`master`, `data`, ingest, `transform`, `ml`.
+`master`, `data`, `ingest`, `transform`, `ml`.
 
 If you use the `node.roles` setting, then all required roles must be explicitly 
 set as the values that you provide for `node.roles` overwrite the default 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -29,9 +29,7 @@ You can define the roles of a node by setting `node.roles`. If you don't
 configure this setting, then the node has the following roles by default: 
 `master`, `data`, `ingest`, `transform`, `ml`.
 
-If you use the `node.roles` setting, then all required roles must be explicitly 
-set as the values that you provide for `node.roles` overwrite the default 
-behavior.
+If you set node.roles, the node is assigned only the roles you specify.
 
 <<master-node,Master-eligible node>>::
 


### PR DESCRIPTION
## Overview

This PR adds a short section to the node description page that explains the logic of `node.roles`.

### Preview

[Node](https://elasticsearch_61206.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html)