### PR TITLE
[DOC] Transform Job & ILM Rollover Alias limitations

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -106,6 +106,14 @@ neither the destination index nor the {kib} index pattern, should one have been
 created, are deleted. These objects must be deleted separately.
 
 [discrete]
+[[transform-ilm-limitations]]
+== Using an alias as destination index for a {transform}
+
+Using an alias as destination index for a {transform} might lead to
+duplicate entries if the actual destination index changes over time.
+E.g. Using a ILM Rollover Alias
+
+[discrete]
 [[transform-aggregation-page-limitations]]
 == Handling dynamic adjustment of aggregation page size
 


### PR DESCRIPTION
Depending on the configuration of the Transform Job, it internally might trigger an upsert over a given document ID.
Especially in a continuous transform job, when a `group_by` date histogram is used, it might happen that a result would be upserted over time.
If the destination alias of such index is changed, it would lead to a duplicate.