### PR TITLE
Some Optimizations around BytesArray (#61183)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
@@ -115,7 +115,7 @@ public abstract class AbstractBytesReference implements BytesReference {
             }
             return hash = result;
         } else {
-            return hash.intValue();
+            return hash;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -20,6 +20,11 @@
 package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FutureArrays;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 public final class BytesArray extends AbstractBytesReference {
 
@@ -66,6 +71,24 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     @Override
+    public int hashCode() {
+        // NOOP override to satisfy Checkstyle's EqualsHashCode
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof BytesArray) {
+            final BytesArray that = (BytesArray) other;
+            return FutureArrays.equals(bytes, offset, offset + length, that.bytes, that.offset, that.offset + that.length);
+        }
+        return super.equals(other);
+    }
+
+    @Override
     public BytesReference slice(int from, int length) {
         if (from < 0 || (from + length) > this.length) {
             throw new IllegalArgumentException("can't slice a buffer with length [" + this.length +
@@ -92,4 +115,13 @@ public final class BytesArray extends AbstractBytesReference {
         return bytes.length;
     }
 
+    @Override
+    public StreamInput streamInput() {
+        return StreamInput.wrap(bytes, offset, length);
+    }
+
+    @Override
+    public void writeTo(OutputStream os) throws IOException {
+        os.write(bytes, offset, length);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -109,6 +110,20 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
     static BytesReference fromByteBuffer(ByteBuffer buffer) {
         assert buffer.hasArray();
         return new BytesArray(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+    }
+
+    /**
+     * Returns BytesReference either wrapping the provided {@link ByteArray} or in case the has a backing raw byte array one that wraps
+     * that backing array directly.
+     */
+    static BytesReference fromByteArray(ByteArray byteArray, int length) {
+        if (length == 0) {
+            return BytesArray.EMPTY;
+        }
+        if (byteArray.hasArray()) {
+            return new BytesArray(byteArray.array(), 0, length);
+        }
+        return new PagedBytesReference(byteArray, 0, length);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.FutureObjects;
 import org.apache.lucene.util.RamUsageEstimator;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -186,6 +187,13 @@ public final class CompositeBytesReference extends AbstractBytesReference {
                 return next;
             }
         };
+    }
+
+    @Override
+    public void writeTo(OutputStream os) throws IOException {
+        for (BytesReference reference : references) {
+            reference.writeTo(os);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -38,11 +38,8 @@ public class PagedBytesReference extends AbstractBytesReference {
     private final int offset;
     private final int length;
 
-    public PagedBytesReference(ByteArray byteArray, int length) {
-        this(byteArray, 0, length);
-    }
-
-    private PagedBytesReference(ByteArray byteArray, int from, int length) {
+    PagedBytesReference(ByteArray byteArray, int from, int length) {
+        assert byteArray.hasArray() == false : "use BytesReference#fromByteArray";
         this.byteArray = byteArray;
         this.offset = from;
         this.length = length;
@@ -70,10 +67,7 @@ public class PagedBytesReference extends AbstractBytesReference {
     @Override
     public BytesRef toBytesRef() {
         BytesRef bref = new BytesRef();
-        // if length <= pagesize this will dereference the page, or materialize the byte[]
-        if (byteArray != null) {
-            byteArray.get(offset, length, bref);
-        }
+        byteArray.get(offset, length, bref);
         return bref;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/RecyclingBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/RecyclingBytesStreamOutput.java
@@ -119,7 +119,7 @@ public class RecyclingBytesStreamOutput extends BytesStream {
         final byte[] newBuffer = new byte[position];
         System.arraycopy(buffer, 0, newBuffer, 0, buffer.length);
         int copyPos = buffer.length;
-        final BytesRefIterator iterator = new PagedBytesReference(overflow, position - buffer.length).iterator();
+        final BytesRefIterator iterator = BytesReference.fromByteArray(overflow, position - buffer.length).iterator();
         BytesRef bytesRef;
         try {
             while ((bytesRef = iterator.next()) != null) {
@@ -142,7 +142,7 @@ public class RecyclingBytesStreamOutput extends BytesStream {
         } else {
             return CompositeBytesReference.of(
                     new BytesArray(buffer, 0, buffer.length),
-                    new PagedBytesReference(overflow, position - buffer.length));
+                    BytesReference.fromByteArray(overflow, position - buffer.length));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
@@ -24,7 +24,6 @@ import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.PagedBytesReference;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.PageCacheRecycler;
@@ -147,7 +146,10 @@ public class BytesStreamOutput extends BytesStream {
 
     @Override
     public BytesReference bytes() {
-        return new PagedBytesReference(bytes, count);
+        if (bytes == null) {
+            return BytesArray.EMPTY;
+        }
+        return BytesReference.fromByteArray(bytes, count);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -145,6 +145,16 @@ public class BigArrays {
             assert indexIsInt(toIndex);
             Arrays.fill(array, (int) fromIndex, (int) toIndex, value);
         }
+
+        @Override
+        public boolean hasArray() {
+            return true;
+        }
+
+        @Override
+        public byte[] array() {
+            return array;
+        }
     }
 
     private static class IntArrayWrapper extends AbstractArrayWrapper implements IntArray {

--- a/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -128,6 +128,17 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
     }
 
     @Override
+    public boolean hasArray() {
+        return false;
+    }
+
+    @Override
+    public byte[] array() {
+        assert false;
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected int numBytesPerElement() {
         return 1;
     }

--- a/server/src/main/java/org/elasticsearch/common/util/ByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ByteArray.java
@@ -21,6 +21,8 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.BytesRef;
 
+import java.nio.ByteBuffer;
+
 /**
  * Abstraction of an array of byte values.
  */
@@ -53,4 +55,13 @@ public interface ByteArray extends BigArray {
      */
     void fill(long fromIndex, long toIndex, byte value);
 
+    /**
+     * Checks if this instance is backed by a single byte array analogous to {@link ByteBuffer#hasArray()}.
+     */
+    boolean hasArray();
+
+    /**
+     * Get backing byte array analogous to {@link ByteBuffer#array()}.
+     */
+    byte[] array();
 }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -54,7 +54,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.bytes.PagedBytesReference;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.RecyclingBytesStreamOutput;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.lease.Releasable;
@@ -847,7 +847,7 @@ public class PersistedClusterStateService {
         DocumentBuffer(int size, BigArrays bigArrays) {
             if (size <= PageCacheRecycler.PAGE_SIZE_IN_BYTES) {
                 final ByteArray byteArray = bigArrays.newByteArray(PageCacheRecycler.PAGE_SIZE_IN_BYTES);
-                final BytesRefIterator iterator = new PagedBytesReference(byteArray, Math.toIntExact(byteArray.size())).iterator();
+                final BytesRefIterator iterator = BytesReference.fromByteArray(byteArray, Math.toIntExact(byteArray.size())).iterator();
                 final BytesRef firstPage;
                 try {
                     firstPage = iterator.next();

--- a/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTests.java
@@ -39,9 +39,13 @@ public class PagedBytesReferenceTests extends AbstractBytesReferenceTestCase {
             byteArray.set(i, (byte) random().nextInt(1 << 8));
         }
         assertThat(byteArray.size(), Matchers.equalTo((long) length));
-        BytesReference ref = new PagedBytesReference(byteArray, length);
+        BytesReference ref = BytesReference.fromByteArray(byteArray, length);
         assertThat(ref.length(), Matchers.equalTo(length));
-        assertThat(ref, Matchers.instanceOf(PagedBytesReference.class));
+        if (byteArray.hasArray()) {
+            assertThat(ref, Matchers.instanceOf(BytesArray.class));
+        } else {
+            assertThat(ref, Matchers.instanceOf(PagedBytesReference.class));
+        }
         return ref;
     }
 
@@ -118,8 +122,8 @@ public class PagedBytesReferenceTests extends AbstractBytesReferenceTestCase {
         }
 
         // get refs & compare
-        BytesReference pbr = new PagedBytesReference(ba1, length);
-        BytesReference pbr2 = new PagedBytesReference(ba2, length);
+        BytesReference pbr = BytesReference.fromByteArray(ba1, length);
+        BytesReference pbr2 = BytesReference.fromByteArray(ba2, length);
         assertEquals(pbr, pbr2);
         int offsetToFlip = randomIntBetween(0, length - 1);
         int value = ~Byte.toUnsignedInt(ba1.get(offsetToFlip));

--- a/server/src/test/java/org/elasticsearch/common/bytes/ReleasableBytesReferenceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ReleasableBytesReferenceTests.java
@@ -60,7 +60,7 @@ public class ReleasableBytesReferenceTests extends AbstractBytesReferenceTestCas
                 byteArray.set(i, (byte) random().nextInt(1 << 8));
             }
             assertThat(byteArray.size(), Matchers.equalTo((long) length));
-            BytesReference ref = new PagedBytesReference(byteArray, length);
+            BytesReference ref = BytesReference.fromByteArray(byteArray, length);
             assertThat(ref.length(), Matchers.equalTo(length));
             delegate = ref;
         } else {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -796,7 +796,7 @@ public class BytesStreamsTests extends ESTestCase {
                     assertEquals(i, ints[i]);
                 }
                 EOFException eofException = expectThrows(EOFException.class, () -> streamInput.readIntArray());
-                assertEquals("tried to read: 100 bytes but only 40 remaining", eofException.getMessage());
+                assertEquals("tried to read: 100 bytes but this stream is limited to: 82", eofException.getMessage());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.http;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.PagedBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
@@ -332,7 +331,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         // ESTestCase#after will invoke ensureAllArraysAreReleased which will fail if the response content was not released
         final BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
         final ByteArray byteArray = bigArrays.newByteArray(0, false);
-        final BytesReference content = new ReleasableBytesReference(new PagedBytesReference(byteArray, 0) , byteArray);
+        final BytesReference content = new ReleasableBytesReference(BytesReference.fromByteArray(byteArray, 0) , byteArray);
         channel.sendResponse(new TestRestResponse(RestStatus.METHOD_NOT_ALLOWED, content));
 
         Class<ActionListener<Void>> listenerClass = (Class<ActionListener<Void>>) (Class) ActionListener.class;
@@ -369,7 +368,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         // ESTestCase#after will invoke ensureAllArraysAreReleased which will fail if the response content was not released
         final BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
         final ByteArray byteArray = bigArrays.newByteArray(0, false);
-        final BytesReference content = new ReleasableBytesReference(new PagedBytesReference(byteArray, 0) , byteArray);
+        final BytesReference content = new ReleasableBytesReference(BytesReference.fromByteArray(byteArray, 0) , byteArray);
 
         expectThrows(IllegalArgumentException.class, () -> channel.sendResponse(new TestRestResponse(RestStatus.OK, content)));
 

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -535,7 +535,7 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
     public void testSliceEquals() {
         int length = randomIntBetween(100, PAGE_SIZE * randomIntBetween(2, 5));
         ByteArray ba1 = bigarrays.newByteArray(length, false);
-        BytesReference pbr = new PagedBytesReference(ba1, length);
+        BytesReference pbr = BytesReference.fromByteArray(ba1, length);
 
         // test equality of slices
         int sliceFrom = randomIntBetween(0, pbr.length());

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -336,6 +336,16 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
+        public boolean hasArray() {
+            return in.hasArray();
+        }
+
+        @Override
+        public byte[] array() {
+            return in.array();
+        }
+
+        @Override
         public Collection<Accountable> getChildResources() {
             return Collections.singleton(Accountables.namedAccountable("delegate", in));
         }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.PagedBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -60,7 +59,7 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
             String sessionUUID = request.getSessionUUID();
             // This is currently safe to do because calling `onResponse` will serialize the bytes to the network layer data
             // structure on the same thread. So the bytes will be copied before the reference is released.
-            PagedBytesReference pagedBytesReference = new PagedBytesReference(array, bytesRequested);
+            BytesReference pagedBytesReference = BytesReference.fromByteArray(array, bytesRequested);
             try (ReleasableBytesReference reference = new ReleasableBytesReference(pagedBytesReference, array)) {
                 try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID)) {
                     long offsetAfterRead = sessionReader.readFileBytes(fileName, reference);


### PR DESCRIPTION
* Faster `equals` for `BytesArray` which is nice since with this change we use it for the search cache
* Lighter `StreamInput` for `BytesArray` that should save memory and some indirection relative to the one on the abstract bytes reference
* Lighter `writeTo` implementation
* Build a `BytesArray` instead of a PagedBytesReference whenever possible to save indirection and memory

backport of #61183 