### PR TITLE
Correct how field retrieval handles multifields and copy_to.

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -181,11 +181,16 @@ public class RankFeatureFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Float parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return objectToFloat(value);
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Float parseSourceValue(Object value) {
+                return objectToFloat(value);
+            }
+        };
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -181,11 +181,11 @@ public class RankFeatureFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Float parseSourceValue(Object value) {
                 return objectToFloat(value);

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -160,11 +160,11 @@ public class RankFeaturesFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -160,11 +160,16 @@ public class RankFeaturesFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -480,11 +480,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Double parseSourceValue(Object value) {
                 double doubleValue;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -357,11 +357,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Double nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected void parseCreateField(ParseContext context) throws IOException {
 
         XContentParser parser = context.parser();

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -480,24 +480,29 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Double parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Double parseSourceValue(Object value) {
+                double doubleValue;
+                if (value.equals("")) {
+                    if (nullValue == null) {
+                        return null;
+                    }
+                    doubleValue = nullValue;
+                } else {
+                    doubleValue = objectToDouble(value);
+                }
 
-        double doubleValue;
-        if (value.equals("")) {
-            if (nullValue == null) {
-                return null;
+                double scalingFactor = fieldType().getScalingFactor();
+                return Math.round(doubleValue * scalingFactor) / scalingFactor;
             }
-            doubleValue = nullValue;
-        } else {
-            doubleValue = objectToDouble(value);
-        }
-
-        double scalingFactor = fieldType().getScalingFactor();
-        return Math.round(doubleValue * scalingFactor) / scalingFactor;
+        };
     }
+
 
     private static class ScaledFloatIndexFieldData extends IndexNumericFieldData {
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -419,7 +419,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -465,7 +465,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -588,7 +588,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         throw new UnsupportedOperationException();
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -419,7 +419,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -465,7 +465,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -588,11 +588,8 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
-        if (format != null) {
-            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
-        }
-        return value.toString();
+    public ValueFetcher valueFetcher(String format) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -159,12 +159,12 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected String parseSourceValue(Object value) {
                 return value.toString();

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -159,12 +159,17 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return value.toString();
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                return value.toString();
+            }
+        };
     }
 
     /**

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class RankFeatureFieldMapperTests extends FieldMapperTestCase<RankFeatureFieldMapper.Builder> {
@@ -189,12 +190,12 @@ public class RankFeatureFieldMapperTests extends FieldMapperTestCase<RankFeature
                 e.getCause().getMessage());
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
         RankFeatureFieldMapper mapper = new RankFeatureFieldMapper.Builder("field").build(context);
 
-        assertEquals(3.14f, mapper.parseSourceValue(3.14, null), 0.0001);
-        assertEquals(42.9f, mapper.parseSourceValue("42.9", null), 0.0001);
+        assertEquals(List.of(3.14f), fetchSourceValue(mapper, 3.14));
+        assertEquals(List.of(42.9f), fetchSourceValue(mapper, "42.9"));
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
@@ -136,8 +137,8 @@ public class MetaJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    public ValueFetcher valueFetcher(String format) {
+        throw new UnsupportedOperationException("Cannot fetch values for metadata field [" + typeName() + "].");
     }
 
     @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -137,7 +138,7 @@ public class MetaJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         throw new UnsupportedOperationException("Cannot fetch values for metadata field [" + typeName() + "].");
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -187,7 +188,7 @@ public final class ParentIdFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
@@ -186,8 +187,8 @@ public final class ParentIdFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    public ValueFetcher valueFetcher(String format) {
+        throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
     }
 
     @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -42,8 +42,10 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
@@ -348,11 +350,16 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -350,11 +350,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -62,6 +62,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
@@ -368,11 +369,11 @@ public class PercolatorFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -66,7 +66,9 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -366,11 +368,16 @@ public class PercolatorFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     static void createQueryBuilderField(Version indexVersion, BinaryFieldMapper qbField,

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -738,12 +738,12 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected String parseSourceValue(Object value) {
                 String keywordValue = value.toString();

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -578,11 +578,6 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
         ICUCollationKeywordFieldMapper icuMergeWith = (ICUCollationKeywordFieldMapper) other;
         if (!Objects.equals(collator, icuMergeWith.collator)) {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -738,15 +738,21 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        String keywordValue = value.toString();
-        if (keywordValue.length() > ignoreAbove) {
-            return null;
-        }
-        return keywordValue;
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                String keywordValue = value.toString();
+                if (keywordValue.length() > ignoreAbove) {
+                    return null;
+                }
+                return keywordValue;
+            }
+        };
     }
+
 }

--- a/plugins/mapper-annotated-text/src/internalClusterTest/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/internalClusterTest/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -677,7 +678,7 @@ public class AnnotatedTextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
@@ -688,8 +689,8 @@ public class AnnotatedTextFieldMapperTests extends ESSingleNodeTestCase {
             .build(context);
         AnnotatedTextFieldMapper mapper = (AnnotatedTextFieldMapper) fieldMapper;
 
-        assertEquals("value", mapper.parseSourceValue("value", null));
-        assertEquals("42", mapper.parseSourceValue(42L, null));
-        assertEquals("true", mapper.parseSourceValue(true, null));
+        assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(mapper, true));
     }
 }

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -40,7 +40,9 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.AnnotatedText.AnnotationToken;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
@@ -584,11 +586,16 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value.toString();
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value.toString();
+            }
+        };
     }
 
     @Override

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -586,11 +587,11 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value.toString();

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -35,8 +35,10 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TypeParsers;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 
@@ -148,11 +150,16 @@ public class Murmur3FieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value.toString();
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                return value.toString();
+            }
+        };
     }
 
     @Override

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -150,11 +151,11 @@ public class Murmur3FieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected String parseSourceValue(Object value) {
                 return value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Base field mapper class for all spatial field types
@@ -183,14 +184,19 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        if (format == null) {
-            format = GeoJsonGeometryFormat.NAME;
-        }
+    public ValueFetcher valueFetcher(String format) {
+        String geoFormat = format != null ? format : GeoJsonGeometryFormat.NAME;
 
         AbstractGeometryFieldType<Parsed, Processed> mappedFieldType = fieldType();
         Parser<Parsed> geometryParser = mappedFieldType.geometryParser();
-        return geometryParser.parseAndFormatObject(value, this, format);
+        Function<Object, Object> valueParser = value -> geometryParser.parseAndFormatObject(value, this, geoFormat);
+
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return valueParser.apply(value);
+            }
+        };
     }
 
     public abstract static class TypeParser<T extends Builder> implements Mapper.TypeParser {

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -184,14 +184,14 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         String geoFormat = format != null ? format : GeoJsonGeometryFormat.NAME;
 
         AbstractGeometryFieldType<Parsed, Processed> mappedFieldType = fieldType();
         Parser<Parsed> geometryParser = mappedFieldType.geometryParser();
         Function<Object, Object> valueParser = value -> geometryParser.parseAndFormatObject(value, this, geoFormat);
 
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return valueParser.apply(value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -190,11 +190,11 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -190,11 +190,16 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -250,12 +250,12 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected Boolean parseSourceValue(Object value) {
                 if (value instanceof Boolean) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -278,8 +278,4 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         return CONTENT_TYPE;
     }
 
-    @Override
-    protected Object nullValue() {
-        return nullValue;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -250,17 +250,22 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public Boolean parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        } else {
-            String textValue = value.toString();
-            return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
-        }
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected Boolean parseSourceValue(Object value) {
+                if (value instanceof Boolean) {
+                    return (Boolean) value;
+                } else {
+                    String textValue = value.toString();
+                    return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
+                }
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -537,16 +537,21 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected List<?> parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        if (value instanceof List) {
-            return (List<?>) value;
-        } else {
-            return List.of(value);
-        }
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected List<?> parseSourceValue(Object value) {
+                if (value instanceof List) {
+                    return (List<?>) value;
+                } else {
+                    return List.of(value);
+                }
+            }
+        };
     }
 
     static class CompletionInputMetadata {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -537,12 +537,12 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected List<?> parseSourceValue(Object value) {
                 if (value instanceof List) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -570,13 +570,13 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         DateFormatter defaultFormatter = fieldType().dateTimeFormatter();
         DateFormatter formatter = format != null
             ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
             : defaultFormatter;
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValueAsString) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValueAsString) {
             @Override
             public String parseSourceValue(Object value) {
                 String date = value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -519,11 +519,6 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected String nullValue() {
-        return nullValueAsString;
-    }
-
-    @Override
     protected void parseCreateField(ParseContext context) throws IOException {
         String dateAsString;
         if (context.externalValueSet()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -285,7 +285,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * Create a helper class to fetch field values during the {@link FetchFieldsPhase}.
      */
-    public abstract ValueFetcher valueFetcher(@Nullable String format);
+    public abstract ValueFetcher valueFetcher(MapperService mapperService, @Nullable String format);
 
     protected void createFieldNamesField(ParseContext context) {
         FieldNamesFieldType fieldNamesFieldType = context.docMapper().metadataMapper(FieldNamesFieldMapper.class).fieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -229,13 +229,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     }
 
     /**
-     * A value to use in place of a {@code null} value in the document source.
-     */
-    protected Object nullValue() {
-        return null;
-    }
-
-    /**
      * Whether this mapper can handle an array value during document parsing. If true,
      * when an array is encountered during parsing, the document parser will pass the
      * whole array to the mapper. If false, the array is split into individual values

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -34,10 +34,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +46,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.TreeMap;
 import java.util.stream.StreamSupport;
 
@@ -285,58 +283,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     protected abstract void parseCreateField(ParseContext context) throws IOException;
 
     /**
-     * Given access to a document's _source, return this field's values.
-     *
-     * In addition to pulling out the values, mappers can parse them into a standard form. This
-     * method delegates parsing to {@link #parseSourceValue} for parsing. Most mappers will choose
-     * to override {@link #parseSourceValue} -- for example numeric field mappers make sure to
-     * parse the source value into a number of the right type. Some mappers may need more
-     * flexibility and can override this entire method instead.
-     *
-     * Note that for array values, the order in which values are returned is undefined and should
-     * not be relied on.
-     *
-     * @param lookup a lookup structure over the document's source.
-     * @param format an optional format string used when formatting values, for example a date format.
-     * @return a list a standardized field values.
+     * Create a helper class to fetch field values during the {@link FetchFieldsPhase}.
      */
-    public List<?> lookupValues(SourceLookup lookup, @Nullable String format) {
-        Object sourceValue = lookup.extractValue(name(), nullValue());
-        if (sourceValue == null) {
-            return List.of();
-        }
-
-        List<Object> values = new ArrayList<>();
-        if (parsesArrayValue()) {
-            return (List<?>) parseSourceValue(sourceValue, format);
-        }
-
-        // We allow source values to contain multiple levels of arrays, such as `"field": [[1, 2]]`.
-        // So we need to unwrap these arrays before passing them on to be parsed.
-        Queue<Object> queue = new ArrayDeque<>();
-        queue.add(sourceValue);
-        while (queue.isEmpty() == false) {
-            Object value = queue.poll();
-            if (value instanceof List) {
-                queue.addAll((List<?>) value);
-            } else {
-                Object parsedValue = parseSourceValue(value, format);
-                if (parsedValue != null) {
-                    values.add(parsedValue);
-                }
-            }
-        }
-        return values;
-    }
-
-    /**
-     * Given a value that has been extracted from a document's source, parse it into a standard
-     * format. This parsing logic should closely mirror the value parsing in
-     * {@link #parseCreateField} or {@link #parse}.
-     *
-     * Note that when overriding this method, {@link #lookupValues} should *not* be overridden.
-     */
-    protected abstract Object parseSourceValue(Object value, @Nullable String format);
+    public abstract ValueFetcher valueFetcher(@Nullable String format);
 
     protected void createFieldNamesField(ParseContext context) {
         FieldNamesFieldType fieldNamesFieldType = context.docMapper().metadataMapper(FieldNamesFieldMapper.class).fieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -328,11 +328,6 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected Object nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected IpFieldMapper clone() {
         return (IpFieldMapper) super.clone();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -385,18 +385,22 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-
-        InetAddress address;
-        if (value instanceof InetAddress) {
-            address = (InetAddress) value;
-        } else {
-            address = InetAddresses.forString(value.toString());
-        }
-        return InetAddresses.toAddrString(address);
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                InetAddress address;
+                if (value instanceof InetAddress) {
+                    address = (InetAddress) value;
+                } else {
+                    address = InetAddresses.forString(value.toString());
+                }
+                return InetAddresses.toAddrString(address);
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -385,11 +385,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected Object parseSourceValue(Object value) {
                 InetAddress address;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -388,26 +388,31 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        String keywordValue = value.toString();
-        if (keywordValue.length() > ignoreAbove) {
-            return null;
-        }
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                String keywordValue = value.toString();
+                if (keywordValue.length() > ignoreAbove) {
+                    return null;
+                }
 
-        NamedAnalyzer normalizer = fieldType().normalizer();
-        if (normalizer == null) {
-            return keywordValue;
-        }
+                NamedAnalyzer normalizer = fieldType().normalizer();
+                if (normalizer == null) {
+                    return keywordValue;
+                }
 
-        try {
-            return normalizeValue(normalizer, keywordValue);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+                try {
+                    return normalizeValue(normalizer, keywordValue);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -388,12 +388,12 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected String parseSourceValue(Object value) {
                 String keywordValue = value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -421,11 +421,6 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected String nullValue() {
-        return nullValue;
-    }
-
-    @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
         return new Builder(simpleName(), indexAnalyzers).init(this);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -165,7 +165,7 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -165,8 +165,8 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    public ValueFetcher valueFetcher(String format) {
+        throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1091,12 +1091,12 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected Object parseSourceValue(Object value) {
                 if (value.equals("")) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1037,11 +1037,6 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Number nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected void parseCreateField(ParseContext context) throws IOException {
         XContentParser parser = context.parser();
         Object value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1091,16 +1091,20 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Number parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        if (value.equals("")) {
-            return nullValue;
-        }
-
-        return fieldType().type.parse(value, coerce.value());
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                if (value.equals("")) {
+                    return nullValue;
+                }
+                return fieldType().type.parse(value, coerce.value());
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -375,13 +375,13 @@ public class RangeFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         DateFormatter defaultFormatter = fieldType().dateTimeFormatter();
         DateFormatter formatter = format != null
             ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
             : defaultFormatter;
 
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
 
             @Override
             @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -375,28 +375,34 @@ public class RangeFieldMapper extends FieldMapper {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected Object parseSourceValue(Object value, String format) {
-        RangeType rangeType = fieldType().rangeType();
-        if (!(value instanceof Map)) {
-            assert rangeType == RangeType.IP;
-            Tuple<InetAddress, Integer> ipRange = InetAddresses.parseCidr(value.toString());
-            return InetAddresses.toCidrString(ipRange.v1(), ipRange.v2());
-        }
+    public ValueFetcher valueFetcher(String format) {
+        DateFormatter defaultFormatter = fieldType().dateTimeFormatter();
+        DateFormatter formatter = format != null
+            ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
+            : defaultFormatter;
 
-        DateFormatter dateTimeFormatter = fieldType().dateTimeFormatter();
-        if (format != null) {
-            dateTimeFormatter = DateFormatter.forPattern(format).withLocale(dateTimeFormatter.locale());
-        }
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
 
-        Map<String, Object> range = (Map<String, Object>) value;
-        Map<String, Object> parsedRange = new HashMap<>();
-        for (Map.Entry<String, Object> entry : range.entrySet()) {
-            Object parsedValue = rangeType.parseValue(entry.getValue(), coerce.value(), fieldType().dateMathParser);
-            Object formattedValue = rangeType.formatValue(parsedValue, dateTimeFormatter);
-            parsedRange.put(entry.getKey(), formattedValue);
-        }
-        return parsedRange;
+            @Override
+            @SuppressWarnings("unchecked")
+            protected Object parseSourceValue(Object value) {
+                RangeType rangeType = fieldType().rangeType();
+                if (!(value instanceof Map)) {
+                    assert rangeType == RangeType.IP;
+                    Tuple<InetAddress, Integer> ipRange = InetAddresses.parseCidr(value.toString());
+                    return InetAddresses.toCidrString(ipRange.v1(), ipRange.v2());
+                }
+
+                Map<String, Object> range = (Map<String, Object>) value;
+                Map<String, Object> parsedRange = new HashMap<>();
+                for (Map.Entry<String, Object> entry : range.entrySet()) {
+                    Object parsedValue = rangeType.parseValue(entry.getValue(), coerce.value(), fieldType().dateMathParser);
+                    Object formattedValue = rangeType.formatValue(parsedValue, formatter);
+                    parsedRange.put(entry.getKey(), formattedValue);
+                }
+                return parsedRange;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -34,12 +34,12 @@ import java.util.Set;
  * to implement value fetching.
  */
 public abstract class SourceValueFetcher implements ValueFetcher {
-    private final String fieldName;
+    private final Set<String> sourcePaths;
     private final @Nullable Object nullValue;
     private final boolean parsesArrayValue;
 
-    public SourceValueFetcher(String fieldName, boolean parsesArrayValue) {
-        this(fieldName, parsesArrayValue, null);
+    public SourceValueFetcher(String fieldName, MapperService mapperService, boolean parsesArrayValue) {
+        this(fieldName, mapperService, parsesArrayValue, null);
     }
 
     /**
@@ -47,14 +47,14 @@ public abstract class SourceValueFetcher implements ValueFetcher {
      * @param parsesArrayValue Whether the fetcher handles array values during document parsing.
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
-    public SourceValueFetcher(String fieldName, boolean parsesArrayValue, Object nullValue) {
-        this.fieldName = fieldName;
+    public SourceValueFetcher(String fieldName, MapperService mapperService, boolean parsesArrayValue, Object nullValue) {
+        this.sourcePaths = mapperService.sourcePath(fieldName);
         this.nullValue = nullValue;
         this.parsesArrayValue = parsesArrayValue;
     }
 
     @Override
-    public List<Object> fetchValues(SourceLookup lookup, Set<String> sourcePaths) {
+    public List<Object> fetchValues(SourceLookup lookup) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
             Object sourceValue = lookup.extractValue(path, nullValue);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.search.lookup.SourceLookup;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * An implementation of {@link ValueFetcher} that knows how to extract values
+ * from the document source. Most standard field mappers will use this class
+ * to implement value fetching.
+ */
+public abstract class SourceValueFetcher implements ValueFetcher {
+    private final String fieldName;
+    private final @Nullable Object nullValue;
+    private final boolean parsesArrayValue;
+
+    public SourceValueFetcher(String fieldName, boolean parsesArrayValue) {
+        this(fieldName, parsesArrayValue, null);
+    }
+
+    /**
+     * @param fieldName The name of the field.
+     * @param parsesArrayValue Whether the fetcher handles array values during document parsing.
+     * @param nullValue A optional substitute value if the _source value is 'null'.
+     */
+    public SourceValueFetcher(String fieldName, boolean parsesArrayValue, Object nullValue) {
+        this.fieldName = fieldName;
+        this.nullValue = nullValue;
+        this.parsesArrayValue = parsesArrayValue;
+    }
+
+    @Override
+    public List<?> fetchValues(SourceLookup lookup) {
+        Object sourceValue = lookup.extractValue(fieldName, nullValue);
+        if (sourceValue == null) {
+            return List.of();
+        }
+
+        if (parsesArrayValue) {
+            return (List<?>) parseSourceValue(sourceValue);
+        } else {
+            List<Object> values = new ArrayList<>();
+
+            // We allow source values to contain multiple levels of arrays, such as `"field": [[1, 2]]`.
+            // So we need to unwrap these arrays before passing them on to be parsed.
+            Queue<Object> queue = new ArrayDeque<>();
+            queue.add(sourceValue);
+            while (queue.isEmpty() == false) {
+                Object value = queue.poll();
+                if (value instanceof List) {
+                    queue.addAll((List<?>) value);
+                } else {
+                    Object parsedValue = parseSourceValue(value);
+                    if (parsedValue != null) {
+                        values.add(parsedValue);
+                    }
+                }
+            }
+            return values;
+        }
+    }
+
+    /**
+     * Given a value that has been extracted from a document's source, parse it into a standard
+     * format. This parsing logic should closely mirror the value parsing in
+     * {@link FieldMapper#parseCreateField} or {@link FieldMapper#parse}.
+     */
+    protected abstract Object parseSourceValue(Object value);
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -497,7 +497,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -528,7 +528,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -835,11 +835,11 @@ public class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -497,7 +497,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -528,7 +528,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -835,11 +835,16 @@ public class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value.toString();
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value.toString();
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
@@ -41,7 +41,8 @@ public interface ValueFetcher {
      * should not be relied on.
      *
      * @param lookup a lookup structure over the document's source.
+     * @param sourcePaths the field paths to look up in the source.
      * @return a list a standardized field values.
      */
-    List<?> fetchValues(SourceLookup lookup);
+    List<Object> fetchValues(SourceLookup lookup, Set<String> sourcePaths);
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
+import org.elasticsearch.search.lookup.SourceLookup;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A helper class for fetching field values during the {@link FetchFieldsPhase}. Each {@link FieldMapper}
+ * is in charge of defining a value fetcher through {@link FieldMapper#valueFetcher}.
+ */
+public interface ValueFetcher {
+    /**
+     * Given access to a document's _source, return this field's values.
+     *
+     * In addition to pulling out the values, they will be parsed into a standard form.
+     * For example numeric field mappers make sure to parse the source value into a number
+     * of the right type.
+     *
+     * Note that for array values, the order in which values are returned is undefined and
+     * should not be relied on.
+     *
+     * @param lookup a lookup structure over the document's source.
+     * @return a list a standardized field values.
+     */
+    List<?> fetchValues(SourceLookup lookup);
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A helper class for fetching field values during the {@link FetchFieldsPhase}. Each {@link FieldMapper}
@@ -41,8 +40,7 @@ public interface ValueFetcher {
      * should not be relied on.
      *
      * @param lookup a lookup structure over the document's source.
-     * @param sourcePaths the field paths to look up in the source.
      * @return a list a standardized field values.
      */
-    List<Object> fetchValues(SourceLookup lookup, Set<String> sourcePaths);
+    List<Object> fetchValues(SourceLookup lookup);
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldValueRetriever.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldValueRetriever.java
@@ -65,9 +65,8 @@ public class FieldValueRetriever {
                 }
 
                 FieldMapper fieldMapper = (FieldMapper) mapper;
-                ValueFetcher valueFetcher = fieldMapper.valueFetcher(format);
-                Set<String> sourcePath = mapperService.sourcePath(field);
-                fieldContexts.add(new FieldContext(field, valueFetcher, sourcePath));
+                ValueFetcher valueFetcher = fieldMapper.valueFetcher(mapperService, format);
+                fieldContexts.add(new FieldContext(field, valueFetcher));
             }
         }
 
@@ -87,7 +86,7 @@ public class FieldValueRetriever {
             }
 
             ValueFetcher valueFetcher = context.valueFetcher;
-            List<Object> parsedValues = valueFetcher.fetchValues(sourceLookup, context.sourcePath);
+            List<Object> parsedValues = valueFetcher.fetchValues(sourceLookup);
 
             if (parsedValues.isEmpty() == false) {
                 documentFields.put(field, new DocumentField(field, parsedValues));
@@ -99,14 +98,10 @@ public class FieldValueRetriever {
     private static class FieldContext {
         final String fieldName;
         final ValueFetcher valueFetcher;
-        final Set<String> sourcePath;
-
 
         FieldContext(String fieldName,
-                     ValueFetcher valueFetcher,
-                     Set<String> sourcePath) {
+                     ValueFetcher valueFetcher) {
             this.fieldName = fieldName;
-            this.sourcePath = sourcePath;
             this.valueFetcher = valueFetcher;
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -938,19 +939,19 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 CompletionFieldMapper.COMPLETION_CONTEXTS_LIMIT + "] has been exceeded"));
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
         NamedAnalyzer defaultAnalyzer = new NamedAnalyzer("standard", AnalyzerScope.INDEX, new StandardAnalyzer());
         CompletionFieldMapper mapper = new CompletionFieldMapper.Builder("completion", defaultAnalyzer, Version.CURRENT).build(context);
 
-        assertEquals(List.of("value"), mapper.parseSourceValue("value", null));
+        assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
 
         List<String> list = List.of("first", "second");
-        assertEquals(list, mapper.parseSourceValue(list, null));
+        assertEquals(list, fetchSourceValue(mapper, list));
 
         Map<String, Object> object = Map.of("input", List.of("first", "second"), "weight", "2.718");
-        assertEquals(List.of(object), mapper.parseSourceValue(object, null));
+        assertEquals(List.of(object), fetchSourceValue(mapper, object));
     }
 
     private Matcher<IndexableField> suggestField(String value) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.junit.Before;
@@ -51,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -457,51 +457,44 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         DateFieldMapper mapper = createMapper(Resolution.MILLISECONDS, null);
         String date = "2020-05-15T21:33:02.000Z";
-        assertEquals(date, mapper.parseSourceValue(date, null));
-        assertEquals(date, mapper.parseSourceValue(1589578382000L, null));
+        assertEquals(List.of(date), fetchSourceValue(mapper, date));
+        assertEquals(List.of(date), fetchSourceValue(mapper, 1589578382000L));
 
         DateFieldMapper mapperWithFormat = createMapper(Resolution.MILLISECONDS, "yyyy/MM/dd||epoch_millis");
         String dateInFormat = "1990/12/29";
-        assertEquals(dateInFormat, mapperWithFormat.parseSourceValue(dateInFormat, null));
-        assertEquals(dateInFormat, mapperWithFormat.parseSourceValue(662428800000L, null));
+        assertEquals(List.of(dateInFormat), fetchSourceValue(mapperWithFormat, dateInFormat));
+        assertEquals(List.of(dateInFormat), fetchSourceValue(mapperWithFormat, 662428800000L));
 
         DateFieldMapper mapperWithMillis = createMapper(Resolution.MILLISECONDS, "epoch_millis");
         String dateInMillis = "662428800000";
-        assertEquals(dateInMillis, mapperWithMillis.parseSourceValue(dateInMillis, null));
-        assertEquals(dateInMillis, mapperWithMillis.parseSourceValue(662428800000L, null));
+        assertEquals(List.of(dateInMillis), fetchSourceValue(mapperWithMillis, dateInMillis));
+        assertEquals(List.of(dateInMillis), fetchSourceValue(mapperWithMillis, 662428800000L));
 
         String nullValueDate = "2020-05-15T21:33:02.000Z";
         DateFieldMapper nullValueMapper = createMapper(Resolution.MILLISECONDS, null, nullValueDate);
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of(nullValueDate), nullValueMapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(nullValueDate), fetchSourceValue(nullValueMapper, null));
     }
 
     public void testParseSourceValueWithFormat() {
         DateFieldMapper mapper = createMapper(Resolution.NANOSECONDS, "strict_date_time", "1970-12-29T00:00:00.000Z");
         String date = "1990-12-29T00:00:00.000Z";
-        assertEquals("1990/12/29", mapper.parseSourceValue(date, "yyyy/MM/dd"));
-        assertEquals("662428800000", mapper.parseSourceValue(date, "epoch_millis"));
-
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of("1970/12/29"), mapper.lookupValues(sourceLookup, "yyyy/MM/dd"));
+        assertEquals(List.of("1990/12/29"), fetchSourceValue(mapper, date, "yyyy/MM/dd"));
+        assertEquals(List.of("662428800000"), fetchSourceValue(mapper, date, "epoch_millis"));
+        assertEquals(List.of("1970/12/29"), fetchSourceValue(mapper, null, "yyyy/MM/dd"));
     }
 
     public void testParseSourceValueNanos() {
         DateFieldMapper mapper = createMapper(Resolution.NANOSECONDS, "strict_date_time||epoch_millis");
         String date = "2020-05-15T21:33:02.123456789Z";
-        assertEquals("2020-05-15T21:33:02.123456789Z", mapper.parseSourceValue(date, null));
-        assertEquals("2020-05-15T21:33:02.123Z", mapper.parseSourceValue(1589578382123L, null));
+        assertEquals(List.of("2020-05-15T21:33:02.123456789Z"), fetchSourceValue(mapper, date));
+        assertEquals(List.of("2020-05-15T21:33:02.123Z"), fetchSourceValue(mapper, 1589578382123L));
 
         String nullValueDate = "2020-05-15T21:33:02.123456789Z";
         DateFieldMapper nullValueMapper = createMapper(Resolution.NANOSECONDS, "strict_date_time||epoch_millis", nullValueDate);
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of(nullValueDate), nullValueMapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(nullValueDate), fetchSourceValue(nullValueMapper, null));
     }
 
     private DateFieldMapper createMapper(Resolution resolution, String format) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -103,7 +103,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -103,7 +103,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -201,8 +201,13 @@ public class ExternalMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        return value;
+    public ValueFetcher valueFetcher(String format) {
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -201,8 +201,8 @@ public class ExternalMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -134,8 +134,8 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected String parseSourceValue(Object value) {
                 return value.toString();

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -134,8 +134,13 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
-        return value.toString();
+    public ValueFetcher valueFetcher(String format) {
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                return value.toString();
+            }
+        };
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -95,23 +95,6 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertEquals(Set.of("field"), lookup.sourcePaths("field.subfield2"));
     }
 
-    public void testSourcePathWithAliases() {
-        Mapper.BuilderContext context = new Mapper.BuilderContext(
-            MockFieldMapper.DEFAULT_SETTINGS, new ContentPath());
-
-        MockFieldMapper field = new MockFieldMapper.Builder("field")
-            .addMultiField(new MockFieldMapper.Builder("field.subfield"))
-            .build(context);
-
-        FieldAliasMapper alias1 = new FieldAliasMapper("alias1", "alias1", "field");
-        FieldAliasMapper alias2 = new FieldAliasMapper("alias2", "alias2", "field.subfield");
-
-        FieldTypeLookup lookup = new FieldTypeLookup(Arrays.asList(field), Arrays.asList(alias1, alias2));
-
-        assertEquals(Set.of("field"), lookup.sourcePaths("alias1"));
-        assertEquals(Set.of("field"), lookup.sourcePaths("alias2"));
-    }
-
     public void testSourcePathsWithCopyTo() {
         Mapper.BuilderContext context = new Mapper.BuilderContext(
             MockFieldMapper.DEFAULT_SETTINGS, new ContentPath());

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -41,7 +41,6 @@ import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -593,7 +592,7 @@ public class GeoPointFieldMapperTests extends FieldMapperTestCase<GeoPointFieldM
             ), XContentType.JSON)).rootDoc().getField("location"), nullValue());
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
@@ -606,24 +605,24 @@ public class GeoPointFieldMapperTests extends FieldMapperTestCase<GeoPointFieldM
         String otherWktPoint = "POINT (30.0 50.0)";
 
         // Test a single point in [lon, lat] array format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(42.0, 27.1)));
-        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        Object sourceValue = List.of(42.0, 27.1);
+        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single point in "lat, lon" string format.
-        sourceLookup.setSource(Collections.singletonMap("field", "27.1,42.0"));
-        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = "27.1,42.0";
+        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of points in [lon, lat] array format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0))));
-        assertEquals(List.of(jsonPoint, otherJsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktPoint, otherWktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = List.of(List.of(42.0, 27.1), List.of(30.0, 50.0));
+        assertEquals(List.of(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single point in well-known text format.
-        sourceLookup.setSource(Collections.singletonMap("field", "POINT (42.0 27.1)"));
-        assertEquals(List.of(jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = "POINT (42.0 27.1)";
+        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.junit.Before;
@@ -363,12 +362,11 @@ public class GeoShapeFieldMapperTests extends FieldMapperTestCase<GeoShapeFieldM
         return toXContentString(mapper, true);
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         GeoShapeFieldMapper mapper = new GeoShapeFieldMapper.Builder("field").build(context);
-        SourceLookup sourceLookup = new SourceLookup();
 
         Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates",
             List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
@@ -377,23 +375,23 @@ public class GeoShapeFieldMapperTests extends FieldMapperTestCase<GeoShapeFieldM
         String wktPoint = "POINT (14.0 15.0)";
 
         // Test a single shape in geojson format.
-        sourceLookup.setSource(Collections.singletonMap("field", jsonLineString));
-        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+        Object sourceValue = jsonLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in geojson format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(jsonLineString, jsonPoint)));
-        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = List.of(jsonLineString, jsonPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single shape in wkt format.
-        sourceLookup.setSource(Collections.singletonMap("field", wktLineString));
-        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = wktLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in wkt format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(wktLineString, wktPoint)));
-        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = List.of(wktLineString, wktPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
@@ -35,8 +35,10 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Before;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.containsString;
 
 public class IpRangeFieldMapperTests extends ESSingleNodeTestCase {
@@ -84,13 +86,13 @@ public class IpRangeFieldMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         RangeFieldMapper mapper = new RangeFieldMapper.Builder("field", RangeType.IP).build(context);
         Map<String, Object> range = Map.of("gte", "2001:db8:0:0:0:0:2:1");
-        assertEquals(Map.of("gte", "2001:db8::2:1"), mapper.parseSourceValue(range, null));
-        assertEquals("2001:db8::2:1/32", mapper.parseSourceValue("2001:db8:0:0:0:0:2:1/32", null));
+        assertEquals(List.of(Map.of("gte", "2001:db8::2:1")), fetchSourceValue(mapper, range));
+        assertEquals(List.of("2001:db8::2:1/32"), fetchSourceValue(mapper, "2001:db8:0:0:0:0:2:1/32"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -31,8 +31,11 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -49,18 +52,17 @@ import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.lucene.analysis.BaseTokenStreamTestCase.assertTokenStreamContents;
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -168,9 +170,6 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         // used by TermVectorsService
         assertArrayEquals(new String[] { "1234" }, TermVectorsService.getValues(doc.rootDoc().getFields("field")));
-
-        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
-        assertEquals("1234", fieldMapper.parseSourceValue("1234", null));
     }
 
     public void testIgnoreAbove() throws IOException {
@@ -494,31 +493,34 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
     }
 
-    public void testParseSourceValue() {
-        Mapper.BuilderContext context = new Mapper.BuilderContext(getIndexSettings(), new ContentPath());
+    public void testFetchSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         KeywordFieldMapper mapper = new KeywordFieldMapper.Builder("field").build(context);
-        assertEquals("value", mapper.parseSourceValue("value", null));
-        assertEquals("42", mapper.parseSourceValue(42L, null));
-        assertEquals("true", mapper.parseSourceValue(true, null));
+        assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(mapper, true));
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> mapper.parseSourceValue(true, "format"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> fetchSourceValue(mapper, "value", "format"));
         assertEquals("Field [field] of type [keyword] doesn't support formats.", e.getMessage());
 
-        KeywordFieldMapper ignoreAboveMapper = new KeywordFieldMapper.Builder("field").ignoreAbove(4).build(context);
-        assertNull(ignoreAboveMapper.parseSourceValue("value", null));
-        assertEquals("42", ignoreAboveMapper.parseSourceValue(42L, null));
-        assertEquals("true", ignoreAboveMapper.parseSourceValue(true, null));
+        KeywordFieldMapper ignoreAboveMapper = new KeywordFieldMapper.Builder("field")
+            .ignoreAbove(4)
+            .build(context);
+        assertEquals(List.of(), fetchSourceValue(ignoreAboveMapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(ignoreAboveMapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(ignoreAboveMapper, true));
 
         KeywordFieldMapper normalizerMapper = new KeywordFieldMapper.Builder("field", createIndexAnalyzers()).normalizer("lowercase")
             .build(context);
-        assertEquals("value", normalizerMapper.parseSourceValue("VALUE", null));
-        assertEquals("42", normalizerMapper.parseSourceValue(42L, null));
-        assertEquals("value", normalizerMapper.parseSourceValue("value", null));
+        assertEquals(List.of("value"), fetchSourceValue(normalizerMapper, "VALUE"));
+        assertEquals(List.of("42"), fetchSourceValue(normalizerMapper, 42L));
+        assertEquals(List.of("value"), fetchSourceValue(normalizerMapper, "value"));
 
-        KeywordFieldMapper nullValueMapper = new KeywordFieldMapper.Builder("field").nullValue("NULL").build(context);
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of("NULL"), nullValueMapper.lookupValues(sourceLookup, null));
+        KeywordFieldMapper nullValueMapper = new KeywordFieldMapper.Builder("field")
+            .nullValue("NULL")
+            .build(context);
+        assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -846,7 +846,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase<LegacyGe
         return toXContentString(mapper, true);
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
@@ -860,23 +860,23 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase<LegacyGe
         String wktPoint = "POINT (14.0 15.0)";
 
         // Test a single shape in geojson format.
-        sourceLookup.setSource(Collections.singletonMap("field", jsonLineString));
-        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+        Object sourceValue = jsonLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in geojson format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(jsonLineString, jsonPoint)));
-        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = List.of(jsonLineString, jsonPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single shape in wkt format.
-        sourceLookup.setSource(Collections.singletonMap("field", wktLineString));
-        assertEquals(List.of(jsonLineString), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = wktLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in wkt format.
-        sourceLookup.setSource(Collections.singletonMap("field", List.of(wktLineString, wktPoint)));
-        assertEquals(List.of(jsonLineString, jsonPoint), mapper.lookupValues(sourceLookup, null));
-        assertEquals(List.of(wktLineString, wktPoint), mapper.lookupValues(sourceLookup, "wkt"));
+        sourceValue = List.of(wktLineString, wktPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -38,13 +38,11 @@ import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -406,22 +404,19 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase<N
         }
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         NumberFieldMapper mapper = new NumberFieldMapper.Builder("field", NumberType.INTEGER).build(context);
-        assertEquals(3, mapper.parseSourceValue(3.14, null));
-        assertEquals(42, mapper.parseSourceValue("42.9", null));
+        assertEquals(List.of(3), fetchSourceValue(mapper, 3.14));
+        assertEquals(List.of(42), fetchSourceValue(mapper, "42.9"));
 
         NumberFieldMapper nullValueMapper = new NumberFieldMapper.Builder("field", NumberType.FLOAT)
             .nullValue(2.71f)
             .build(context);
-        assertEquals(2.71f, (float) nullValueMapper.parseSourceValue("", null), 0.00001);
-
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of(2.71f), nullValueMapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of(2.71f), fetchSourceValue(nullValueMapper, ""));
+        assertEquals(List.of(2.71f), fetchSourceValue(nullValueMapper, null));
     }
 
     @Timeout(millis = 30000)

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -189,7 +189,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        public ValueFetcher valueFetcher(String format) {
+        public ValueFetcher valueFetcher(MapperService mapperService, String format) {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -189,7 +189,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        protected Object parseSourceValue(Object value, String format) {
+        public ValueFetcher valueFetcher(String format) {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -42,6 +42,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -491,20 +492,20 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase<Ra
         assertEquals("Invalid format: [[test_format]]: Unknown pattern letter: t", e.getMessage());
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         RangeFieldMapper longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG).build(context);
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
-        assertEquals(Map.of("gte", 3L, "lt", 42L), longMapper.parseSourceValue(longRange, null));
+        assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
         RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE)
             .format("yyyy/MM/dd||epoch_millis")
             .build(context);
         Map<String, Object> dateRange = Map.of("lt", "1990/12/29", "gte", 597429487111L);
-        assertEquals(Map.of("lt", "1990/12/29", "gte", "1988/12/06"),
-            dateMapper.parseSourceValue(dateRange, null));
+        assertEquals(List.of(Map.of("lt", "1990/12/29", "gte", "1988/12/06")),
+            fetchSourceValue(dateMapper, dateRange));
     }
 
     public void testParseSourceValueWithFormat() {
@@ -513,13 +514,13 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase<Ra
 
         RangeFieldMapper longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG).build(context);
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
-        assertEquals(Map.of("gte", 3L, "lt", 42L), longMapper.parseSourceValue(longRange, null));
+        assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
         RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE)
             .format("strict_date_time")
             .build(context);
         Map<String, Object> dateRange = Map.of("lt", "1990-12-29T00:00:00.000Z");
-        assertEquals(Map.of("lt", "1990/12/29"), dateMapper.parseSourceValue(dateRange, "yyy/MM/dd"));
-        assertEquals(Map.of("lt", "662428800000"), dateMapper.parseSourceValue(dateRange, "epoch_millis"));
+        assertEquals(List.of(Map.of("lt", "1990/12/29")), fetchSourceValue(dateMapper, dateRange, "yyy/MM/dd"));
+        assertEquals(List.of(Map.of("lt", "662428800000")), fetchSourceValue(dateMapper, dateRange,"epoch_millis"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -85,6 +85,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -1334,15 +1335,15 @@ public class TextFieldMapperTests extends FieldMapperTestCase<TextFieldMapper.Bu
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         FieldMapper fieldMapper = newBuilder().build(context);
         TextFieldMapper mapper = (TextFieldMapper) fieldMapper;
 
-        assertEquals("value", mapper.parseSourceValue("value", null));
-        assertEquals("42", mapper.parseSourceValue(42L, null));
-        assertEquals("true", mapper.parseSourceValue(true, null));
+        assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(mapper, true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
@@ -309,7 +309,7 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         DocumentField field = fields.get("field.keyword");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(1));
-        assertThat(field.getValues(), hasItems(42));
+        assertThat(field.getValues(), hasItems("42"));
 
         fields = retrieveFields(mapperService, source, "field*");
         assertThat(fields.size(), equalTo(2));
@@ -344,7 +344,7 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         DocumentField field = fields.get("field");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(6));
-        assertThat(field.getValues(), hasItems("one", "two", "three", 1, 2, 3));
+        assertThat(field.getValues(), hasItems("one", "two", "three", "1", "2", "3"));
     }
 
     public void testObjectFields() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
@@ -250,6 +251,18 @@ public abstract class FieldMapperTestCase<T extends FieldMapper.Builder<?>> exte
         builder.toXContent(x, params);
         x.endObject().endObject();
         return Strings.toString(x);
+    }
+
+    public static List<?> fetchSourceValue(FieldMapper mapper, Object sourceValue) {
+        return fetchSourceValue(mapper, sourceValue, null);
+    }
+
+    public static List<?> fetchSourceValue(FieldMapper mapper, Object sourceValue, String format) {
+        String field = mapper.name();
+        ValueFetcher fetcher = mapper.valueFetcher(format);
+        SourceLookup lookup = new SourceLookup();
+        lookup.setSource(Collections.singletonMap(field, sourceValue));
+        return fetcher.fetchValues(lookup);
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
@@ -46,6 +46,8 @@ import java.util.function.BiConsumer;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Base class for testing {@link FieldMapper}s.
@@ -259,10 +261,14 @@ public abstract class FieldMapperTestCase<T extends FieldMapper.Builder<?>> exte
 
     public static List<?> fetchSourceValue(FieldMapper mapper, Object sourceValue, String format) {
         String field = mapper.name();
-        ValueFetcher fetcher = mapper.valueFetcher(format);
+
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.sourcePath(field)).thenReturn(Set.of(field));
+
+        ValueFetcher fetcher = mapper.valueFetcher(mapperService, format);
         SourceLookup lookup = new SourceLookup();
         lookup.setSource(Collections.singletonMap(field, sourceValue));
-        return fetcher.fetchValues(lookup, Set.of(field));
+        return fetcher.fetchValues(lookup);
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
@@ -262,7 +262,7 @@ public abstract class FieldMapperTestCase<T extends FieldMapper.Builder<?>> exte
         ValueFetcher fetcher = mapper.valueFetcher(format);
         SourceLookup lookup = new SourceLookup();
         lookup.setSource(Collections.singletonMap(field, sourceValue));
-        return fetcher.fetchValues(lookup);
+        return fetcher.fetchValues(lookup, Set.of(field));
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -90,7 +90,7 @@ public class MockFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         throw new UnsupportedOperationException();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -90,7 +90,7 @@ public class MockFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         throw new UnsupportedOperationException();
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -167,11 +167,11 @@ public class HistogramFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -44,8 +44,10 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TypeParsers;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -165,11 +167,16 @@ public class HistogramFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     public static class HistogramFieldType extends MappedFieldType {

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -36,9 +36,9 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TypeParsers;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -264,19 +264,14 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    public List<String> lookupValues(SourceLookup lookup, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return fieldType().value == null
+        return lookup -> fieldType().value == null
             ? List.of()
             : List.of(fieldType().value);
-    }
-
-    @Override
-    protected Object parseSourceValue(Object value, String format) {
-        throw new UnsupportedOperationException("This should never be called, since lookupValues is implemented directly.");
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -269,7 +269,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return lookup -> fieldType().value == null
+        return (lookup, paths) -> fieldType().value == null
             ? List.of()
             : List.of(fieldType().value);
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.mapper.ValueFetcher;
@@ -264,12 +265,12 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return (lookup, paths) -> fieldType().value == null
+        return lookup -> fieldType().value == null
             ? List.of()
             : List.of(fieldType().value);
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -270,9 +270,9 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return lookup -> fieldType().value == null
-            ? List.of()
-            : List.of(fieldType().value);
+        return fieldType().value == null
+            ? lookup -> List.of()
+            : lookup -> List.of(fieldType().value);
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -115,18 +115,19 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
         FieldMapper fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         ValueFetcher fetcher = fieldMapper.valueFetcher(null);
 
+        Set<String> sourcePaths = Set.of("field");
         SourceLookup missingValueLookup = new SourceLookup();
         SourceLookup nullValueLookup = new SourceLookup();
         nullValueLookup.setSource(Collections.singletonMap("field", null));
 
-        assertTrue(fetcher.fetchValues(missingValueLookup).isEmpty());
-        assertTrue(fetcher.fetchValues(nullValueLookup).isEmpty());
+        assertTrue(fetcher.fetchValues(missingValueLookup, sourcePaths).isEmpty());
+        assertTrue(fetcher.fetchValues(nullValueLookup, sourcePaths).isEmpty());
 
         merge(mapperService, fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         fetcher = fieldMapper.valueFetcher(null);
 
-        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup));
-        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup));
+        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup, sourcePaths));
+        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup, sourcePaths));
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin;
@@ -27,6 +28,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -108,16 +110,23 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
         b.field("type", "constant_keyword");
     }
 
-    public void testLookupValues() throws Exception {
+    public void testFetchValue() throws Exception {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword")));
         FieldMapper fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        List<?> values = fieldMapper.lookupValues(new SourceLookup(), null);
-        assertTrue(values.isEmpty());
-        merge(mapperService, fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
+        ValueFetcher fetcher = fieldMapper.valueFetcher(null);
 
+        SourceLookup missingValueLookup = new SourceLookup();
+        SourceLookup nullValueLookup = new SourceLookup();
+        nullValueLookup.setSource(Collections.singletonMap("field", null));
+
+        assertTrue(fetcher.fetchValues(missingValueLookup).isEmpty());
+        assertTrue(fetcher.fetchValues(nullValueLookup).isEmpty());
+
+        merge(mapperService, fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        values = fieldMapper.lookupValues(new SourceLookup(), null);
-        assertEquals(1, values.size());
-        assertEquals("foo", values.get(0));
+        fetcher = fieldMapper.valueFetcher(null);
+
+        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup));
+        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup));
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -113,21 +113,20 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
     public void testFetchValue() throws Exception {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword")));
         FieldMapper fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        ValueFetcher fetcher = fieldMapper.valueFetcher(null);
+        ValueFetcher fetcher = fieldMapper.valueFetcher(mapperService, null);
 
-        Set<String> sourcePaths = Set.of("field");
         SourceLookup missingValueLookup = new SourceLookup();
         SourceLookup nullValueLookup = new SourceLookup();
         nullValueLookup.setSource(Collections.singletonMap("field", null));
 
-        assertTrue(fetcher.fetchValues(missingValueLookup, sourcePaths).isEmpty());
-        assertTrue(fetcher.fetchValues(nullValueLookup, sourcePaths).isEmpty());
+        assertTrue(fetcher.fetchValues(missingValueLookup).isEmpty());
+        assertTrue(fetcher.fetchValues(nullValueLookup).isEmpty());
 
         merge(mapperService, fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         fieldMapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        fetcher = fieldMapper.valueFetcher(null);
+        fetcher = fieldMapper.valueFetcher(mapperService, null);
 
-        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup, sourcePaths));
-        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup, sourcePaths));
+        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup));
+        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup));
     }
 }

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -512,11 +512,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     @Override
-    protected String nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected void mergeOptions(FieldMapper mergeWith, List<String> conflicts) {
         FlatObjectFieldMapper other = ((FlatObjectFieldMapper) mergeWith);
         if (Objects.equals(this.nullValue, other.nullValue) == false) {

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -567,11 +567,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -41,8 +41,10 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
@@ -565,11 +567,16 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapperTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapperTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.flattened.FlattenedMapperPlugin;
 import org.elasticsearch.xpack.flattened.mapper.FlatObjectFieldMapper.KeyedFlatObjectFieldType;
@@ -42,7 +41,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -515,19 +513,17 @@ public class FlatObjectFieldMapperTests extends FieldMapperTestCase<FlatObjectFi
             new String[] {"Hello", "World"});
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         Map<String, Object> sourceValue = Map.of("key", "value");
         FlatObjectFieldMapper mapper = new FlatObjectFieldMapper.Builder("field").build(context);
-        assertEquals(sourceValue, mapper.parseSourceValue(sourceValue, null));
+        assertEquals(List.of(sourceValue), fetchSourceValue(mapper, sourceValue));
 
         FlatObjectFieldMapper nullValueMapper = new FlatObjectFieldMapper.Builder("field")
             .nullValue("NULL")
             .build(context);
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of("NULL"), nullValueMapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper, null));
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -208,11 +209,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -24,7 +24,9 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -206,11 +208,16 @@ public class DenseVectorFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return value;
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -18,7 +18,9 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 
@@ -143,8 +145,16 @@ public class SparseVectorFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value, String format) {
-        throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
+    public ValueFetcher valueFetcher(String format) {
+        if (format != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
+        }
+        return new SourceValueFetcher(name(), parsesArrayValue()) {
+            @Override
+            protected Object parseSourceValue(Object value) {
+                return value;
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -145,11 +146,11 @@ public class SparseVectorFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(name(), parsesArrayValue()) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -989,11 +989,6 @@ public class WildcardFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String nullValue() {
-        return nullValue;
-    }
-
-    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
         this.ignoreAbove = ((WildcardFieldMapper) other).ignoreAbove;
     }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -60,7 +60,9 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -939,16 +941,21 @@ public class WildcardFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected String parseSourceValue(Object value, String format) {
+    public ValueFetcher valueFetcher(String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        String keywordValue = value.toString();
-        if (keywordValue.length() > ignoreAbove) {
-            return null;
-        }
-        return keywordValue;
+        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+            @Override
+            protected String parseSourceValue(Object value) {
+                String keywordValue = value.toString();
+                if (keywordValue.length() > ignoreAbove) {
+                    return null;
+                }
+                return keywordValue;
+            }
+        };
     }
 
     void createFields(String value, Document parseDoc, List<IndexableField>fields) throws IOException {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -941,12 +941,12 @@ public class WildcardFieldMapper extends FieldMapper {
     }
 
     @Override
-    public ValueFetcher valueFetcher(String format) {
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
 
-        return new SourceValueFetcher(name(), parsesArrayValue(), nullValue) {
+        return new SourceValueFetcher(name(), mapperService, parsesArrayValue(), nullValue) {
             @Override
             protected String parseSourceValue(Object value) {
                 String keywordValue = value.toString();

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -55,7 +55,6 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -65,11 +64,11 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import static org.elasticsearch.index.mapper.FieldMapperTestCase.fetchSourceValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -777,28 +776,26 @@ public class WildcardFieldMapperTests extends ESTestCase {
         return result.toString();
     }
 
-    public void testParseSourceValue() {
+    public void testFetchSourceValue() {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         WildcardFieldMapper mapper = new WildcardFieldMapper.Builder("field").build(context);
-        assertEquals("value", mapper.parseSourceValue("value", null));
-        assertEquals("42", mapper.parseSourceValue(42L, null));
-        assertEquals("true", mapper.parseSourceValue(true, null));
+        assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(mapper, true));
 
         WildcardFieldMapper ignoreAboveMapper = new WildcardFieldMapper.Builder("field")
             .ignoreAbove(4)
             .build(context);
-        assertNull(ignoreAboveMapper.parseSourceValue("value", null));
-        assertEquals("42", ignoreAboveMapper.parseSourceValue(42L, null));
-        assertEquals("true", ignoreAboveMapper.parseSourceValue(true, null));
+        assertEquals(List.of(), fetchSourceValue(ignoreAboveMapper, "value"));
+        assertEquals(List.of("42"), fetchSourceValue(ignoreAboveMapper, 42L));
+        assertEquals(List.of("true"), fetchSourceValue(ignoreAboveMapper, true));
 
         WildcardFieldMapper nullValueMapper = new WildcardFieldMapper.Builder("field")
             .nullValue("NULL")
             .build(context);
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(Collections.singletonMap("field", null));
-        assertEquals(List.of("NULL"), nullValueMapper.lookupValues(sourceLookup, null));
+        assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper, null));
     }
 
     protected MappedFieldType provideMappedFieldType(String name) {


### PR DESCRIPTION
Before when a value was copied to a field through a parent field or `copy_to`,
we parsed it using the `FieldMapper` from the source field. Instead we should
parse it using the target `FieldMapper`. This ensures that we apply the
appropriate mapping type and options to the copied value.

To implement the fix cleanly, this PR refactors the value parsing strategy. Now
instead of looking up values directly, field mappers produce a helper object
`ValueFetcher`. The value fetchers are responsible for almost all aspects of
fetching, including looking up the right paths in the _source.

The PR is fairly big but each commit can be reviewed individually.

Fixes #61033.