### PR TITLE
docs: add link from DLS/FLS page to limitations

### DIFF
--- a/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
@@ -28,6 +28,8 @@ document level permissions per data stream or index. See <<multiple-roles-dls-fl
 NOTE: Document- and field-level security disables the
 <<shard-request-cache,shard request cache>>.
 
+NOTE: Some {ref}/security-limitations.html#_field_and_document_level_security_limitations[limitations] apply to the queries which can be used.
+
 [[multiple-roles-dls-fls]]
 ==== Multiple roles with document and field level security
 


### PR DESCRIPTION
the documentation for document level security & field level security
does not mention that there are certain limitations to the query. this
is however documented on a separate page, but no link to it exists.
this cost me quite a bit of time to find that page (and, to be honest,
that page is also lacking: it does not document *why* these things are
not supported).

i have now added the link. though please note that i'm not 100% certain
if the deeplink will work with this asciidoc format since the
documentation (https://github.com/elastic/docs) does not offer an
example for this.