### PR TITLE
Fix fieldnames field type for pre-6.1 indexes

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -98,7 +98,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         type = getOldClusterVersion().before(Version.V_6_7_0) ? "doc" : "_doc";
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/57245")
     public void testSearch() throws Exception {
         int count;
         if (isRunningAgainstOldCluster()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -235,9 +235,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             }
             for (String path : paths) {
                 for (String fieldName : extractFieldNames(path)) {
-                    if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-                        document.add(new Field(fieldType().name(), fieldName, fieldType));
-                    }
+                    document.add(new Field(fieldType().name(), fieldName, Defaults.FIELD_TYPE));
                 }
             }
         }


### PR DESCRIPTION
The FieldNamesFieldMapper field has different behaviour for indexes created in 
clusters earlier than v6.1, and the code to deal with this was still using the vestigial
`FieldType` field of `FieldMapper` in its indexing path.  This meant that documents
added after an upgrade were not correctly indexing their field names field.  This 
commit corrects the `parseCreateField` method to use the default field type.

Fixes #61305 