### PR TITLE
SQL: Introduce ordering in the constant_keyword test

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
@@ -233,7 +233,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
         }
 
         try (Connection connection = esJdbc()) {
-            try (PreparedStatement statement = connection.prepareStatement("SELECT id, text FROM test WHERE text = ?")) {
+            try (PreparedStatement statement = connection.prepareStatement("SELECT id, text FROM test WHERE text = ? ORDER BY id")) {
                 statement.setString(1, text);
 
                 try (ResultSet results = statement.executeQuery()) {


### PR DESCRIPTION
Addresses test failures similar to:

```
java.lang.AssertionError: expected:<1001> but was:<1003>
	at __randomizedtesting.SeedInfo.seed([FAAE2116E1E1A3F2:11DCA4D592802DBE]:0)
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.elasticsearch.xpack.sql.qa.jdbc.PreparedStatementTestCase.testConstantKeywordField(PreparedStatementTestCase.java:242)
```

This happens only in a multi-node scenario on `master` bwc tests or on 7.x and 7.9 branches. Likely reason: the order in which the documents are actually added to the index shards.
`gradlew ':x-pack:plugin:sql:qa:jdbc:multi-node:v7.9.0#bwcTest' --tests "org.elasticsearch.xpack.sql.qa.jdbc.multi_node.JdbcPreparedStatementIT.testConstantKeywordField" -Dtests.seed=DC3217238BF910D`

`gradlew ':x-pack:plugin:sql:qa:jdbc:multi-node:v7.10.0#bwcTest' --tests "org.elasticsearch.xpack.sql.qa.jdbc.multi_node.JdbcPreparedStatementIT.testConstantKeywordField" -Dtests.seed=FAAE2116E1E1A3F2`

`gradlew ':x-pack:plugin:sql:qa:jdbc:multi-node:integTestRunner' --tests "org.elasticsearch.xpack.sql.qa.jdbc.multi_node.JdbcPreparedStatementIT.testConstantKeywordField" -Dtests.seed=16979161F67F3DBE`