### PR TITLE
[DOCS] Removes 7.9.0 coming tags

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 
-coming::[7.9.0]
-
 [[breaking-7.9.0]]
 [discrete]
 === Breaking changes


### PR DESCRIPTION
This PR removes the coming[7.9.0] tags from the Elasticsearch documentation.