### PR TITLE
[7.9][ML] Remove redundant logging for creation of annotations index …

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -89,12 +89,7 @@ class MlInitializationService implements LocalNodeMasterListener, ClusterStateLi
         // index if there is a flurry of cluster state updates in quick succession
         if (event.localNodeMaster() && isIndexCreationInProgress.compareAndSet(false, true)) {
             AnnotationIndex.createAnnotationsIndexIfNecessary(client, event.state(), ActionListener.wrap(
-                r -> {
-                    isIndexCreationInProgress.set(false);
-                    if (r) {
-                        logger.info("Created ML annotations index and aliases");
-                    }
-                },
+                r -> isIndexCreationInProgress.set(false),
                 e -> {
                     isIndexCreationInProgress.set(false);
                     logger.error("Error creating ML annotations index or aliases", e);


### PR DESCRIPTION
…(#61461)

This commit removes the log info message "Created ML annotations index and aliases".

The message comes in addition to elasticsearch's index creation logging and it does
not add to it. In addition, since #61107 that message may be logged multiple times.

Backport of #61461
