### PR TITLE
Optimize a few Spots on IO Loop (#60865)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -107,35 +107,31 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
     @Override
     protected void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        new AsyncSingleAction(task, request, listener).start();
+        ClusterState state = clusterService.state();
+        logger.trace("starting processing request [{}] with cluster state version [{}]", request, state.version());
+        if (task != null) {
+            request.setParentTask(clusterService.localNode().getId(), task.getId());
+        }
+        new AsyncSingleAction(task, request, listener).doStart(state);
     }
 
     class AsyncSingleAction {
 
         private final ActionListener<Response> listener;
         private final Request request;
-        private volatile ClusterStateObserver observer;
+        private ClusterStateObserver observer;
+        private final long startTime;
         private final Task task;
 
         AsyncSingleAction(Task task, Request request, ActionListener<Response> listener) {
             this.task = task;
             this.request = request;
-            if (task != null) {
-                request.setParentTask(clusterService.localNode().getId(), task.getId());
-            }
             this.listener = listener;
-        }
-
-        public void start() {
-            ClusterState state = clusterService.state();
-            this.observer
-                = new ClusterStateObserver(state, clusterService, request.masterNodeTimeout(), logger, threadPool.getThreadContext());
-            doStart(state);
+            this.startTime = threadPool.relativeTimeInMillis();
         }
 
         protected void doStart(ClusterState clusterState) {
             try {
-                final Predicate<ClusterState> masterChangePredicate = MasterNodeChangePredicate.build(clusterState);
                 final DiscoveryNodes nodes = clusterState.nodes();
                 if (nodes.isLocalNodeElectedMaster() || localExecute(request)) {
                     // check for block, if blocked, retry, else, execute locally
@@ -144,8 +140,8 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                         if (!blockException.retryable()) {
                             listener.onFailure(blockException);
                         } else {
-                            logger.trace("can't execute due to a cluster block, retrying", blockException);
-                            retry(blockException, newState -> {
+                            logger.debug("can't execute due to a cluster block, retrying", blockException);
+                            retry(clusterState, blockException, newState -> {
                                 try {
                                     ClusterBlockException newException = checkBlock(request, newState);
                                     return (newException == null || !newException.retryable());
@@ -161,7 +157,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                             if (t instanceof FailedToCommitClusterStateException || t instanceof NotMasterException) {
                                 logger.debug(() -> new ParameterizedMessage("master could not publish cluster state or " +
                                     "stepped down before publishing action [{}], scheduling a retry", actionName), t);
-                                retry(t, masterChangePredicate);
+                                retryOnMasterChange(clusterState, t);
                             } else {
                                 delegatedListener.onFailure(t);
                             }
@@ -172,7 +168,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                 } else {
                     if (nodes.getMasterNode() == null) {
                         logger.debug("no known master node, scheduling a retry");
-                        retry(null, masterChangePredicate);
+                        retryOnMasterChange(clusterState, null);
                     } else {
                         DiscoveryNode masterNode = nodes.getMasterNode();
                         final String actionName = getMasterActionName(masterNode);
@@ -187,7 +183,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                                         logger.debug("connection exception while trying to forward request with action name [{}] to " +
                                                 "master node [{}], scheduling a retry. Error: [{}]",
                                             actionName, nodes.getMasterNode(), exp.getDetailedMessage());
-                                        retry(cause, masterChangePredicate);
+                                        retryOnMasterChange(clusterState, cause);
                                     } else {
                                         listener.onFailure(exp);
                                     }
@@ -200,7 +196,21 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
             }
         }
 
-        private void retry(final Throwable failure, final Predicate<ClusterState> statePredicate) {
+        private void retryOnMasterChange(ClusterState state, Throwable failure) {
+            retry(state, failure, MasterNodeChangePredicate.build(state));
+        }
+
+        private void retry(ClusterState state, final Throwable failure, final Predicate<ClusterState> statePredicate) {
+            if (observer == null) {
+                final long remainingTimeoutMS = request.masterNodeTimeout().millis() - (threadPool.relativeTimeInMillis() - startTime);
+                if (remainingTimeoutMS <= 0) {
+                    logger.debug(() -> new ParameterizedMessage("timed out before retrying [{}] after failure", actionName), failure);
+                    listener.onFailure(new MasterNotDiscoveredException(failure));
+                    return;
+                }
+                this.observer = new ClusterStateObserver(
+                        state, clusterService, TimeValue.timeValueMillis(remainingTimeoutMS), logger, threadPool.getThreadContext());
+            }
             observer.waitForNextChange(
                 new ClusterStateObserver.Listener() {
                     @Override


### PR DESCRIPTION
Saving some cycles here and there on the IO loop:

* Don't instantiate new `Runnable` to execute on `SAME` in a few spots
* Don't instantiate complicated wrapped stream for empty messages
* Stop instantiating almost never used `ClusterStateObserver` in two spots
* Some minor cleanup and preventing pointless `Predicate<>` instantiation in transport master node action

backport of #60865 