### PR TITLE
[DOCS] Adding ignore_unavailable param to restore snapshot API

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -100,6 +100,12 @@ Name of the snapshot to restore.
 [[restore-snapshot-api-request-body]]
 ==== {api-request-body-title}
 
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, the request returns an error for any data stream or index that is missing or closed. Defaults to `false`.
++
+If `true`, the request ignores data streams and indices in `indices` that are missing or closed.
+
 `ignore_index_settings`::
 (Optional, string)
 A comma-separated list of index settings that should not be restored from a snapshot.


### PR DESCRIPTION
The `ignore_unavailable` parameter was missing from the restore snapshot API page. This change adds the missing parameter.

Backports:
* 7.x #61370
* 7.9 #61371
* 7.8 #61372