### PR TITLE
[7.x] [DOCS] Document `xpack.graph.enabled` setting (#60073)

### DIFF
--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -15,6 +15,10 @@ For additional information about working with the explore API, see the Graph
 {kibana-ref}/graph-troubleshooting.html[Troubleshooting] and
 {kibana-ref}/graph-limitations.html[Limitations] topics.
 
+NOTE: The graph explore API is enabled by default. To disable access to the
+graph explore API and the Kibana {kibana-ref}/graph-getting-started.html[Graph
+UI], add `xpack.graph.enabled: false` to `elasticsearch.yml`.
+
 [discrete]
 === Request
 


### PR DESCRIPTION
7.x backport of #60073