### PR TITLE
Drop compile limit on runtime fields scripts

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("boolean_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("boolean_script_field", Factory.class);
 
     static List<Whitelist> whitelist() {
         return List.of(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "boolean_whitelist.txt"));

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("double_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("double_script_field", Factory.class);
 
     static List<Whitelist> whitelist() {
         return List.of(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "double_whitelist.txt"));

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * </ul>
  */
 public abstract class IpScriptFieldScript extends AbstractScriptFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ip_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("ip_script_field", Factory.class);
 
     static List<Whitelist> whitelist() {
         return List.of(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "ip_whitelist.txt"));

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class LongScriptFieldScript extends AbstractLongScriptFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("long_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("long_script_field", Factory.class);
 
     static List<Whitelist> whitelist() {
         return List.of(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "long_whitelist.txt"));

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class StringScriptFieldScript extends AbstractScriptFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("string_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("string_script_field", Factory.class);
 
     static List<Whitelist> whitelist() {
         return List.of(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "string_whitelist.txt"));

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
@@ -8,26 +8,25 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
-public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateScriptFieldScript.Factory> {
-    public static final DateScriptFieldScript.Factory DUMMY = (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(
+public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<BooleanScriptFieldScript.Factory> {
+    public static final BooleanScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new BooleanScriptFieldScript(
         params,
         lookup,
-        formatter,
         ctx
     ) {
         @Override
         public void execute() {
-            new DateScriptFieldScript.Millis(this).millis(1595431354874L);
+            new BooleanScriptFieldScript.Value(this).value(false);
         }
     };
 
     @Override
-    protected ScriptContext<DateScriptFieldScript.Factory> context() {
-        return DateScriptFieldScript.CONTEXT;
+    protected ScriptContext<BooleanScriptFieldScript.Factory> context() {
+        return BooleanScriptFieldScript.CONTEXT;
     }
 
     @Override
-    protected DateScriptFieldScript.Factory dummyScript() {
+    protected BooleanScriptFieldScript.Factory dummyScript() {
         return DUMMY;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -8,26 +8,25 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
-public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateScriptFieldScript.Factory> {
-    public static final DateScriptFieldScript.Factory DUMMY = (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(
+public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<DoubleScriptFieldScript.Factory> {
+    public static final DoubleScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new DoubleScriptFieldScript(
         params,
         lookup,
-        formatter,
         ctx
     ) {
         @Override
         public void execute() {
-            new DateScriptFieldScript.Millis(this).millis(1595431354874L);
+            new DoubleScriptFieldScript.Value(this).value(1.0);
         }
     };
 
     @Override
-    protected ScriptContext<DateScriptFieldScript.Factory> context() {
-        return DateScriptFieldScript.CONTEXT;
+    protected ScriptContext<DoubleScriptFieldScript.Factory> context() {
+        return DoubleScriptFieldScript.CONTEXT;
     }
 
     @Override
-    protected DateScriptFieldScript.Factory dummyScript() {
+    protected DoubleScriptFieldScript.Factory dummyScript() {
         return DUMMY;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class IpScriptFieldScriptTests extends ScriptFieldScriptTestCase<IpScriptFieldScript.Factory> {
+    public static final IpScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new IpScriptFieldScript(params, lookup, ctx) {
+        @Override
+        public void execute() {
+            new IpScriptFieldScript.StringValue(this).stringValue("192.168.0.1");
+        }
+    };
+
+    @Override
+    protected ScriptContext<IpScriptFieldScript.Factory> context() {
+        return IpScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected IpScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class LongScriptFieldScriptTests extends ScriptFieldScriptTestCase<LongScriptFieldScript.Factory> {
+    public static final LongScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new LongScriptFieldScript(params, lookup, ctx) {
+        @Override
+        public void execute() {
+            new LongScriptFieldScript.Value(this).value(1);
+        }
+    };
+
+    @Override
+    protected ScriptContext<LongScriptFieldScript.Factory> context() {
+        return LongScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected LongScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/ScriptFieldScriptTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/ScriptFieldScriptTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class ScriptFieldScriptTestCase<T> extends ESTestCase {
+    protected abstract ScriptContext<T> context();
+
+    protected abstract T dummyScript();
+
+    public final void testRateLimitingDisabled() throws IOException {
+        try (ScriptService scriptService = TestScriptEngine.scriptService(context(), dummyScript())) {
+            for (int i = 0; i < 1000; i++) {
+                scriptService.compile(new Script(ScriptType.INLINE, "test", "test_" + i, Map.of()), context());
+            }
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
@@ -8,26 +8,25 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
-public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateScriptFieldScript.Factory> {
-    public static final DateScriptFieldScript.Factory DUMMY = (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(
+public class StringScriptFieldScriptTests extends ScriptFieldScriptTestCase<StringScriptFieldScript.Factory> {
+    public static final StringScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new StringScriptFieldScript(
         params,
         lookup,
-        formatter,
         ctx
     ) {
         @Override
         public void execute() {
-            new DateScriptFieldScript.Millis(this).millis(1595431354874L);
+            new StringScriptFieldScript.Value(this).value("foo");
         }
     };
 
     @Override
-    protected ScriptContext<DateScriptFieldScript.Factory> context() {
-        return DateScriptFieldScript.CONTEXT;
+    protected ScriptContext<StringScriptFieldScript.Factory> context() {
+        return StringScriptFieldScript.CONTEXT;
     }
 
     @Override
-    protected DateScriptFieldScript.Factory dummyScript() {
+    protected StringScriptFieldScript.Factory dummyScript() {
         return DUMMY;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
@@ -24,13 +24,18 @@ import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
 import org.elasticsearch.xpack.runtimefields.DateScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.RuntimeFields;
 import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScriptTests;
 import org.elasticsearch.xpack.runtimefields.TestScriptEngine;
 
 import java.io.IOException;
@@ -320,59 +325,22 @@ public class RuntimeScriptFieldMapperTests extends ESSingleNodeTestCase {
                 @Override
                 protected Object buildScriptFactory(ScriptContext<?> context) {
                     if (context == BooleanScriptFieldScript.CONTEXT) {
-                        return (BooleanScriptFieldScript.Factory) (params, lookup) -> ctx -> new BooleanScriptFieldScript(
-                            params,
-                            lookup,
-                            ctx
-                        ) {
-                            @Override
-                            public void execute() {
-                                new BooleanScriptFieldScript.Value(this).value(true);
-                            }
-                        };
+                        return BooleanScriptFieldScriptTests.DUMMY;
                     }
                     if (context == DateScriptFieldScript.CONTEXT) {
                         return DateScriptFieldScriptTests.DUMMY;
                     }
                     if (context == DoubleScriptFieldScript.CONTEXT) {
-                        return (DoubleScriptFieldScript.Factory) (params, lookup) -> ctx -> new DoubleScriptFieldScript(
-                            params,
-                            lookup,
-                            ctx
-                        ) {
-                            @Override
-                            public void execute() {
-                                new DoubleScriptFieldScript.Value(this).value(1.0);
-                            }
-                        };
+                        return DoubleScriptFieldScriptTests.DUMMY;
                     }
                     if (context == IpScriptFieldScript.CONTEXT) {
-                        return (IpScriptFieldScript.Factory) (params, lookup) -> ctx -> new IpScriptFieldScript(params, lookup, ctx) {
-                            @Override
-                            public void execute() {
-                                new IpScriptFieldScript.StringValue(this).stringValue("192.168.0.1");
-                            }
-                        };
-                    }
-                    if (context == StringScriptFieldScript.CONTEXT) {
-                        return (StringScriptFieldScript.Factory) (params, lookup) -> ctx -> new StringScriptFieldScript(
-                            params,
-                            lookup,
-                            ctx
-                        ) {
-                            @Override
-                            public void execute() {
-                                new StringScriptFieldScript.Value(this).value("test");
-                            }
-                        };
+                        return IpScriptFieldScriptTests.DUMMY;
                     }
                     if (context == LongScriptFieldScript.CONTEXT) {
-                        return (LongScriptFieldScript.Factory) (params, lookup) -> ctx -> new LongScriptFieldScript(params, lookup, ctx) {
-                            @Override
-                            public void execute() {
-                                new LongScriptFieldScript.Value(this).value(1);
-                            }
-                        };
+                        return LongScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == StringScriptFieldScript.CONTEXT) {
+                        return StringScriptFieldScriptTests.DUMMY;
                     }
                     throw new IllegalArgumentException("No test script for [" + context + "]");
                 }


### PR DESCRIPTION
This opts all of the script contexts used by `runtime_script` our of the
compilation rate limiting because it'd be lame to prevent a mapping
update because we can't compile the script.
