### PR TITLE
Introduce ordering in the constant_keyword test (#61248)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
@@ -233,7 +233,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
         }
 
         try (Connection connection = esJdbc()) {
-            try (PreparedStatement statement = connection.prepareStatement("SELECT id, text FROM test WHERE text = ?")) {
+            try (PreparedStatement statement = connection.prepareStatement("SELECT id, text FROM test WHERE text = ? ORDER BY id")) {
                 statement.setString(1, text);
 
                 try (ResultSet results = statement.executeQuery()) {


### PR DESCRIPTION
(cherry picked from commit 69193f9de8178dbaa1d8467f1686b100dd2b161c)