### PR TITLE
[DOCS] Add security updates to release notes

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -3,6 +3,18 @@
 
 Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 
+[[security-updates-6.8.12]]
+[float]
+=== Security updates
+
+* A field disclosure flaw was found in {es} when running a scrolling search with
+field level security. If a user runs the same query another more privileged user
+recently ran, the scrolling search can leak fields that should be hidden. This
+could result in an attacker gaining additional permissions against a restricted
+index. All versions of {es} before 7.9.0 and 6.8.12 are affected by this flaw.
+You must upgrade to {es} version 7.9.0 or 6.8.12 to obtain the fix.
+https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7019[CVE-2020-7019]
+
 [[bug-6.8.12]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Related to https://discuss.elastic.co/t/elastic-stack-7-9-0-and-6-8-12-security-update/245456

This PR adds a security update to the Elasticsearch 6.8.12 release notes.

### Preview

https://elasticsearch_61287.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.12.html