### PR TITLE
Handle incoming fragments directly

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -71,9 +71,10 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
 
         final ByteBuf buffer = (ByteBuf) msg;
         Netty4TcpChannel channel = ctx.channel().attr(Netty4Transport.CHANNEL_KEY).get();
+        pipeline.setChannel(channel);
         final BytesReference wrapped = Netty4Utils.toBytesReference(buffer);
         try (ReleasableBytesReference reference = new ReleasableBytesReference(wrapped, buffer::release)) {
-            pipeline.handleBytes(channel, reference);
+            pipeline.handleBytes(reference);
         }
     }
 

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
@@ -43,7 +43,6 @@ public class TcpReadWriteHandler extends BytesWriteHandler {
     private final InboundPipeline pipeline;
 
     public TcpReadWriteHandler(NioTcpChannel channel, PageCacheRecycler recycler, TcpTransport transport) {
-        this.channel = channel;
         final ThreadPool threadPool = transport.getThreadPool();
         final Supplier<CircuitBreaker> breaker = transport.getInflightBreaker();
         final Transport.RequestHandlers requestHandlers = transport.getRequestHandlers();

--- a/server/src/main/java/org/elasticsearch/transport/InboundFragmentHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundFragmentHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+
+import java.io.IOException;
+
+interface InboundFragmentHandler {
+    void handleHeader(Header header);
+
+    void handlePing();
+
+    void handleEndContent() throws IOException;
+
+    void handleFragment(ReleasableBytesReference fragment);
+}

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -86,6 +86,7 @@ public class OutboundHandlerTests extends ESTestCase {
                     throw new AssertionError(e);
                 }
             });
+        pipeline.setChannel(channel);
     }
 
     @After
@@ -157,8 +158,7 @@ public class OutboundHandlerTests extends ESTestCase {
         assertEquals(action, actionRef.get());
         assertEquals(request, requestRef.get());
 
-        pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
-        }));
+        pipeline.handleBytes(ReleasableBytesReference.wrap(reference));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
         final TestRequest message = new TestRequest(tuple.v2().streamInput());
@@ -216,8 +216,7 @@ public class OutboundHandlerTests extends ESTestCase {
         assertEquals(action, actionRef.get());
         assertEquals(response, responseRef.get());
 
-        pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
-        }));
+        pipeline.handleBytes(ReleasableBytesReference.wrap(reference));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
         final TestResponse message = new TestResponse(tuple.v2().streamInput());
@@ -275,8 +274,7 @@ public class OutboundHandlerTests extends ESTestCase {
         assertEquals(error, responseRef.get());
 
 
-        pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
-        }));
+        pipeline.handleBytes(ReleasableBytesReference.wrap(reference));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
         assertEquals(version, header.getVersion());


### PR DESCRIPTION
Today we accumulate incoming message fragments in an `ArrayList` and
pass then onto the aggregator only once we've run out of bytes or got to
the end of the message. With this commit we avoid the intermediate
accumulation and pass them onto the aggregator as they're decoded.