### PR TITLE
Add note about negative epoch times

### DIFF
--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -10,6 +10,9 @@ JSON doesn't have a date data type, so dates in Elasticsearch can either be:
 * a long number representing _milliseconds-since-the-epoch_.
 * an integer representing _seconds-since-the-epoch_.
 
+NOTE: Values for _milliseconds-since-the-epoch_ and _seconds-since-the-epoch_
+must be non-negative. Use a formatted date to represent dates before 1970.
+
 Internally, dates are converted to UTC (if the time-zone is specified) and
 stored as a long number representing milliseconds-since-the-epoch.
 


### PR DESCRIPTION
This commit adds a reminder to date type documentation that negative
epoch times are not supported.