### PR TITLE
Convert double script to return array

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -166,6 +166,9 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
             return null;
         }
         StringBuilder b = new StringBuilder();
+        if ("double".equals(type)) {
+            b.append("List result = new ArrayList();");
+        }
         b.append("def v = source['").append(name).append("'];\n");
         b.append("if (v instanceof Iterable) {\n");
         b.append("  for (def vv : ((Iterable) v)) {\n");
@@ -180,6 +183,9 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
         b.append("    ").append(emit).append("\n");
         b.append("  }\n");
         b.append("}\n");
+        if ("double".equals(type)) {
+            b.append("return result;");
+        }
         return b.toString();
     }
 
@@ -188,7 +194,7 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
         Map.entry(DateFieldMapper.CONTENT_TYPE, "millis(parse(value.toString()));"),
         Map.entry(
             NumberType.DOUBLE.typeName(),
-            "value(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
+            "result.add(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
         ),
         Map.entry(KeywordFieldMapper.CONTENT_TYPE, "value(value.toString());"),
         Map.entry(IpFieldMapper.CONTENT_TYPE, "stringValue(value.toString());"),

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
@@ -23,6 +23,8 @@ public abstract class AbstractLongScriptFieldScript extends AbstractScriptFieldS
         super(params, searchLookup, ctx);
     }
 
+    public abstract void execute();
+
     /**
      * Execute the script for the provided {@code docId}.
      */

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractScriptFieldScript.java
@@ -81,6 +81,4 @@ public abstract class AbstractScriptFieldScript {
     public final Map<String, ScriptDocValues<?>> getDoc() {
         return leafSearchLookup.doc();
     }
-
-    public abstract void execute();
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
@@ -42,6 +42,8 @@ public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript
         super(params, searchLookup, ctx);
     }
 
+    public abstract void execute();
+
     /**
      * Execute the script for the provided {@code docId}.
      */

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -65,6 +65,8 @@ public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript 
     public static double[] convertFromDef(Object o) {
         if (o instanceof Double) {
             return convertFromDouble(((Double) o).doubleValue());
+        } else if (o instanceof Collection) {
+            return convertFromCollection((Collection<?>) o);
         } else {
             return (double[]) o;
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.runtimefields;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
@@ -15,6 +14,7 @@ import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -35,55 +35,38 @@ public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript 
         DoubleScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
     }
 
-    private double[] values = new double[1];
-    private int count;
-
     public DoubleScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
         super(params, searchLookup, ctx);
     }
 
+    public abstract double[] execute();
+
     /**
      * Execute the script for the provided {@code docId}.
      */
