### PR TITLE
[DOCS] Update info about geo_shape bounding boxes

### DIFF
--- a/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
@@ -50,6 +50,7 @@ POST /museums/_search?size=0
 --------------------------------------------------
 
 <1> The `geo_bounds` aggregation specifies the field to use to obtain the bounds.
+[[geo-bounds-wrap-longitude]]
 <2> `wrap_longitude` is an optional parameter which specifies whether the bounding box should be allowed to overlap the international date line. The default value is `true`.
 
 The above aggregation demonstrates how one would compute the bounding box of the location field for all documents with a business type of shop.
@@ -83,6 +84,18 @@ The response for the above aggregation:
 ==== Geo Bounds Aggregation on `geo_shape` fields
 
 The Geo Bounds Aggregation is also supported on `geo_shape` fields.
+
+If <<geo-bounds-wrap-longitude,`wrap_longitude`>> is set to `true`
+(the default), the bounding box can overlap the international date line. If
+these shapes also include `geo_shape` fields, the `geo_bounds` aggregation
+returns a bounds where the `top_left` longitude is larger than the `top_right`
+longitude.
+
+For example, the upper right longitude will typically be greater than the lower
+left longitude of a geographic bounding box. However, when the area
+crosses the 180° meridian, the value of the lower left longitude will be
+greater than the value of the upper right longitude. See
+http://docs.opengeospatial.org/is/12-063r5/12-063r5.html#30[Geographic bounding box] on the Open Geospatial Consortium website for more information.
 
 Example:
 

--- a/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
@@ -3,7 +3,6 @@
 
 A metric aggregation that computes the bounding box containing all geo values for a field.
 
-
 Example:
 
 [source,console]
@@ -50,8 +49,7 @@ POST /museums/_search?size=0
 --------------------------------------------------
 
 <1> The `geo_bounds` aggregation specifies the field to use to obtain the bounds.
-[[geo-bounds-wrap-longitude]]
-<2> `wrap_longitude` is an optional parameter which specifies whether the bounding box should be allowed to overlap the international date line. The default value is `true`.
+<2> [[geo-bounds-wrap-longitude]] `wrap_longitude` is an optional parameter which specifies whether the bounding box should be allowed to overlap the international date line. The default value is `true`.
 
 The above aggregation demonstrates how one would compute the bounding box of the location field for all documents with a business type of shop.
 
@@ -86,9 +84,8 @@ The response for the above aggregation:
 The Geo Bounds Aggregation is also supported on `geo_shape` fields.
 
 If <<geo-bounds-wrap-longitude,`wrap_longitude`>> is set to `true`
-(the default), the bounding box can overlap the international date line. If
-these shapes also include `geo_shape` fields, the `geo_bounds` aggregation
-returns a bounds where the `top_left` longitude is larger than the `top_right`
+(the default), the bounding box can overlap the international date line and
+return a bounds where the `top_left` longitude is larger than the `top_right`
 longitude.
 
 For example, the upper right longitude will typically be greater than the lower


### PR DESCRIPTION
Per #55812, this PR adds clarifications around the `geo_bounds` aggregation where the `top_left` area of the bounding box can exceed the `top_right`.

Closes #55812 

Backports:
* 7.x #61216
* 7.9 #61217
* 7.8 #61218