### PR TITLE
[DOCS] Document static field cache settings

### DIFF
--- a/docs/reference/modules/indices/fielddata.asciidoc
+++ b/docs/reference/modules/indices/fielddata.asciidoc
@@ -13,10 +13,10 @@ reloading  the field data which does not fit into your cache will be expensive
 and  perform poorly.
 
 `indices.fielddata.cache.size`::
-
-    The max size of the field data cache, eg `30%` of node heap space, or an
-    absolute value, eg `12GB`. Defaults to unbounded.  Also see
-    <<fielddata-circuit-breaker>>.
+(<<static-cluster-setting,Static>>)
+The max size of the field data cache, eg `30%` of node heap space, or an
+absolute value, eg `12GB`. Defaults to unbounded.  Also see
+<<fielddata-circuit-breaker>>.
 
 NOTE: These are static settings which must be configured on every data node in
 the cluster.

--- a/docs/reference/modules/indices/fielddata.asciidoc
+++ b/docs/reference/modules/indices/fielddata.asciidoc
@@ -18,9 +18,6 @@ The max size of the field data cache, eg `30%` of node heap space, or an
 absolute value, eg `12GB`. Defaults to unbounded.  Also see
 <<fielddata-circuit-breaker>>.
 
-NOTE: These are static settings which must be configured on every data node in
-the cluster.
-
 [discrete]
 [[fielddata-monitoring]]
 ==== Monitoring field data


### PR DESCRIPTION
Notes whether field cache settings are dynamic or static.
Also fixes some indentation/wrapping for the page.

### Preview
https://elasticsearch_61424.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-fielddata.html