### PR TITLE
Scripting: Converts casting and def support

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -160,9 +160,7 @@ public final class MethodWriter extends GeneratorAdapter {
         if (cast == null) {
             return;
         }
-        if (cast.converter != null) {
-            invokeStatic(Type.getType(cast.converter.getDeclaringClass()), Method.getMethod(cast.converter));
-        } else if (cast.originalType == char.class && cast.targetType == String.class) {
+        if (cast.originalType == char.class && cast.targetType == String.class) {
             invokeStatic(UTILITY_TYPE, CHAR_TO_STRING);
         } else if (cast.originalType == String.class && cast.targetType == char.class) {
             invokeStatic(UTILITY_TYPE, STRING_TO_CHAR);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
@@ -107,9 +107,6 @@ public class ScriptClassInfo {
                         throw new IllegalStateException("convertFromDef must take a single Object as an argument, " +
                             "not [" + m.getParameterTypes()[0] + "]");
                     }
-                    if (defConverter != null) {
-                        throw new IllegalStateException("duplicate convertFromDef converters");
-                    }
                     defConverter = new FunctionTable.LocalFunction(m.getName(), m.getReturnType(), Arrays.asList(m.getParameterTypes()),
                                                                    true, true);
                 } else {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
@@ -22,12 +22,13 @@ package org.elasticsearch.painless;
 import org.elasticsearch.painless.lookup.PainlessLookup;
 import org.elasticsearch.painless.lookup.PainlessLookupUtility;
 import org.elasticsearch.painless.lookup.def;
+import org.elasticsearch.painless.symbol.FunctionTable;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -46,7 +47,8 @@ public class ScriptClassInfo {
     private final List<org.objectweb.asm.commons.Method> needsMethods;
     private final List<org.objectweb.asm.commons.Method> getMethods;
     private final List<Class<?>> getReturns;
-    private final List<ConverterSignature> converterSignatures;
+    public final List<FunctionTable.LocalFunction> converters;
+    public final FunctionTable.LocalFunction defConverter;
 
     public ScriptClassInfo(PainlessLookup painlessLookup, Class<?> baseClass) {
         this.baseClass = baseClass;
@@ -92,17 +94,33 @@ public class ScriptClassInfo {
         if (executeMethod == null) {
             throw new IllegalStateException("no execute method found");
         }
-        ArrayList<ConverterSignature> converterSignatures = new ArrayList<>();
+        ArrayList<FunctionTable.LocalFunction> converters = new ArrayList<>();
+        FunctionTable.LocalFunction defConverter = null;
         for (java.lang.reflect.Method m : baseClass.getMethods()) {
             if (m.getName().startsWith("convertFrom") &&
                 m.getParameterTypes().length == 1 &&
                 m.getReturnType() == returnType &&
                 Modifier.isStatic(m.getModifiers())) {
 
-                converterSignatures.add(new ConverterSignature(m));
+                if (m.getName().equals("convertFromDef")) {
+                    if (m.getParameterTypes()[0] != Object.class) {
+                        throw new IllegalStateException("convertFromDef must take a single Object as an argument, " +
+                            "not [" + m.getParameterTypes()[0] + "]");
+                    }
+                    if (defConverter != null) {
+                        throw new IllegalStateException("duplicate convertFromDef converters");
+                    }
+                    defConverter = new FunctionTable.LocalFunction(m.getName(), m.getReturnType(), Arrays.asList(m.getParameterTypes()),
+                                                                   true, true);
+                } else {
+                    converters.add(
+                        new FunctionTable.LocalFunction(m.getName(), m.getReturnType(), Arrays.asList(m.getParameterTypes()), true, true)
+                    );
+                }
             }
         }
-        this.converterSignatures = unmodifiableList(converterSignatures);
+        this.defConverter = defConverter;
+        this.converters = unmodifiableList(converters);
 
         MethodType methodType = MethodType.methodType(executeMethod.getReturnType(), executeMethod.getParameterTypes());
         this.executeMethod = new org.objectweb.asm.commons.Method(executeMethod.getName(), methodType.toMethodDescriptorString());
@@ -238,24 +256,5 @@ public class ScriptClassInfo {
         } catch (IllegalArgumentException | IllegalAccessException e) {
             throw new IllegalArgumentException("Error trying to read [" + iface.getName() + "#ARGUMENTS]", e);
         }
-    }
-
-    private static class ConverterSignature {
-        final Class<?> parameter;
-        final Method method;
-
-        ConverterSignature(Method method) {
-            this.method = method;
-            this.parameter = method.getParameterTypes()[0];
-        }
-    }
-
-    public Method getConverter(Class<?> original) {
-        for (ConverterSignature converterSignature: converterSignatures) {
-            if (converterSignature.parameter.isAssignableFrom(original)) {
-                return converterSignature.method;
-            }
-        }
-        return null;
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessCast.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessCast.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.lookup;
 
-import java.lang.reflect.Method;
 import java.util.Objects;
 
 public class PainlessCast {
@@ -85,14 +84,6 @@ public class PainlessCast {
         return new PainlessCast(null, null, explicitCast, unboxOriginalType, null, null, boxTargetType);
     }
 
-    public static PainlessCast convertedReturn(Class<?> originalType, Class<?> targetType, Method converter) {
-        Objects.requireNonNull(originalType);
-        Objects.requireNonNull(targetType);
-        Objects.requireNonNull(converter);
-
-        return new PainlessCast(originalType, targetType, false, null, null, null, null, converter);
-    }
-
     public final Class<?> originalType;
     public final Class<?> targetType;
     public final boolean explicitCast;
@@ -100,26 +91,9 @@ public class PainlessCast {
     public final Class<?> unboxTargetType;
     public final Class<?> boxOriginalType;
     public final Class<?> boxTargetType;
-    public final Method converter; // access
 
-    private PainlessCast(Class<?> originalType,
-                         Class<?> targetType,
-                         boolean explicitCast,
-                         Class<?> unboxOriginalType,
-                         Class<?> unboxTargetType,
-                         Class<?> boxOriginalType,
-                         Class<?> boxTargetType) {
-        this(originalType, targetType, explicitCast, unboxOriginalType, unboxTargetType, boxOriginalType, boxTargetType, null);
-    }
-
-    private PainlessCast(Class<?> originalType,
-                         Class<?> targetType,
-                         boolean explicitCast,
-                         Class<?> unboxOriginalType,
-                         Class<?> unboxTargetType,
-                         Class<?> boxOriginalType,
-                         Class<?> boxTargetType,
-                         Method converter) {
+    private PainlessCast(Class<?> originalType, Class<?> targetType, boolean explicitCast,
+                         Class<?> unboxOriginalType, Class<?> unboxTargetType, Class<?> boxOriginalType, Class<?> boxTargetType) {
 
         this.originalType = originalType;
         this.targetType = targetType;
@@ -128,7 +102,6 @@ public class PainlessCast {
         this.unboxTargetType = unboxTargetType;
         this.boxOriginalType = boxOriginalType;
         this.boxTargetType = boxTargetType;
-        this.converter = converter;
     }
 
     @Override
@@ -144,18 +117,16 @@ public class PainlessCast {
         PainlessCast that = (PainlessCast)object;
 
         return explicitCast == that.explicitCast &&
-                Objects.equals(originalType, that.originalType) &&
-                Objects.equals(targetType, that.targetType) &&
-                Objects.equals(unboxOriginalType, that.unboxOriginalType) &&
-                Objects.equals(unboxTargetType, that.unboxTargetType) &&
-                Objects.equals(boxOriginalType, that.boxOriginalType) &&
-                Objects.equals(boxTargetType, that.boxTargetType) &&
-                Objects.equals(converter, that.converter);
+            Objects.equals(originalType, that.originalType) &&
+            Objects.equals(targetType, that.targetType) &&
+            Objects.equals(unboxOriginalType, that.unboxOriginalType) &&
+            Objects.equals(unboxTargetType, that.unboxTargetType) &&
+            Objects.equals(boxOriginalType, that.boxOriginalType) &&
+            Objects.equals(boxTargetType, that.boxTargetType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(originalType, targetType, explicitCast, unboxOriginalType, unboxTargetType, boxOriginalType, boxTargetType,
-                            converter);
+        return Objects.hash(originalType, targetType, explicitCast, unboxOriginalType, unboxTargetType, boxOriginalType, boxTargetType);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
@@ -601,6 +601,17 @@ public class Decorations {
         }
     }
 
+    public static class Converter implements Decoration {
+        private final LocalFunction converter;
+        public Converter(LocalFunction converter) {
+            this.converter = converter;
+        }
+
+        public LocalFunction getConverter() {
+            return converter;
+        }
+    }
+
     // collect additional information about where doc is used
 
     public interface IsDocument extends Condition {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
@@ -325,6 +325,19 @@ public class FactoryTests extends ScriptTestCase {
             }
             return converted;
         }
+
+        public static long[] convertFromDef(Object def) {
+            if (def instanceof String) {
+                return convertFromString((String)def);
+            } else if (def instanceof Integer) {
+                return convertFromInt(((Integer) def).intValue());
+            } else if (def instanceof List) {
+                return convertFromList((List) def);
+            } else {
+                return (long[]) def;
+            }
+            //throw new ClassCastException("Cannot convert [" + def + "] to long[]");
+        }
     }
 
 
@@ -367,6 +380,71 @@ public class FactoryTests extends ScriptTestCase {
             FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
         script = factory.newInstance(Collections.singletonMap("test", 2));
         assertArrayEquals(new long[]{123, 456, 789}, script.execute(123));
+
+        // autoreturn, no converter
+        factory = scriptEngine.compile("converter_test",
+            "new long[]{test}",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{123}, script.execute(123));
+
+        // autoreturn, converter
+        factory = scriptEngine.compile("converter_test",
+            "test",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{456}, script.execute(456));
+
+        factory = scriptEngine.compile("converter_test",
+            "'1001'",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{1001}, script.execute(456));
+
+        // def tests
+        factory = scriptEngine.compile("converter_test",
+            "def a = new long[]{test, 123}; return a;",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{1000, 123}, script.execute(1000));
+
+        factory = scriptEngine.compile("converter_test",
+            "def l = [test, 123]; l;",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{1000, 123}, script.execute(1000));
+
+        factory = scriptEngine.compile("converter_test",
+            "def a = new ArrayList(); a.add(test); a.add(456); a.add('789'); return a;",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{123, 456, 789}, script.execute(123));
+
+        // autoreturn, no converter
+        factory = scriptEngine.compile("converter_test",
+            "def a = new long[]{test}; a;",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{123}, script.execute(123));
+
+        // autoreturn, converter
+        factory = scriptEngine.compile("converter_test",
+            "def a = '1001'; a",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{1001}, script.execute(456));
+
+        factory = scriptEngine.compile("converter_test",
+            "int x = 1",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(null, script.execute(123));
+
+        factory = scriptEngine.compile("converter_test",
+            "short x = 1; return x",
+            FactoryTestConverterScript.CONTEXT, Collections.emptyMap());
+        script = factory.newInstance(Collections.singletonMap("test", 2));
+        assertArrayEquals(new long[]{1}, script.execute(123));
 
         ClassCastException cce = expectScriptThrows(ClassCastException.class, () ->
             scriptEngine.compile("converter_test",


### PR DESCRIPTION
Painless will cast returned values to a converter
argument type, if necessary.

Painless will also look for a special `convertFromDef`
converter which is called to explicitly handle `def`
conversions.

`convertFromDef` must handle all valid def conversions.

Refs: #59647
