### PR TITLE
Add parse methods for long and double

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -185,17 +185,11 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
 
     private static final Map<String, String> PAINLESS_TO_EMIT = Map.ofEntries(
         Map.entry(BooleanFieldMapper.CONTENT_TYPE, "value(parse(value));"),
-        Map.entry(DateFieldMapper.CONTENT_TYPE, "millis(parse(value.toString()));"),
-        Map.entry(
-            NumberType.DOUBLE.typeName(),
-            "value(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
-        ),
+        Map.entry(DateFieldMapper.CONTENT_TYPE, "millis(parse(value));"),
+        Map.entry(NumberType.DOUBLE.typeName(), "value(parse(value));"),
         Map.entry(KeywordFieldMapper.CONTENT_TYPE, "value(value.toString());"),
         Map.entry(IpFieldMapper.CONTENT_TYPE, "stringValue(value.toString());"),
-        Map.entry(
-            NumberType.LONG.typeName(),
-            "value(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
-        )
+        Map.entry(NumberType.LONG.typeName(), "value(parse(value));")
     );
 
     private static final ExecutableSection ADD_TEMPLATE = new ExecutableSection() {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
@@ -74,8 +74,8 @@ public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript
         }
     }
 
-    public static boolean parse(Object str) {
-        return Booleans.parseBoolean(str.toString());
+    public static boolean parse(Object o) {
+        return Booleans.parseBoolean(o.toString());
     }
 
     public static class Value {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
@@ -78,8 +78,8 @@ public abstract class DateScriptFieldScript extends AbstractLongScriptFieldScrip
             this.script = script;
         }
 
-        public long parse(Object str) {
-            return script.formatter.parseMillis(str.toString());
+        public long parse(Object o) {
+            return script.formatter.parseMillis(o.toString());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
@@ -66,6 +67,10 @@ public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript 
      */
     public final int count() {
         return count;
+    }
+
+    public static double parse(Object o) {
+        return NumberType.objectToDouble(o);
     }
 
     private void collectValue(double v) {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.runtimefields;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
@@ -36,6 +37,10 @@ public abstract class LongScriptFieldScript extends AbstractLongScriptFieldScrip
 
     public LongScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
         super(params, searchLookup, ctx);
+    }
+
+    public static long parse(Object o) {
+        return NumberType.objectToLong(o, false);
     }
 
     public static class Value {

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
@@ -11,6 +11,7 @@ class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript @no_import {
 
 static_import {
     void value(org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript, double) bound_to org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Value
+    double parse(def) from_class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript
 }
 
 # This import is required to make painless happy and it isn't 100% clear why

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
@@ -11,6 +11,7 @@ class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript @no_import {
 
 static_import {
     void value(org.elasticsearch.xpack.runtimefields.LongScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Value
+    long parse(def) from_class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript
 }
 
 # This import is required to make painless happy and it isn't 100% clear why

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
@@ -58,7 +58,7 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.0]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [3.14, 1.4]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"3.14\", 1.4]}"))));
             List<Double> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
@@ -272,7 +272,7 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new DoubleScriptFieldScript.Value(this).value(((Number) foo).doubleValue());
+                                            new DoubleScriptFieldScript.Value(this).value(parse(foo));
                                         }
                                     }
                                 };
@@ -282,7 +282,7 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
                                             new DoubleScriptFieldScript.Value(this).value(
-                                                ((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue()
+                                                parse(foo) + ((Number) getParams().get("param")).doubleValue()
                                             );
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
@@ -58,7 +58,7 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2, 1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"2\", 1]}"))));
             List<Long> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
@@ -271,7 +271,7 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new LongScriptFieldScript.Value(this).value(((Number) foo).longValue());
+                                            new LongScriptFieldScript.Value(this).value(parse(foo));
                                         }
                                     }
                                 };
@@ -281,7 +281,7 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
                                             new LongScriptFieldScript.Value(this).value(
-                                                ((Number) foo).longValue() + ((Number) getParams().get("param")).longValue()
+                                                parse(foo) + ((Number) getParams().get("param")).longValue()
                                             );
                                         }
                                     }


### PR DESCRIPTION
Adds a consistently named `parse` method to `long` and `double` valued
runtime_scripts that parses `Object`s returned from `_source` into the
target type of the script.
