### PR TITLE
[7.x] [DOCS] Note the cluster settings API can override `elasticsearch.yml`(#61394)

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -94,17 +94,36 @@ Cluster and node settings can be categorized based on how they are configured:
 
 [[dynamic-cluster-setting]]
 Dynamic::
++
+--
 You can configure and update dynamic settings on a running cluster using the
-<<cluster-update-settings,cluster update settings API>>.
-+
-You can also configure dynamic settings locally on an unstarted or shut down
-node using `elasticsearch.yml`.
-+
+<<cluster-update-settings,cluster update settings API>>. You can also configure
+dynamic settings locally on an unstarted or shut down node using
+`elasticsearch.yml`.
+
+Updates made using the cluster update settings API can be _persistent_, which
+apply across cluster restarts, or _transient_, which reset after a cluster
+restart. You can also reset transient or persistent settings by assigning them
+a `null` value using the API.
+
+If you configure the same setting using multiple methods, {es} applies the
+settings in following order of precedence:
+
+1. Transient setting
+2. Persistent setting
+3. `elasticsearch.yml` setting
+4. Default setting value
+
+For example, you can apply a transient setting to override a persistent setting
+or `elasticsearch.yml` setting. However, a change to an `elasticsearch.yml`
+setting will not override a defined transient or persistent setting.
+
 TIP: It’s best to set dynamic, cluster-wide settings with the cluster update
 settings API and use `elasticsearch.yml` only for local configurations. Using
 the cluster update settings API ensures the setting is the same on all nodes. If
 you accidentally configure different settings in `elasticsearch.yml` on
 different nodes, it can be difficult to notice discrepancies.
+--
 
 [[static-cluster-setting]]
 Static::


### PR DESCRIPTION
7.x backport of #61394