### PR TITLE
Fix PutPolicyRequestTests.testFromXContent (#61485)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
@@ -78,7 +78,10 @@ public final class PutPolicyRequest implements Validatable, ToXContentObject {
         return query;
     }
 
-    public void setQuery(BytesReference query) {
+    // package private for testing only
+    void setQuery(BytesReference query) {
+        assert query == null || XContentHelper.xContentType(query) == XContentType.JSON :
+                "Only accepts JSON encoded query but received [" + Strings.toString(query) + "]";
         this.query = query;
     }
 
@@ -106,7 +109,7 @@ public final class PutPolicyRequest implements Validatable, ToXContentObject {
             {
                 builder.field(NamedPolicy.INDICES_FIELD.getPreferredName(), indices);
                 if (query != null) {
-                    builder.field(NamedPolicy.QUERY_FIELD.getPreferredName(), asMap(query, builder.contentType()));
+                    builder.field(NamedPolicy.QUERY_FIELD.getPreferredName(), asMap(query, XContentType.JSON));
                 }
                 builder.field(NamedPolicy.MATCH_FIELD_FIELD.getPreferredName(), matchField);
                 builder.field(NamedPolicy.ENRICH_FIELDS_FIELD.getPreferredName(), enrichFields);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
@@ -94,7 +94,7 @@ public class PutPolicyRequestTests extends AbstractRequestTestCase<PutPolicyRequ
         assertThat(clientTestInstance.getIndices(), equalTo(serverInstance.getPolicy().getIndices()));
         if (clientTestInstance.getQuery() != null) {
             XContentType type = serverInstance.getPolicy().getQuery().getContentType();
-            assertThat(PutPolicyRequest.asMap(clientTestInstance.getQuery(), type),
+            assertThat(PutPolicyRequest.asMap(clientTestInstance.getQuery(), XContentType.JSON),
                 equalTo(PutPolicyRequest.asMap(serverInstance.getPolicy().getQuery().getQuery(), type)));
         } else {
             assertThat(serverInstance.getPolicy().getQuery(), nullValue());


### PR DESCRIPTION
We only ever support `JSON` for the query source format in practice.
The reason this test worked before is a bug in xcontent parsing that parses
empty maps out of streams of the wrong format.

Closes #61483

backport of #61485