### PR TITLE
[DOCS] Document that boolean field treats empty string as `false`

### DIFF
--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -10,7 +10,7 @@ strings which are interpreted as either true or false:
 [horizontal]
 False values::
 
-    `false`, `"false"`
+    `false`, `"false"`, `""` (empty string)
 
 True values::
 


### PR DESCRIPTION
Relates to #61038 

This may change as a result of later fixes for #61038, but that's likely to be a breaking change
in the next major release.
This docs change will be backported to 7.x branches and 6.8 so our users are aware.
Without docs, many users may assume an empty string (`""`) is treated as null.