-    public final void runForDoc(int docId) {
-        count = 0;
+    public final double[] runForDoc(int docId) {
         setDocument(docId);
-        execute();
+        return execute();
     }
 
-    /**
-     * Values from the last time {@link #runForDoc(int)} was called. This array
-     * is mutable and will change with the next call of {@link #runForDoc(int)}.
-     * It is also oversized and will contain garbage at all indices at and
-     * above {@link #count()}.
-     */
-    public final double[] values() {
-        return values;
+    public static double[] convertFromDouble(double v) {
+        return new double[] { v };
     }
 
-    /**
-     * The number of results produced the last time {@link #runForDoc(int)} was called.
-     */
-    public final int count() {
-        return count;
-    }
-
-    private void collectValue(double v) {
-        if (values.length < count + 1) {
-            values = ArrayUtil.grow(values, count + 1);
+    public static double[] convertFromCollection(Collection<?> v) {
+        double[] result = new double[v.size()];
+        int i = 0;
+        for (Object o : v) {
+            result[i++] = ((Number) o).doubleValue();
         }
-        values[count++] = v;
+        return result;
     }
 
-    public static class Value {
-        private final DoubleScriptFieldScript script;
-
-        public Value(DoubleScriptFieldScript script) {
-            this.script = script;
-        }
-
-        public void value(double v) {
-            script.collectValue(v);
+    public static double[] convertFromDef(Object o) {
+        if (o instanceof Double) {
+            return convertFromDouble(((Double) o).doubleValue());
+        } else {
+            return (double[]) o;
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -63,8 +63,8 @@ public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript 
     }
 
     public static double[] convertFromDef(Object o) {
-        if (o instanceof Double) {
-            return convertFromDouble(((Double) o).doubleValue());
+        if (o instanceof Number) {
+            return convertFromDouble(((Number) o).doubleValue());
         } else if (o instanceof Collection) {
             return convertFromCollection((Collection<?>) o);
         } else {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
@@ -63,6 +63,8 @@ public abstract class IpScriptFieldScript extends AbstractScriptFieldScript {
         super(params, searchLookup, ctx);
     }
 
+    public abstract void execute();
+
     /**
      * Execute the script for the provided {@code docId}.
      */

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
@@ -41,6 +41,8 @@ public abstract class StringScriptFieldScript extends AbstractScriptFieldScript 
         super(params, searchLookup, ctx);
     }
 
+    public abstract void execute();
+
     /**
      * Execute the script for the provided {@code docId}.
      * <p>

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleDocValues.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 
 public final class ScriptDoubleDocValues extends SortedNumericDoubleValues {
     private final DoubleScriptFieldScript script;
+    private double[] values;
     private int cursor;
 
     ScriptDoubleDocValues(DoubleScriptFieldScript script) {
@@ -22,22 +23,22 @@ public final class ScriptDoubleDocValues extends SortedNumericDoubleValues {
 
     @Override
     public boolean advanceExact(int docId) {
-        script.runForDoc(docId);
-        if (script.count() == 0) {
+        values = script.runForDoc(docId);
+        if (values.length == 0) {
             return false;
         }
-        Arrays.sort(script.values(), 0, script.count());
+        Arrays.sort(values);
         cursor = 0;
         return true;
     }
 
     @Override
     public double nextValue() throws IOException {
-        return script.values()[cursor++];
+        return values[cursor++];
     }
 
     @Override
     public int docValueCount() {
-        return script.count();
+        return values.length;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQuery.java
@@ -36,7 +36,7 @@ abstract class AbstractDoubleScriptFieldQuery extends AbstractScriptFieldQuery {
     /**
      * Does the value match this query?
      */
-    protected abstract boolean matches(double[] values, int count);
+    protected abstract boolean matches(double[] values);
 
     @Override
     public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
@@ -53,8 +53,7 @@ abstract class AbstractDoubleScriptFieldQuery extends AbstractScriptFieldQuery {
                 TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
                     @Override
                     public boolean matches() throws IOException {
-                        script.runForDoc(approximation().docID());
-                        return AbstractDoubleScriptFieldQuery.this.matches(script.values(), script.count());
+                        return AbstractDoubleScriptFieldQuery.this.matches(script.runForDoc(approximation().docID()));
                     }
 
                     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQuery.java
@@ -15,8 +15,8 @@ public class DoubleScriptFieldExistsQuery extends AbstractDoubleScriptFieldQuery
     }
 
     @Override
-    protected boolean matches(double[] values, int count) {
-        return count > 0;
+    protected boolean matches(double[] values) {
+        return values.length > 0;
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQuery.java
@@ -29,9 +29,9 @@ public class DoubleScriptFieldRangeQuery extends AbstractDoubleScriptFieldQuery 
     }
 
     @Override
-    protected boolean matches(double[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (lowerValue <= values[i] && values[i] <= upperValue) {
+    protected boolean matches(double[] values) {
+        for (double value : values) {
+            if (lowerValue <= value && value <= upperValue) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQuery.java
@@ -20,9 +20,9 @@ public class DoubleScriptFieldTermQuery extends AbstractDoubleScriptFieldQuery {
     }
 
     @Override
-    protected boolean matches(double[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (term == values[i]) {
+    protected boolean matches(double[] values) {
+        for (double value : values) {
+            if (term == value) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQuery.java
@@ -29,9 +29,9 @@ public class DoubleScriptFieldTermsQuery extends AbstractDoubleScriptFieldQuery 
     }
 
     @Override
-    protected boolean matches(double[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (terms.contains(Double.doubleToLongBits(values[i]))) {
+    protected boolean matches(double[] values) {
+        for (double value : values) {
+            if (terms.contains(Double.doubleToLongBits(value))) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
@@ -9,10 +9,6 @@
 class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript @no_import {
 }
 
-static_import {
-    void value(org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript, double) bound_to org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Value
-}
-
-# This import is required to make painless happy and it isn't 100% clear why
+# This whitelist is required to allow painless to build the factory
 class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Factory @no_import {
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -15,8 +15,8 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
         ctx
     ) {
         @Override
-        public void execute() {
-            new DoubleScriptFieldScript.Value(this).value(1.0);
+        public double[] execute() {
+            return new double[] { 1.0 };
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -52,4 +52,10 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
         double[] a = new double[] { 1, 2, 3 };
         assertThat(DoubleScriptFieldScript.convertFromDef(a), equalTo(a));
     }
+
+    public void testConvertNumberFromDef() {
+        for (Number n : new Number[] { randomByte(), randomShort(), randomInt(), randomLong(), randomFloat() }) {
+            assertThat(DoubleScriptFieldScript.convertFromDef(n), equalTo(new double[] { n.doubleValue() }));
+        }
+    }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -36,20 +36,20 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
 
     public void testConvertDouble() {
         double v = randomDouble();
-        assertThat(DoubleScriptFieldScript.convertFromDouble(v), equalTo(new double[] {v}));
-        assertThat(DoubleScriptFieldScript.convertFromDef(v), equalTo(new double[] {v}));
+        assertThat(DoubleScriptFieldScript.convertFromDouble(v), equalTo(new double[] { v }));
+        assertThat(DoubleScriptFieldScript.convertFromDef(v), equalTo(new double[] { v }));
     }
 
     public void testConvertFromCollection() {
         double d = randomDouble();
         long l = randomLong();
         int i = randomInt();
-        assertThat(DoubleScriptFieldScript.convertFromCollection(List.of(d, l, i)), equalTo(new double[] {d, l, i}));
-        assertThat(DoubleScriptFieldScript.convertFromDef(List.of(d, l, i)), equalTo(new double[] {d, l, i}));
+        assertThat(DoubleScriptFieldScript.convertFromCollection(List.of(d, l, i)), equalTo(new double[] { d, l, i }));
+        assertThat(DoubleScriptFieldScript.convertFromDef(List.of(d, l, i)), equalTo(new double[] { d, l, i }));
     }
 
     public void testConvertDoubleArrayFromDef() {
-        double[] a = new double[] {1, 2, 3};
+        double[] a = new double[] { 1, 2, 3 };
         assertThat(DoubleScriptFieldScript.convertFromDef(a), equalTo(a));
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -8,6 +8,10 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
 public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<DoubleScriptFieldScript.Factory> {
     public static final DoubleScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new DoubleScriptFieldScript(
         params,
@@ -28,5 +32,24 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
     @Override
     protected DoubleScriptFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testConvertDouble() {
+        double v = randomDouble();
+        assertThat(DoubleScriptFieldScript.convertFromDouble(v), equalTo(new double[] {v}));
+        assertThat(DoubleScriptFieldScript.convertFromDef(v), equalTo(new double[] {v}));
+    }
+
+    public void testConvertFromCollection() {
+        double d = randomDouble();
+        long l = randomLong();
+        int i = randomInt();
+        assertThat(DoubleScriptFieldScript.convertFromCollection(List.of(d, l, i)), equalTo(new double[] {d, l, i}));
+        assertThat(DoubleScriptFieldScript.convertFromDef(List.of(d, l, i)), equalTo(new double[] {d, l, i}));
+    }
+
+    public void testConvertDoubleArrayFromDef() {
+        double[] a = new double[] {1, 2, 3};
+        assertThat(DoubleScriptFieldScript.convertFromDef(a), equalTo(a));
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
@@ -270,21 +270,27 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
                             case "read_foo":
                                 return (params, lookup) -> (ctx) -> new DoubleScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new DoubleScriptFieldScript.Value(this).value(((Number) foo).doubleValue());
+                                    public double[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        double[] results = new double[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = ((Number) foo).doubleValue();
                                         }
+                                        return results;
                                     }
                                 };
                             case "add_param":
                                 return (params, lookup) -> (ctx) -> new DoubleScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new DoubleScriptFieldScript.Value(this).value(
-                                                ((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue()
-                                            );
+                                    public double[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        double[] results = new double[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = ((Number) getParams().get("param")).doubleValue() + ((Number) foo).doubleValue();
                                         }
+                                        return results;
                                     }
                                 };
                             default:

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQueryTests.java
@@ -29,9 +29,13 @@ public class DoubleScriptFieldExistsQueryTests extends AbstractDoubleScriptField
 
     @Override
     public void testMatches() {
-        assertTrue(createTestInstance().matches(new double[0], randomIntBetween(1, Integer.MAX_VALUE)));
-        assertFalse(createTestInstance().matches(new double[0], 0));
-        assertFalse(createTestInstance().matches(new double[] { 1, 2, 3 }, 0));
+        assertTrue(createTestInstance().matches(new double[] { 1 }));
+        assertFalse(createTestInstance().matches(new double[0]));
+        double[] big = new double[between(1, 10000)];
+        for (int i = 0; i < big.length; i++) {
+            big[i] = 1.0;
+        }
+        assertTrue(createTestInstance().matches(big));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQueryTests.java
@@ -57,14 +57,14 @@ public class DoubleScriptFieldRangeQueryTests extends AbstractDoubleScriptFieldQ
     @Override
     public void testMatches() {
         DoubleScriptFieldRangeQuery query = new DoubleScriptFieldRangeQuery(randomScript(), leafFactory, "test", 1.2, 3.14);
-        assertTrue(query.matches(new double[] { 1.2 }, 1));
-        assertTrue(query.matches(new double[] { 3.14 }, 1));
-        assertTrue(query.matches(new double[] { 2 }, 1));
-        assertFalse(query.matches(new double[] { 0 }, 0));
-        assertFalse(query.matches(new double[] { 5 }, 1));
-        assertTrue(query.matches(new double[] { 2, 5 }, 2));
-        assertTrue(query.matches(new double[] { 5, 2 }, 2));
-        assertFalse(query.matches(new double[] { 5, 2 }, 1));
+        assertTrue(query.matches(new double[] { 1.2 }));
+        assertTrue(query.matches(new double[] { 3.14 }));
+        assertTrue(query.matches(new double[] { 2 }));
+        assertFalse(query.matches(new double[] {}));
+        assertFalse(query.matches(new double[] { 5 }));
+        assertTrue(query.matches(new double[] { 2, 5 }));
+        assertTrue(query.matches(new double[] { 5, 2 }));
+        assertFalse(query.matches(new double[] { 1 }));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQueryTests.java
@@ -46,10 +46,9 @@ public class DoubleScriptFieldTermQueryTests extends AbstractDoubleScriptFieldQu
     @Override
     public void testMatches() {
         DoubleScriptFieldTermQuery query = new DoubleScriptFieldTermQuery(randomScript(), leafFactory, "test", 3.14);
-        assertTrue(query.matches(new double[] { 3.14 }, 1));     // Match because value matches
-        assertFalse(query.matches(new double[] { 2 }, 1));       // No match because wrong value
-        assertFalse(query.matches(new double[] { 2, 3.14 }, 1)); // No match because value after count of values
-        assertTrue(query.matches(new double[] { 2, 3.14 }, 2));  // Match because one value matches
+        assertTrue(query.matches(new double[] { 3.14 }));
+        assertFalse(query.matches(new double[] { 2 }));
+        assertTrue(query.matches(new double[] { 2, 3.14 }));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQueryTests.java
@@ -75,13 +75,12 @@ public class DoubleScriptFieldTermsQueryTests extends AbstractDoubleScriptFieldQ
             "test",
             LongHashSet.from(Double.doubleToLongBits(0.1), Double.doubleToLongBits(0.2), Double.doubleToLongBits(7.5))
         );
-        assertTrue(query.matches(new double[] { 0.1 }, 1));
-        assertTrue(query.matches(new double[] { 0.2 }, 1));
-        assertTrue(query.matches(new double[] { 7.5 }, 1));
-        assertTrue(query.matches(new double[] { 0.1, 0 }, 2));
-        assertTrue(query.matches(new double[] { 0, 0.1 }, 2));
-        assertFalse(query.matches(new double[] { 0 }, 1));
-        assertFalse(query.matches(new double[] { 0, 0.1 }, 1));
+        assertTrue(query.matches(new double[] { 0.1 }));
+        assertTrue(query.matches(new double[] { 0.2 }));
+        assertTrue(query.matches(new double[] { 7.5 }));
+        assertTrue(query.matches(new double[] { 0.1, 0 }));
+        assertTrue(query.matches(new double[] { 0, 0.1 }));
+        assertFalse(query.matches(new double[] { 0 }));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
@@ -22,33 +22,47 @@ setup:
                 runtime_type: double
                 script:
                   source: |
-                    for (double v : doc['voltage']) {
-                      value(v / params.max);
+                    def voltage = doc['voltage'];
+                    double[] result = new double[voltage.size()];
+                    int i = 0;
+                    for (double v : voltage) {
+                      result[i++] = v / params.max;
                     }
+                    return result;
                   params:
                     max: 5.8
-              # Test fetching from _source
+              # Test fetching from _source and the the def -> double[] conversion
               voltage_percent_from_source:
                 type: runtime_script
                 runtime_type: double
                 script:
                   source: |
-                    value(source['voltage'] / params.max);
+                    source['voltage'] / params.max;
                   params:
                     max: 5.8
-              # Test fetching many values
+              # Test the implicit conversion from double -> double[]
+              voltage_percent_returning_double:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                     ((double) source['voltage']) / 5.8;
+              # Test fetching many values and the Collection -> double[] conversion
               voltage_sqrts:
                 type: runtime_script
                 runtime_type: double
                 script:
                   source: |
+                    List result = new ArrayList();
+                    int i = 0;
                     for (double voltage : doc['voltage']) {
                       double v = voltage;
                       while (v > 1.2) {
-                        value(v);
+                        result.add(v);
                         v = Math.sqrt(v);
                       }
                     }
+                    return result;
 
   - do:
       bulk:
@@ -77,9 +91,13 @@ setup:
   - match: {sensor.mappings.properties.voltage_percent.runtime_type: double }
   - match:
       sensor.mappings.properties.voltage_percent.script.source: |
-        for (double v : doc['voltage']) {
-          value(v / params.max);
+        def voltage = doc['voltage'];
+        double[] result = new double[voltage.size()];
+        int i = 0;
+        for (double v : voltage) {
+          result[i++] = v / params.max;
         }
+        return result;
   - match: {sensor.mappings.properties.voltage_percent.script.params: {max: 5.8} }
   - match: {sensor.mappings.properties.voltage_percent.script.lang: painless }
 
@@ -90,7 +108,7 @@ setup:
         index: sensor
         body:
           sort: timestamp
-          docvalue_fields: [voltage_percent, voltage_percent_from_source, voltage_sqrts]
+          docvalue_fields: [voltage_percent, voltage_percent_from_source, voltage_percent_returning_double, voltage_sqrts]
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
   - match: {hits.hits.0.fields.voltage_percent_from_source: [0.6896551724137931] }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
@@ -37,7 +37,7 @@ setup:
                 runtime_type: double
                 script:
                   source: |
-                    source['voltage'] / params.max;
+                    source['voltage'] / params.max
                   params:
                     max: 5.8
               # Test the implicit conversion from double -> double[]
@@ -46,7 +46,22 @@ setup:
                 runtime_type: double
                 script:
                   source: |
-                     ((double) source['voltage']) / 5.8;
+                     ((double) source['voltage']) / 5.8
+              # Test the implicit conversion from long -> double[]
+              voltage_percent_returning_long:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                     (long) (doc['voltage_percent_returning_double'].value * 100)
+              # Test the implicit conversion from def (secretly a long) -> double[]
+              voltage_percent_returning_def_long:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                     def v = (long) doc['voltage_percent_returning_long'].value;
+                     return v;
               # Test fetching many values and the Collection -> double[] conversion
               voltage_sqrts:
                 type: runtime_script
@@ -108,10 +123,19 @@ setup:
         index: sensor
         body:
           sort: timestamp
-          docvalue_fields: [voltage_percent, voltage_percent_from_source, voltage_percent_returning_double, voltage_sqrts]
+          docvalue_fields:
+            - voltage_percent
+            - voltage_percent_from_source
+            - voltage_percent_returning_double
+            - voltage_percent_returning_long
+            - voltage_percent_returning_def_long
+            - voltage_sqrts
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
   - match: {hits.hits.0.fields.voltage_percent_from_source: [0.6896551724137931] }
+  - match: {hits.hits.0.fields.voltage_percent_returning_double: [0.6896551724137931] }
+  - match: {hits.hits.0.fields.voltage_percent_returning_long: [68.0] }
+  - match: {hits.hits.0.fields.voltage_percent_returning_def_long: [68.0] }
   # Scripts that scripts that emit multiple values are supported and their results are sorted
   - match: {hits.hits.0.fields.voltage_sqrts: [1.4142135623730951, 2.0, 4.0] }
   - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }


### PR DESCRIPTION
This replaces the value collection method in `double` valued runtime
script fields with simply returning a `double[]`. Painless has some
"convert" features that allow us to define automatic conversions from
things like `double` and `Collection` into `double[]` so we use those.


Relates to #59332