### PR TITLE
Kerberos doc kibana link

### DIFF
--- a/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
@@ -63,3 +63,10 @@ server. It contains an encrypted authenticator.
 ==== Configuring a Kerberos realm
 
 include::configuring-kerberos-realm.asciidoc[]
+
+[[kerberos-realm-kibana]]
+===== Configure Kibana for Kerberos
+
+If you want to use Kerberos to authenticate via your browser and {kib}, you
+need to enable the relevant authentication provider in {kib} configuration. See
+the {kibana-ref}/kibana-authentication.html#kerberos[relavant {kib} documentation]

--- a/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
@@ -69,4 +69,4 @@ include::configuring-kerberos-realm.asciidoc[]
 
 If you want to use Kerberos to authenticate via your browser and {kib}, you
 need to enable the relevant authentication provider in {kib} configuration. See
-the {kibana-ref}/kibana-authentication.html#kerberos[kerberos single sign-on]
+{kibana-ref}/kibana-authentication.html#kerberos[kerberos single sign-on]

--- a/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
@@ -69,4 +69,4 @@ include::configuring-kerberos-realm.asciidoc[]
 
 If you want to use Kerberos to authenticate via your browser and {kib}, you
 need to enable the relevant authentication provider in {kib} configuration. See
-the {kibana-ref}/kibana-authentication.html#kerberos[relavant {kib} documentation]
+the {kibana-ref}/kibana-authentication.html#kerberos[kerberos single sign-on]


### PR DESCRIPTION
Add a note in Kerberos documentation that Kibana requires a
configuration change too, and link to that documentation page.

### Preview

https://elasticsearch_61466.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/kerberos-realm.html
