### PR TITLE
[7.9] [DOCS] Fix query example for wildcard datatype (#61398)

### DIFF
--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -37,14 +37,14 @@ PUT my-index-000001/_doc/1
   "my_wildcard" : "This string can be quite lengthy"
 }
 
-POST my-index-000001/_doc/_search
+GET my-index-000001/_search
 {
   "query": {
-      "wildcard" : {
+    "wildcard": {
       "my_wildcard": {
-          "value": "*quite*lengthy"
-        }
-     }   
+        "value": "*quite*lengthy"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
7.9 backport of #61398