### PR TITLE
[7.x] [DOCS] Fix `field` def for join processor (#61395)

### DIFF
--- a/docs/reference/ingest/processors/join.asciidoc
+++ b/docs/reference/ingest/processors/join.asciidoc
@@ -12,7 +12,7 @@ Throws an error when the field is not an array.
 [options="header"]
 |======
 | Name              | Required  | Default  | Description
-| `field`           | yes       | -        | The field to be separated
+| `field`           | yes       | -        | Field containing array values to join
 | `separator`       | yes       | -        | The separator character
 | `target_field`    | no        | `field`  | The field to assign the joined value to, by default `field` is updated in-place
 include::common-options.asciidoc[]


### PR DESCRIPTION
7.x backport of #61395