### PR TITLE
Muting test o.e.t.t.ESTestCaseTests.testRandomDateFormatterPattern

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -202,6 +202,7 @@ public class ESTestCaseTests extends ESTestCase {
         assertEquals(10300, ESTestCase.getBasePort());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/61496")
     public void testRandomDateFormatterPattern() {
         DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern());
         /*


### PR DESCRIPTION
See issue: https://github.com/elastic/elasticsearch/issues/61496