### PR TITLE
Configurable output format for date processor

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
@@ -146,4 +146,42 @@ public class DateProcessorFactoryTests extends ESTestCase {
         DateProcessor processor = factory.create(null, null, null, config);
         assertThat(processor.getTargetField(), equalTo(targetField));
     }
+
+    public void testParseOutputFormat() throws Exception {
+        final String outputFormat = "dd:MM:yyyy";
+        Map<String, Object> config = new HashMap<>();
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
+        config.put("field", sourceField);
+        config.put("target_field", targetField);
+        config.put("formats", Arrays.asList("dd/MM/yyyy", "dd-MM-yyyy"));
+        config.put("output_format", outputFormat);
+        DateProcessor processor = factory.create(null, null, null, config);
+        assertThat(processor.getOutputFormat(), equalTo(outputFormat));
+    }
+
+    public void testDefaultOutputFormat() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
+        config.put("field", sourceField);
+        config.put("target_field", targetField);
+        config.put("formats", Arrays.asList("dd/MM/yyyy", "dd-MM-yyyy"));
+        DateProcessor processor = factory.create(null, null, null, config);
+        assertThat(processor.getOutputFormat(), equalTo(DateProcessor.DEFAULT_OUTPUT_FORMAT));
+    }
+
+    public void testInvalidOutputFormatRejected() throws Exception {
+        final String outputFormat = "invalid_date_format";
+        Map<String, Object> config = new HashMap<>();
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
+        config.put("field", sourceField);
+        config.put("target_field", targetField);
+        config.put("formats", Arrays.asList("dd/MM/yyyy", "dd-MM-yyyy"));
+        config.put("output_format", outputFormat);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> factory.create(null, null, null, config));
+        assertThat(e.getMessage(), containsString("invalid output format [" + outputFormat + "]"));
+    }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -234,6 +234,7 @@ public class DateProcessorTests extends ESTestCase {
         document.put("date_as_string", Instant.EPOCH.plusNanos(nanosAfterEpoch).toString());
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
         processor.execute(ingestDocument);
+        // output format is time only with nanosecond precision
         String expectedDate = "00:00:00." + String.format(Locale.ROOT, "%09d", nanosAfterEpoch);
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo(expectedDate));
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.test.ESTestCase;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -223,5 +224,17 @@ public class DateProcessorTests extends ESTestCase {
             () -> processor.execute(RandomDocumentPicks.randomIngestDocument(random(), document)));
         assertThat(e.getMessage(), equalTo("unable to parse date [2010]"));
         assertThat(e.getCause().getMessage(), equalTo("Unknown language: invalid"));
+    }
+
+    public void testOutputFormat() {
+        long nanosAfterEpoch = randomLongBetween(1, 999999);
+        DateProcessor processor = new DateProcessor(randomAlphaOfLength(10), null, null, null,
+            "date_as_string", Collections.singletonList("iso8601"), "date_as_date", "HH:mm:ss.SSSSSSSSS");
+        Map<String, Object> document = new HashMap<>();
+        document.put("date_as_string", Instant.EPOCH.plusNanos(nanosAfterEpoch).toString());
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        processor.execute(ingestDocument);
+        String expectedDate = "00:00:00." + String.format(Locale.ROOT, "%09d", nanosAfterEpoch);
+        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo(expectedDate));
     }
 }


### PR DESCRIPTION
Adds an optional `output_format` setting to the date processor that controls the formatting of the date. Supports the same formats as the `formats` option and can be used to output times including microsecond or nanosecond components.

Resolves #42523.
