### PR TITLE
Add base precommit task to all java projects

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -23,6 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import nebula.plugin.info.InfoBrokerPlugin;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
+import org.elasticsearch.gradle.precommit.PrecommitPlugin;
 import org.elasticsearch.gradle.util.Util;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -67,6 +68,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply(RepositoriesSetupPlugin.class);
         project.getPluginManager().apply(JavaLibraryPlugin.class);
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
+        project.getPluginManager().apply(PrecommitPlugin.PrecommitTaskPlugin.class);
 
         configureConfigurations(project);
         configureCompile(project);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import nebula.plugin.info.InfoBrokerPlugin;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
-import org.elasticsearch.gradle.precommit.PrecommitPlugin;
+import org.elasticsearch.gradle.precommit.PrecommitTaskPlugin;
 import org.elasticsearch.gradle.util.Util;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -68,7 +68,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply(RepositoriesSetupPlugin.class);
         project.getPluginManager().apply(JavaLibraryPlugin.class);
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
-        project.getPluginManager().apply(PrecommitPlugin.PrecommitTaskPlugin.class);
+        project.getPluginManager().apply(PrecommitTaskPlugin.class);
 
         configureConfigurations(project);
         configureCompile(project);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
@@ -71,15 +71,19 @@ public abstract class PrecommitPlugin implements Plugin<Project> {
                     "lifecycle-base",
                     p -> project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit))
                 );
-            project.getPluginManager().withPlugin("java", p -> {
-                // run compilation as part of precommit
-                for (SourceSet sourceSet : GradleUtils.getJavaSourceSets(project)) {
-                    precommit.configure(t -> t.dependsOn(sourceSet.getClassesTaskName()));
-                }
+            project.getPluginManager()
+                .withPlugin(
+                    "java",
+                    p -> {
+                        // run compilation as part of precommit
+                        for (SourceSet sourceSet : GradleUtils.getJavaSourceSets(project)) {
+                            precommit.configure(t -> t.dependsOn(sourceSet.getClassesTaskName()));
+                        }
 
-                // make sure tests run after all precommit tasks
-                project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit));
-            });
+                        // make sure tests run after all precommit tasks
+                        project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit));
+                    }
+                );
         }
     }
 }


### PR DESCRIPTION
This commit adds java compilation to the base precommit task, and adds
that to the java plugin. This further reduces dependence on the build
plugin.