### PR TITLE
Detect noop of update index settings

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -21,10 +21,13 @@ package org.elasticsearch.indices.settings;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
@@ -687,4 +690,40 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(response.getIndexToSettings().get("test")), equalTo(1));
     }
 
+    public void testNoopUpdate() {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        final ClusterService clusterService = internalCluster().getMasterNodeInstance(ClusterService.class);
+        assertAcked(client().admin().indices().prepareCreate("test")
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)));
+        client().admin().cluster().prepareHealth()
+            .setWaitForNoInitializingShards(true)
+            .setWaitForEvents(Priority.LANGUID)
+            .setTimeout(TimeValue.MAX_VALUE)
+            .get();
+
+        ClusterState currentState = clusterService.state();
+        assertAcked(client().admin().indices().prepareUpdateSettings("test")
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)));
+        assertNotSame(currentState, clusterService.state());
+        currentState = clusterService.state();
+
+        assertAcked(client().admin().indices().prepareUpdateSettings("test")
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)));
+        assertSame(clusterService.state(), currentState);
+
+        assertAcked(client().admin().indices().prepareUpdateSettings("test")
+            .setSettings(Settings.builder().putNull(IndexMetadata.SETTING_NUMBER_OF_REPLICAS)));
+        assertSame(clusterService.state(), currentState);
+
+        assertAcked(client().admin().indices().prepareUpdateSettings("test")
+            .setSettings(Settings.builder()
+                .put(SETTING_BLOCKS_READ, true)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)));
+        assertNotSame(currentState, clusterService.state());
+        currentState = clusterService.state();
+
+        assertAcked(client().admin().indices().prepareUpdateSettings("test")
+            .setSettings(Settings.builder().put(SETTING_BLOCKS_READ, true)));
+        assertNotSame(currentState, clusterService.state());
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -403,6 +404,10 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
             }
             indices.remove(index);
             return this;
+        }
+
+        public boolean hasIndexBlock(String index, ClusterBlock block) {
+            return indices.getOrDefault(index, Collections.emptySet()).contains(block);
         }
 
         public Builder removeIndexBlock(String index, ClusterBlock block) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -177,11 +177,6 @@ public class MetadataUpdateSettingsService {
                     }
                 }
 
-                ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-                for (IndexMetadata.APIBlock block : IndexMetadata.APIBlock.values()) {
-                    maybeUpdateClusterBlock(actualIndices, blocks, block.block, block.setting, openSettings);
-                }
-
                 if (!openIndices.isEmpty()) {
                     for (Index index : openIndices) {
                         IndexMetadata indexMetadata = metadataBuilder.getSafe(index);
@@ -246,13 +241,24 @@ public class MetadataUpdateSettingsService {
                         MetadataCreateIndexService.validateTranslogRetentionSettings(metadataBuilder.get(index).getSettings());
                     }
                 }
+                boolean changed = false;
                 // increment settings versions
                 for (final String index : actualIndices) {
                     if (same(currentState.metadata().index(index).getSettings(), metadataBuilder.get(index).getSettings()) == false) {
+                        changed = true;
                         final IndexMetadata.Builder builder = IndexMetadata.builder(metadataBuilder.get(index));
                         builder.settingsVersion(1 + builder.settingsVersion());
                         metadataBuilder.put(builder);
                     }
+                }
+
+                final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                for (IndexMetadata.APIBlock block : IndexMetadata.APIBlock.values()) {
+                    changed |= maybeUpdateClusterBlock(actualIndices, blocks, block.block, block.setting, openSettings);
+                }
+
+                if (changed == false) {
+                    return currentState;
                 }
 
                 ClusterState updatedState = ClusterState.builder(currentState).metadata(metadataBuilder)
@@ -294,8 +300,9 @@ public class MetadataUpdateSettingsService {
     /**
      * Updates the cluster block only iff the setting exists in the given settings
      */
-    private static void maybeUpdateClusterBlock(String[] actualIndices, ClusterBlocks.Builder blocks, ClusterBlock block,
+    private static boolean maybeUpdateClusterBlock(String[] actualIndices, ClusterBlocks.Builder blocks, ClusterBlock block,
                                                 Setting<Boolean> setting, Settings openSettings) {
+        boolean changed = false;
         if (setting.exists(openSettings)) {
             final boolean updateBlock = setting.get(openSettings);
             for (String index : actualIndices) {
@@ -304,8 +311,10 @@ public class MetadataUpdateSettingsService {
                 } else {
                     blocks.removeIndexBlock(index, block);
                 }
+                changed = true;
             }
         }
+        return changed;
     }
 
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -307,11 +307,16 @@ public class MetadataUpdateSettingsService {
             final boolean updateBlock = setting.get(openSettings);
             for (String index : actualIndices) {
                 if (updateBlock) {
-                    blocks.addIndexBlock(index, block);
+                    if (blocks.hasIndexBlock(index, block) == false) {
+                        blocks.addIndexBlock(index, block);
+                        changed = true;
+                    }
                 } else {
-                    blocks.removeIndexBlock(index, block);
+                    if (blocks.hasIndexBlock(index, block)) {
+                        blocks.removeIndexBlock(index, block);
+                        changed = true;
+                    }
                 }
-                changed = true;
             }
         }
         return changed;


### PR DESCRIPTION
This optimization is more relevant in the context of CCR. When a node in the follower leaves, we reallocate the shard-follow tasks on that node to other nodes. The new tasks will [overwhelm](https://github.com/elastic/elasticsearch/blob/2a49ba3252cfbb99175e5808dd204a229e1662dd/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java#L152-L179) the follower cluster with many put-mapping, update-settings requests, although most of them are noop. This change detects and optimizes for noop update-settings requests.