### PR TITLE
[DOCS] Fix query example for wildcard datatype

### DIFF
--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -37,10 +37,14 @@ PUT my-index-000001/_doc/1
   "my_wildcard" : "This string can be quite lengthy"
 }
 
-POST my-index-000001/_doc/_search
+GET my-index-000001/_search
 {
   "query": {
-      "wildcard" : "*quite*lengthy"
+    "wildcard": {
+        "my_wildcard": {
+          "value": "*quite*lengthy"
+        }
+      }
   }
 }
 


### PR DESCRIPTION
The field is missing in the wildcard datatype query example.
Specifying types in search requests is deprecated