### PR TITLE
Add method to make random DateFormatter pattern (backport of #60613)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -769,88 +770,14 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 
         ZonedDateTime javaDate = ZonedDateTime.of(year, month, day, hour, minute, second, 0, ZoneOffset.UTC);
         DateTime jodaDate = new DateTime(year, month, day, hour, minute, second, DateTimeZone.UTC);
-        assertSamePrinterOutput("epoch_second", javaDate, jodaDate);
 
-        assertSamePrinterOutput("basicDate", javaDate, jodaDate);
-        assertSamePrinterOutput("basicDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("basicDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("basicOrdinalDate", javaDate, jodaDate);
-        assertSamePrinterOutput("basicOrdinalDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("basicOrdinalDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("basicTime", javaDate, jodaDate);
-        assertSamePrinterOutput("basicTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("basicTTime", javaDate, jodaDate);
-        assertSamePrinterOutput("basicTTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("basicWeekDate", javaDate, jodaDate);
-        assertSamePrinterOutput("basicWeekDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("basicWeekDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("date", javaDate, jodaDate);
-        assertSamePrinterOutput("dateHour", javaDate, jodaDate);
-        assertSamePrinterOutput("dateHourMinute", javaDate, jodaDate);
-        assertSamePrinterOutput("dateHourMinuteSecond", javaDate, jodaDate);
-        assertSamePrinterOutput("dateHourMinuteSecondFraction", javaDate, jodaDate);
-        assertSamePrinterOutput("dateHourMinuteSecondMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("dateOptionalTime", javaDate, jodaDate);
-        assertSamePrinterOutput("dateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("dateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("hour", javaDate, jodaDate);
-        assertSamePrinterOutput("hourMinute", javaDate, jodaDate);
-        assertSamePrinterOutput("hourMinuteSecond", javaDate, jodaDate);
-        assertSamePrinterOutput("hourMinuteSecondFraction", javaDate, jodaDate);
-        assertSamePrinterOutput("hourMinuteSecondMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinalDate", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinalDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("ordinalDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("time", javaDate, jodaDate);
-        assertSamePrinterOutput("timeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("tTime", javaDate, jodaDate);
-        assertSamePrinterOutput("tTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("weekDate", javaDate, jodaDate);
-        assertSamePrinterOutput("weekDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("weekDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("weekyear", javaDate, jodaDate);
-        assertSamePrinterOutput("weekyearWeek", javaDate, jodaDate);
-        assertSamePrinterOutput("weekyearWeekDay", javaDate, jodaDate);
-        assertSamePrinterOutput("year", javaDate, jodaDate);
-        assertSamePrinterOutput("yearMonth", javaDate, jodaDate);
-        assertSamePrinterOutput("yearMonthDay", javaDate, jodaDate);
-
-        assertSamePrinterOutput("epoch_millis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictBasicWeekDate", javaDate, jodaDate);
-        assertSamePrinterOutput("strictBasicWeekDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictBasicWeekDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDate", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateHour", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateHourMinute", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateHourMinuteSecond", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateHourMinuteSecondFraction", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateHourMinuteSecondMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateOptionalTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictHour", javaDate, jodaDate);
-        assertSamePrinterOutput("strictHourMinute", javaDate, jodaDate);
-        assertSamePrinterOutput("strictHourMinuteSecond", javaDate, jodaDate);
-        assertSamePrinterOutput("strictHourMinuteSecondFraction", javaDate, jodaDate);
-        assertSamePrinterOutput("strictHourMinuteSecondMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictOrdinalDate", javaDate, jodaDate);
-        assertSamePrinterOutput("strictOrdinalDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictOrdinalDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictTTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictTTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekDate", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekDateTime", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekDateTimeNoMillis", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekyear", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekyearWeek", javaDate, jodaDate);
-        assertSamePrinterOutput("strictWeekyearWeekDay", javaDate, jodaDate);
-        assertSamePrinterOutput("strictYear", javaDate, jodaDate);
-        assertSamePrinterOutput("strictYearMonth", javaDate, jodaDate);
-        assertSamePrinterOutput("strictYearMonthDay", javaDate, jodaDate);
-        assertSamePrinterOutput("strict_date_optional_time", javaDate, jodaDate);
-        assertSamePrinterOutput("epoch_millis", javaDate, jodaDate);
+        for (FormatNames format : FormatNames.values()) {
+            if (format == FormatNames.ISO8601 || format == FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS) {
+                // Nanos aren't supported by joda
+                continue;
+            }
+            assertSamePrinterOutput(format.getSnakeCaseName(), javaDate, jodaDate);
+        }
     }
 
     public void testSamePrinterOutputWithTimeZone() {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -71,6 +71,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
@@ -888,6 +889,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     private static String randomJodaAndJavaSupportedTimezone(List<String> zoneIds) {
         return randomValueOtherThanMany(id -> JODA_TIMEZONE_IDS.contains(id) == false,
             () -> randomFrom(zoneIds));
+    }
+
+    /**
+     * Generate a random valid date formatter pattern.
+     */
+    public static String randomDateFormatterPattern() {
+        return randomFrom(FormatNames.values()).getSnakeCaseName();
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.test.test;
 import junit.framework.AssertionFailedError;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -40,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -198,5 +200,10 @@ public class ESTestCaseTests extends ESTestCase {
     public void testBasePortIDE() {
         assumeTrue("requires running tests without Gradle", System.getProperty("tests.gradle") == null);
         assertEquals(10300, ESTestCase.getBasePort());
+    }
+
+    public void testRandomDateFormatterPattern() {
+        DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern());
+        assertThat(formatter.parseMillis(formatter.formatMillis(0)), equalTo(0L));
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -545,8 +545,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
      */
     private Map<String, MappedFieldType> createFieldTypes(RollupJobConfig job) {
         Map<String, MappedFieldType> fieldTypes = new HashMap<>();
-        DateFormatter formatter
-            = DateFormatter.forPattern(randomFrom("basic_date", "date_optional_time", "epoch_second")).withLocale(Locale.ROOT);
+        DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(Locale.ROOT);
         MappedFieldType fieldType = new DateFieldMapper.DateFieldType(job.getGroupConfig().getDateHistogram().getField(), formatter);
         fieldTypes.put(fieldType.name(), fieldType);
 


### PR DESCRIPTION
Adds a method to make a random date `DateFormatter` pattern. We expect
this'll be useful for runtime fields to compate their formatting with
the standard date field.
