### PR TITLE
[DOCS] Add usage tips to `top_hits` agg

### DIFF
--- a/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
@@ -4,8 +4,9 @@
 A `top_hits` metric aggregator keeps track of the most relevant document being aggregated. This aggregator is intended
 to be used as a sub aggregator, so that the top matching documents can be aggregated per bucket.
 
-TIP: `top_hits` is designed for use in nested aggregations. If you want to group
-search hits, use the <<collapse-search-results,`collapse`>> parameter instead.
+TIP: We do not recommend using `top_hits` as a top-level aggregation. If you
+want to group search hits, use the <<collapse-search-results,`collapse`>>
+parameter instead.
 
 The `top_hits` aggregator can effectively be used to group result sets by certain fields via a bucket aggregator.
 One or more bucket aggregators determines by which properties a result set get sliced into.

--- a/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
@@ -4,6 +4,9 @@
 A `top_hits` metric aggregator keeps track of the most relevant document being aggregated. This aggregator is intended
 to be used as a sub aggregator, so that the top matching documents can be aggregated per bucket.
 
+TIP: `top_hits` is designed for use in nested aggregations. If you want to group
+search hits, use the <<collapse-search-results,`collapse`>> parameter instead.
+
 The `top_hits` aggregator can effectively be used to group result sets by certain fields via a bucket aggregator.
 One or more bucket aggregators determines by which properties a result set get sliced into.
 
@@ -29,6 +32,11 @@ The top_hits aggregation returns regular search hits, because of this many per h
 
 IMPORTANT: If you *only* need `docvalue_fields`, `size`, and `sort` then
 <<search-aggregations-metrics-top-metrics>> might be a more efficient choice than the Top Hits Aggregation.
+
+`top_hits` does not support the <<rescore,`rescore`>> parameter. Query rescoring
+applies only to search hits, not aggregation results. To change the scores used
+by aggregations, use a <<query-dsl-function-score-query,`function_score`>> or
+<<query-dsl-script-score-query,`script_score`>> query.
 
 ==== Example
 


### PR DESCRIPTION
Changes:
* Adds an admon to point users to the `collapse` docs if they only want to group search hits.
* Notes the `top_hits` agg does not use query rescoring.

Closes #61084