### PR TITLE
[DOCS] Clarifies node.roles settings

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -27,7 +27,7 @@ dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 You can define the roles of a node by setting `node.roles`. If you don't 
 configure this setting, then the node has the following roles by default: 
-`master`, `data`, `ingest`, `transform`, `ml`.
+`master`, `data`, `ingest`, `ml`.
 
 If you set node.roles, the node is assigned only the roles you specify.
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -79,7 +79,7 @@ In the _scatter_ phase, the coordinating node forwards the request to the data
 nodes which hold the data.  Each data node executes the request locally and
 returns its results to the coordinating node. In the _gather_  phase, the
 coordinating node reduces each data node's results into a single global
-resultset.
+result set.
 
 Every node is implicitly a coordinating node. This means that a node that has
 an explicit empty list of roles via `node.roles` will only act as a coordinating
@@ -213,7 +213,9 @@ node.roles: [ ingest ]
 [[node-ingest-node-setting]]
 // tag::node-ingest-tag[]
 `node.ingest` {ess-icon}::
-Determines whether a node is an ingest node. <<ingest,Ingest nodes>> can apply an ingest pipeline to transform and enrich a document before indexing. Default: `true`.
+Determines whether a node is an ingest node. <<ingest,Ingest nodes>> can apply 
+an ingest pipeline to transform and enrich a document before indexing. Default: 
+`true`.
 // end::node-ingest-tag[]
 
 [[coordinating-only-node]]
@@ -269,9 +271,9 @@ xpack.ml.enabled: true <1>
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
-{transform-cap} nodes run {transforms} and handle {transform} API requests. By
-default, data nodes are also transform nodes. If you have the {oss-dist}, do not
-use these settings. For more information, see <<transform-settings>>.
+{transform-cap} nodes run {transforms} and handle {transform} API requests. If 
+you have the {oss-dist}, do not use these settings. For more information, see 
+<<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 
@@ -298,8 +300,9 @@ Each node checks the contents of its data path at startup. If it discovers
 unexpected data then it will refuse to start. This is to avoid importing
 unwanted <<modules-gateway-dangling-indices,dangling indices>> which can lead
 to a red cluster health. To be more precise, nodes without the `data` role will
-refuse to start if they find any shard data on disk at startup, and nodes with
-without both the `master` and `data` roles will refuse to start if they have any index metadata on disk at startup.
+refuse to start if they find any shard data on disk at startup, and nodes 
+without both the `master` and `data` roles will refuse to start if they have any 
+index metadata on disk at startup.
 
 It is possible to change the roles of a node by adjusting its
 `elasticsearch.yml` file and restarting it. This is known as _repurposing_ a


### PR DESCRIPTION
## Overview

This PR clarifies that nodes with the `data` role are not automatically `transform` nodes.


### Preview

[Nodes](https://elasticsearch_61266.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html)