### PR TITLE
[DOCS] Document static HTTP settings

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -17,9 +17,6 @@ client not to do {wikipedia}/Chunked_transfer_encoding[HTTP chunking].
 
 The following settings can be configured for HTTP. These settings also use the common <<modules-network,network settings>>.
 
-NOTE: HTTP settings cannot be updated dynamically. You must configure these settings in the {es} <<settings, configuration file>>
-and restart {es} for changes to take effect.
-
 `http.port`::
 (<<static-cluster-setting,Static>>)
 A bind port range. Defaults to `9200-9300`.

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -21,35 +21,44 @@ NOTE: HTTP settings cannot be updated dynamically. You must configure these sett
 and restart {es} for changes to take effect.
 
 `http.port`::
+(<<static-cluster-setting,Static>>)
 A bind port range. Defaults to `9200-9300`.
 
 `http.publish_port`::
+(<<static-cluster-setting,Static>>)
 The port that HTTP clients should use when
 communicating with this node. Useful when a cluster node is behind a
 proxy or firewall and the `http.port` is not directly addressable
 from the outside. Defaults to the actual port assigned via `http.port`.
 
 `http.bind_host`::
+(<<static-cluster-setting,Static>>)
 The host address to bind the HTTP service to. Defaults to `http.host` (if set) or `network.bind_host`.
 
 `http.publish_host`::
+(<<static-cluster-setting,Static>>)
 The host address to publish for HTTP clients to connect to. Defaults to `http.host` (if set) or `network.publish_host`.
 
 `http.host`::
+(<<static-cluster-setting,Static>>)
 Used to set the `http.bind_host` and the `http.publish_host`.
 
 `http.max_content_length`::
+(<<static-cluster-setting,Static>>)
 The max content of an HTTP request. Defaults to `100MB`.
 
 `http.max_initial_line_length`::
+(<<static-cluster-setting,Static>>)
 The max length of an HTTP URL. Defaults to `4KB`.
 
 `http.max_header_size`::
+(<<static-cluster-setting,Static>>)
 The max size of allowed headers. Defaults to `8KB`.
 
 [[http-compression]]
 // tag::http-compression-tag[]
 `http.compression` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Support for compression when possible (with Accept-Encoding). If HTTPS is enabled, defaults to `false`. Otherwise, defaults to `true`.
 +
 Disabling compression for HTTPS mitigates potential security risks, such as a
@@ -58,11 +67,13 @@ you must explicitly set `http.compression` to `true`.
 // end::http-compression-tag[]
 
 `http.compression_level`::
+(<<static-cluster-setting,Static>>)
 Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression) and 9 (maximum compression). Defaults to `3`.
 
 [[http-cors-enabled]]
 // tag::http-cors-enabled-tag[]
 `http.cors.enabled` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Enable or disable cross-origin resource sharing, which determines whether a browser on another origin can execute requests against {es}. Set to `true` to enable {es} to process pre-flight
 {wikipedia}/Cross-origin_resource_sharing[CORS] requests.
 {es} will respond to those requests with the `Access-Control-Allow-Origin` header if the `Origin` sent in the request is permitted by the `http.cors.allow-origin` list. Set to `false` (the default) to make {es} ignore the `Origin` request header, effectively disabling CORS requests because {es} will never respond with the `Access-Control-Allow-Origin` response header.
@@ -76,6 +87,7 @@ compromised. If CORS is not enabled on {es}, the only way for the client to know
 [[http-cors-allow-origin]]
 // tag::http-cors-allow-origin-tag[]
 `http.cors.allow-origin` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Which origins to allow. If you prepend and append a forward slash (`/`) to the value, this will be treated as a regular expression, allowing you to support HTTP and HTTPs. For example, using `/https?:\/\/localhost(:[0-9]+)?/` would return the request header appropriately in both cases. Defaults to no origins allowed.
 +
 IMPORTANT: A wildcard (`*`) is a valid value but is considered a security risk, as your {es} instance is open to cross origin requests from *anywhere*.
