### PR TITLE
Copy gradle/system jdk to local dir for packaging tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -35,6 +35,7 @@ import org.elasticsearch.gradle.docker.DockerSupportService;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
+import org.elasticsearch.gradle.util.Util;
 import org.elasticsearch.gradle.vagrant.VagrantBasePlugin;
 import org.elasticsearch.gradle.vagrant.VagrantExtension;
 import org.gradle.api.Action;
@@ -47,9 +48,11 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Specs;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -79,6 +82,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
         project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
+        project.getPlugins().apply(JdkDownloadPlugin.class);
         project.getPluginManager().apply("elasticsearch.build");
 
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(
@@ -157,11 +161,22 @@ public class DistroTestPlugin implements Plugin<Project> {
             }
         }
 
+        // setup jdks used by no-jdk tests, and by gradle executing
+        TaskProvider<Copy> linuxGradleJdk = createJdk(project, "gradle", GRADLE_JDK_VENDOR, GRADLE_JDK_VERSION, "linux", "x64");
+        TaskProvider<Copy> linuxSystemJdk = createJdk(project, "system", SYSTEM_JDK_VENDOR, SYSTEM_JDK_VERSION, "linux", "x64");
+        TaskProvider<Copy> windowsGradleJdk = createJdk(project, "gradle", GRADLE_JDK_VENDOR, GRADLE_JDK_VERSION, "windows", "x64");
+        TaskProvider<Copy> windowsSystemJdk = createJdk(project, "system", SYSTEM_JDK_VENDOR, SYSTEM_JDK_VERSION, "windows", "x64");
+
         project.subprojects(vmProject -> {
             vmProject.getPluginManager().apply(VagrantBasePlugin.class);
-            vmProject.getPluginManager().apply(JdkDownloadPlugin.class);
-            List<Object> vmDependencies = new ArrayList<>(configureVM(vmProject));
-            vmDependencies.add(project.getConfigurations().getByName("testRuntimeClasspath"));
+            TaskProvider<Copy> gradleJdk = isWindows(vmProject) ? windowsGradleJdk : linuxGradleJdk;
+            TaskProvider<Copy> systemJdk = isWindows(vmProject) ? windowsSystemJdk : linuxSystemJdk;
+            configureVM(vmProject, gradleJdk, systemJdk);
+            List<Object> vmDependencies = Arrays.asList(
+                gradleJdk,
+                systemJdk,
+                project.getConfigurations().getByName("testRuntimeClasspath")
+            );
 
             Map<ElasticsearchDistribution.Type, TaskProvider<?>> vmLifecyleTasks = lifecycleTasks(vmProject, "distroTest");
             Map<String, TaskProvider<?>> vmVersionTasks = versionTasks(vmProject, "distroUpgradeTest");
@@ -237,57 +252,56 @@ public class DistroTestPlugin implements Plugin<Project> {
         return versionTasks;
     }
 
-    private static Jdk createJdk(
-        NamedDomainObjectContainer<Jdk> jdksContainer,
-        String name,
+    private static TaskProvider<Copy> createJdk(
+        Project project,
+        String purpose,
         String vendor,
         String version,
         String platform,
         String architecture
     ) {
-        Jdk jdk = jdksContainer.create(name);
+        Jdk jdk = JdkDownloadPlugin.getContainer(project).create(platform + "-" + purpose);
         jdk.setVendor(vendor);
         jdk.setVersion(version);
         jdk.setPlatform(platform);
         jdk.setArchitecture(architecture);
-        return jdk;
+
+        String taskname = "copy" + Util.capitalize(platform) + Util.capitalize(purpose) + "Jdk";
+        TaskProvider<Copy> copyTask = project.getTasks().register(taskname, Copy.class);
+        copyTask.configure(t -> {
+            t.from(jdk);
+            t.into(new File(project.getBuildDir(), "jdks/" + platform + "-" + architecture + "-" + vendor + "-" + version));
+        });
+        return copyTask;
     }
 
-    private static List<Object> configureVM(Project project) {
+    private static void configureVM(Project project, TaskProvider<Copy> gradleJdkProvider, TaskProvider<Copy> systemJdkProvider) {
         String box = project.getName();
-
-        // setup jdks used by the distro tests, and by gradle executing
-
-        NamedDomainObjectContainer<Jdk> jdksContainer = JdkDownloadPlugin.getContainer(project);
-        String platform = box.contains("windows") ? "windows" : "linux";
-        Jdk systemJdk = createJdk(jdksContainer, "system", SYSTEM_JDK_VENDOR, SYSTEM_JDK_VERSION, platform, "x64");
-        Jdk gradleJdk = createJdk(jdksContainer, "gradle", GRADLE_JDK_VENDOR, GRADLE_JDK_VERSION, platform, "x64");
 
         // setup VM used by these tests
         VagrantExtension vagrant = project.getExtensions().getByType(VagrantExtension.class);
         vagrant.setBox(box);
-        vagrant.vmEnv("SYSTEM_JAVA_HOME", convertPath(project, vagrant, systemJdk, "", ""));
-        vagrant.vmEnv("JAVA_HOME", ""); // make sure any default java on the system is ignored
-        vagrant.vmEnv("PATH", convertPath(project, vagrant, gradleJdk, "/bin:$PATH", "\\bin;$Env:PATH"));
+
+        vagrant.vmEnv("SYSTEM_JAVA_HOME", convertPath(project, vagrant, systemJdkProvider, "", ""));
+        vagrant.vmEnv("JAVA_HOME",""); // make sure any default java on the system is ignored
+        vagrant.vmEnv("PATH", convertPath(project, vagrant, gradleJdkProvider, "/bin:$PATH", "\\bin;$Env:PATH"));
         // pass these along to get correct build scans
         if (System.getenv("JENKINS_URL") != null) {
             Stream.of("JOB_NAME", "JENKINS_URL", "BUILD_NUMBER", "BUILD_URL").forEach(name -> vagrant.vmEnv(name, System.getenv(name)));
         }
         vagrant.setIsWindowsVM(isWindows(project));
-
-        return Arrays.asList(systemJdk, gradleJdk);
     }
 
-    private static Object convertPath(Project project, VagrantExtension vagrant, Jdk jdk, String additionaLinux, String additionalWindows) {
-        return new Object() {
-            @Override
-            public String toString() {
-                if (vagrant.isWindowsVM()) {
-                    return convertWindowsPath(project, jdk.getPath()) + additionalWindows;
-                }
-                return convertLinuxPath(project, jdk.getPath()) + additionaLinux;
+    private static Object convertPath(Project project, VagrantExtension vagrant, TaskProvider<Copy> jdkProvider,
+                                      String additionaLinux, String additionalWindows) {
+        return Util.toStringable(() -> {
+            String hostPath = jdkProvider.get().getDestinationDir().toString();
+            if (vagrant.isWindowsVM()) {
+                return convertWindowsPath(project, hostPath) + additionalWindows;
+            } else {
+                return convertLinuxPath(project, hostPath) + additionaLinux;
             }
-        };
+        });
     }
 
     private static Configuration configureExamplePlugin(Project project) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -283,7 +283,7 @@ public class DistroTestPlugin implements Plugin<Project> {
         vagrant.setBox(box);
 
         vagrant.vmEnv("SYSTEM_JAVA_HOME", convertPath(project, vagrant, systemJdkProvider, "", ""));
-        vagrant.vmEnv("JAVA_HOME",""); // make sure any default java on the system is ignored
+        vagrant.vmEnv("JAVA_HOME", ""); // make sure any default java on the system is ignored
         vagrant.vmEnv("PATH", convertPath(project, vagrant, gradleJdkProvider, "/bin:$PATH", "\\bin;$Env:PATH"));
         // pass these along to get correct build scans
         if (System.getenv("JENKINS_URL") != null) {
@@ -292,8 +292,13 @@ public class DistroTestPlugin implements Plugin<Project> {
         vagrant.setIsWindowsVM(isWindows(project));
     }
 
-    private static Object convertPath(Project project, VagrantExtension vagrant, TaskProvider<Copy> jdkProvider,
-                                      String additionaLinux, String additionalWindows) {
+    private static Object convertPath(
+        Project project,
+        VagrantExtension vagrant,
+        TaskProvider<Copy> jdkProvider,
+        String additionaLinux,
+        String additionalWindows
+    ) {
         return Util.toStringable(() -> {
             String hostPath = jdkProvider.get().getDestinationDir().toString();
             if (vagrant.isWindowsVM()) {


### PR DESCRIPTION
The distro tests rely on two jdks, pulled in by the jdk download plugin.
The move to artifact transforms for jdks resulted in the path to the extracted
jdks existing under the gradle cache dir, which is outside the vagrant
mount of the elasticsearch project. This commit creates a local copy
within the `qa:os` project that the packaging tests use.

closes #61138