### PR TITLE
[DOCS] Reorder ES Ref TOC

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -20,29 +20,29 @@ include::setup.asciidoc[]
 
 include::upgrade.asciidoc[]
 
-include::indices/index-templates.asciidoc[]
-
-include::data-streams/data-streams.asciidoc[]
-
-include::search/search-your-data.asciidoc[]
-
-include::query-dsl.asciidoc[]
-
-include::eql/eql.asciidoc[]
-
-include::sql/index.asciidoc[]
-
-include::aggregations.asciidoc[]
-
-include::scripting.asciidoc[]
+include::index-modules.asciidoc[]
 
 include::mapping.asciidoc[]
 
 include::analysis.asciidoc[]
 
-include::index-modules.asciidoc[]
+include::indices/index-templates.asciidoc[]
+
+include::data-streams/data-streams.asciidoc[]
 
 include::ingest.asciidoc[]
+
+include::search/search-your-data.asciidoc[]
+
+include::query-dsl.asciidoc[]
+
+include::aggregations.asciidoc[]
+
+include::eql/eql.asciidoc[]
+
+include::sql/index.asciidoc[]
+
+include::scripting.asciidoc[]
 
 include::ilm/index.asciidoc[]
 


### PR DESCRIPTION
Reorders the ES TOC so it's a bit more logical.

Changes:
* Moves index settings, mappings, and analysis before index templates and data streams.
* Moves ingest before search
* Moves aggs  directly after search. Moves EQL/SQL after search as they don't use the search API.

Happy to incorporate any additional feedback!