### PR TITLE
Fix `value` method on ip scripts 

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -481,25 +481,30 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         public int size() {
             return count;
         }
-
     }
 
-    public static final class Strings extends BinaryScriptDocValues<String> {
-
+    public static class Strings extends BinaryScriptDocValues<String> {
         public Strings(SortedBinaryDocValues in) {
             super(in);
         }
 
         @Override
-        public String get(int index) {
+        public final String get(int index) {
             if (count == 0) {
                 throw new IllegalStateException("A document doesn't have a value for a field! " +
                     "Use doc[<field>].size()==0 to check if a document is missing a field!");
             }
-            return values[index].get().utf8ToString();
+            return bytesToString(values[index].get());
         }
 
-        public String getValue() {
+        /**
+         * Convert the stored bytes to a String.
+         */
+        protected String bytesToString(BytesRef bytes) {
+            return bytes.utf8ToString();
+        }
+
+        public final String getValue() {
             return get(0);
         }
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -112,6 +112,24 @@ setup:
   - match: {aggregations.ip.buckets.1.doc_count: 1}
 
 ---
+"use in scripts":
+  - do:
+      search:
+        index: http_logs
+        body:
+          aggs:
+            ip:
+              terms:
+                script:
+                  String v = doc['ip'].value;
+                  return v.substring(0, v.indexOf('.') - 1);
+  - match: {hits.total.value: 6}
+  - match: {aggregations.ip.buckets.0.key: 247}
+  - match: {aggregations.ip.buckets.0.doc_count: 2}
+  - match: {aggregations.ip.buckets.1.key: 26}
+  - match: {aggregations.ip.buckets.1.doc_count: 1}
+
+---
 "term query":
   - do:
       search:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -122,11 +122,11 @@ setup:
               terms:
                 script:
                   String v = doc['ip'].value;
-                  return v.substring(0, v.indexOf('.') - 1);
+                  return v.substring(0, v.indexOf('.'));
   - match: {hits.total.value: 6}
-  - match: {aggregations.ip.buckets.0.key: 247}
+  - match: {aggregations.ip.buckets.0.key: '247'}
   - match: {aggregations.ip.buckets.0.doc_count: 2}
-  - match: {aggregations.ip.buckets.1.key: 26}
+  - match: {aggregations.ip.buckets.1.key: '232'}
   - match: {aggregations.ip.buckets.1.doc_count: 1}
 
 ---


### PR DESCRIPTION
Fixes `doc['ip'].value` when `ip` is a script field. It didn't work
properly before because it wasn't whitelisted. We can't whitelist it
easilly because it was over in a module rather than core. This fixes
that by sharing more code with core that *is* whitelisted.