### PR TITLE
Suppress noisy SSL exceptions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
@@ -34,6 +34,9 @@ public final class SecurityTransportExceptionHandler implements BiConsumer<TcpCh
         } else if (SSLExceptionHelper.isCloseDuringHandshakeException(e)) {
             logger.debug("connection {} closed during handshake", channel);
             CloseableChannel.closeChannel(channel);
+        } else if (SSLExceptionHelper.isInsufficientBufferRemainingException(e)) {
+            logger.debug("connection {} closed abruptly", channel);
+            CloseableChannel.closeChannel(channel);
         } else if (SSLExceptionHelper.isReceivedCertificateUnknownException(e)) {
             logger.warn("client did not trust this server's certificate, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
@@ -13,6 +13,7 @@ import org.elasticsearch.http.HttpChannel;
 import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isCloseDuringHandshakeException;
+import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isInsufficientBufferRemainingException;
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isNotSslRecordException;
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isReceivedCertificateUnknownException;
 
@@ -38,6 +39,9 @@ public final class SecurityHttpExceptionHandler implements BiConsumer<HttpChanne
             CloseableChannel.closeChannel(channel);
         } else if (isCloseDuringHandshakeException(e)) {
             logger.debug("connection {} closed during ssl handshake", channel);
+            CloseableChannel.closeChannel(channel);
+        } else if (isInsufficientBufferRemainingException(e)) {
+            logger.debug("connection {} closed abruptly", channel);
             CloseableChannel.closeChannel(channel);
         } else if (isReceivedCertificateUnknownException(e)) {
             logger.warn("http client did not trust this server's certificate, closing connection {}", channel);


### PR DESCRIPTION
If a TLS-protected connection closes unexpectedly then today we often
emit a `WARN` log, typically one of the following:

    io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: Insufficient buffer remaining for AEAD cipher fragment (2). Needs to be more than tag size (16)

    io.netty.handler.codec.DecoderException: javax.net.ssl.SSLException: Received close_notify during handshake

We typically only report unexpectedly-closed connections at `DEBUG`
level, but these two messages don't follow that rule and generate a lot
of noise as a result. This commit adjusts the logging to report these
two exceptions at `DEBUG` level only.