### PR TITLE
[7.9] [DOCS] Fix ingest script compilation rate and cache size (#61468)

### DIFF
--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -98,10 +98,10 @@ second version is only compiled once.
 
 If you compile too many unique scripts within a small amount of time,
 Elasticsearch will reject the new dynamic scripts with a
-`circuit_breaking_exception` error. By default, up to 75 scripts per
-5 minutes will be compiled for most contexts and 375 scripts per 5 minutes
-for `ingest` contexts. You can change these settings dynamically by setting
-`script.context.$CONTEXT.max_compilations_rate` e.g.,
+`circuit_breaking_exception` error. For most contexts, you can compile up to 75
+scripts per 5 minutes by default. For ingest contexts, the default script
+compilation rate is unlimited. You can change these settings dynamically by
+setting `script.context.$CONTEXT.max_compilations_rate` eg.
 `script.context.field.max_compilations_rate=100/10m`.
 
 ========================================


### PR DESCRIPTION
7.9 backport of #61468