### PR TITLE
Fixes casting in constant folding

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -667,6 +667,7 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
             ConstantNode irConstantNode = (ConstantNode)irCastNode.getChildNode();
             irConstantNode.setConstant(
                     AnalyzerCaster.constCast(irCastNode.getLocation(), irConstantNode.getConstant(), irCastNode.getCast()));
+            irConstantNode.setExpressionType(irCastNode.getExpressionType());
             scope.accept(irConstantNode);
         }
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefCastTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/DefCastTests.java
@@ -485,7 +485,7 @@ public class DefCastTests extends ScriptTestCase {
         expectScriptThrows(ClassCastException.class, () -> exec("def d = Double.valueOf(0); Float b = d;"));
         expectScriptThrows(ClassCastException.class, () -> exec("def d = new ArrayList(); Float b = d;"));
     }
-    
+
     public void testdefToDoubleImplicit() {
         expectScriptThrows(ClassCastException.class, () -> exec("def d = 'string'; Double b = d;"));
         expectScriptThrows(ClassCastException.class, () -> exec("def d = true; Double b = d;"));
@@ -682,6 +682,19 @@ public class DefCastTests extends ScriptTestCase {
 
     public void testdefToStringExplicit() {
         assertEquals("s", exec("def d = (char)'s'; String b = (String)d; b"));
+    }
+
+    public void testConstFoldingDefCast() {
+        assertFalse((boolean)exec("def chr = 10; return (chr == (char)'x');"));
+        assertFalse((boolean)exec("def chr = 10; return (chr >= (char)'x');"));
+        assertTrue((boolean)exec("def chr = (char)10; return (chr <= (char)'x');"));
+        assertTrue((boolean)exec("def chr = 10; return (chr < (char)'x');"));
+        assertFalse((boolean)exec("def chr = (char)10; return (chr > (char)'x');"));
+        assertFalse((boolean)exec("def chr = 10L; return (chr > (char)'x');"));
+        assertFalse((boolean)exec("def chr = 10F; return (chr > (char)'x');"));
+        assertFalse((boolean)exec("def chr = 10D; return (chr > (char)'x');"));
+        assertFalse((boolean)exec("def chr = (char)10L; return (chr > (byte)10);"));
+        assertFalse((boolean)exec("def chr = (char)10L; return (chr > (double)(byte)(char)10);"));
     }
 
     // TODO: remove this when the transition from Joda to Java datetimes is completed


### PR DESCRIPTION
The expression type wasn't being set to the target type after a constant fold on a ir cast node. This changes fixes that requirement.

cc: @adriansr Thanks for raising this bug!