### PR TITLE
[DOCS] Document static transform settings

### DIFF
--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -12,33 +12,32 @@ default.
 
 All of these settings can be added to the `elasticsearch.yml` configuration file.
 The dynamic settings can also be updated across a cluster with the
-<<cluster-update-settings,cluster update settings API>>.
-
-TIP: Dynamic settings take precedence over settings in the `elasticsearch.yml`
-file.
+<<cluster-update-settings,cluster update settings API>>. Dynamic settings take
+precedence over settings in the `elasticsearch.yml` file.
 
 [discrete]
 [[general-transform-settings]]
 ==== General {transforms} settings
 
 `node.roles: [ transform ]`::
-Set to `node.roles` to contain `transform` to identify the node as a _transform 
-node_. If you use the default settings for a node, it does not have the 
-`transform` role.
+(<<static-cluster-setting,Static>>) Set `node.roles` to contain `transform` to
+identify the node as a _transform node_. If you use the default settings for a
+node, it does not have the `transform` role.
 +
 If a node doesn't have this role, the node cannot run transforms. If you want to 
 run transforms, there must be at least one transform node in your cluster.
 +
-If you use the `node.roles` setting, then all required roles must be explicitly  
-set. Consult <<modules-node>> to learn more.
+If you use the `node.roles` setting, all required roles must be explicitly set.
+Consult <<modules-node>> to learn more.
 
 `xpack.transform.enabled`::
-deprecated:[7.8.0,Basic License features should always be enabled] +
-This deprecated setting no longer has any effect.
+deprecated:[7.8.0,Basic License features should always be enabled]
+(<<static-cluster-setting,Static>>) This deprecated setting no longer has any
+effect.
 
-`xpack.transform.num_transform_failure_retries` (<<cluster-update-settings,Dynamic>>)::
-The number of times that a {transform} retries when it experiences a non-fatal 
-error. Once the number of retries is exhausted, the {transform} task is marked 
-as `failed`. The default value is `10` with a valid minimum of `0` and maximum 
-of `100`. If a {transform} is already running, it has to be restarted to use the 
-changed setting.
+`xpack.transform.num_transform_failure_retries`::
+(<<cluster-update-settings,Dynamic>>) The number of times that a {transform}
+retries when it experiences a non-fatal error. Once the number of retries is
+exhausted, the {transform} task is marked as `failed`. The default value is `10`
+with a valid minimum of `0` and maximum of `100`. If a {transform} is already
+running, it has to be restarted to use the changed setting.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/61236

Updates transform settings to indicate whether they are static or dynamic.

### Preview

https://elasticsearch_61384.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-settings.html