@@ -85,24 +97,28 @@ IMPORTANT: A wildcard (`*`) is a valid value but is considered a security risk, 
 [[http-cors-max-age]]
 // tag::http-cors-max-age-tag[]
 `http.cors.max-age` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Browsers send a "preflight" OPTIONS-request to determine CORS settings. `max-age` defines how long the result should be cached for. Defaults to `1728000` (20 days).
 // end::http-cors-max-age-tag[]
 
 [[http-cors-allow-methods]]
 // tag::http-cors-allow-methods-tag[]
 `http.cors.allow-methods` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Which methods to allow. Defaults to `OPTIONS, HEAD, GET, POST, PUT, DELETE`.
 // end::http-cors-allow-methods-tag[]
 
 [[http-cors-allow-headers]]
 // tag::http-cors-allow-headers-tag[]
 `http.cors.allow-headers` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Which headers to allow. Defaults to `X-Requested-With, Content-Type, Content-Length`.
 // end::http-cors-allow-headers-tag[]
 
 [[http-cors-allow-credentials]]
 // tag::http-cors-allow-credentials-tag[]
 `http.cors.allow-credentials` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Whether the `Access-Control-Allow-Credentials` header should be returned. Defaults to `false`.
 +
 NOTE: This header is only returned when the setting is set to `true`.
@@ -110,54 +126,66 @@ NOTE: This header is only returned when the setting is set to `true`.
 // end::http-cors-allow-credentials-tag[]
 
 `http.detailed_errors.enabled`::
+(<<static-cluster-setting,Static>>)
 If `true`, enables the output of detailed error messages and stack traces in the response output. Defaults to `true`.
 +
 If `false`, use the `error_trace` parameter to <<common-options-error-options,enable stack traces>> and return detailed error messages. Otherwise, only a simple message will be returned.
 
 `http.pipelining.max_events`::
+(<<static-cluster-setting,Static>>)
 The maximum number of events to be queued up in memory before an HTTP connection is closed, defaults to `10000`.
 
 `http.max_warning_header_count`::
+(<<static-cluster-setting,Static>>)
 The maximum number of warning headers in client HTTP responses. Defaults to `unbounded`.
 
 `http.max_warning_header_size`::
+(<<static-cluster-setting,Static>>)
 The maximum total size of warning headers in client HTTP responses. Defaults to `unbounded`.
 
 `http.tcp.no_delay`::
+(<<static-cluster-setting,Static>>)
 Enable or disable the {wikipedia}/Nagle%27s_algorithm[TCP no delay]
 setting. Defaults to `network.tcp.no_delay`.
 
 `http.tcp.keep_alive`::
+(<<static-cluster-setting,Static>>)
 Configures the `SO_KEEPALIVE` option for this socket, which
 determines whether it sends TCP keepalive probes.
 Defaults to `network.tcp.keep_alive`.
 
-`http.tcp.keep_idle`:: Configures the `TCP_KEEPIDLE` option for this socket, which
+`http.tcp.keep_idle`::
+(<<static-cluster-setting,Static>>) Configures the `TCP_KEEPIDLE` option for this socket, which
 determines the time in seconds that a connection must be idle before
 starting to send TCP keepalive probes. Defaults to `network.tcp.keep_idle`, which
 uses the system default. This value cannot exceed `300` seconds. Only applicable on
 Linux and macOS, and requires Java 11 or newer.
 
-`http.tcp.keep_interval`:: Configures the `TCP_KEEPINTVL` option for this socket,
+`http.tcp.keep_interval`::
+(<<static-cluster-setting,Static>>) Configures the `TCP_KEEPINTVL` option for this socket,
 which determines the time in seconds between sending TCP keepalive probes.
 Defaults to `network.tcp.keep_interval`, which uses the system default.
 This value cannot exceed `300` seconds. Only applicable on Linux and macOS, and requires
 Java 11 or newer.
 
-`http.tcp.keep_count`:: Configures the `TCP_KEEPCNT` option for this socket, which
+`http.tcp.keep_count`::
+(<<static-cluster-setting,Static>>) Configures the `TCP_KEEPCNT` option for this socket, which
 determines the number of unacknowledged TCP keepalive probes that may be
 sent on a connection before it is dropped. Defaults to `network.tcp.keep_count`,
 which uses the system default. Only applicable on Linux and macOS, and
 requires Java 11 or newer.
 
 `http.tcp.reuse_address`::
+(<<static-cluster-setting,Static>>)
 Should an address be reused or not. Defaults to `network.tcp.reuse_address`.
 
 `http.tcp.send_buffer_size`::
+(<<static-cluster-setting,Static>>)
 The size of the TCP send buffer (specified with <<size-units,size units>>).
 Defaults to `network.tcp.send_buffer_size`.
 
 `http.tcp.receive_buffer_size`::
+(<<static-cluster-setting,Static>>)
 The size of the TCP receive buffer (specified with <<size-units,size units>>).
 Defaults to `network.tcp.receive_buffer_size`.
 


### PR DESCRIPTION
Notes whether HTTP settings are dynamic or static.
Also fixes some indentation/wrapping for the page.

### Preview
https://elasticsearch_61429.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-http.html