### PR TITLE
Move versions convenience property to java plugin

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -49,8 +49,7 @@ class BuildPlugin implements Plugin<Project> {
         configureLicenseAndNotice(project)
         project.pluginManager.apply('elasticsearch.publish')
         project.pluginManager.apply(DependenciesInfoPlugin)
-
-        project.extensions.getByType(ExtraPropertiesExtension).set('versions', VersionProperties.versions)
+        
         PrecommitTasks.create(project, true)
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -34,7 +34,6 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -34,6 +34,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -74,6 +75,9 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         configureJars(project);
         configureJarManifest(project);
         configureJavadoc(project);
+
+        // convenience access to common versions used in dependencies
+        project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
     }
 
     /**


### PR DESCRIPTION
Access the common versions map is done in a lot of places. While it can
be access through an import of VersionProperties, the vast majority of
places use it through the provided convenience property added by
BuildPlugin. This commit moves that convenience property to the base
java plugin, so further reduce dependence on the BuildPlugin.