### PR TITLE
Remove old test mute code

### DIFF
--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
@@ -39,7 +39,6 @@ public class HdfsBlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTest
 
     @Override
     protected Settings repositorySettings() {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/31498", HdfsRepositoryTests.isJava11());
         return Settings.builder()
             .put("uri", "hdfs:///")
             .put("conf.fs.AbstractFileSystem.hdfs.impl", TestingFs.class.getName())

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.repositories.hdfs;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -47,15 +46,7 @@ public class HdfsRepositoryTests extends AbstractThirdPartyRepositoryTestCase {
     }
 
     @Override
-    public void tearDown() throws Exception {
-        if (isJava11() == false) {
-            super.tearDown();
-        }
-    }
-
-    @Override
     protected void createRepository(String repoName) {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/31498", isJava11());
         AcknowledgedResponse putRepositoryResponse = client().admin().cluster().preparePutRepository(repoName)
             .setType("hdfs")
             .setSettings(Settings.builder()
@@ -76,9 +67,5 @@ public class HdfsRepositoryTests extends AbstractThirdPartyRepositoryTestCase {
         } else {
             assertThat(response.result().blobs(), equalTo(0L));
         }
-    }
-
-    public static boolean isJava11() {
-        return JavaVersion.current().equals(JavaVersion.parse("11"));
     }
 }


### PR DESCRIPTION
It seems that some old test mute code, added as part of #31498, was never removed. This meant that the HDFS tests would fail when run under JDK 11.