### PR TITLE
[DOCS] Replaces node.transform with node.roles: [ transform ] in transforms settings

### DIFF
--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -21,27 +21,24 @@ file.
 [[general-transform-settings]]
 ==== General {transforms} settings
 
-`node.transform`::
-deprecated:[7.9.0,"Use <<modules-node,node.roles>> instead."]
-Set to `true` to identify the node as a _transform node_. If `node.data`
-is `false` for the node, the default value is `false`. Otherwise, the default
-value is `true`.
+`node.roles: [ transform ]`::
+Set to `node.roles` to contain `transform` to identify the node as a _transform 
+node_. If you use the default settings for a node, it does not have the 
+`transform` role.
 +
-If set to `false` in `elasticsearch.yml`, the node cannot run transforms. If
-you want to run transforms, there must be at least one transform node in your
-cluster. +
+If a node doesn't have this role, the node cannot run transforms. If you want to 
+run transforms, there must be at least one transform node in your cluster.
 +
-IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, disable
-the node.transform role.
+If you use the `node.roles` setting, then all required roles must be explicitly  
+set. Consult <<modules-node>> to learn more.
 
 `xpack.transform.enabled`::
 deprecated:[7.8.0,Basic License features should always be enabled] +
 This deprecated setting no longer has any effect.
 
 `xpack.transform.num_transform_failure_retries` (<<cluster-update-settings,Dynamic>>)::
-The number of times that a {transform} retries when it experiences a
-non-fatal error. Once the number of retries is exhausted, the {transform}
-task will be marked as `failed`. The default value is `10` with a valid minimum of `0`
-and maximum of `100`.
-If a {transform} is already running, it will have to be restarted
-to use the changed setting.
+The number of times that a {transform} retries when it experiences a non-fatal 
+error. Once the number of retries is exhausted, the {transform} task is marked 
+as `failed`. The default value is `10` with a valid minimum of `0` and maximum 
+of `100`. If a {transform} is already running, it has to be restarted to use the 
+changed setting.


### PR DESCRIPTION
## Overview

This PR replaces `node.transform` setting with `node.roles: [ transform ]` on the `Transforms settings in Elasticsearch` page as `transform.node` will be depricated from 7.9.0.

### Preview

[Transforms settings in Elasticsearch]()