### PR TITLE
Header warning logging refactoring backport(#55941)

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -519,7 +519,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
     }
 
     /**
-     * Emulates Elasticsearch's DeprecationLogger.formatWarning in simple
+     * Emulates Elasticsearch's HeaderWarningLogger.formatWarning in simple
      * cases. We don't have that available because we're testing against 1.7.
      */
     private static String formatWarningWithoutDate(String warningBody) {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CJKBigramFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CJKBigramFilterFactory.java
@@ -104,7 +104,7 @@ public final class CJKBigramFilterFactory extends AbstractTokenFilterFactory {
                     "] cannot be used to parse synonyms");
             }
             else {
-                DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+                DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                     + "] will not be usable to parse synonyms after v7.0");
             }
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -250,7 +250,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.put("dutch_stem", DutchStemTokenFilterFactory::new);
         filters.put("edge_ngram", EdgeNGramTokenFilterFactory::new);
         filters.put("edgeNGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
-            deprecationLogger.deprecatedAndMaybeLog("edgeNGram_deprecation",
+            deprecationLogger.deprecate("edgeNGram_deprecation",
                     "The [edgeNGram] token filter name is deprecated and will be removed in a future version. "
                             + "Please change the filter name to [edge_ngram] instead.");
             return new EdgeNGramTokenFilterFactory(indexSettings, environment, name, settings);
@@ -275,7 +275,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.put("multiplexer", MultiplexerTokenFilterFactory::new);
         filters.put("ngram", NGramTokenFilterFactory::new);
         filters.put("nGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
-            deprecationLogger.deprecatedAndMaybeLog("nGram_deprecation",
+            deprecationLogger.deprecate("nGram_deprecation",
                     "The [nGram] token filter name is deprecated and will be removed in a future version. "
                             + "Please change the filter name to [ngram] instead.");
             return new NGramTokenFilterFactory(indexSettings, environment, name, settings);
@@ -324,7 +324,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         tokenizers.put("thai", ThaiTokenizerFactory::new);
         tokenizers.put("nGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
             if (indexSettings.getIndexVersionCreated().onOrAfter(org.elasticsearch.Version.V_7_6_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("nGram_tokenizer_deprecation",
+                deprecationLogger.deprecate("nGram_tokenizer_deprecation",
                         "The [nGram] tokenizer name is deprecated and will be removed in a future version. "
                                 + "Please change the tokenizer name to [ngram] instead.");
             }
@@ -333,7 +333,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         tokenizers.put("ngram", NGramTokenizerFactory::new);
         tokenizers.put("edgeNGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
             if (indexSettings.getIndexVersionCreated().onOrAfter(org.elasticsearch.Version.V_7_6_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("edgeNGram_tokenizer_deprecation",
+                deprecationLogger.deprecate("edgeNGram_tokenizer_deprecation",
                         "The [edgeNGram] tokenizer name is deprecated and will be removed in a future version. "
                                 + "Please change the tokenizer name to [edge_ngram] instead.");
             }
@@ -414,7 +414,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.add(PreConfiguredCharFilter.singleton("html_strip", false, HTMLStripCharFilter::new));
         filters.add(PreConfiguredCharFilter.elasticsearchVersion("htmlStrip", false, (reader, version) -> {
             if (version.onOrAfter(org.elasticsearch.Version.V_6_3_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("htmlStrip_deprecation",
+                deprecationLogger.deprecate("htmlStrip_deprecation",
                         "The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
                                 + "Please change the filter name to [html_strip] instead.");
             }
@@ -445,7 +445,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
                     "[delimited_payload_filter] is not supported for new indices, use [delimited_payload] instead");
             }
             if (version.onOrAfter(Version.V_6_2_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("analysis_delimited_payload_filter",
+                deprecationLogger.deprecate("analysis_delimited_payload_filter",
                     "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]");
             }
             return new DelimitedPayloadTokenFilter(input,
@@ -465,7 +465,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
                         "The [edgeNGram] token filter name was deprecated in 6.4 and cannot be used in new indices. "
                                 + "Please change the filter name to [edge_ngram] instead.");
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("edgeNGram_deprecation",
+                deprecationLogger.deprecate("edgeNGram_deprecation",
                         "The [edgeNGram] token filter name is deprecated and will be removed in a future version. "
                                 + "Please change the filter name to [edge_ngram] instead.");
             }
@@ -492,7 +492,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
                 throw new IllegalArgumentException("The [nGram] token filter name was deprecated in 6.4 and cannot be used in new indices. "
                         + "Please change the filter name to [ngram] instead.");
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("nGram_deprecation",
+                deprecationLogger.deprecate("nGram_deprecation",
                         "The [nGram] token filter name is deprecated and will be removed in a future version. "
                                 + "Please change the filter name to [ngram] instead.");
             }
@@ -570,7 +570,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         // Temporary shim for aliases. TODO deprecate after they are moved
         tokenizers.add(PreConfiguredTokenizer.elasticsearchVersion("nGram", (version) -> {
             if (version.onOrAfter(org.elasticsearch.Version.V_7_6_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("nGram_tokenizer_deprecation",
+                deprecationLogger.deprecate("nGram_tokenizer_deprecation",
                         "The [nGram] tokenizer name is deprecated and will be removed in a future version. "
                                 + "Please change the tokenizer name to [ngram] instead.");
             }
@@ -578,7 +578,7 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         }));
         tokenizers.add(PreConfiguredTokenizer.elasticsearchVersion("edgeNGram", (version) -> {
             if (version.onOrAfter(org.elasticsearch.Version.V_7_6_0)) {
-                deprecationLogger.deprecatedAndMaybeLog("edgeNGram_tokenizer_deprecation",
+                deprecationLogger.deprecate("edgeNGram_tokenizer_deprecation",
                         "The [edgeNGram] tokenizer name is deprecated and will be removed in a future version. "
                                 + "Please change the tokenizer name to [edge_ngram] instead.");
             }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonGramsTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonGramsTokenFilterFactory.java
@@ -71,7 +71,7 @@ public class CommonGramsTokenFilterFactory extends AbstractTokenFilterFactory {
         if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0)) {
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         } else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
         }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenFilterFactory.java
@@ -93,7 +93,7 @@ public class EdgeNGramTokenFilterFactory extends AbstractTokenFilterFactory {
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintTokenFilterFactory.java
@@ -60,7 +60,7 @@ public class FingerprintTokenFilterFactory extends AbstractTokenFilterFactory {
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
@@ -38,7 +38,7 @@ public class LegacyDelimitedPayloadTokenFilterFactory extends DelimitedPayloadTo
                     "[delimited_payload_filter] is not supported for new indices, use [delimited_payload] instead");
         }
         if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_6_2_0)) {
-            deprecationLogger.deprecatedAndMaybeLog("analysis_legacy_delimited_payload_filter",
+            deprecationLogger.deprecate("analysis_legacy_delimited_payload_filter",
                 "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]");
         }
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
@@ -68,7 +68,7 @@ public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
         }
         else {
             if (preserveOriginal) {
-                DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+                DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                     + "] will not be usable to parse synonyms after v7.0");
                 return IDENTITY_FILTER;
             }
@@ -131,7 +131,7 @@ public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
                 }
                 else {
                     if (preserveOriginal) {
-                        DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+                        DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                             + "] will not be usable to parse synonyms after v7.0");
                         return IDENTITY_FILTER;
                     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenFilterFactory.java
@@ -54,7 +54,7 @@ public class NGramTokenFilterFactory extends AbstractTokenFilterFactory {
                         + maxAllowedNgramDiff + "] but was [" + ngramDiff + "]. This limit can be set by changing the ["
                         + IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey() + "] index level setting.");
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("ngram_big_difference",
+                deprecationLogger.deprecate("ngram_big_difference",
                     "Deprecated big difference between max_gram and min_gram in NGram Tokenizer,"
                     + "expected difference must be less than or equal to: [" + maxAllowedNgramDiff + "]");
             }
@@ -73,7 +73,7 @@ public class NGramTokenFilterFactory extends AbstractTokenFilterFactory {
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenizerFactory.java
@@ -118,7 +118,7 @@ public class NGramTokenizerFactory extends AbstractTokenizerFactory {
                         + maxAllowedNgramDiff + "] but was [" + ngramDiff + "]. This limit can be set by changing the ["
                         + IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey() + "] index level setting.");
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("ngram_big_difference",
+                deprecationLogger.deprecate("ngram_big_difference",
                     "Deprecated big difference between max_gram and min_gram in NGram Tokenizer,"
                     + "expected difference must be less than or equal to: [" + maxAllowedNgramDiff + "]");
             }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StandardHtmlStripAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StandardHtmlStripAnalyzerProvider.java
@@ -50,7 +50,7 @@ public class StandardHtmlStripAnalyzerProvider extends AbstractIndexAnalyzerProv
             throw new IllegalArgumentException("[standard_html_strip] analyzer is not supported for new indices, " +
                 "use a custom analyzer using [standard] tokenizer and [html_strip] char_filter, plus [lowercase] filter");
         } else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("standard_html_strip_deprecation",
+            DEPRECATION_LOGGER.deprecate("standard_html_strip_deprecation",
                 "Deprecated analyzer [standard_html_strip] used, " +
                     "replace it with a custom analyzer using [standard] tokenizer and [html_strip] char_filter, plus [lowercase] filter");
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -59,10 +59,9 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         this.settings = settings;
 
         if (settings.get("ignore_case") != null) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog(
-                "synonym_ignore_case_option",
+            DEPRECATION_LOGGER.deprecate("synonym_ignore_case_option",
                 "The ignore_case option on the synonym_graph filter is deprecated. " +
-                    "Instead, insert a lowercase filter in the filter chain before the synonym_graph filter.");
+                        "Instead, insert a lowercase filter in the filter chain before the synonym_graph filter.");
         }
 
         this.expand = settings.getAsBoolean("expand", true);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactory.java
@@ -113,7 +113,7 @@ public class WordDelimiterGraphTokenFilterFactory extends AbstractTokenFilterFac
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterTokenFilterFactory.java
@@ -116,7 +116,7 @@ public class WordDelimiterTokenFilterFactory extends AbstractTokenFilterFactory 
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -56,7 +56,7 @@ public final class ScriptProcessor extends AbstractProcessor {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "_type", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("script_processor",
+                deprecationLogger.deprecate("script_processor",
                         "[types removal] Looking up doc types [_type] in scripts is deprecated.");
                 return value;
             });

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -315,7 +315,7 @@ public class UserAgentProcessor extends AbstractProcessor {
             }
 
             if (useECS == false) {
-                deprecationLogger.deprecatedAndMaybeLog("ecs_false_non_common_schema",
+                deprecationLogger.deprecate("ecs_false_non_common_schema",
                     "setting [ecs] to false for non-common schema " +
                     "format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format");
             }
@@ -358,7 +358,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                 Property value = valueOf(propertyName.toUpperCase(Locale.ROOT));
                 if (DEPRECATED_PROPERTIES.contains(value)) {
                     final String key = "user_agent_processor_property_" + propertyName.replaceAll("[^\\w_]+", "_");
-                        deprecationLogger.deprecatedAndMaybeLog(key,
+                        deprecationLogger.deprecate(key,
                         "the [{}] property is deprecated for the user-agent processor", propertyName);
                 }
                 return value;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -86,7 +86,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
         // Emit a single deprecation message if any search template contains types.
         for (SearchTemplateRequest searchTemplateRequest : multiRequest.requests()) {
             if (searchTemplateRequest.getRequest().types().length > 0) {
-                deprecationLogger.deprecatedAndMaybeLog("msearch_with_types", TYPES_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("msearch_with_types", TYPES_DEPRECATION_MESSAGE);
                 break;
             }
         }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -144,7 +144,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
             throw new IllegalArgumentException("[" + NAME + "] requires non-negative 'min_children' field");
         }
         if (minChildren == 0) {
-            deprecationLogger.deprecatedAndMaybeLog("min_children", MIN_CHILDREN_0_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("min_children", MIN_CHILDREN_0_DEPRECATION_MESSAGE);
         }
         if (maxChildren < 0) {
             throw new IllegalArgumentException("[" + NAME + "] requires non-negative 'max_children' field");

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -472,7 +472,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
         GetRequest getRequest;
         if (indexedDocumentType != null) {
-            deprecationLogger.deprecatedAndMaybeLog("percolate_with_type", TYPE_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("percolate_with_type", TYPE_DEPRECATION_MESSAGE);
             getRequest = new GetRequest(indexedDocumentIndex, indexedDocumentType, indexedDocumentId);
         } else {
             getRequest = new GetRequest(indexedDocumentIndex, indexedDocumentId);
@@ -543,7 +543,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         final MapperService mapperService = context.getMapperService();
         String type = mapperService.documentMapper().type();
         if (documentType != null) {
-            deprecationLogger.deprecatedAndMaybeLog("percolate_with_document_type", DOCUMENT_TYPE_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("percolate_with_document_type", DOCUMENT_TYPE_DEPRECATION_MESSAGE);
             if (documentType.equals(type) == false) {
                 throw new IllegalArgumentException("specified document_type [" + documentType +
                     "] is not equal to the actual type [" + type + "]");

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
@@ -69,7 +69,7 @@ class ReindexValidator {
             state);
         SearchSourceBuilder searchSource = request.getSearchRequest().source();
         if (searchSource != null && searchSource.sorts() != null && searchSource.sorts().isEmpty() == false) {
-            deprecationLogger.deprecatedAndMaybeLog("reindex_sort", SORT_DEPRECATED_MESSAGE);
+            deprecationLogger.deprecate("reindex_sort", SORT_DEPRECATED_MESSAGE);
         }
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -186,7 +186,7 @@ final class RemoteRequestBuilders {
     private static String encodeIndex(String s) {
         if (s.contains("%")) { // already encoded, pass-through to allow this in mixed version clusters
             checkIndexOrType("Index", s);
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("reindex_url_encoded_index", DEPRECATED_URL_ENCODED_INDEX_WARNING);
+            DEPRECATION_LOGGER.deprecate("reindex_url_encoded_index", DEPRECATED_URL_ENCODED_INDEX_WARNING);
             return s;
         }
         try {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuNormalizerTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuNormalizerTokenFilterFactory.java
@@ -62,7 +62,7 @@ public class IcuNormalizerTokenFilterFactory extends AbstractTokenFilterFactory 
         String unicodeSetFilter = settings.get("unicodeSetFilter");
         if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0)) {
             if (unicodeSetFilter != null) {
-                deprecationLogger.deprecatedAndMaybeLog("icu_normalizer_unicode_set_filter",
+                deprecationLogger.deprecate("icu_normalizer_unicode_set_filter",
                     "[unicodeSetFilter] has been deprecated in favor of [unicode_set_filter]");
             } else {
                 unicodeSetFilter = settings.get("unicode_set_filter");

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
@@ -152,7 +152,7 @@ public class PhoneticTokenFilterFactory extends AbstractTokenFilterFactory {
             throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter [" + name()
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter [" + name()
                 + "] will not be usable to parse synonyms after v7.0");
             return this;
         }

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/plugin/discovery/azure/classic/AzureDiscoveryPlugin.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/plugin/discovery/azure/classic/AzureDiscoveryPlugin.java
@@ -48,7 +48,7 @@ public class AzureDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
 
     public AzureDiscoveryPlugin(Settings settings) {
         this.settings = settings;
-        deprecationLogger.deprecatedAndMaybeLog("azure_discovery_plugin", "azure classic discovery plugin is deprecated.");
+        deprecationLogger.deprecate("azure_discovery_plugin", "azure classic discovery plugin is deprecated.");
         logger.trace("starting azure classic discovery plugin...");
     }
 

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
@@ -135,13 +135,13 @@ final class Ec2ClientSettings {
                 return null;
             } else {
                 if (key.length() == 0) {
-                    deprecationLogger.deprecatedAndMaybeLog("ec2_invalid_settings",
+                    deprecationLogger.deprecate("ec2_invalid_settings",
                         "Setting [{}] is set but [{}] is not, which will be unsupported in future",
                         SECRET_KEY_SETTING.getKey(), ACCESS_KEY_SETTING.getKey());
                 }
                 if (secret.length() == 0) {
-                    deprecationLogger.deprecatedAndMaybeLog("ec2_invalid_settings",
-                       "Setting [{}] is set but [{}] is not, which will be unsupported in future",
+                    deprecationLogger.deprecate("ec2_invalid_settings",
+                        "Setting [{}] is set but [{}] is not, which will be unsupported in future",
                         ACCESS_KEY_SETTING.getKey(), SECRET_KEY_SETTING.getKey());
                 }
 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -248,7 +248,7 @@ class S3Repository extends BlobStoreRepository {
 
         if (S3ClientSettings.checkDeprecatedCredentials(metadata.settings())) {
             // provided repository settings
-            deprecationLogger.deprecatedAndMaybeLog("s3_repository_secret_settings",
+            deprecationLogger.deprecate("s3_repository_secret_settings",
                     "Using s3 access/secret key from repository settings. Instead "
                     + "store these in named clients and the elasticsearch keystore for secure settings.");
         }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -67,6 +67,7 @@ public class EvilLoggerTests extends ESTestCase {
 
     @Override
     public void setUp() throws Exception {
+        assert "false".equals(System.getProperty("tests.security.manager")) : "-Dtests.security.manager=false has to be set";
         super.setUp();
         LogConfigurator.registerErrorListener();
     }
@@ -126,7 +127,7 @@ public class EvilLoggerTests extends ESTestCase {
                 }
                 for (int j = 0; j < iterations; j++) {
                     for (final Integer id : ids) {
-                        deprecationLogger.deprecatedAndMaybeLog(Integer.toString(id), "This is a maybe logged deprecation message" + id);
+                        deprecationLogger.deprecate(Integer.toString(id), "This is a maybe logged deprecation message" + id);
                     }
                 }
 
@@ -137,12 +138,12 @@ public class EvilLoggerTests extends ESTestCase {
                  */
                 final List<String> warnings = threadContext.getResponseHeaders().get("Warning");
                 final Set<String> actualWarningValues =
-                        warnings.stream().map(s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, true))
+                        warnings.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, true))
                             .collect(Collectors.toSet());
                 for (int j = 0; j < 128; j++) {
                     assertThat(
                             actualWarningValues,
-                            hasItem(DeprecationLogger.escapeAndEncode("This is a maybe logged deprecation message" + j)));
+                            hasItem(HeaderWarning.escapeAndEncode("This is a maybe logged deprecation message" + j)));
                 }
 
                 try {
@@ -174,7 +175,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                     deprecationEvents.get(i),
                     Level.WARN,
-                    "org.elasticsearch.common.logging.DeprecationLogger\\$2\\.run",
+                    "org.elasticsearch.common.logging.ThrottlingLogger\\$2\\.run",
                     "This is a maybe logged deprecation message" + i);
         }
 
@@ -192,17 +193,17 @@ public class EvilLoggerTests extends ESTestCase {
         final int iterations = randomIntBetween(1, 16);
 
         for (int i = 0; i < iterations; i++) {
-            deprecationLogger.deprecatedAndMaybeLog("key", "This is a maybe logged deprecation message");
+            deprecationLogger.deprecate("key", "This is a maybe logged deprecation message");
             assertWarnings("This is a maybe logged deprecation message");
         }
         for (int k = 0; k < 128; k++) {
             for (int i = 0; i < iterations; i++) {
-                deprecationLogger.deprecatedAndMaybeLog("key" + k, "This is a maybe logged deprecation message" + k);
+                deprecationLogger.deprecate("key" + k, "This is a maybe logged deprecation message" + k);
                 assertWarnings("This is a maybe logged deprecation message" + k);
             }
         }
         for (int i = 0; i < iterations; i++) {
-            deprecationLogger.deprecatedAndMaybeLog("key", "This is a maybe logged deprecation message");
+            deprecationLogger.deprecate("key", "This is a maybe logged deprecation message");
             assertWarnings("This is a maybe logged deprecation message");
         }
 
@@ -216,13 +217,13 @@ public class EvilLoggerTests extends ESTestCase {
         assertLogLine(
                 deprecationEvents.get(0),
                 Level.WARN,
-                "org.elasticsearch.common.logging.DeprecationLogger\\$2\\.run",
+                "org.elasticsearch.common.logging.ThrottlingLogger\\$2\\.run",
                 "This is a maybe logged deprecation message");
         for (int k = 0; k < 128; k++) {
             assertLogLine(
                     deprecationEvents.get(1 + k),
                     Level.WARN,
-                    "org.elasticsearch.common.logging.DeprecationLogger\\$2\\.run",
+                    "org.elasticsearch.common.logging.ThrottlingLogger\\$2\\.run",
                     "This is a maybe logged deprecation message" + k);
         }
     }
@@ -250,7 +251,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                     deprecationEvents.get(0),
                     Level.WARN,
-                    "org.elasticsearch.common.logging.DeprecationLogger\\$2\\.run",
+                    "org.elasticsearch.common.logging.ThrottlingLogger\\$2\\.run",
                     "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! " +
                             "See the breaking changes documentation for the next major version.");
         }

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -79,7 +79,7 @@ public class JsonLoggerTests extends ESTestCase {
     }
     public void testDeprecatedMessage() throws IOException {
         final Logger testLogger = LogManager.getLogger("test");
-        testLogger.info(new DeprecatedMessage("deprecated message1", "someId"));
+        testLogger.info(new DeprecatedMessage("someId", "deprecated message1"));
 
         final Path path = PathUtils.get(System.getProperty("es.logs.base_path"),
             System.getProperty("es.logs.cluster_name") + "_deprecated.json");
@@ -104,9 +104,9 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testDeprecatedMessageWithoutXOpaqueId() throws IOException {
         final Logger testLogger = LogManager.getLogger("test");
-        testLogger.info(new DeprecatedMessage("deprecated message1", "someId"));
-        testLogger.info(new DeprecatedMessage("deprecated message2", ""));
-        testLogger.info(new DeprecatedMessage("deprecated message3", null));
+        testLogger.info(new DeprecatedMessage("someId", "deprecated message1"));
+        testLogger.info(new DeprecatedMessage("", "deprecated message2"));
+        testLogger.info(new DeprecatedMessage(null, "deprecated message3"));
         testLogger.info("deprecated message4");
 
         final Path path = PathUtils.get(System.getProperty("es.logs.base_path"),

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -277,8 +277,8 @@ public class JsonLoggerTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader(Task.X_OPAQUE_ID, "ID1");
             DeprecationLogger.setThreadContext(threadContext);
-            deprecationLogger.deprecatedAndMaybeLog("key", "message1");
-            deprecationLogger.deprecatedAndMaybeLog("key", "message2");
+            deprecationLogger.deprecate("key", "message1");
+            deprecationLogger.deprecate("key", "message2");
             assertWarnings("message1", "message2");
 
             final Path path = PathUtils.get(System.getProperty("es.logs.base_path"),
@@ -309,8 +309,8 @@ public class JsonLoggerTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader(Task.X_OPAQUE_ID, "ID2");
             DeprecationLogger.setThreadContext(threadContext);
-            deprecationLogger.deprecatedAndMaybeLog("key", "message1");
-            deprecationLogger.deprecatedAndMaybeLog("key", "message2");
+            deprecationLogger.deprecate("key", "message1");
+            deprecationLogger.deprecate("key", "message2");
             assertWarnings("message1", "message2");
 
             final Path path = PathUtils.get(System.getProperty("es.logs.base_path"),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -84,7 +84,7 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         }
 
         if (nodeDescriptions.length > 0) {
-            deprecationLogger.deprecatedAndMaybeLog("voting_config_exclusion", DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("voting_config_exclusion", DEPRECATION_MESSAGE);
         }
 
         this.nodeDescriptions = nodeDescriptions;
@@ -106,7 +106,7 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         timeout = in.readTimeValue();
 
         if (nodeDescriptions.length > 0) {
-            deprecationLogger.deprecatedAndMaybeLog("voting_config_exclusion",
+            deprecationLogger.deprecate("voting_config_exclusion",
                 "nodeDescription is deprecated and will be removed, use nodeIds or nodeNames instead");
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -498,7 +498,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
                 if (!(entry.getValue() instanceof Map)) {
                     throw new IllegalArgumentException("malformed settings section");
                 }
-                DEPRECATION_LOGGER.deprecatedAndMaybeLog("RestoreSnapshotRequest#settings",
+                DEPRECATION_LOGGER.deprecate("RestoreSnapshotRequest#settings",
                     "specifying [settings] when restoring a snapshot has no effect and will not be supported in a future version");
             } else if (name.equals("include_global_state")) {
                 includeGlobalState = nodeBooleanValue(entry.getValue(), "include_global_state");

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -343,7 +343,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             if (name.equals("template")) {
                 // This is needed to allow for bwc (beats, logstash) with pre-5.0 templates (#21009)
                 if(entry.getValue() instanceof String) {
-                    deprecationLogger.deprecatedAndMaybeLog("put_index_template_field",
+                    deprecationLogger.deprecate("put_index_template_field",
                         "Deprecated field [template] used, replaced by [index_patterns]");
                     patterns(Collections.singletonList((String) entry.getValue()));
                 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -208,7 +208,7 @@ public final class BulkRequestParser {
                                 index = stringDeduplicator.computeIfAbsent(parser.text(), Function.identity());
                             } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 if (warnOnTypeUsage && typesDeprecationLogged == false) {
-                                    deprecationLogger.deprecatedAndMaybeLog("bulk_with_types", RestBulkAction.TYPES_DEPRECATION_MESSAGE);
+                                    deprecationLogger.deprecate("bulk_with_types", RestBulkAction.TYPES_DEPRECATION_MESSAGE);
                                     typesDeprecationLogged = true;
                                 }
                                 type = stringDeduplicator.computeIfAbsent(parser.text(), Function.identity());

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -187,7 +187,7 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
             String index = ConfigurationUtils.readStringOrIntProperty(null, null,
                 dataMap, Metadata.INDEX.getFieldName(), "_index");
             if (dataMap.containsKey(Metadata.TYPE.getFieldName())) {
-                deprecationLogger.deprecatedAndMaybeLog("simulate_pipeline_with_types",
+                deprecationLogger.deprecate("simulate_pipeline_with_types",
                     "[types removal] specifying _type in pipeline simulation requests is deprecated");
             }
             String type = ConfigurationUtils.readStringOrIntProperty(null, null,

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -195,7 +195,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             // support first line with \n
             if (nextMarker == 0) {
                 from = nextMarker + 1;
-                deprecationLogger.deprecatedAndMaybeLog("multi_search_empty_first_line",
+                deprecationLogger.deprecate("multi_search_empty_first_line",
                     "support for empty first line before any action metadata in msearch API is deprecated and " +
                     "will be removed in the next major version");
                 continue;

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -615,7 +615,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
                     termVectorsRequest.index = parser.text();
                 } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.type = parser.text();
-                    deprecationLogger.deprecatedAndMaybeLog("termvectors_with_types",
+                    deprecationLogger.deprecate("termvectors_with_types",
                         RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
                 } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (termVectorsRequest.doc != null) {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -361,7 +361,7 @@ final class Bootstrap {
                             "future versions of Elasticsearch will require Java 11; " +
                                     "your Java version from [%s] does not meet this requirement",
                             System.getProperty("java.home"));
-            new DeprecationLogger(LogManager.getLogger(Bootstrap.class)).deprecatedAndMaybeLog("java_version_11_required", message);
+            new DeprecationLogger(LogManager.getLogger(Bootstrap.class)).deprecate("java_version_11_required", message);
         }
         if (environment.pidFile() != null) {
             try {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -103,7 +103,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
         this.settings = settings;
         this.mappings = mappings;
         if (this.mappings.size() > 1) {
-            deprecationLogger.deprecatedAndMaybeLog("index-templates",
+            deprecationLogger.deprecate("index-templates",
                 "Index template {} contains multiple typed mappings; templates in 8x will only support a single mapping",
                 name);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -688,7 +688,7 @@ public class MetadataCreateIndexService {
          */
         shardLimitValidator.validateShardLimit(indexSettings, currentState);
         if (indexSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true) == false) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("soft_deletes_disabled",
+            DEPRECATION_LOGGER.deprecate("soft_deletes_disabled",
                 "Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. " +
                     "Please do not specify value for setting [index.soft_deletes.enabled] of index [" + request.index() + "].");
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -196,7 +196,7 @@ public class MetadataCreateIndexService {
             } else if (isHidden) {
                 logger.trace("index [{}] is a hidden index", index);
             } else {
-                DEPRECATION_LOGGER.deprecatedAndMaybeLog("index_name_starts_with_dot",
+                DEPRECATION_LOGGER.deprecate("index_name_starts_with_dot",
                     "index name [{}] starts with a dot '.', in the next major version, index names " +
                         "starting with a dot are reserved for hidden indices and system indices", index);
             }
@@ -346,7 +346,7 @@ public class MetadataCreateIndexService {
                     request.index(), isHiddenFromRequest);
 
                 if (v1Templates.size() > 1) {
-                    DEPRECATION_LOGGER.deprecatedAndMaybeLog("index_template_multiple_match",
+                    DEPRECATION_LOGGER.deprecate("index_template_multiple_match",
                         "index [{}] matches multiple legacy templates [{}], composable templates will only match a single template",
                         request.index(), v1Templates.stream().map(IndexTemplateMetadata::name).sorted().collect(Collectors.joining(", ")));
                 }
@@ -1156,7 +1156,7 @@ public class MetadataCreateIndexService {
         if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
             (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("translog_retention", "Translog retention settings [index.translog.retention.age] "
+            DEPRECATION_LOGGER.deprecate("translog_retention", "Translog retention settings [index.translog.retention.age] "
                 + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -41,7 +41,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -99,8 +99,6 @@ public class MetadataIndexTemplateService {
         "   }\n" +
         " }";
     private static final Logger logger = LogManager.getLogger(MetadataIndexTemplateService.class);
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
-
     private final ClusterService clusterService;
     private final AliasValidator aliasValidator;
     private final IndicesService indicesService;
@@ -466,7 +464,7 @@ public class MetadataIndexTemplateService {
                     .collect(Collectors.joining(",")),
                 name);
             logger.warn(warning);
-            deprecationLogger.deprecatedAndMaybeLog("index_template_pattern_overlap", warning);
+            HeaderWarning.addWarning(warning);
         }
 
         ComposableIndexTemplate finalIndexTemplate = template;
@@ -784,7 +782,7 @@ public class MetadataIndexTemplateService {
                     .collect(Collectors.joining(",")),
                 request.name);
             logger.warn(warning);
-            deprecationLogger.deprecatedAndMaybeLog("index_template_pattern_overlap", warning);
+            HeaderWarning.addWarning(warning);
         }
 
         templateBuilder.order(request.order);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -67,7 +67,7 @@ public class OperationRouting {
         if (ignoreAwarenessAttr == false) {
             awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
             if (awarenessAttributes.isEmpty() == false) {
-                deprecationLogger.deprecatedAndMaybeLog("searches_not_routed_on_awareness_attributes",
+                deprecationLogger.deprecate("searches_not_routed_on_awareness_attributes",
                     IGNORE_AWARENESS_ATTRIBUTES_DEPRECATION_MESSAGE);
             }
             clusterSettings.addSettingsUpdateConsumer(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
@@ -92,7 +92,7 @@ public class OperationRouting {
         boolean ignoreAwarenessAttr = parseBoolean(System.getProperty(IGNORE_AWARENESS_ATTRIBUTES_PROPERTY), false);
         if (ignoreAwarenessAttr == false) {
             if (this.awarenessAttributes.isEmpty() && awarenessAttributes.isEmpty() == false) {
-                deprecationLogger.deprecatedAndMaybeLog("searches_not_routed_on_awareness_attributes",
+                deprecationLogger.deprecate("searches_not_routed_on_awareness_attributes",
                     IGNORE_AWARENESS_ATTRIBUTES_DEPRECATION_MESSAGE);
             }
             this.awarenessAttributes = awarenessAttributes;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -101,7 +101,7 @@ public class DiskThresholdMonitor {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
         this.client = client;
         if (diskThresholdSettings.isAutoReleaseIndexEnabled() == false) {
-            deprecationLogger.deprecatedAndMaybeLog(DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY.replace(".", "_"),
+            deprecationLogger.deprecate(DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY.replace(".", "_"),
                 "[{}] will be removed in version {}",
                 DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY, Version.V_7_4_0.major + 1);
         }
@@ -305,7 +305,7 @@ public class DiskThresholdMonitor {
                 logger.info("releasing read-only-allow-delete block on indices: [{}]", indicesToAutoRelease);
                 updateIndicesReadOnly(indicesToAutoRelease, listener, false);
             } else {
-                deprecationLogger.deprecatedAndMaybeLog(
+                deprecationLogger.deprecate(
                     DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY.replace(".", "_"),
                     "[{}] will be removed in version {}",
                     DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY, Version.V_7_4_0.major + 1);

--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -286,7 +286,7 @@ public class Joda {
     private static void maybeLogJodaDeprecation(String format) {
         if (JodaDeprecationPatterns.isDeprecatedPattern(format)) {
             String suggestion = JodaDeprecationPatterns.formatSuggestion(format);
-            getDeprecationLogger().deprecatedAndMaybeLog("joda-pattern-deprecation",
+            getDeprecationLogger().deprecate("joda-pattern-deprecation",
                 suggestion + " " + JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
         }
     }
@@ -396,11 +396,11 @@ public class Joda {
                 long millis = new BigDecimal(text).longValue() * factor;
                 // check for deprecations, but after it has parsed correctly so invalid values aren't counted as deprecated
                 if (millis < 0) {
-                    getDeprecationLogger().deprecatedAndMaybeLog("epoch-negative", "Use of negative values" +
+                    getDeprecationLogger().deprecate("epoch-negative", "Use of negative values" +
                         " in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch.");
                 }
                 if (scientificNotation.matcher(text).find()) {
-                    getDeprecationLogger().deprecatedAndMaybeLog("epoch-scientific-notation", "Use of scientific notation" +
+                    getDeprecationLogger().deprecate("epoch-scientific-notation", "Use of scientific notation" +
                         " in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch.");
                 }
                 DateTime dt = new DateTime(millis, DateTimeZone.UTC);

--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -77,7 +77,7 @@ public class Joda {
             String msg = "Camel case format name {} is deprecated and will be removed in a future version. " +
                 "Use snake case name {} instead.";
             getDeprecationLogger()
-                .deprecatedAndMaybeLog("camelCaseDateFormat", msg, formatName.getCamelCaseName(), formatName.getSnakeCaseName());
+                .deprecate("camelCaseDateFormat", msg, formatName.getCamelCaseName(), formatName.getSnakeCaseName());
         }
 
         DateTimeFormatter formatter;

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class DeprecatedMessage extends ESLogMessage {
 
-    public DeprecatedMessage(String messagePattern, String xOpaqueId, Object... args) {
+    public DeprecatedMessage(String xOpaqueId, String messagePattern, Object... args) {
         super(fieldMap(xOpaqueId), messagePattern, args);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.logging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 
 /**
@@ -71,6 +72,7 @@ public class DeprecationLogger {
      * Logs a deprecation message, adding a formatted warning message as a response header on the thread context.
      * The deprecation message will be throttled to deprecation log.
      */
+    @SuppressLoggerChecks(reason = "Safely delegates to a deprecated message")
     public void deprecate(final String key, final String msg, final Object... params) {
         String opaqueId = HeaderWarning.getXOpaqueId();
         ESLogMessage deprecationMessage = new DeprecatedMessage(opaqueId, msg, params);

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -21,79 +21,23 @@ package org.elasticsearch.common.logging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Build;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.tasks.Task;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
- * A logger that logs deprecation notices.
+ * A logger that logs deprecation notices. Logger should be initialized with a parent logger which name will be used
+ * for deprecation logger. For instance <code>new DeprecationLogger("org.elasticsearch.test.SomeClass")</code> will
+ * result in a deprecation logger with name <code>org.elasticsearch.deprecation.test.SomeClass</code>. This allows to use
+ * <code>deprecation</code> logger defined in log4j2.properties.
+ *
+ * Deprecation logs are written to deprecation log file - defined in log4j2.properties, as well as warnings added to a response header.
+ * All deprecation usages are throttled basing on a key. Key is a string provided in an argument and can be prefixed with
+ * <code>X-Opaque-Id</code>. This allows to throttle deprecations per client usage.
+ * <code>deprecationLogger.deprecate("key","message {}", "param");</code>
+ *
+ * @see ThrottlingAndHeaderWarningLogger for throttling and header warnings implementation details
  */
 public class DeprecationLogger {
-
-    private final Logger logger;
-
-    /**
-     * This is set once by the {@code Node} constructor, but it uses {@link CopyOnWriteArraySet} to ensure that tests can run in parallel.
-     * <p>
-     * Integration tests will create separate nodes within the same classloader, thus leading to a shared, {@code static} state.
-     * In order for all tests to appropriately be handled, this must be able to remember <em>all</em> {@link ThreadContext}s that it is
-     * given in a thread safe manner.
-     * <p>
-     * For actual usage, multiple nodes do not share the same JVM and therefore this will only be set once in practice.
-     */
-    private static final CopyOnWriteArraySet<ThreadContext> THREAD_CONTEXT = new CopyOnWriteArraySet<>();
-
-    /**
-     * Set the {@link ThreadContext} used to add deprecation headers to network responses.
-     * <p>
-     * This is expected to <em>only</em> be invoked by the {@code Node}'s constructor (therefore once outside of tests).
-     *
-     * @param threadContext The thread context owned by the {@code ThreadPool} (and implicitly a {@code Node})
-     * @throws IllegalStateException if this {@code threadContext} has already been set
-     */
-    public static void setThreadContext(ThreadContext threadContext) {
-        Objects.requireNonNull(threadContext, "Cannot register a null ThreadContext");
-
-        // add returning false means it _did_ have it already
-        if (THREAD_CONTEXT.add(threadContext) == false) {
-            throw new IllegalStateException("Double-setting ThreadContext not allowed!");
-        }
-    }
-
-    /**
-     * Remove the {@link ThreadContext} used to add deprecation headers to network responses.
-     * <p>
-     * This is expected to <em>only</em> be invoked by the {@code Node}'s {@code close} method (therefore once outside of tests).
-     *
-     * @param threadContext The thread context owned by the {@code ThreadPool} (and implicitly a {@code Node})
-     * @throws IllegalStateException if this {@code threadContext} is unknown (and presumably already unset before)
-     */
-    public static void removeThreadContext(ThreadContext threadContext) {
-        assert threadContext != null;
-
-        // remove returning false means it did not have it already
-        if (THREAD_CONTEXT.remove(threadContext) == false) {
-            throw new IllegalStateException("Removing unknown ThreadContext not allowed!");
-        }
-    }
+    private final ThrottlingAndHeaderWarningLogger deprecationLogger;
 
     /**
      * Creates a new deprecation logger based on the parent logger. Automatically
@@ -102,316 +46,35 @@ public class DeprecationLogger {
      * the "org.elasticsearch" namespace.
      */
     public DeprecationLogger(Logger parentLogger) {
+        deprecationLogger = new ThrottlingAndHeaderWarningLogger(deprecatedLoggerName(parentLogger));
+    }
+
+    private static Logger deprecatedLoggerName(Logger parentLogger) {
         String name = parentLogger.getName();
         if (name.startsWith("org.elasticsearch")) {
             name = name.replace("org.elasticsearch.", "org.elasticsearch.deprecation.");
         } else {
             name = "deprecation." + name;
         }
-        this.logger = LogManager.getLogger(name);
+        return LogManager.getLogger(name);
     }
 
-    // LRU set of keys used to determine if a deprecation message should be emitted to the deprecation logs
-    private final Set<String> keys = Collections.newSetFromMap(Collections.synchronizedMap(new LinkedHashMap<String, Boolean>() {
-        @Override
-        protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {
-            return size() > 128;
-        }
-    }));
-
-    /**
-     * Adds a formatted warning message as a response header on the thread context, and logs a deprecation message if the associated key has
-     * not recently been seen.
-     *
-     * @param key    the key used to determine if this deprecation should be logged
-     * @param msg    the message to log
-     * @param params parameters to the message
-     */
-    public void deprecatedAndMaybeLog(final String key, final String msg, final Object... params) {
-        String xOpaqueId = getXOpaqueId(THREAD_CONTEXT);
-        boolean shouldLog = keys.add(xOpaqueId + key);
-        deprecated(THREAD_CONTEXT, msg, shouldLog, params);
+    public static void setThreadContext(ThreadContext threadContext) {
+        HeaderWarning.setThreadContext(threadContext);
     }
 
-    /*
-     * RFC7234 specifies the warning format as warn-code <space> warn-agent <space> "warn-text" [<space> "warn-date"]. Here, warn-code is a
-     * three-digit number with various standard warn codes specified. The warn code 299 is apt for our purposes as it represents a
-     * miscellaneous persistent warning (can be presented to a human, or logged, and must not be removed by a cache). The warn-agent is an
-     * arbitrary token; here we use the Elasticsearch version and build hash. The warn text must be quoted. The warn-date is an optional
-     * quoted field that can be in a variety of specified date formats; here we use RFC 1123 format.
-     */
-    private static final String WARNING_PREFIX =
-            String.format(
-                    Locale.ROOT,
-                    "299 Elasticsearch-%s%s-%s",
-                    Version.CURRENT.toString(),
-                    Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
-                    Build.CURRENT.hash());
-
-    /**
-     * Regular expression to test if a string matches the RFC7234 specification for warning headers. This pattern assumes that the warn code
-     * is always 299. Further, this pattern assumes that the warn agent represents a version of Elasticsearch including the build hash.
-     */
-    public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
-            "299 " + // warn code
-                    "Elasticsearch-" + // warn agent
-                    "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
-                    "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
-                    "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
-                    // quoted RFC 1123 date format
-                    "\"" + // opening quote
-                    "(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), " + // weekday
-                    "\\d{2} " + // 2-digit day
-                    "(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) " + // month
-                    "\\d{4} " + // 4-digit year
-                    "\\d{2}:\\d{2}:\\d{2} " + // (two-digit hour):(two-digit minute):(two-digit second)
-                    "GMT" + // GMT
-                    "\")?"); // closing quote (optional, since an older version can still send a warn-date)
-
-    public static final Pattern WARNING_XCONTENT_LOCATION_PATTERN = Pattern.compile("^\\[.*?]\\[-?\\d+:-?\\d+] ");
-
-    /**
-     * Extracts the warning value from the value of a warning header that is formatted according to RFC 7234. That is, given a string
-     * {@code 299 Elasticsearch-6.0.0 "warning value"}, the return value of this method would be {@code warning value}.
-     *
-     * @param s the value of a warning header formatted according to RFC 7234.
-     * @return the extracted warning value
-     */
-    public static String extractWarningValueFromWarningHeader(final String s, boolean stripXContentPosition) {
-        /*
-         * We know the exact format of the warning header, so to extract the warning value we can skip forward from the front to the first
-         * quote and we know the last quote is at the end of the string
-         *
-         *   299 Elasticsearch-6.0.0 "warning value"
-         *                           ^             ^
-         *                           firstQuote    lastQuote
-         *
-         * We parse this manually rather than using the capturing regular expression because the regular expression involves a lot of
-         * backtracking and carries a performance penalty. However, when assertions are enabled, we still use the regular expression to
-         * verify that we are maintaining the warning header format.
-         */
-        final int firstQuote = s.indexOf('\"');
-        final int lastQuote = s.length() - 1;
-        String warningValue = s.substring(firstQuote + 1, lastQuote);
-        assert assertWarningValue(s, warningValue);
-        if (stripXContentPosition) {
-            Matcher matcher = WARNING_XCONTENT_LOCATION_PATTERN.matcher(warningValue);
-            if (matcher.find()) {
-                warningValue = warningValue.substring(matcher.end());
-            }
-        }
-        return warningValue;
+    public static void removeThreadContext(ThreadContext threadContext) {
+        HeaderWarning.removeThreadContext(threadContext);
     }
 
     /**
-     * Assert that the specified string has the warning value equal to the provided warning value.
-     *
-     * @param s            the string representing a full warning header
-     * @param warningValue the expected warning header
-     * @return {@code true} if the specified string has the expected warning value
+     * Logs a deprecation message, adding a formatted warning message as a response header on the thread context.
+     * The deprecation message will be throttled to deprecation log.
      */
-    private static boolean assertWarningValue(final String s, final String warningValue) {
-        final Matcher matcher = WARNING_HEADER_PATTERN.matcher(s);
-        final boolean matches = matcher.matches();
-        assert matches;
-        return matcher.group(1).equals(warningValue);
-    }
-
-    /**
-     * Logs a deprecated message to the deprecation log, as well as to the local {@link ThreadContext}.
-     *
-     * @param threadContexts The node's {@link ThreadContext} (outside of concurrent tests, this should only ever have one context).
-     * @param message The deprecation message.
-     * @param params The parameters used to fill in the message, if any exist.
-     */
-    void deprecated(final Set<ThreadContext> threadContexts, final String message, final Object... params) {
-        deprecated(threadContexts, message, true, params);
-    }
-
-    void deprecated(final Set<ThreadContext> threadContexts, final String message, final boolean shouldLog, final Object... params) {
-        final Iterator<ThreadContext> iterator = threadContexts.iterator();
-        if (iterator.hasNext()) {
-            final String formattedMessage = LoggerMessageFormat.format(message, params);
-            final String warningHeaderValue = formatWarning(formattedMessage);
-            assert WARNING_HEADER_PATTERN.matcher(warningHeaderValue).matches();
-            assert extractWarningValueFromWarningHeader(warningHeaderValue, false).equals(escapeAndEncode(formattedMessage));
-            while (iterator.hasNext()) {
-                try {
-                    final ThreadContext next = iterator.next();
-                    next.addResponseHeader("Warning", warningHeaderValue);
-                } catch (final IllegalStateException e) {
-                    // ignored; it should be removed shortly
-                }
-            }
-        }
-
-        if (shouldLog) {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @SuppressLoggerChecks(reason = "safely delegates to logger")
-                @Override
-                public Void run() {
-                    /*
-                     * There should be only one threadContext (in prod env), @see DeprecationLogger#setThreadContext
-                     */
-                    String opaqueId = getXOpaqueId(threadContexts);
-
-                    logger.warn(new DeprecatedMessage(message, opaqueId, params));
-                    return null;
-                }
-            });
-        }
-    }
-
-    public String getXOpaqueId(Set<ThreadContext> threadContexts) {
-        return threadContexts.stream()
-                             .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
-                             .findFirst()
-                             .map(t -> t.getHeader(Task.X_OPAQUE_ID))
-                             .orElse("");
-    }
-
-    /**
-     * Format a warning string in the proper warning format by prepending a warn code, warn agent, wrapping the warning string in quotes,
-     * and appending the RFC 7231 date.
-     *
-     * @param s the warning string to format
-     * @return a warning value formatted according to RFC 7234
-     */
-    public static String formatWarning(final String s) {
-        // Assume that the common scenario won't have a string to escape and encode.
-        int length = WARNING_PREFIX.length() + s.length() + 3;
-        final StringBuilder sb = new StringBuilder(length);
-        sb.append(WARNING_PREFIX).append(" \"").append(escapeAndEncode(s)).append("\"");
-        return sb.toString();
-    }
-
-    /**
-     * Escape and encode a string as a valid RFC 7230 quoted-string.
-     *
-     * @param s the string to escape and encode
-     * @return the escaped and encoded string
-     */
-    public static String escapeAndEncode(final String s) {
-        return encode(escapeBackslashesAndQuotes(s));
-    }
-
-    /**
-     * Escape backslashes and quotes in the specified string.
-     *
-     * @param s the string to escape
-     * @return the escaped string
-     */
-    static String escapeBackslashesAndQuotes(final String s) {
-        /*
-         * We want a fast path check to avoid creating the string builder and copying characters if needed. So we walk the string looking
-         * for either of the characters that we need to escape. If we find a character that needs escaping, we start over and
-         */
-        boolean escapingNeeded = false;
-        for (int i = 0; i < s.length(); i++) {
-            final char c = s.charAt(i);
-            if (c == '\\' || c == '"') {
-                escapingNeeded = true;
-                break;
-            }
-        }
-
-        if (escapingNeeded) {
-            final StringBuilder sb = new StringBuilder();
-            for (final char c : s.toCharArray()) {
-                if (c == '\\' || c == '"') {
-                    sb.append("\\");
-                }
-                sb.append(c);
-            }
-            return sb.toString();
-        } else {
-            return s;
-        }
-    }
-
-    private static BitSet doesNotNeedEncoding;
-
-    static {
-        doesNotNeedEncoding = new BitSet(1 + 0xFF);
-        doesNotNeedEncoding.set('\t');
-        doesNotNeedEncoding.set(' ');
-        doesNotNeedEncoding.set('!');
-        doesNotNeedEncoding.set('\\');
-        doesNotNeedEncoding.set('"');
-        // we have to skip '%' which is 0x25 so that it is percent-encoded too
-        for (int i = 0x23; i <= 0x24; i++) {
-            doesNotNeedEncoding.set(i);
-        }
-        for (int i = 0x26; i <= 0x5B; i++) {
-            doesNotNeedEncoding.set(i);
-        }
-        for (int i = 0x5D; i <= 0x7E; i++) {
-            doesNotNeedEncoding.set(i);
-        }
-        for (int i = 0x80; i <= 0xFF; i++) {
-            doesNotNeedEncoding.set(i);
-        }
-        assert doesNotNeedEncoding.get('%') == false : doesNotNeedEncoding;
-    }
-
-    private static final Charset UTF_8 = StandardCharsets.UTF_8;
-
-    /**
-     * Encode a string containing characters outside of the legal characters for an RFC 7230 quoted-string.
-     *
-     * @param s the string to encode
-     * @return the encoded string
-     */
-    static String encode(final String s) {
-        // first check if the string needs any encoding; this is the fast path and we want to avoid creating a string builder and copying
-        boolean encodingNeeded = false;
-        for (int i = 0; i < s.length(); i++) {
-            int current = s.charAt(i);
-            if (doesNotNeedEncoding.get(current) == false) {
-                encodingNeeded = true;
-                break;
-            }
-        }
-
-        if (encodingNeeded == false) {
-            return s;
-        }
-
-        final StringBuilder sb = new StringBuilder(s.length());
-        for (int i = 0; i < s.length();) {
-            int current = s.charAt(i);
-            /*
-             * Either the character does not need encoding or it does; when the character does not need encoding we append the character to
-             * a buffer and move to the next character and when the character does need encoding, we peel off as many characters as possible
-             * which we encode using UTF-8 until we encounter another character that does not need encoding.
-             */
-            if (doesNotNeedEncoding.get(current)) {
-                // append directly and move to the next character
-                sb.append((char) current);
-                i++;
-            } else {
-                int startIndex = i;
-                do {
-                    i++;
-                } while (i < s.length() && doesNotNeedEncoding.get(s.charAt(i)) == false);
-
-                final byte[] bytes = s.substring(startIndex, i).getBytes(UTF_8);
-                // noinspection ForLoopReplaceableByForEach
-                for (int j = 0; j < bytes.length; j++) {
-                    sb.append('%').append(hex(bytes[j] >> 4)).append(hex(bytes[j]));
-                }
-            }
-        }
-        return sb.toString();
-    }
-
-    private static char hex(int b) {
-        final char ch = Character.forDigit(b & 0xF, 16);
-        if (Character.isLetter(ch)) {
-            return Character.toUpperCase(ch);
-        } else {
-            return ch;
-        }
+    public void deprecate(final String key, final String msg, final Object... params) {
+        String opaqueId = HeaderWarning.getXOpaqueId();
+        ESLogMessage deprecationMessage = new DeprecatedMessage(opaqueId, msg, params);
+        deprecationLogger.throttleLogAndAddWarning(key, deprecationMessage);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 /**
  * A base class for custom log4j logger messages. Carries additional fields which will populate JSON fields in logs.
  */
+@SuppressLoggerChecks(reason = "super is not calling a constructor")
 public abstract class ESLogMessage extends ParameterizedMessage {
     private final Map<String, Object> fields;
 
@@ -65,12 +66,10 @@ public abstract class ESLogMessage extends ParameterizedMessage {
             .collect(Collectors.joining(", ")) + "]";
     }
 
-    @SuppressLoggerChecks(reason = "super is not calling a constructor")
     public Object[] getArguments() {
         return super.getParameters();
     }
 
-    @SuppressLoggerChecks(reason = "super is not calling a constructor")
     public String getMessagePattern() {
         return super.getFormat();
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 /**
  * A base class for custom log4j logger messages. Carries additional fields which will populate JSON fields in logs.
  */
-@SuppressLoggerChecks(reason = "super is not calling a constructor")
+@SuppressLoggerChecks(reason = "Safe as this is abstract class")
 public abstract class ESLogMessage extends ParameterizedMessage {
     private final Map<String, Object> fields;
 
@@ -37,7 +37,6 @@ public abstract class ESLogMessage extends ParameterizedMessage {
      * This is an abstract class, so this is safe. The check is done on DeprecationMessage.
      * Other subclasses are not allowing varargs
      */
-    @SuppressLoggerChecks(reason = "Safe as this is abstract class")
     public ESLogMessage(Map<String, Object> fields, String messagePattern, Object... args) {
         super(messagePattern, args);
         this.fields = fields;

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -64,4 +64,12 @@ public abstract class ESLogMessage extends ParameterizedMessage {
             .map(ESLogMessage::inQuotes)
             .collect(Collectors.joining(", ")) + "]";
     }
+
+    public Object[] getArguments() {
+        return arguments.toArray();
+    }
+
+    public String getMessagePattern() {
+        return messagePattern;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -65,11 +65,13 @@ public abstract class ESLogMessage extends ParameterizedMessage {
             .collect(Collectors.joining(", ")) + "]";
     }
 
+    @SuppressLoggerChecks(reason = "super is not calling a constructor")
     public Object[] getArguments() {
-        return arguments.toArray();
+        return super.getParameters();
     }
 
+    @SuppressLoggerChecks(reason = "super is not calling a constructor")
     public String getMessagePattern() {
-        return messagePattern;
+        return super.getFormat();
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.tasks.Task;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This is a simplistic logger that adds warning messages to HTTP headers.
+ * Use <code>HeaderWarning.addWarning(message,params)</code>. Message will be formatted according to RFC7234.
+ * The result will be returned as HTTP response headers.
+ */
+public class HeaderWarning {
+    /**
+     * Regular expression to test if a string matches the RFC7234 specification for warning headers. This pattern assumes that the warn code
+     * is always 299. Further, this pattern assumes that the warn agent represents a version of Elasticsearch including the build hash.
+     */
+    public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
+        "299 " + // warn code
+            "Elasticsearch-" + // warn agent
+            "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
+            "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
+            "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
+            // quoted RFC 1123 date format
+            "\"" + // opening quote
+            "(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), " + // weekday
+            "\\d{2} " + // 2-digit day
+            "(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) " + // month
+            "\\d{4} " + // 4-digit year
+            "\\d{2}:\\d{2}:\\d{2} " + // (two-digit hour):(two-digit minute):(two-digit second)
+            "GMT" + // GMT
+            "\")?"); // closing quote (optional, since an older version can still send a warn-date)
+    public static final Pattern WARNING_XCONTENT_LOCATION_PATTERN = Pattern.compile("^\\[.*?]\\[-?\\d+:-?\\d+] ");
+
+    /*
+     * RFC7234 specifies the warning format as warn-code <space> warn-agent <space> "warn-text" [<space> "warn-date"]. Here, warn-code is a
+     * three-digit number with various standard warn codes specified. The warn code 299 is apt for our purposes as it represents a
+     * miscellaneous persistent warning (can be presented to a human, or logged, and must not be removed by a cache). The warn-agent is an
+     * arbitrary token; here we use the Elasticsearch version and build hash. The warn text must be quoted. The warn-date is an optional
+     * quoted field that can be in a variety of specified date formats; here we use RFC 1123 format.
+     */
+    private static final String WARNING_PREFIX =
+        String.format(
+            Locale.ROOT,
+            "299 Elasticsearch-%s%s-%s",
+            Version.CURRENT.toString(),
+            Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
+            Build.CURRENT.hash());
+
+    private static BitSet doesNotNeedEncoding;
+
+    static {
+        doesNotNeedEncoding = new BitSet(1 + 0xFF);
+        doesNotNeedEncoding.set('\t');
+        doesNotNeedEncoding.set(' ');
+        doesNotNeedEncoding.set('!');
+        doesNotNeedEncoding.set('\\');
+        doesNotNeedEncoding.set('"');
+        // we have to skip '%' which is 0x25 so that it is percent-encoded too
+        for (int i = 0x23; i <= 0x24; i++) {
+            doesNotNeedEncoding.set(i);
+        }
+        for (int i = 0x26; i <= 0x5B; i++) {
+            doesNotNeedEncoding.set(i);
+        }
+        for (int i = 0x5D; i <= 0x7E; i++) {
+            doesNotNeedEncoding.set(i);
+        }
+        for (int i = 0x80; i <= 0xFF; i++) {
+            doesNotNeedEncoding.set(i);
+        }
+        assert doesNotNeedEncoding.get('%') == false : doesNotNeedEncoding;
+    }
+
+    private static final Charset UTF_8 = StandardCharsets.UTF_8;
+
+    /**
+     * This is set once by the {@code Node} constructor, but it uses {@link CopyOnWriteArraySet} to ensure that tests can run in parallel.
+     * <p>
+     * Integration tests will create separate nodes within the same classloader, thus leading to a shared, {@code static} state.
+     * In order for all tests to appropriately be handled, this must be able to remember <em>all</em> {@link ThreadContext}s that it is
+     * given in a thread safe manner.
+     * <p>
+     * For actual usage, multiple nodes do not share the same JVM and therefore this will only be set once in practice.
+     */
+    static final CopyOnWriteArraySet<ThreadContext> THREAD_CONTEXT = new CopyOnWriteArraySet<>();
+
+    /**
+     * Set the {@link ThreadContext} used to add warning headers to network responses.
+     * <p>
+     * This is expected to <em>only</em> be invoked by the {@code Node}'s constructor (therefore once outside of tests).
+     *
+     * @param threadContext The thread context owned by the {@code ThreadPool} (and implicitly a {@code Node})
+     * @throws IllegalStateException if this {@code threadContext} has already been set
+     */
+    public static void setThreadContext(ThreadContext threadContext) {
+        Objects.requireNonNull(threadContext, "Cannot register a null ThreadContext");
+
+        // add returning false means it _did_ have it already
+        if (THREAD_CONTEXT.add(threadContext) == false) {
+            throw new IllegalStateException("Double-setting ThreadContext not allowed!");
+        }
+    }
+
+    /**
+     * Remove the {@link ThreadContext} used to add warning headers to network responses.
+     * <p>
+     * This is expected to <em>only</em> be invoked by the {@code Node}'s {@code close} method (therefore once outside of tests).
+     *
+     * @param threadContext The thread context owned by the {@code ThreadPool} (and implicitly a {@code Node})
+     * @throws IllegalStateException if this {@code threadContext} is unknown (and presumably already unset before)
+     */
+    public static void removeThreadContext(ThreadContext threadContext) {
+        assert threadContext != null;
+
+        // remove returning false means it did not have it already
+        if (THREAD_CONTEXT.remove(threadContext) == false) {
+            throw new IllegalStateException("Removing unknown ThreadContext not allowed!");
+        }
+    }
+
+    /**
+     * Extracts the warning value from the value of a warning header that is formatted according to RFC 7234. That is, given a string
+     * {@code 299 Elasticsearch-6.0.0 "warning value"}, the return value of this method would be {@code warning value}.
+     *
+     * @param s the value of a warning header formatted according to RFC 7234.
+     * @return the extracted warning value
+     */
+    public static String extractWarningValueFromWarningHeader(final String s, boolean stripXContentPosition) {
+        /*
+         * We know the exact format of the warning header, so to extract the warning value we can skip forward from the front to the first
+         * quote and we know the last quote is at the end of the string
+         *
+         *   299 Elasticsearch-6.0.0 "warning value"
+         *                           ^             ^
+         *                           firstQuote    lastQuote
+         *
+         * We parse this manually rather than using the capturing regular expression because the regular expression involves a lot of
+         * backtracking and carries a performance penalty. However, when assertions are enabled, we still use the regular expression to
+         * verify that we are maintaining the warning header format.
+         */
+        final int firstQuote = s.indexOf('\"');
+        final int lastQuote = s.length() - 1;
+        String warningValue = s.substring(firstQuote + 1, lastQuote);
+        assert assertWarningValue(s, warningValue);
+        if (stripXContentPosition) {
+            Matcher matcher = WARNING_XCONTENT_LOCATION_PATTERN.matcher(warningValue);
+            if (matcher.find()) {
+                warningValue = warningValue.substring(matcher.end());
+            }
+        }
+        return warningValue;
+    }
+
+    /**
+     * Assert that the specified string has the warning value equal to the provided warning value.
+     *
+     * @param s            the string representing a full warning header
+     * @param warningValue the expected warning header
+     * @return {@code true} if the specified string has the expected warning value
+     */
+    private static boolean assertWarningValue(final String s, final String warningValue) {
+        final Matcher matcher = WARNING_HEADER_PATTERN.matcher(s);
+        final boolean matches = matcher.matches();
+        assert matches;
+        return matcher.group(1).equals(warningValue);
+    }
+
+    /**
+     * Format a warning string in the proper warning format by prepending a warn code, warn agent, wrapping the warning string in quotes,
+     * and appending the RFC 7231 date.
+     *
+     * @param s the warning string to format
+     * @return a warning value formatted according to RFC 7234
+     */
+    public static String formatWarning(final String s) {
+        // Assume that the common scenario won't have a string to escape and encode.
+        int length = WARNING_PREFIX.length() + s.length() + 3;
+        final StringBuilder sb = new StringBuilder(length);
+        sb.append(WARNING_PREFIX).append(" \"").append(escapeAndEncode(s)).append("\"");
+        return sb.toString();
+    }
+
+    /**
+     * Escape and encode a string as a valid RFC 7230 quoted-string.
+     *
+     * @param s the string to escape and encode
+     * @return the escaped and encoded string
+     */
+    public static String escapeAndEncode(final String s) {
+        return encode(escapeBackslashesAndQuotes(s));
+    }
+
+    /**
+     * Escape backslashes and quotes in the specified string.
+     *
+     * @param s the string to escape
+     * @return the escaped string
+     */
+    static String escapeBackslashesAndQuotes(final String s) {
+        /*
+         * We want a fast path check to avoid creating the string builder and copying characters if needed. So we walk the string looking
+         * for either of the characters that we need to escape. If we find a character that needs escaping, we start over and
+         */
+        boolean escapingNeeded = false;
+        for (int i = 0; i < s.length(); i++) {
+            final char c = s.charAt(i);
+            if (c == '\\' || c == '"') {
+                escapingNeeded = true;
+                break;
+            }
+        }
+
+        if (escapingNeeded) {
+            final StringBuilder sb = new StringBuilder();
+            for (final char c : s.toCharArray()) {
+                if (c == '\\' || c == '"') {
+                    sb.append("\\");
+                }
+                sb.append(c);
+            }
+            return sb.toString();
+        } else {
+            return s;
+        }
+    }
+
+    /**
+     * Encode a string containing characters outside of the legal characters for an RFC 7230 quoted-string.
+     *
+     * @param s the string to encode
+     * @return the encoded string
+     */
+    static String encode(final String s) {
+        // first check if the string needs any encoding; this is the fast path and we want to avoid creating a string builder and copying
+        boolean encodingNeeded = false;
+        for (int i = 0; i < s.length(); i++) {
+            int current = s.charAt(i);
+            if (doesNotNeedEncoding.get(current) == false) {
+                encodingNeeded = true;
+                break;
+            }
+        }
+
+        if (encodingNeeded == false) {
+            return s;
+        }
+
+        final StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); ) {
+            int current = s.charAt(i);
+            /*
+             * Either the character does not need encoding or it does; when the character does not need encoding we append the character to
+             * a buffer and move to the next character and when the character does need encoding, we peel off as many characters as possible
+             * which we encode using UTF-8 until we encounter another character that does not need encoding.
+             */
+            if (doesNotNeedEncoding.get(current)) {
+                // append directly and move to the next character
+                sb.append((char) current);
+                i++;
+            } else {
+                int startIndex = i;
+                do {
+                    i++;
+                } while (i < s.length() && doesNotNeedEncoding.get(s.charAt(i)) == false);
+
+                final byte[] bytes = s.substring(startIndex, i).getBytes(UTF_8);
+                // noinspection ForLoopReplaceableByForEach
+                for (int j = 0; j < bytes.length; j++) {
+                    sb.append('%').append(hex(bytes[j] >> 4)).append(hex(bytes[j]));
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static char hex(int b) {
+        final char ch = Character.forDigit(b & 0xF, 16);
+        if (Character.isLetter(ch)) {
+            return Character.toUpperCase(ch);
+        } else {
+            return ch;
+        }
+    }
+
+    public static String getXOpaqueId() {
+        return THREAD_CONTEXT.stream()
+            .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
+            .findFirst()
+            .map(t -> t.getHeader(Task.X_OPAQUE_ID))
+            .orElse("");
+    }
+
+    public static void addWarning(String message, Object... params) {
+        addWarning(THREAD_CONTEXT, message, params);
+    }
+
+    // package scope for testing
+    static void addWarning(Set<ThreadContext> threadContexts, String message, Object... params) {
+        final Iterator<ThreadContext> iterator = threadContexts.iterator();
+        if (iterator.hasNext()) {
+            final String formattedMessage = LoggerMessageFormat.format(message, params);
+            final String warningHeaderValue = formatWarning(formattedMessage);
+            assert WARNING_HEADER_PATTERN.matcher(warningHeaderValue).matches();
+            assert extractWarningValueFromWarningHeader(warningHeaderValue, false)
+                .equals(escapeAndEncode(formattedMessage));
+            while (iterator.hasNext()) {
+                try {
+                    final ThreadContext next = iterator.next();
+                    next.addResponseHeader("Warning", warningHeaderValue);
+                } catch (final IllegalStateException e) {
+                    // ignored; it should be removed shortly
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/ThrottlingAndHeaderWarningLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ThrottlingAndHeaderWarningLogger.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This class wraps both <code>HeaderWarningLogger</code> and <code>ThrottlingLogger</code>
+ * which is a common use case across Elasticsearch
+ */
+class ThrottlingAndHeaderWarningLogger {
+    private final ThrottlingLogger throttlingLogger;
+
+    ThrottlingAndHeaderWarningLogger(Logger logger) {
+        this.throttlingLogger = new ThrottlingLogger(logger);
+    }
+
+    /**
+     * Adds a formatted warning message as a response header on the thread context, and logs a message if the associated key has
+     * not recently been seen.
+     *
+     * @param key     the key used to determine if this message should be logged
+     * @param message the message to log
+     */
+    void throttleLogAndAddWarning(final String key, ESLogMessage message) {
+        String messagePattern = message.getMessagePattern();
+        Object[] arguments = message.getArguments();
+        HeaderWarning.addWarning(messagePattern, arguments);
+        throttlingLogger.throttleLog(key, message);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/ThrottlingLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ThrottlingLogger.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.Message;
+import org.elasticsearch.common.SuppressLoggerChecks;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * TODO wrapping logging this way limits the usage of %location. It will think this is used from that class.
+ * <p>
+ * This is a wrapper around a logger that allows to throttle log messages.
+ * In order to throttle a key has to be used and throttling happens per each key combined with X-Opaque-Id.
+ * X-Opaque-Id allows throttling per user. This value is set in ThreadContext from X-Opaque-Id HTTP header.
+ * <p>
+ * The throttling algorithm is relying on LRU set of keys which evicts entries when its size is &gt; 128.
+ * When a log with a key is emitted, it won't be logged again until the set reaches size 128 and the key is removed from the set.
+ *
+ * @see HeaderWarning
+ */
+class ThrottlingLogger {
+
+    // LRU set of keys used to determine if a message should be emitted to the logs
+    private final Set<String> keys = Collections.newSetFromMap(Collections.synchronizedMap(new LinkedHashMap<String, Boolean>() {
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {
+            return size() > 128;
+        }
+    }));
+
+    private final Logger logger;
+
+    ThrottlingLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void throttleLog(String key, Message message) {
+        String xOpaqueId = HeaderWarning.getXOpaqueId();
+        boolean shouldLog = keys.add(xOpaqueId + key);
+        if (shouldLog) {
+            log(message);
+        }
+    }
+
+    private void log(Message message) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @SuppressLoggerChecks(reason = "safely delegates to logger")
+            @Override
+            public Void run() {
+                logger.warn(message);
+                return null;
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -522,11 +522,9 @@ public class Setting<T> implements ToXContentObject {
         if (this.isDeprecated() && this.exists(settings)) {
             // It would be convenient to show its replacement key, but replacement is often not so simple
             final String key = getKey();
-            Settings.DeprecationLoggerHolder.deprecationLogger.deprecatedAndMaybeLog(
-                    key,
-                    "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                            + "See the breaking changes documentation for the next major version.",
-                    key);
+            Settings.DeprecationLoggerHolder.deprecationLogger
+                .deprecate(key, "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                    + "See the breaking changes documentation for the next major version.", key);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1649,7 +1649,7 @@ public class DateFormatters {
             String msg = "Camel case format name {} is deprecated and will be removed in a future version. " +
                 "Use snake case name {} instead.";
             deprecationLogger.getOrCompute()
-                .deprecatedAndMaybeLog("camelCaseDateFormat", msg, formatName.getCamelCaseName(), formatName.getSnakeCaseName());
+                .deprecate("camelCaseDateFormat", msg, formatName.getCamelCaseName(), formatName.getSnakeCaseName());
         }
 
         if (FormatNames.ISO8601.matches(input)) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -201,7 +201,7 @@ public class DateUtils {
     public static ZoneId of(String zoneId) {
         String deprecatedId = DEPRECATED_SHORT_TIMEZONES.get(zoneId);
         if (deprecatedId != null) {
-            deprecationLogger.deprecatedAndMaybeLog("timezone",
+            deprecationLogger.deprecate("timezone",
                 "Use of short timezone id " + zoneId + " is deprecated. Use " + deprecatedId + " instead");
             return ZoneId.of(deprecatedId);
         }

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -245,10 +245,10 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
             } catch (final NumberFormatException e) {
                 try {
                     final double doubleValue = Double.parseDouble(s);
-                    DeprecationLoggerHolder.deprecationLogger.deprecatedAndMaybeLog(
-                            "fractional_byte_values",
-                            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: [{}] found for setting [{}]",
-                            initialInput, settingName);
+                    DeprecationLoggerHolder.deprecationLogger
+                        .deprecate("fractional_byte_values",
+                         "Fractional bytes values are deprecated. Use non-fractional bytes values instead: [{}] found for setting [{}]",
+                         initialInput, settingName);
                     return new ByteSizeValue((long) (doubleValue * unit.toBytes(1)));
                 } catch (final NumberFormatException ignored) {
                     throw new ElasticsearchParseException("failed to parse [{}]", e, initialInput);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -79,7 +79,8 @@ public class EsExecutors {
             if (value > availableProcessors) {
                 deprecationLogger.deprecate(
                     "processors",
-                    "setting [" + name + "] to value [{}] which is more than available processors [{}] is deprecated",
+                    "setting [{}] to value [{}] which is more than available processors [{}] is deprecated",
+                    name,
                     value,
                     availableProcessors);
             }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -77,7 +77,7 @@ public class EsExecutors {
             final int value = Setting.parseInt(s, 1, name);
             final int availableProcessors = Runtime.getRuntime().availableProcessors();
             if (value > availableProcessors) {
-                deprecationLogger.deprecatedAndMaybeLog(
+                deprecationLogger.deprecate(
                     "processors",
                     "setting [" + name + "] to value [{}] which is more than available processors [{}] is deprecated",
                     value,

--- a/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
@@ -53,21 +53,21 @@ public class LoggingDeprecationHandler implements DeprecationHandler {
     @Override
     public void usedDeprecatedName(String parserName, Supplier<XContentLocation> location, String usedName, String modernName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecatedAndMaybeLog("deprecated_field", "{}Deprecated field [{}] used, expected [{}] instead",
-            prefix, usedName, modernName);
+        deprecationLogger.deprecate("deprecated_field",
+            "{}Deprecated field [{}] used, expected [{}] instead", prefix, usedName, modernName);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName, String replacedWith) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecatedAndMaybeLog("deprecated_field", "{}Deprecated field [{}] used, replaced by [{}]",
-            prefix, usedName, replacedWith);
+        deprecationLogger.deprecate("deprecated_field",
+            "{}Deprecated field [{}] used, replaced by [{}]", prefix, usedName, replacedWith);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecatedAndMaybeLog("deprecated_field",
+        deprecationLogger.deprecate("deprecated_field",
             "{}Deprecated field [{}] used, this field is unused and will be removed entirely", prefix, usedName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -73,7 +73,7 @@ public class HttpInfo implements ReportingService.Info {
         String publishAddressString = publishAddress.toString();
         String hostString = publishAddress.address().getHostString();
         if (CNAME_IN_PUBLISH_HOST) {
-            deprecationLogger.deprecatedAndMaybeLog(
+            deprecationLogger.deprecate(
                 "cname_in_publish_address",
                 "es.http.cname_in_publish_address system property is deprecated and no longer affects http.publish_address " +
                     "formatting. Remove this property to get rid of this deprecation warning."

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -132,7 +132,7 @@ public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisCompone
                         throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
                     }
                     else {
-                        DEPRECATION_LOGGER.deprecatedAndMaybeLog(name(), "Token filter [" + name()
+                        DEPRECATION_LOGGER.deprecate(name(), "Token filter [" + name()
                             + "] will not be usable to parse synonyms after v7.0");
                         return this;
                     }
@@ -159,7 +159,7 @@ public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisCompone
                     throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
                 }
                 else {
-                    DEPRECATION_LOGGER.deprecatedAndMaybeLog(name(), "Token filter [" + name()
+                    DEPRECATION_LOGGER.deprecate(name(), "Token filter [" + name()
                         + "] will not be usable to parse synonyms after v7.0");
                     return this;
                 }

--- a/server/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
@@ -51,9 +51,9 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
                         + " must be less than or equal to: [" + maxAllowedShingleDiff + "] but was [" + shingleDiff + "]. This limit"
                         + " can be set by changing the [" + IndexSettings.MAX_SHINGLE_DIFF_SETTING.getKey() + "] index level setting.");
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("excessive_shingle_diff",
+                deprecationLogger.deprecate("excessive_shingle_diff",
                     "Deprecated big difference between maxShingleSize and minShingleSize" +
-                    " in Shingle TokenFilter, expected difference must be less than or equal to: [" + maxAllowedShingleDiff + "]");
+                            " in Shingle TokenFilter, expected difference must be less than or equal to: [" + maxAllowedShingleDiff + "]");
             }
         }
 
@@ -77,8 +77,8 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
                 "] cannot be used to parse synonyms");
         }
         else {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synonym_tokenfilters", "Token filter " + name()
-                + "] will not be usable to parse synonym after v7.0");
+            DEPRECATION_LOGGER.deprecate("synonym_tokenfilters", "Token filter " + name()
+                    + "] will not be usable to parse synonym after v7.0");
         }
         return this;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -209,7 +209,7 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
 
         private void checkCompletionContextsLimit(BuilderContext context) {
             if (this.contexts.getValue() != null && this.contexts.getValue().size() > COMPLETION_CONTEXTS_LIMIT) {
-                deprecationLogger.deprecatedAndMaybeLog("excessive_completion_contexts",
+                deprecationLogger.deprecate("excessive_completion_contexts",
                     "You have defined more than [" + COMPLETION_CONTEXTS_LIMIT + "] completion contexts" +
                         " in the mapping for index [" + context.indexSettings().get(IndexMetadata.SETTING_INDEX_PROVIDED_NAME) + "]. " +
                         "The maximum allowed number of completion contexts in a mapping will be limited to " +

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -208,7 +208,7 @@ public class DynamicTemplate implements ToXContentObject {
                 if (indexVersionCreated.onOrAfter(Version.V_6_0_0_alpha1)) {
                     throw e;
                 } else {
-                    deprecationLogger.deprecatedAndMaybeLog("invalid_mapping_type",
+                    deprecationLogger.deprecate("invalid_mapping_type",
                         "match_mapping_type [" + matchMappingType + "] is invalid and will be ignored: "
                         + e.getMessage());
                     // this template is on an unknown type so it will never match anything

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -139,9 +139,8 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             if (isEnabled() == false) {
                 throw new IllegalStateException("Cannot run [exists] queries if the [_field_names] field is disabled");
             }
-            deprecationLogger.deprecatedAndMaybeLog(
-                    "terms_query_on_field_names",
-                    "terms query on the _field_names field is deprecated and will be removed, use exists query instead");
+            deprecationLogger.deprecate("terms_query_on_field_names",
+                "terms query on the _field_names field is deprecated and will be removed, use exists query instead");
             return super.termQuery(value, context);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -99,7 +99,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         @Override
         public FieldNamesFieldMapper build(BuilderContext context) {
             if (enabled.getValue().explicit()) {
-                deprecationLogger.deprecatedAndMaybeLog("field_names_enabled_parameter", ENABLED_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("field_names_enabled_parameter", ENABLED_DEPRECATION_MESSAGE);
             }
             FieldNamesFieldType fieldNamesFieldType = new FieldNamesFieldType(enabled.getValue().value());
             return new FieldNamesFieldMapper(enabled.getValue(), indexVersionCreated, fieldNamesFieldType);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -160,7 +160,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
                             + "you can re-enable it by updating the dynamic cluster setting: "
                             + IndicesService.INDICES_ID_FIELD_DATA_ENABLED_SETTING.getKey());
                     }
-                    deprecationLogger.deprecatedAndMaybeLog("id_field_data", ID_FIELD_DATA_DEPRECATION_MESSAGE);
+                    deprecationLogger.deprecate("id_field_data", ID_FIELD_DATA_DEPRECATION_MESSAGE);
                     final IndexFieldData<?> fieldData = fieldDataBuilder.build(cache, breakerService, mapperService);
                     return new IndexFieldData<LeafFieldData>() {
                         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -176,7 +176,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
                 throw new ElasticsearchParseException("Field parameter [{}] is not supported for [{}] field type",
                     fieldName, CONTENT_TYPE);
             }
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("geo_mapper_field_parameter",
+            DEPRECATION_LOGGER.deprecate("geo_mapper_field_parameter",
                 "Field parameter [{}] is deprecated and will be removed in a future version.", fieldName);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -452,7 +452,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0)) {
                 throw new IllegalArgumentException(DEFAULT_MAPPING_ERROR_MESSAGE);
             } else if (reason == MergeReason.MAPPING_UPDATE) { // only log in case of explicit mapping updates
-                deprecationLogger.deprecatedAndMaybeLog("default_mapping_not_allowed", DEFAULT_MAPPING_ERROR_MESSAGE);
+                deprecationLogger.deprecate("default_mapping_not_allowed", DEFAULT_MAPPING_ERROR_MESSAGE);
             }
             assert defaultMapper.type().equals(DEFAULT_MAPPING);
             results.put(DEFAULT_MAPPING, defaultMapper);
@@ -631,7 +631,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      */
     public MappedFieldType unmappedFieldType(String type) {
         if (type.equals("string")) {
-            deprecationLogger.deprecatedAndMaybeLog("unmapped_type_string",
+            deprecationLogger.deprecate("unmapped_type_string",
                 "[unmapped_type:string] should be replaced with [unmapped_type:keyword]");
             type = "keyword";
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -238,7 +238,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 }
                 return true;
             } else if (fieldName.equals("include_in_all")) {
-                deprecationLogger.deprecatedAndMaybeLog("include_in_all",
+                deprecationLogger.deprecate("include_in_all",
                     "[include_in_all] is deprecated, the _all field have been removed in this version");
                 return true;
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -547,14 +547,14 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 }
                 Parameter<?> parameter = deprecatedParamsMap.get(propName);
                 if (parameter != null) {
-                    deprecationLogger.deprecatedAndMaybeLog(propName, "Parameter [{}] on mapper [{}] is deprecated, use [{}]",
+                    deprecationLogger.deprecate(propName, "Parameter [{}] on mapper [{}] is deprecated, use [{}]",
                         propName, name, parameter.name);
                 } else {
                     parameter = paramsMap.get(propName);
                 }
                 if (parameter == null) {
                     if (isDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
-                        deprecationLogger.deprecatedAndMaybeLog(propName,
+                        deprecationLogger.deprecate(propName,
                             "Parameter [{}] has no effect on type [{}] and will be removed in future", propName, type);
                         iterator.remove();
                         continue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -418,7 +418,7 @@ public class RootObjectMapper extends ObjectMapper {
             } else {
                 deprecationMessage = message;
             }
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("invalid_dynamic_template", deprecationMessage);
+                DEPRECATION_LOGGER.deprecate("invalid_dynamic_template", deprecationMessage);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -251,7 +251,7 @@ public class TypeParsers {
                 builder.indexOptions(nodeIndexOptionValue(propNode));
                 iterator.remove();
             } else if (propName.equals("similarity")) {
-                deprecationLogger.deprecatedAndMaybeLog("similarity",
+                deprecationLogger.deprecate("similarity",
                     "The [similarity] parameter has no effect on field [" + name + "] and will be removed in 8.0");
                 iterator.remove();
             } else if (parseMultiField(builder::addMultiField, name, parserContext, propName, propNode)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -276,7 +276,7 @@ public class TypeParsers {
                                           Mapper.TypeParser.ParserContext parserContext, String propName, Object propNode) {
         if (propName.equals("fields")) {
             if (parserContext.isWithinMultiField()) {
-                deprecationLogger.deprecatedAndMaybeLog("multifield_within_multifield", "At least one multi-field, [" + name + "], was " +
+                deprecationLogger.deprecate("multifield_within_multifield", "At least one multi-field, [" + name + "], was " +
                     "encountered that itself contains a multi-field. Defining multi-fields within a multi-field is deprecated and will " +
                     "no longer be supported in 8.0. To resolve the issue, all instances of [fields] that occur within a [fields] block " +
                     "should be removed from the mappings, either by flattening the chained [fields] blocks into a single level, or " +

--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -272,7 +272,7 @@ public class GeoShapeQueryBuilder extends AbstractGeometryQueryBuilder<GeoShapeQ
 
         GeoShapeQueryBuilder builder;
         if (pgsqp.type != null) {
-            deprecationLogger.deprecatedAndMaybeLog("geo_share_query_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("geo_share_query_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         if (pgsqp.shape != null) {

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -154,7 +154,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         try {
             IdsQueryBuilder builder = PARSER.apply(parser, null);
             if (builder.types().length > 0) {
-                deprecationLogger.deprecatedAndMaybeLog("ids_query_with_types", TYPES_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("ids_query_with_types", TYPES_DEPRECATION_MESSAGE);
             }
             return builder;
         } catch (IllegalArgumentException e) {

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -969,7 +969,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         }
 
         if (moreLikeThisQueryBuilder.isTypeless() == false) {
-            deprecationLogger.deprecatedAndMaybeLog("more_like_this_query_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("more_like_this_query_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         return moreLikeThisQueryBuilder;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -249,7 +249,7 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public MappedFieldType fieldMapper(String name) {
         if (name.equals(TypeFieldMapper.NAME)) {
-            deprecationLogger.deprecatedAndMaybeLog("query_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("query_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         return failIfFieldMappingNotFound(name, mapperService.fieldType(name));
     }

--- a/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -130,7 +130,7 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        deprecationLogger.deprecatedAndMaybeLog("type_query", TYPES_DEPRECATION_MESSAGE);
+        deprecationLogger.deprecate("type_query", TYPES_DEPRECATION_MESSAGE);
         //LUCENE 4 UPGRADE document mapper should use bytesref as well?
         DocumentMapper documentMapper = context.getMapperService().documentMapper(type);
         if (documentMapper == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -168,8 +168,8 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             if (field != null) {
                 fieldType = context.getMapperService().fieldType(field);
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("seed_requires_field",
-                        "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
+                deprecationLogger.deprecate("seed_requires_field",
+                    "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
                 fieldType = context.getMapperService().fieldType(IdFieldMapper.NAME);
             }
             if (fieldType == null) {

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -374,7 +374,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             }
             String[] types = extractStringArray(source, "type");
             if (types != null) {
-                deprecationLogger.deprecatedAndMaybeLog("reindex_with_types", TYPES_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("reindex_with_types", TYPES_DEPRECATION_MESSAGE);
                 request.getSearchRequest().types(types);
             }
             request.setRemoteInfo(buildRemoteInfo(source));
@@ -390,7 +390,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
         ObjectParser<IndexRequest, Void> destParser = new ObjectParser<>("dest");
         destParser.declareString(IndexRequest::index, new ParseField("index"));
         destParser.declareString((request, type) -> {
-            deprecationLogger.deprecatedAndMaybeLog("reindex_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("reindex_with_types", TYPES_DEPRECATION_MESSAGE);
             request.type(type);
         }, new ParseField("type"));
         destParser.declareString(IndexRequest::routing, new ParseField("routing"));

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProviders.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProviders.java
@@ -143,8 +143,8 @@ final class SimilarityProviders {
                     throw new IllegalArgumentException("Basic model [" + basicModel + "] isn't supported anymore, " +
                         "please use another model.");
                 } else {
-                    deprecationLogger.deprecatedAndMaybeLog(basicModel + "_similarity_model_replaced", "Basic model [" + basicModel +
-                        "] isn't supported anymore and has arbitrarily been replaced with [" + replacement + "].");
+                    deprecationLogger.deprecate(basicModel + "_similarity_model_replaced", "Basic model [" + basicModel +
+                                    "] isn't supported anymore and has arbitrarily been replaced with [" + replacement + "].");
                     model = BASIC_MODELS.get(replacement);
                     assert model != null;
                 }
@@ -174,8 +174,8 @@ final class SimilarityProviders {
                     throw new IllegalArgumentException("After effect [" + afterEffect +
                         "] isn't supported anymore, please use another effect.");
                 } else {
-                    deprecationLogger.deprecatedAndMaybeLog(afterEffect + "_after_effect_replaced", "After effect [" + afterEffect +
-                        "] isn't supported anymore and has arbitrarily been replaced with [" + replacement + "].");
+                    deprecationLogger.deprecate(afterEffect + "_after_effect_replaced", "After effect [" + afterEffect +
+                                    "] isn't supported anymore and has arbitrarily been replaced with [" + replacement + "].");
                     effect = AFTER_EFFECTS.get(replacement);
                     assert effect != null;
                 }
@@ -264,7 +264,7 @@ final class SimilarityProviders {
             if (version.onOrAfter(Version.V_7_0_0)) {
                 throw new IllegalArgumentException("Unknown settings for similarity of type [" + type + "]: " + unknownSettings);
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("unknown_similarity_setting",
+                deprecationLogger.deprecate("unknown_similarity_setting",
                     "Unknown settings for similarity of type [" + type + "]: " + unknownSettings);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -156,7 +156,7 @@ public final class SimilarityService extends AbstractIndexComponent {
         defaultSimilarity = (providers.get("default") != null) ? providers.get("default").get()
                                                               : providers.get(SimilarityService.DEFAULT_SIMILARITY).get();
         if (providers.get("base") != null) {
-            deprecationLogger.deprecatedAndMaybeLog("base_similarity_ignored",
+            deprecationLogger.deprecate("base_similarity_ignored",
                 "The [base] similarity is ignored since query normalization and coords have been removed");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -67,7 +67,7 @@ public final class SimilarityService extends AbstractIndexComponent {
             } else {
                 final ClassicSimilarity similarity = SimilarityProviders.createClassicSimilarity(Settings.EMPTY, version);
                 return () -> {
-                    deprecationLogger.deprecatedAndMaybeLog("classic_similarity",
+                    deprecationLogger.deprecate("classic_similarity",
                         "The [classic] similarity is now deprecated in favour of BM25, which is generally "
                             + "accepted as a better alternative. Use the [BM25] similarity or build a custom [scripted] similarity "
                             + "instead.");
@@ -91,7 +91,7 @@ public final class SimilarityService extends AbstractIndexComponent {
                         throw new IllegalArgumentException("The [classic] similarity may not be used anymore. Please use the [BM25] "
                                 + "similarity or build a custom [scripted] similarity instead.");
                     } else {
-                        deprecationLogger.deprecatedAndMaybeLog("classic_similarity",
+                        deprecationLogger.deprecate("classic_similarity",
                             "The [classic] similarity is now deprecated in favour of BM25, which is generally "
                                 + "accepted as a better alternative. Use the [BM25] similarity or build a custom [scripted] similarity "
                                 + "instead.");
@@ -274,7 +274,7 @@ public final class SimilarityService extends AbstractIndexComponent {
         if (indexCreatedVersion.onOrAfter(Version.V_7_0_0)) {
             throw new IllegalArgumentException(message);
         } else if (indexCreatedVersion.onOrAfter(Version.V_6_5_0)) {
-            deprecationLogger.deprecatedAndMaybeLog("similarity_failure", message);
+            deprecationLogger.deprecate("similarity_failure", message);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
@@ -126,7 +126,7 @@ public final class AnalysisModule {
             @Override
             public TokenFilterFactory get(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
                 if (indexSettings.getIndexVersionCreated().before(Version.V_7_0_0)) {
-                    deprecationLogger.deprecatedAndMaybeLog("standard_deprecation",
+                    deprecationLogger.deprecate("standard_deprecation",
                         "The [standard] token filter name is deprecated and will be removed in a future version.");
                 } else {
                     throw new IllegalArgumentException("The [standard] token filter has been removed.");
@@ -184,7 +184,7 @@ public final class AnalysisModule {
         preConfiguredTokenFilters.register( "standard",
             PreConfiguredTokenFilter.elasticsearchVersion("standard", true, (reader, version) -> {
                 if (version.before(Version.V_7_0_0)) {
-                    deprecationLogger.deprecatedAndMaybeLog("standard_deprecation",
+                    deprecationLogger.deprecate("standard_deprecation",
                         "The [standard] token filter is deprecated and will be removed in a future version.");
                 } else {
                     throw new IllegalArgumentException("The [standard] token filter has been removed.");

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -160,7 +160,7 @@ public class SyncedFlushService implements IndexEventListener {
                                    final ActionListener<SyncedFlushResponse> listener) {
         final ClusterState state = clusterService.state();
         if (state.nodes().getMinNodeVersion().onOrAfter(Version.V_7_6_0)) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("synced_flush", SYNCED_FLUSH_DEPRECATION_MESSAGE);
+            DEPRECATION_LOGGER.deprecate("synced_flush", SYNCED_FLUSH_DEPRECATION_MESSAGE);
         }
         final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, indicesOptions, aliasesOrIndices);
         final Map<String, List<ShardsSyncedFlushResult>> results = ConcurrentCollections.newConcurrentMap();

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -51,7 +51,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "_type", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("conditional-processor__type",
+                deprecationLogger.deprecate("conditional-processor__type",
                         "[types removal] Looking up doc types [_type] in scripts is deprecated.");
                 return value;
             });

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -73,7 +73,7 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.NodeAndClusterIdStateListener;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkModule;
@@ -361,8 +361,8 @@ public class Node implements Closeable {
             final ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, threadPool);
             resourcesToClose.add(resourceWatcherService);
             // adds the context to the DeprecationLogger so that it does not need to be injected everywhere
-            DeprecationLogger.setThreadContext(threadPool.getThreadContext());
-            resourcesToClose.add(() -> DeprecationLogger.removeThreadContext(threadPool.getThreadContext()));
+            HeaderWarning.setThreadContext(threadPool.getThreadContext());
+            resourcesToClose.add(() -> HeaderWarning.removeThreadContext(threadPool.getThreadContext()));
 
             final List<Setting<?>> additionalSettings = new ArrayList<>();
             // register the node.data, node.ingest, node.master, node.remote_cluster_client settings here so we can mark them private

--- a/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
@@ -57,7 +57,7 @@ public class DeprecationRestHandler implements RestHandler {
      */
     @Override
     public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
-        deprecationLogger.deprecatedAndMaybeLog("deprecated_route", deprecationMessage);
+        deprecationLogger.deprecate("deprecated_route", deprecationMessage);
 
         handler.handleRequest(request, channel, client);
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -62,7 +62,7 @@ public class RestCreateIndexAction extends BaseRestHandler {
             DEFAULT_INCLUDE_TYPE_NAME_POLICY);
 
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("create_index_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("create_index_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         CreateIndexRequest createIndexRequest = new CreateIndexRequest(request.param("index"));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
@@ -60,7 +60,7 @@ public class RestForceMergeAction extends BaseRestHandler {
         mergeRequest.onlyExpungeDeletes(request.paramAsBoolean("only_expunge_deletes", mergeRequest.onlyExpungeDeletes()));
         mergeRequest.flush(request.paramAsBoolean("flush", mergeRequest.flush()));
         if (mergeRequest.onlyExpungeDeletes() && mergeRequest.maxNumSegments() != ForceMergeRequest.Defaults.MAX_NUM_SEGMENTS) {
-            deprecationLogger.deprecatedAndMaybeLog("force_merge_expunge_deletes_and_max_num_segments_deprecation",
+            deprecationLogger.deprecate("force_merge_expunge_deletes_and_max_num_segments_deprecation",
                "setting only_expunge_deletes and max_num_segments at the same time is deprecated and will be rejected in a future version");
         }
         return channel -> client.admin().indices().forceMerge(mergeRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -80,7 +80,7 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
                 " is set to true.");
         }
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("get_field_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_field_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
@@ -88,7 +88,7 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
 
         if (request.hasParam("local")) {
-            deprecationLogger.deprecatedAndMaybeLog("get_field_mapping_local",
+            deprecationLogger.deprecate("get_field_mapping_local",
                 "Use [local] in get field mapping requests is deprecated. "
                     + "The parameter will be removed in the next major version");
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
@@ -75,7 +75,7 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
 
         final GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("get_index_template_include_type_name", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_index_template_include_type_name", TYPES_DEPRECATION_MESSAGE);
         }
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
         getIndexTemplatesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getIndexTemplatesRequest.masterNodeTimeout()));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -73,7 +73,7 @@ public class RestGetIndicesAction extends BaseRestHandler {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         // starting with 7.0 we don't include types by default in the response to GET requests
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER) && request.method().equals(GET)) {
-            deprecationLogger.deprecatedAndMaybeLog("get_indices_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_indices_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         final GetIndexRequest getIndexRequest = new GetIndexRequest();
         getIndexRequest.indices(indices);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -100,14 +100,14 @@ public class RestGetMappingAction extends BaseRestHandler {
         boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, DEFAULT_INCLUDE_TYPE_NAME_POLICY);
 
         if (request.method().equals(HEAD)) {
-            deprecationLogger.deprecatedAndMaybeLog("get_mapping_types_removal",
+            deprecationLogger.deprecate("get_mapping_types_removal",
                     "Type exists requests are deprecated, as types have been deprecated.");
         } else if (includeTypeName == false && types.length > 0) {
             throw new IllegalArgumentException("Types cannot be provided in get mapping requests, unless" +
                     " include_type_name is set to true.");
         }
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("get_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         final GetMappingsRequest getMappingsRequest = new GetMappingsRequest();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -66,10 +66,10 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
 
         PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("put_index_template_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("put_index_template_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         if (request.hasParam("template")) {
-            deprecationLogger.deprecatedAndMaybeLog("put_index_template_deprecated_parameter",
+            deprecationLogger.deprecate("put_index_template_deprecated_parameter",
                 "Deprecated parameter [template] used, replaced by [index_patterns]");
             putRequest.patterns(Collections.singletonList(request.param("template")));
         } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -79,7 +79,7 @@ public class RestPutMappingAction extends BaseRestHandler {
         final boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER,
             DEFAULT_INCLUDE_TYPE_NAME_POLICY);
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("put_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("put_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResizeHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResizeHandler.java
@@ -71,7 +71,7 @@ public abstract class RestResizeHandler extends BaseRestHandler {
                     throw new IllegalArgumentException("parameter [copy_settings] can not be explicitly set to [false]");
                 }
             }
-            deprecationLogger.deprecatedAndMaybeLog("resize_deprecated_parameter",
+            deprecationLogger.deprecate("resize_deprecated_parameter",
                 "parameter [copy_settings] is deprecated and will be removed in 8.0.0");
         }
         resizeRequest.setCopySettings(copySettings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -58,7 +58,7 @@ public class RestRolloverIndexAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, DEFAULT_INCLUDE_TYPE_NAME_POLICY);
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
-            deprecationLogger.deprecatedAndMaybeLog("index_rollover_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("index_rollover_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         RolloverRequest rolloverIndexRequest = new RolloverRequest(request.param("index"), request.param("new_index"));
         request.applyContentParser(parser -> rolloverIndexRequest.fromXContent(includeTypeName, parser));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -74,7 +74,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
         validateQueryRequest.explain(request.paramAsBoolean("explain", false));
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("validate_query_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("validate_query_with_types", TYPES_DEPRECATION_MESSAGE);
             validateQueryRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -96,7 +96,7 @@ public class RestNodesAction extends AbstractCatAction {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().nodes(true);
         if (request.hasParam("local")) {
-            deprecationLogger.deprecatedAndMaybeLog("cat_nodes_local_parameter", LOCAL_DEPRECATED_MESSAGE);
+            deprecationLogger.deprecate("cat_nodes_local_parameter", LOCAL_DEPRECATED_MESSAGE);
         }
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -88,7 +88,7 @@ public class RestBulkAction extends BaseRestHandler {
         if (defaultType == null) {
             defaultType = MapperService.SINGLE_MAPPING_NAME;
         } else {
-            deprecationLogger.deprecatedAndMaybeLog("bulk_with_types", RestBulkAction.TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("bulk_with_types", RestBulkAction.TYPES_DEPRECATION_MESSAGE);
         }
         String defaultRouting = request.param("routing");
         FetchSourceContext defaultFetchSourceContext = FetchSourceContext.parseFromRestRequest(request);

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
@@ -60,7 +60,7 @@ public class RestDeleteAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         DeleteRequest deleteRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("delete_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("delete_with_types", TYPES_DEPRECATION_MESSAGE);
             deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));
         } else {
             deleteRequest = new DeleteRequest(request.param("index"), request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -68,7 +68,7 @@ public class RestGetAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         GetRequest getRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("get_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_with_types", TYPES_DEPRECATION_MESSAGE);
             getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         } else {
             getRequest = new GetRequest(request.param("index"), request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
@@ -74,7 +74,7 @@ public class RestGetSourceAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final GetRequest getRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("get_source_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("get_source_with_types", TYPES_DEPRECATION_MESSAGE);
             getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         } else {
             getRequest = new GetRequest(request.param("index"), request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -131,7 +131,7 @@ public class RestIndexAction extends BaseRestHandler {
         IndexRequest indexRequest;
         final String type = request.param("type");
         if (type != null && type.equals(MapperService.SINGLE_MAPPING_NAME) == false) {
-            deprecationLogger.deprecatedAndMaybeLog("index_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("index_with_types", TYPES_DEPRECATION_MESSAGE);
             indexRequest = new IndexRequest(request.param("index"), type, request.param("id"));
         } else {
             indexRequest = new IndexRequest(request.param("index"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -71,7 +71,7 @@ public class RestMultiGetAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         if (request.param("type") != null) {
-            deprecationLogger.deprecatedAndMaybeLog("mget_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("mget_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 
         MultiGetRequest multiGetRequest = new MultiGetRequest();
@@ -96,7 +96,7 @@ public class RestMultiGetAction extends BaseRestHandler {
 
         for (MultiGetRequest.Item item : multiGetRequest.getItems()) {
             if (item.type() != null) {
-                deprecationLogger.deprecatedAndMaybeLog("multi_get_types_removal", TYPES_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("multi_get_types_removal", TYPES_DEPRECATION_MESSAGE);
                 break;
             }
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsAction.java
@@ -68,7 +68,7 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
             .index(request.param("index"));
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("mtermvectors_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("mtermvectors_with_types", TYPES_DEPRECATION_MESSAGE);
             template.type(request.param("type"));
         } else {
             template.type(MapperService.SINGLE_MAPPING_NAME);

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
@@ -75,7 +75,7 @@ public class RestTermVectorsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         TermVectorsRequest termVectorsRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("termvectors_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("termvectors_with_types", TYPES_DEPRECATION_MESSAGE);
             termVectorsRequest = new TermVectorsRequest(request.param("index"),
                 request.param("type"),
                 request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -64,7 +64,7 @@ public class RestUpdateAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         UpdateRequest updateRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("update_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("update_with_types", TYPES_DEPRECATION_MESSAGE);
             updateRequest = new UpdateRequest(request.param("index"),
                 request.param("type"),
                 request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
@@ -92,7 +92,7 @@ public class RestCountAction extends BaseRestHandler {
         }
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("count_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("count_with_types", TYPES_DEPRECATION_MESSAGE);
             countRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestExplainAction.java
@@ -67,7 +67,7 @@ public class RestExplainAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         ExplainRequest explainRequest;
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("explain_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("explain_with_types", TYPES_DEPRECATION_MESSAGE);
             explainRequest = new ExplainRequest(request.param("index"),
                 request.param("type"),
                 request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -97,7 +97,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
         // Emit a single deprecation message if any search request contains types.
         for (SearchRequest searchRequest : multiSearchRequest.requests()) {
             if (searchRequest.types().length > 0) {
-                deprecationLogger.deprecatedAndMaybeLog("msearch_with_types", TYPES_DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("msearch_with_types", TYPES_DEPRECATION_MESSAGE);
                 break;
             }
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -175,7 +175,7 @@ public class RestSearchAction extends BaseRestHandler {
         }
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("search_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("search_with_types", TYPES_DEPRECATION_MESSAGE);
             searchRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         }
         searchRequest.routing(request.param("routing"));

--- a/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
@@ -40,13 +40,13 @@ abstract class AbstractSortScript implements ScorerAware {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("sort-script_doc",
+                deprecationLogger.deprecate("sort-script_doc",
                         "Accessing variable [doc] via [params.doc] from within an sort-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;
             },
             "_doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("sort-script__doc",
+                deprecationLogger.deprecate("sort-script__doc",
                         "Accessing variable [doc] via [params._doc] from within an sort-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;

--- a/server/src/main/java/org/elasticsearch/script/AggregationScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AggregationScript.java
@@ -44,13 +44,13 @@ public abstract class AggregationScript implements ScorerAware {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("aggregation-script_doc",
+                deprecationLogger.deprecate("aggregation-script_doc",
                         "Accessing variable [doc] via [params.doc] from within an aggregation-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;
             },
             "_doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("aggregation-script__doc",
+                deprecationLogger.deprecate("aggregation-script__doc",
                         "Accessing variable [doc] via [params._doc] from within an aggregation-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;

--- a/server/src/main/java/org/elasticsearch/script/FieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/FieldScript.java
@@ -43,13 +43,13 @@ public abstract class FieldScript {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("field-script_doc",
+                deprecationLogger.deprecate("field-script_doc",
                         "Accessing variable [doc] via [params.doc] from within an field-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;
             },
             "_doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("field-script__doc",
+                deprecationLogger.deprecate("field-script__doc",
                         "Accessing variable [doc] via [params._doc] from within an field-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -21,6 +21,7 @@ package org.elasticsearch.script;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
@@ -65,10 +66,13 @@ public class JodaCompatibleZonedDateTime
         new DeprecationLogger(LogManager.getLogger(JodaCompatibleZonedDateTime.class));
 
     private static void logDeprecated(String key, String message, Object... params) {
-        // NOTE: we don't check SpecialPermission because this will be called (indirectly) from scripts
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            deprecationLogger.deprecatedAndMaybeLog(key, message, params);
-            return null;
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @SuppressLoggerChecks(reason = "safely delegates to logger")
+            @Override
+            public Void run() {
+                deprecationLogger.deprecate(key, message, params);
+                return null;
+            }
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/script/ScoreScript.java
+++ b/server/src/main/java/org/elasticsearch/script/ScoreScript.java
@@ -69,13 +69,13 @@ public abstract class ScoreScript {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("score-script_doc",
+                deprecationLogger.deprecate("score-script_doc",
                         "Accessing variable [doc] via [params.doc] from within an score-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;
             },
             "_doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("score-script__doc",
+                deprecationLogger.deprecate("score-script__doc",
                         "Accessing variable [doc] via [params._doc] from within an score-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -463,7 +463,7 @@ public final class Script implements ToXContentObject, Writeable {
                         throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                     }
                 } else {
-                    deprecationLogger.deprecatedAndMaybeLog("script_unsupported_fields", "script section does not support ["
+                    deprecationLogger.deprecate("script_unsupported_fields", "script section does not support ["
                         + parameterName + "]");
                 }
             }

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -219,9 +219,9 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXCont
 
                         if (source.getSource().isEmpty()) {
                             if (source.getLang().equals(Script.DEFAULT_TEMPLATE_LANG)) {
-                                deprecationLogger.deprecatedAndMaybeLog("empty_templates","empty templates should no longer be used");
+                                deprecationLogger.deprecate("empty_templates", "empty templates should no longer be used");
                             } else {
-                                deprecationLogger.deprecatedAndMaybeLog("empty_scripts", "empty scripts should no longer be used");
+                                deprecationLogger.deprecate("empty_scripts", "empty scripts should no longer be used");
                             }
                         }
                     }

--- a/server/src/main/java/org/elasticsearch/script/ScriptedMetricAggContexts.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptedMetricAggContexts.java
@@ -70,18 +70,18 @@ public class ScriptedMetricAggContexts {
                 new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
         private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
                 "doc", value -> {
-                    deprecationLogger.deprecatedAndMaybeLog("map-script_doc",
+                    deprecationLogger.deprecate("map-script_doc",
                             "Accessing variable [doc] via [params.doc] from within an scripted metric agg map script "
                                     + "is deprecated in favor of directly accessing [doc].");
                     return value;
                 },
                 "_doc", value -> {
-                    deprecationLogger.deprecatedAndMaybeLog("map-script__doc",
+                    deprecationLogger.deprecate("map-script__doc",
                             "Accessing variable [doc] via [params._doc] from within an scripted metric agg map script "
                                     + "is deprecated in favor of directly accessing [doc].");
                     return value;
                 }, "_agg", value -> {
-                    deprecationLogger.deprecatedAndMaybeLog("map-script__agg",
+                    deprecationLogger.deprecate("map-script__agg",
                             "Accessing variable [_agg] via [params._agg] from within a scripted metric agg map script "
                                     + "is deprecated in favor of using [state].");
                     return value;

--- a/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -145,9 +145,9 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
             if (source == null) {
                 if (ignoreEmpty || Script.DEFAULT_TEMPLATE_LANG.equals(lang)) {
                     if (Script.DEFAULT_TEMPLATE_LANG.equals(lang)) {
-                        deprecationLogger.deprecatedAndMaybeLog("empty_templates", "empty templates should no longer be used");
+                        deprecationLogger.deprecate("empty_templates", "empty templates should no longer be used");
                     } else {
-                        deprecationLogger.deprecatedAndMaybeLog("empty_scripts", "empty scripts should no longer be used");
+                        deprecationLogger.deprecate("empty_scripts", "empty scripts should no longer be used");
                     }
                 } else {
                     throw new IllegalArgumentException("must specify source for stored script");
@@ -155,9 +155,9 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
             } else if (source.isEmpty()) {
                 if (ignoreEmpty || Script.DEFAULT_TEMPLATE_LANG.equals(lang)) {
                     if (Script.DEFAULT_TEMPLATE_LANG.equals(lang)) {
-                        deprecationLogger.deprecatedAndMaybeLog("empty_templates", "empty templates should no longer be used");
+                        deprecationLogger.deprecate("empty_templates", "empty templates should no longer be used");
                     } else {
-                        deprecationLogger.deprecatedAndMaybeLog("empty_scripts", "empty scripts should no longer be used");
+                        deprecationLogger.deprecate("empty_scripts", "empty scripts should no longer be used");
                     }
                 } else {
                     throw new IllegalArgumentException("source cannot be empty");
@@ -257,7 +257,7 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
             token = parser.nextToken();
 
             if (token == Token.END_OBJECT) {
-                deprecationLogger.deprecatedAndMaybeLog("empty_templates", "empty templates should no longer be used");
+                deprecationLogger.deprecate("empty_templates", "empty templates should no longer be used");
 
                 return new StoredScriptSource(Script.DEFAULT_TEMPLATE_LANG, "", Collections.emptyMap());
             }

--- a/server/src/main/java/org/elasticsearch/script/TermsSetQueryScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TermsSetQueryScript.java
@@ -41,13 +41,13 @@ public abstract class TermsSetQueryScript {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("terms-set-query-script_doc",
+                deprecationLogger.deprecate("terms-set-query-script_doc",
                         "Accessing variable [doc] via [params.doc] from within an terms-set-query-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;
             },
             "_doc", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("terms-set-query-script__doc",
+                deprecationLogger.deprecate("terms-set-query-script__doc",
                         "Accessing variable [doc] via [params._doc] from within an terms-set-query-script "
                                 + "is deprecated in favor of directly accessing [doc].");
                 return value;

--- a/server/src/main/java/org/elasticsearch/script/UpdateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateScript.java
@@ -35,7 +35,7 @@ public abstract class UpdateScript {
             new DeprecationLogger(LogManager.getLogger(DynamicMap.class));
     private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
             "_type", value -> {
-                deprecationLogger.deprecatedAndMaybeLog("update-script",
+                deprecationLogger.deprecate("update-script",
                         "[types removal] Looking up doc types [_type] in scripts is deprecated.");
                 return value;
             });

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -574,7 +574,7 @@ public abstract class InternalOrder extends BucketOrder {
             }
             // _term and _time order deprecated in 6.0; replaced by _key
             if ("_term".equals(orderKey) || "_time".equals(orderKey)) {
-                deprecationLogger.deprecatedAndMaybeLog("aggregation_order_key",
+                deprecationLogger.deprecate("aggregation_order_key",
                     "Deprecated aggregation order key [{}] used, replaced by [_key]", orderKey);
             }
             switch (orderKey) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
@@ -137,7 +137,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
     /** Get the current interval in milliseconds that is set on this builder. */
     @Deprecated
     public long interval() {
-        DEPRECATION_LOGGER.deprecatedAndMaybeLog("date-interval-getter", DEPRECATION_TEXT);
+        DEPRECATION_LOGGER.deprecate("date-interval-getter", DEPRECATION_TEXT);
         if (intervalType.equals(IntervalTypeEnum.LEGACY_INTERVAL)) {
             return TimeValue.parseTimeValue(dateHistogramInterval.toString(), "interval").getMillis();
         }
@@ -158,14 +158,14 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
             throw new IllegalArgumentException("[interval] must be 1 or greater for aggregation [date_histogram]");
         }
         setIntervalType(IntervalTypeEnum.LEGACY_INTERVAL);
-        DEPRECATION_LOGGER.deprecatedAndMaybeLog("date-interval-setter", DEPRECATION_TEXT);
+        DEPRECATION_LOGGER.deprecate("date-interval-setter", DEPRECATION_TEXT);
         this.dateHistogramInterval = new DateHistogramInterval(interval + "ms");
     }
 
     /** Get the current date interval that is set on this builder. */
     @Deprecated
     public DateHistogramInterval dateHistogramInterval() {
-        DEPRECATION_LOGGER.deprecatedAndMaybeLog("date-histogram-interval-getter", DEPRECATION_TEXT);
+        DEPRECATION_LOGGER.deprecate("date-histogram-interval-getter", DEPRECATION_TEXT);
         if (intervalType.equals(IntervalTypeEnum.LEGACY_DATE_HISTO)) {
             return dateHistogramInterval;
         }
@@ -186,7 +186,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
             throw new IllegalArgumentException("[dateHistogramInterval] must not be null: [date_histogram]");
         }
         setIntervalType(IntervalTypeEnum.LEGACY_DATE_HISTO);
-        DEPRECATION_LOGGER.deprecatedAndMaybeLog("date-histogram-interval-setter", DEPRECATION_TEXT);
+        DEPRECATION_LOGGER.deprecate("date-histogram-interval-setter", DEPRECATION_TEXT);
         this.dateHistogramInterval = dateHistogramInterval;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -338,7 +338,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
             if ("global_ordinals".equals(value)) {
                 return GLOBAL_ORDINALS;
             } else if ("global_ordinals_hash".equals(value)) {
-                deprecationLogger.deprecatedAndMaybeLog("global_ordinals_hash",
+                deprecationLogger.deprecate("global_ordinals_hash",
                     "global_ordinals_hash is deprecated. Please use [global_ordinals] instead.");
                 return GLOBAL_ORDINALS;
             } else if ("map".equals(value)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
@@ -301,7 +301,7 @@ public class MovAvgPipelineAggregationBuilder extends AbstractPipelineAggregatio
         Integer predict = null;
         Boolean minimize = null;
 
-        DEPRECATION_LOGGER.deprecatedAndMaybeLog("moving_avg_aggregation",
+        DEPRECATION_LOGGER.deprecate("moving_avg_aggregation",
             "The moving_avg aggregation has been deprecated in favor of the moving_fn aggregation.");
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1147,7 +1147,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                         scriptFields.add(new ScriptField(parser));
                     }
                 } else if (INDICES_BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("indices_boost_object_format",
+                    deprecationLogger.deprecate("indices_boost_object_format",
                         "Object format in indices_boost is deprecated, please use array format instead");
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -80,7 +80,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
                 .filter(USE_DEFAULT_FORMAT::equals)
                 .findAny()
                 .isPresent()) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog("explicit_default_format",
+            DEPRECATION_LOGGER.deprecate("explicit_default_format",
                     "[" + USE_DEFAULT_FORMAT + "] is a special format that was only used to " +
                     "ease the transition to 7.x. It has become the default and shouldn't be set explicitly anymore.");
         }

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -78,7 +78,7 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
     public ScriptDocValues<?> get(Object key) {
         // deprecate _type
         if ("_type".equals(key)) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog(TYPES_DEPRECATION_KEY, TYPES_DEPRECATION_MESSAGE);
+            DEPRECATION_LOGGER.deprecate(TYPES_DEPRECATION_KEY, TYPES_DEPRECATION_MESSAGE);
         }
         // assume its a string...
         String fieldName = key.toString();

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -263,7 +263,7 @@ public class SliceBuilder implements Writeable, ToXContentObject {
             if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_7_0_0)) {
                 throw new IllegalArgumentException("Computing slices on the [_uid] field is illegal for 7.x indices, use [_id] instead");
             }
-            DEPRECATION_LOG.deprecatedAndMaybeLog("slice_on_uid",
+            DEPRECATION_LOG.deprecate("slice_on_uid",
                 "Computing slices on the [_uid] field is deprecated for 6.x indices, use [_id] instead");
             useTermQuery = true;
         } else if (IdFieldMapper.NAME.equals(field)) {

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -703,7 +703,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     static {
         PARSER.declareField(FieldSortBuilder::missing, XContentParser::objectText,  MISSING, ValueType.VALUE);
         PARSER.declareString((fieldSortBuilder, nestedPath) -> {
-            deprecationLogger.deprecatedAndMaybeLog("field_sort_nested_path",
+            deprecationLogger.deprecate("field_sort_nested_path",
                 "[nested_path] has been deprecated in favor of the [nested] parameter");
             fieldSortBuilder.setNestedPath(nestedPath);
         }, NESTED_PATH_FIELD);
@@ -711,7 +711,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         PARSER.declareString((b, v) -> b.order(SortOrder.fromString(v)) , ORDER_FIELD);
         PARSER.declareString((b, v) -> b.sortMode(SortMode.fromString(v)), SORT_MODE);
         PARSER.declareObject(FieldSortBuilder::setNestedFilter, (p, c) -> {
-            deprecationLogger.deprecatedAndMaybeLog("field_sort_nested_filter",
+            deprecationLogger.deprecate("field_sort_nested_filter",
                 "[nested_filter] has been deprecated in favour for the [nested] parameter");
             return SortBuilder.parseNestedFilter(p);
         }, NESTED_FILTER_FIELD);

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -491,7 +491,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                 fieldName = currentName;
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (NESTED_FILTER_FIELD.match(currentName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("geo_distance_nested_filter",
+                    deprecationLogger.deprecate("geo_distance_nested_filter",
                         "[nested_filter] has been deprecated in favour of the [nested] parameter");
                     nestedFilter = parseInnerQueryBuilder(parser);
                 } else if (NESTED_FIELD.match(currentName, parser.getDeprecationHandler())) {
@@ -522,7 +522,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                 } else if (SORTMODE_FIELD.match(currentName, parser.getDeprecationHandler())) {
                     sortMode = SortMode.fromString(parser.text());
                 } else if (NESTED_PATH_FIELD.match(currentName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("geo_distance_nested_path",
+                    deprecationLogger.deprecate("geo_distance_nested_path",
                         "[nested_path] has been deprecated in favour of the [nested] parameter");
                     nestedPath = parser.text();
                 } else if (IGNORE_UNMAPPED.match(currentName, parser.getDeprecationHandler())) {

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -281,12 +281,12 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         PARSER.declareString((b, v) -> b.order(SortOrder.fromString(v)), ORDER_FIELD);
         PARSER.declareString((b, v) -> b.sortMode(SortMode.fromString(v)), SORTMODE_FIELD);
         PARSER.declareString((fieldSortBuilder, nestedPath) -> {
-            deprecationLogger.deprecatedAndMaybeLog("script_nested_path",
+            deprecationLogger.deprecate("script_nested_path",
                 "[nested_path] has been deprecated in favor of the [nested] parameter");
             fieldSortBuilder.setNestedPath(nestedPath);
         }, NESTED_PATH_FIELD);
         PARSER.declareObject(ScriptSortBuilder::setNestedFilter, (p, c) -> {
-            deprecationLogger.deprecatedAndMaybeLog("script_nested_filter",
+            deprecationLogger.deprecate("script_nested_filter",
                 "[nested_filter] has been deprecated in favour for the [nested] parameter");
             return SortBuilder.parseNestedFilter(p);
         }, NESTED_FILTER_FIELD);

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -296,7 +296,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
             MappedFieldType mappedFieldType = fieldResolver.apply(fieldName);
             if (mappedFieldType == null) {
                 if (indexVersionCreated.before(Version.V_7_0_0)) {
-                    deprecationLogger.deprecatedAndMaybeLog("geo_context_mapping",
+                    deprecationLogger.deprecate("geo_context_mapping",
                         "field [{}] referenced in context [{}] is not defined in the mapping", fieldName, name);
                 } else {
                     throw new ElasticsearchParseException(
@@ -304,7 +304,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
                 }
             } else if (GeoPointFieldMapper.CONTENT_TYPE.equals(mappedFieldType.typeName()) == false) {
                 if (indexVersionCreated.before(Version.V_7_0_0)) {
-                    deprecationLogger.deprecatedAndMaybeLog("geo_context_mapping",
+                    deprecationLogger.deprecate("geo_context_mapping",
                         "field [{}] referenced in context [{}] must be mapped to geo_point, found [{}]",
                         fieldName, name, mappedFieldType.typeName());
                 } else {

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -103,7 +103,7 @@ public class TransportInfo implements ReportingService.Info {
             if (cnameInPublishAddress) {
                 publishAddressString = hostString + '/' + publishAddress.toString();
             } else {
-                deprecationLogger.deprecatedAndMaybeLog("cname_in_publish_address",
+                deprecationLogger.deprecate("cname_in_publish_address",
                         propertyName + " was printed as [ip:port] instead of [hostname/ip:port]. "
                                 + "This format is deprecated and will change to [hostname/ip:port] in a future version. "
                                 + "Use -Des.transport.cname_in_publish_address=true to enforce non-deprecated formatting."

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -118,15 +118,13 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
                 @Override
                 public TokenStream create(TokenStream tokenStream) {
-                    deprecationLogger.deprecatedAndMaybeLog("deprecated_token_filter_create",
-                        "Using deprecated token filter [deprecated]");
+                    deprecationLogger.deprecate("deprecated_token_filter_create", "Using deprecated token filter [deprecated]");
                     return tokenStream;
                 }
 
                 @Override
                 public TokenStream normalize(TokenStream tokenStream) {
-                    deprecationLogger.deprecatedAndMaybeLog("deprecated_token_filter_normalize",
-                        "Using deprecated token filter [deprecated]");
+                    deprecationLogger.deprecate("deprecated_token_filter_normalize", "Using deprecated token filter [deprecated]");
                     return tokenStream;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -7,7 +7,7 @@
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.common.logging;
 
-import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.simple.SimpleLoggerContext;
@@ -27,284 +27,23 @@ import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.elasticsearch.common.SuppressLoggerChecks;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.hamcrest.RegexMatcher;
-import org.hamcrest.core.IsSame;
 
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.Permissions;
 import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.IntStream;
 
-import static org.elasticsearch.common.logging.DeprecationLogger.WARNING_HEADER_PATTERN;
-import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Tests {@link DeprecationLogger}
- */
 public class DeprecationLoggerTests extends ESTestCase {
-
-    private static final RegexMatcher warningValueMatcher = matches(WARNING_HEADER_PATTERN.pattern());
-
-    private final DeprecationLogger logger = new DeprecationLogger(LogManager.getLogger(getClass()));
-
-    @Override
-    protected boolean enableWarningsCheck() {
-        //this is a low level test for the deprecation logger, setup and checks are done manually
-        return false;
-    }
-
-    public void testAddsHeaderWithThreadContext() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-
-        final String param = randomAlphaOfLengthBetween(1, 5);
-        logger.deprecated(threadContexts, "A simple message [{}]", param);
-
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-
-        assertThat(responseHeaders.size(), equalTo(1));
-        final List<String> responses = responseHeaders.get("Warning");
-        assertThat(responses, hasSize(1));
-        assertThat(responses.get(0), warningValueMatcher);
-        assertThat(responses.get(0), containsString("\"A simple message [" + param + "]\""));
-    }
-
-    public void testContainingNewline() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-
-        logger.deprecated(threadContexts, "this message contains a newline\n");
-
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-
-        assertThat(responseHeaders.size(), equalTo(1));
-        final List<String> responses = responseHeaders.get("Warning");
-        assertThat(responses, hasSize(1));
-        assertThat(responses.get(0), warningValueMatcher);
-        assertThat(responses.get(0), containsString("\"this message contains a newline%0A\""));
-    }
-
-    public void testSurrogatePair() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-
-        logger.deprecated(threadContexts, "this message contains a surrogate pair 😱");
-
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-
-        assertThat(responseHeaders.size(), equalTo(1));
-        final List<String> responses = responseHeaders.get("Warning");
-        assertThat(responses, hasSize(1));
-        assertThat(responses.get(0), warningValueMatcher);
-
-        // convert UTF-16 to UTF-8 by hand to show the hard-coded constant below is correct
-        assertThat("😱", equalTo("\uD83D\uDE31"));
-        final int code = 0x10000 + ((0xD83D & 0x3FF) << 10) + (0xDE31 & 0x3FF);
-        @SuppressWarnings("PointlessBitwiseExpression")
-        final int[] points = new int[] {
-                (code >> 18) & 0x07 | 0xF0,
-                (code >> 12) & 0x3F | 0x80,
-                (code >> 6) & 0x3F | 0x80,
-                (code >> 0) & 0x3F | 0x80};
-        final StringBuilder sb = new StringBuilder();
-        // noinspection ForLoopReplaceableByForEach
-        for (int i = 0; i < points.length; i++) {
-            sb.append("%").append(Integer.toString(points[i], 16).toUpperCase(Locale.ROOT));
-        }
-        assertThat(sb.toString(), equalTo("%F0%9F%98%B1"));
-        assertThat(responses.get(0), containsString("\"this message contains a surrogate pair %F0%9F%98%B1\""));
-    }
-
-    public void testAddsCombinedHeaderWithThreadContext() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-
-        final String param = randomAlphaOfLengthBetween(1, 5);
-        logger.deprecated(threadContexts, "A simple message [{}]", param);
-        final String second = randomAlphaOfLengthBetween(1, 10);
-        logger.deprecated(threadContexts, second);
-
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-
-        assertEquals(1, responseHeaders.size());
-
-        final List<String> responses = responseHeaders.get("Warning");
-
-        assertEquals(2, responses.size());
-        assertThat(responses.get(0), warningValueMatcher);
-        assertThat(responses.get(0), containsString("\"A simple message [" + param + "]\""));
-        assertThat(responses.get(1), warningValueMatcher);
-        assertThat(responses.get(1), containsString("\"" + second + "\""));
-    }
-
-    public void testCanRemoveThreadContext() throws IOException {
-        final String expected = "testCanRemoveThreadContext";
-        final String unexpected = "testCannotRemoveThreadContext";
-
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        DeprecationLogger.setThreadContext(threadContext);
-        logger.deprecatedAndMaybeLog("testCanRemoveThreadContext_key1", expected);
-
-        {
-            final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-            final List<String> responses = responseHeaders.get("Warning");
-
-            assertThat(responses, hasSize(1));
-            assertThat(responses.get(0), warningValueMatcher);
-            assertThat(responses.get(0), containsString(expected));
-        }
-
-        DeprecationLogger.removeThreadContext(threadContext);
-        logger.deprecatedAndMaybeLog("testCanRemoveThreadContext_key2", unexpected);
-
-        {
-            final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-            final List<String> responses = responseHeaders.get("Warning");
-
-            assertThat(responses, hasSize(1));
-            assertThat(responses.get(0), warningValueMatcher);
-            assertThat(responses.get(0), containsString(expected));
-            assertThat(responses.get(0), not(containsString(unexpected)));
-        }
-    }
-
-    public void testSafeWithoutThreadContext() {
-        logger.deprecated(Collections.emptySet(), "Ignored");
-    }
-
-    public void testFailsWithoutThreadContextSet() {
-        expectThrows(NullPointerException.class, () -> logger.deprecated((Set<ThreadContext>)null, "Does not explode"));
-    }
-
-    public void testFailsWhenDoubleSettingSameThreadContext() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        DeprecationLogger.setThreadContext(threadContext);
-
-        try {
-            expectThrows(IllegalStateException.class, () -> DeprecationLogger.setThreadContext(threadContext));
-        } finally {
-            // cleanup after ourselves
-            DeprecationLogger.removeThreadContext(threadContext);
-        }
-    }
-
-    public void testFailsWhenRemovingUnknownThreadContext() throws IOException {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        expectThrows(IllegalStateException.class, () -> DeprecationLogger.removeThreadContext(threadContext));
-    }
-
-    public void testWarningValueFromWarningHeader() {
-        final String s = randomAlphaOfLength(16);
-        final String first = DeprecationLogger.formatWarning(s);
-        assertThat(DeprecationLogger.extractWarningValueFromWarningHeader(first, false), equalTo(s));
-
-        final String withPos = "[context][1:11] Blah blah blah";
-        final String formatted = DeprecationLogger.formatWarning(withPos);
-        assertThat(DeprecationLogger.extractWarningValueFromWarningHeader(formatted, true), equalTo("Blah blah blah"));
-
-        final String withNegativePos = "[context][-1:-1] Blah blah blah";
-        assertThat(DeprecationLogger.extractWarningValueFromWarningHeader(DeprecationLogger.formatWarning(withNegativePos), true),
-            equalTo("Blah blah blah"));
-    }
-
-    public void testEscapeBackslashesAndQuotes() {
-        assertThat(DeprecationLogger.escapeBackslashesAndQuotes("\\"), equalTo("\\\\"));
-        assertThat(DeprecationLogger.escapeBackslashesAndQuotes("\""), equalTo("\\\""));
-        assertThat(DeprecationLogger.escapeBackslashesAndQuotes("\\\""), equalTo("\\\\\\\""));
-        assertThat(DeprecationLogger.escapeBackslashesAndQuotes("\"foo\\bar\""),equalTo("\\\"foo\\\\bar\\\""));
-        // test that characters other than '\' and '"' are left unchanged
-        String chars = "\t !" + range(0x23, 0x24) + range(0x26, 0x5b) + range(0x5d, 0x73) + range(0x80, 0xff);
-        final String s = new CodepointSetGenerator(chars.toCharArray()).ofCodePointsLength(random(), 16, 16);
-        assertThat(DeprecationLogger.escapeBackslashesAndQuotes(s), equalTo(s));
-    }
-
-    public void testEncode() {
-        assertThat(DeprecationLogger.encode("\n"), equalTo("%0A"));
-        assertThat(DeprecationLogger.encode("😱"), equalTo("%F0%9F%98%B1"));
-        assertThat(DeprecationLogger.encode("福島深雪"), equalTo("%E7%A6%8F%E5%B3%B6%E6%B7%B1%E9%9B%AA"));
-        assertThat(DeprecationLogger.encode("100%\n"), equalTo("100%25%0A"));
-        // test that valid characters are left unchanged
-        String chars = "\t !" + range(0x23, 0x24) + range(0x26, 0x5b) + range(0x5d, 0x73) + range(0x80, 0xff) + '\\' + '"';
-        final String s = new CodepointSetGenerator(chars.toCharArray()).ofCodePointsLength(random(), 16, 16);
-        assertThat(DeprecationLogger.encode(s), equalTo(s));
-        // when no encoding is needed, the original string is returned (optimization)
-        assertThat(DeprecationLogger.encode(s), IsSame.sameInstance(s));
-    }
-
-
-    public void testWarningHeaderCountSetting() throws IOException{
-        // Test that the number of warning headers don't exceed 'http.max_warning_header_count'
-        final int maxWarningHeaderCount = 2;
-        Settings settings = Settings.builder()
-            .put("http.max_warning_header_count", maxWarningHeaderCount)
-            .build();
-        ThreadContext threadContext = new ThreadContext(settings);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-        // try to log three warning messages
-        logger.deprecated(threadContexts, "A simple message 1");
-        logger.deprecated(threadContexts, "A simple message 2");
-        logger.deprecated(threadContexts, "A simple message 3");
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-        final List<String> responses = responseHeaders.get("Warning");
-
-        assertEquals(maxWarningHeaderCount, responses.size());
-        assertThat(responses.get(0), warningValueMatcher);
-        assertThat(responses.get(0), containsString("\"A simple message 1"));
-        assertThat(responses.get(1), warningValueMatcher);
-        assertThat(responses.get(1), containsString("\"A simple message 2"));
-    }
-
-    public void testWarningHeaderSizeSetting() throws IOException{
-        // Test that the size of warning headers don't exceed 'http.max_warning_header_size'
-        Settings settings = Settings.builder()
-            .put("http.max_warning_header_size", "1Kb")
-            .build();
-
-        byte [] arr = new byte[300];
-        String message1 = new String(arr, StandardCharsets.UTF_8) + "1";
-        String message2 = new String(arr, StandardCharsets.UTF_8) + "2";
-        String message3 = new String(arr, StandardCharsets.UTF_8) + "3";
-
-        ThreadContext threadContext = new ThreadContext(settings);
-        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
-        // try to log three warning messages
-        logger.deprecated(threadContexts, message1);
-        logger.deprecated(threadContexts, message2);
-        logger.deprecated(threadContexts, message3);
-        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
-        final List<String> responses = responseHeaders.get("Warning");
-
-        long warningHeadersSize = 0L;
-        for (String response : responses){
-            warningHeadersSize += "Warning".getBytes(StandardCharsets.UTF_8).length +
-                response.getBytes(StandardCharsets.UTF_8).length;
-        }
-        // assert that the size of all warning headers is less or equal to 1Kb
-        assertTrue(warningHeadersSize <= 1024);
-    }
     @SuppressLoggerChecks(reason = "Safe as this is using mockito")
     public void testLogPermissions() {
         AtomicBoolean supplierCalled = new AtomicBoolean(false);
@@ -340,20 +79,15 @@ public class DeprecationLoggerTests extends ESTestCase {
                 new ProtectionDomain[]{new ProtectionDomain(null, new Permissions())}
             );
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                deprecationLogger.deprecatedAndMaybeLog("testLogPermissions_key", "foo", "bar");
+                deprecationLogger.deprecate("testLogPermissions_key", "foo {}", "bar");
                 return null;
             }, noPermissionsAcc);
             assertThat("supplier called", supplierCalled.get(), is(true));
+
+            assertWarnings("foo bar");
         } finally {
             LogManager.setFactory(originalFactory);
         }
-    }
-
-    private String range(int lowerInclusive, int upperInclusive) {
-        return IntStream
-                .range(lowerInclusive, upperInclusive + 1)
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -56,7 +56,7 @@ public class DeprecationLoggerTests extends ESTestCase {
             supplierCalled.set(true);
             createTempDir(); // trigger file permission, like rolling logs would
             return null;
-        }).when(mockLogger).warn(new DeprecatedMessage("foo", any()));
+        }).when(mockLogger).warn(new DeprecatedMessage(any(), "foo"));
         final LoggerContext context = new SimpleLoggerContext() {
             @Override
             public ExtendedLogger getLogger(String name) {

--- a/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.logging;
+
+import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.hamcrest.RegexMatcher;
+import org.hamcrest.core.IsSame;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.common.logging.HeaderWarning.WARNING_HEADER_PATTERN;
+import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tests {@link HeaderWarning}
+ */
+public class HeaderWarningTests extends ESTestCase {
+
+    private static final RegexMatcher warningValueMatcher = matches(WARNING_HEADER_PATTERN.pattern());
+
+    private final HeaderWarning logger = new HeaderWarning();
+
+    @Override
+    protected boolean enableWarningsCheck() {
+        //this is a low level test for the deprecation logger, setup and checks are done manually
+        return false;
+    }
+
+    public void testAddsHeaderWithThreadContext() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+        final String param = randomAlphaOfLengthBetween(1, 5);
+        HeaderWarning.addWarning(threadContexts, "A simple message [{}]", param);
+
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+        assertThat(responseHeaders.size(), equalTo(1));
+        final List<String> responses = responseHeaders.get("Warning");
+        assertThat(responses, hasSize(1));
+        assertThat(responses.get(0), warningValueMatcher);
+        assertThat(responses.get(0), containsString("\"A simple message [" + param + "]\""));
+    }
+
+    public void testContainingNewline() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+        HeaderWarning.addWarning(threadContexts, "this message contains a newline\n");
+
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+        assertThat(responseHeaders.size(), equalTo(1));
+        final List<String> responses = responseHeaders.get("Warning");
+        assertThat(responses, hasSize(1));
+        assertThat(responses.get(0), warningValueMatcher);
+        assertThat(responses.get(0), containsString("\"this message contains a newline%0A\""));
+    }
+
+    public void testSurrogatePair() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+        HeaderWarning.addWarning(threadContexts, "this message contains a surrogate pair 😱");
+
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+        assertThat(responseHeaders.size(), equalTo(1));
+        final List<String> responses = responseHeaders.get("Warning");
+        assertThat(responses, hasSize(1));
+        assertThat(responses.get(0), warningValueMatcher);
+
+        // convert UTF-16 to UTF-8 by hand to show the hard-coded constant below is correct
+        assertThat("😱", equalTo("\uD83D\uDE31"));
+        final int code = 0x10000 + ((0xD83D & 0x3FF) << 10) + (0xDE31 & 0x3FF);
+        @SuppressWarnings("PointlessBitwiseExpression")
+        final int[] points = new int[] {
+                (code >> 18) & 0x07 | 0xF0,
+                (code >> 12) & 0x3F | 0x80,
+                (code >> 6) & 0x3F | 0x80,
+                (code >> 0) & 0x3F | 0x80};
+        final StringBuilder sb = new StringBuilder();
+        // noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < points.length; i++) {
+            sb.append("%").append(Integer.toString(points[i], 16).toUpperCase(Locale.ROOT));
+        }
+        assertThat(sb.toString(), equalTo("%F0%9F%98%B1"));
+        assertThat(responses.get(0), containsString("\"this message contains a surrogate pair %F0%9F%98%B1\""));
+    }
+
+    public void testAddsCombinedHeaderWithThreadContext() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+        final String param = randomAlphaOfLengthBetween(1, 5);
+        HeaderWarning.addWarning(threadContexts, "A simple message [{}]", param);
+        final String second = randomAlphaOfLengthBetween(1, 10);
+        HeaderWarning.addWarning(threadContexts, second);
+
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+
+        assertEquals(1, responseHeaders.size());
+
+        final List<String> responses = responseHeaders.get("Warning");
+
+        assertEquals(2, responses.size());
+        assertThat(responses.get(0), warningValueMatcher);
+        assertThat(responses.get(0), containsString("\"A simple message [" + param + "]\""));
+        assertThat(responses.get(1), warningValueMatcher);
+        assertThat(responses.get(1), containsString("\"" + second + "\""));
+    }
+
+    public void testCanRemoveThreadContext() throws IOException {
+        final String expected = "testCanRemoveThreadContext";
+        final String unexpected = "testCannotRemoveThreadContext";
+
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        HeaderWarning.setThreadContext(threadContext);
+        /*"testCanRemoveThreadContext_key1",*/
+        HeaderWarning.addWarning(HeaderWarning.THREAD_CONTEXT, expected);
+
+        {
+            final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+            final List<String> responses = responseHeaders.get("Warning");
+
+            assertThat(responses, hasSize(1));
+            assertThat(responses.get(0), warningValueMatcher);
+            assertThat(responses.get(0), containsString(expected));
+        }
+
+        HeaderWarning.removeThreadContext(threadContext);
+        /*"testCanRemoveThreadContext_key2", */
+        HeaderWarning.addWarning(HeaderWarning.THREAD_CONTEXT, unexpected);
+
+        {
+            final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+            final List<String> responses = responseHeaders.get("Warning");
+
+            assertThat(responses, hasSize(1));
+            assertThat(responses.get(0), warningValueMatcher);
+            assertThat(responses.get(0), containsString(expected));
+            assertThat(responses.get(0), not(containsString(unexpected)));
+        }
+    }
+
+    public void testSafeWithoutThreadContext() {
+        HeaderWarning.addWarning(Collections.emptySet(), "Ignored");
+    }
+
+    public void testFailsWithoutThreadContextSet() {
+        expectThrows(NullPointerException.class,
+            () -> HeaderWarning.addWarning((Set<ThreadContext>)null, "Does not explode"));
+    }
+
+    public void testFailsWhenDoubleSettingSameThreadContext() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        HeaderWarning.setThreadContext(threadContext);
+
+        try {
+            expectThrows(IllegalStateException.class, () -> HeaderWarning.setThreadContext(threadContext));
+        } finally {
+            // cleanup after ourselves
+            HeaderWarning.removeThreadContext(threadContext);
+        }
+    }
+
+    public void testFailsWhenRemovingUnknownThreadContext() throws IOException {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        expectThrows(IllegalStateException.class, () -> HeaderWarning.removeThreadContext(threadContext));
+    }
+
+    public void testWarningValueFromWarningHeader() {
+        final String s = randomAlphaOfLength(16);
+        final String first = HeaderWarning.formatWarning(s);
+        assertThat(HeaderWarning.extractWarningValueFromWarningHeader(first, false), equalTo(s));
+
+        final String withPos = "[context][1:11] Blah blah blah";
+        final String formatted = HeaderWarning.formatWarning(withPos);
+        assertThat(HeaderWarning.extractWarningValueFromWarningHeader(formatted, true), equalTo("Blah blah blah"));
+
+        final String withNegativePos = "[context][-1:-1] Blah blah blah";
+        assertThat(HeaderWarning.extractWarningValueFromWarningHeader(HeaderWarning.formatWarning(withNegativePos), true),
+            equalTo("Blah blah blah"));
+    }
+
+    public void testEscapeBackslashesAndQuotes() {
+        assertThat(HeaderWarning.escapeBackslashesAndQuotes("\\"), equalTo("\\\\"));
+        assertThat(HeaderWarning.escapeBackslashesAndQuotes("\""), equalTo("\\\""));
+        assertThat(HeaderWarning.escapeBackslashesAndQuotes("\\\""), equalTo("\\\\\\\""));
+        assertThat(HeaderWarning.escapeBackslashesAndQuotes("\"foo\\bar\""),equalTo("\\\"foo\\\\bar\\\""));
+        // test that characters other than '\' and '"' are left unchanged
+        String chars = "\t !" + range(0x23, 0x24) + range(0x26, 0x5b) + range(0x5d, 0x73) + range(0x80, 0xff);
+        final String s = new CodepointSetGenerator(chars.toCharArray()).ofCodePointsLength(random(), 16, 16);
+        assertThat(HeaderWarning.escapeBackslashesAndQuotes(s), equalTo(s));
+    }
+
+    public void testEncode() {
+        assertThat(HeaderWarning.encode("\n"), equalTo("%0A"));
+        assertThat(HeaderWarning.encode("😱"), equalTo("%F0%9F%98%B1"));
+        assertThat(HeaderWarning.encode("福島深雪"), equalTo("%E7%A6%8F%E5%B3%B6%E6%B7%B1%E9%9B%AA"));
+        assertThat(HeaderWarning.encode("100%\n"), equalTo("100%25%0A"));
+        // test that valid characters are left unchanged
+        String chars = "\t !" + range(0x23, 0x24) + range(0x26, 0x5b) + range(0x5d, 0x73) + range(0x80, 0xff) + '\\' + '"';
+        final String s = new CodepointSetGenerator(chars.toCharArray()).ofCodePointsLength(random(), 16, 16);
+        assertThat(HeaderWarning.encode(s), equalTo(s));
+        // when no encoding is needed, the original string is returned (optimization)
+        assertThat(HeaderWarning.encode(s), IsSame.sameInstance(s));
+    }
+
+
+    public void testWarningHeaderCountSetting() throws IOException{
+        // Test that the number of warning headers don't exceed 'http.max_warning_header_count'
+        final int maxWarningHeaderCount = 2;
+        Settings settings = Settings.builder()
+            .put("http.max_warning_header_count", maxWarningHeaderCount)
+            .build();
+        ThreadContext threadContext = new ThreadContext(settings);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+        // try to log three warning messages
+        HeaderWarning.addWarning(threadContexts, "A simple message 1");
+        HeaderWarning.addWarning(threadContexts, "A simple message 2");
+        HeaderWarning.addWarning(threadContexts, "A simple message 3");
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+        final List<String> responses = responseHeaders.get("Warning");
+
+        assertEquals(maxWarningHeaderCount, responses.size());
+        assertThat(responses.get(0), warningValueMatcher);
+        assertThat(responses.get(0), containsString("\"A simple message 1"));
+        assertThat(responses.get(1), warningValueMatcher);
+        assertThat(responses.get(1), containsString("\"A simple message 2"));
+    }
+
+    public void testWarningHeaderSizeSetting() throws IOException{
+        // Test that the size of warning headers don't exceed 'http.max_warning_header_size'
+        Settings settings = Settings.builder()
+            .put("http.max_warning_header_size", "1Kb")
+            .build();
+
+        byte [] arr = new byte[300];
+        String message1 = new String(arr, StandardCharsets.UTF_8) + "1";
+        String message2 = new String(arr, StandardCharsets.UTF_8) + "2";
+        String message3 = new String(arr, StandardCharsets.UTF_8) + "3";
+
+        ThreadContext threadContext = new ThreadContext(settings);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+        // try to log three warning messages
+        HeaderWarning.addWarning(threadContexts, message1);
+        HeaderWarning.addWarning(threadContexts, message2);
+        HeaderWarning.addWarning(threadContexts, message3);
+        final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
+        final List<String> responses = responseHeaders.get("Warning");
+
+        long warningHeadersSize = 0L;
+        for (String response : responses){
+            warningHeadersSize += "Warning".getBytes(StandardCharsets.UTF_8).length +
+                response.getBytes(StandardCharsets.UTF_8).length;
+        }
+        // assert that the size of all warning headers is less or equal to 1Kb
+        assertTrue(warningHeadersSize <= 1024);
+    }
+
+    private String range(int lowerInclusive, int upperInclusive) {
+        return IntStream
+                .range(lowerInclusive, upperInclusive + 1)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -203,12 +204,12 @@ public class ThreadContextTests extends ESTestCase {
             threadContext.addResponseHeader("foo", "bar");
         }
 
-        final String value = DeprecationLogger.formatWarning("qux");
-        threadContext.addResponseHeader("baz", value, s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, false));
+        final String value = HeaderWarning.formatWarning("qux");
+        threadContext.addResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         // pretend that another thread created the same response at a different time
         if (randomBoolean()) {
-            final String duplicateValue = DeprecationLogger.formatWarning("qux");
-            threadContext.addResponseHeader("baz", duplicateValue, s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, false));
+            final String duplicateValue = HeaderWarning.formatWarning("qux");
+            threadContext.addResponseHeader("baz", duplicateValue, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         }
 
         threadContext.addResponseHeader("Warning", "One is the loneliest number");

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.MockTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -326,7 +325,7 @@ public class AnalysisRegistryTests extends ESTestCase {
                 @Override
                 public TokenStream create(TokenStream tokenStream) {
                     if (indexSettings.getIndexVersionCreated().equals(Version.CURRENT)) {
-                        deprecationLogger.deprecatedAndMaybeLog("deprecated_token_filter", "Using deprecated token filter [deprecated]");
+                        deprecationLogger.deprecate("deprecated_token_filter", "Using deprecated token filter [deprecated]");
                     }
                     return tokenStream;
                 }
@@ -354,7 +353,7 @@ public class AnalysisRegistryTests extends ESTestCase {
 
                 @Override
                 public TokenStream create(TokenStream tokenStream) {
-                    deprecationLogger.deprecatedAndMaybeLog("unused_token_filter", "Using deprecated token filter [unused]");
+                    deprecationLogger.deprecate("unused_token_filter", "Using deprecated token filter [unused]");
                     return tokenStream;
                 }
             }
@@ -367,8 +366,7 @@ public class AnalysisRegistryTests extends ESTestCase {
 
                 @Override
                 public TokenStream create(TokenStream tokenStream) {
-                    deprecationLogger.deprecatedAndMaybeLog("deprecated_normalizer",
-                        "Using deprecated token filter [deprecated_normalizer]");
+                    deprecationLogger.deprecate("deprecated_normalizer", "Using deprecated token filter [deprecated_normalizer]");
                     return tokenStream;
                 }
 

--- a/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -77,7 +77,7 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         InOrder inOrder = inOrder(handler, request, channel, deprecationLogger);
 
         // log, then forward
-        inOrder.verify(deprecationLogger).deprecatedAndMaybeLog("deprecated_route", deprecationMessage);
+        inOrder.verify(deprecationLogger).deprecate("deprecated_route", deprecationMessage);
         inOrder.verify(handler).handleRequest(request, channel, client);
         inOrder.verifyNoMoreInteractions();
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -65,9 +65,8 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.joda.JodaDeprecationPatterns;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
@@ -449,7 +448,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             final Set<String> actualWarningValues =
                 actualWarnings.stream()
                     .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, true))
-                    .map(DeprecationLogger::escapeAndEncode)
+                    .map(HeaderWarning::escapeAndEncode)
                     .collect(Collectors.toSet());
             Set<String> expectedWarnings = new HashSet<>(Arrays.asList(allowedWarnings));
             final Set<String> warningsNotExpected = Sets.difference(actualWarningValues, expectedWarnings);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -65,6 +65,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.joda.JodaDeprecationPatterns;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.LogConfigurator;
@@ -344,7 +345,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         assertNull("Thread context initialized twice", threadContext);
         if (enableWarningsCheck()) {
             this.threadContext = new ThreadContext(Settings.EMPTY);
-            DeprecationLogger.setThreadContext(threadContext);
+            HeaderWarning.setThreadContext(threadContext);
         }
     }
 
@@ -374,7 +375,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         // initialized
         if (threadContext != null) {
             ensureNoWarnings();
-            DeprecationLogger.removeThreadContext(threadContext);
+            HeaderWarning.removeThreadContext(threadContext);
             threadContext = null;
         }
         ensureAllSearchContextsReleased();
@@ -447,7 +448,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             }
             final Set<String> actualWarningValues =
                 actualWarnings.stream()
-                    .map(s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, true))
+                    .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, true))
                     .map(DeprecationLogger::escapeAndEncode)
                     .collect(Collectors.toSet());
             Set<String> expectedWarnings = new HashSet<>(Arrays.asList(allowedWarnings));
@@ -486,10 +487,10 @@ public abstract class ESTestCase extends LuceneTestCase {
     private void assertWarnings(boolean stripXContentPosition, List<String> actualWarnings, String[] expectedWarnings) {
         assertNotNull("no warnings, expected: " + Arrays.asList(expectedWarnings), actualWarnings);
         final Set<String> actualWarningValues =
-                actualWarnings.stream().map(s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, stripXContentPosition))
+                    actualWarnings.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, stripXContentPosition))
                     .collect(Collectors.toSet());
         for (String msg : expectedWarnings) {
-            assertThat(actualWarningValues, hasItem(DeprecationLogger.escapeAndEncode(msg)));
+                assertThat(actualWarningValues, hasItem(HeaderWarning.escapeAndEncode(msg)));
         }
         assertEquals("Expected " + expectedWarnings.length + " warnings but found " + actualWarnings.size() + "\nExpected: "
                 + Arrays.asList(expectedWarnings) + "\nActual: " + actualWarnings,
@@ -1509,5 +1510,4 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new AssertionError();
         }
     }
-
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentLocation;
@@ -56,7 +56,6 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.common.collect.Tuple.tuple;
-import static org.elasticsearch.common.logging.DeprecationLogger.WARNING_HEADER_PATTERN;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -321,14 +320,14 @@ public class DoSection implements ExecutableSection {
         final List<String> unmatched = new ArrayList<>();
         final List<String> missing = new ArrayList<>();
         Set<String> allowed = allowedWarningHeaders.stream()
-                .map(DeprecationLogger::escapeAndEncode)
+                .map(HeaderWarning::escapeAndEncode)
                 .collect(toSet());
         // LinkedHashSet so that missing expected warnings come back in a predictable order which is nice for testing
         final Set<String> expected = expectedWarningHeaders.stream()
-                .map(DeprecationLogger::escapeAndEncode)
+                .map(HeaderWarning::escapeAndEncode)
                 .collect(toCollection(LinkedHashSet::new));
         for (final String header : warningHeaders) {
-            final Matcher matcher = WARNING_HEADER_PATTERN.matcher(header);
+            final Matcher matcher = HeaderWarning.WARNING_HEADER_PATTERN.matcher(header);
             final boolean matches = matcher.matches();
             if (matches) {
                 final String message = DeprecationLogger.extractWarningValueFromWarningHeader(header, true);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -330,7 +330,7 @@ public class DoSection implements ExecutableSection {
             final Matcher matcher = HeaderWarning.WARNING_HEADER_PATTERN.matcher(header);
             final boolean matches = matcher.matches();
             if (matches) {
-                final String message = DeprecationLogger.extractWarningValueFromWarningHeader(header, true);
+                final String message = HeaderWarning.extractWarningValueFromWarningHeader(header, true);
                 if (masterVersion.before(Version.V_7_0_0)
                         && message.equals("the default number of shards will change from [5] to [1] in 7.0.0; "
                         + "if you wish to continue using the default of [5] shards, "

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
@@ -61,10 +61,10 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             section.checkWarningHeaders(emptyList(), Version.CURRENT);
         }
 
-        final String testHeader = DeprecationLogger.formatWarning("test");
-        final String anotherHeader = DeprecationLogger.formatWarning("another");
-        final String someMoreHeader = DeprecationLogger.formatWarning("some more");
-        final String catHeader = DeprecationLogger.formatWarning("cat");
+        final String testHeader = HeaderWarning.formatWarning("test");
+        final String anotherHeader = HeaderWarning.formatWarning("another");
+        final String someMoreHeader = HeaderWarning.formatWarning("some more");
+        final String catHeader = HeaderWarning.formatWarning("cat");
         // Any warning headers fail
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -138,8 +138,8 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     }
 
     public void testIgnoreTypesWarnings() {
-        String legitimateWarning = DeprecationLogger.formatWarning("warning");
-        String typesWarning = DeprecationLogger.formatWarning("[types removal] " +
+        String legitimateWarning = HeaderWarning.formatWarning("warning");
+        String typesWarning = HeaderWarning.formatWarning("[types removal] " +
             "The endpoint /{index}/{type}/_count is deprecated, use /{index}/_count instead.");
 
         DoSection section = new DoSection(new XContentLocation(1, 1));

--- a/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
+++ b/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
@@ -277,27 +277,8 @@ public class ESLoggerUsageChecker {
 
                         int lengthWithoutMarker = argumentTypes.length - markerOffset;
 
-                        if (lengthWithoutMarker == 2 &&
-                            argumentTypes[markerOffset + 0].equals(STRING_CLASS) &&
-                            (argumentTypes[markerOffset + 1].equals(OBJECT_ARRAY_CLASS) ||
-                                argumentTypes[markerOffset + 1].equals(SUPPLIER_ARRAY_CLASS))) {
-                            // VARARGS METHOD: debug(Marker?, String, (Object...|Supplier...))
-                            checkArrayArgs(methodNode, logMessageFrames[i], arraySizeFrames[i], lineNumber, methodInsn, markerOffset + 0,
-                                markerOffset + 1);
-                        } else if (lengthWithoutMarker >= 2 &&
-                            argumentTypes[markerOffset + 0].equals(STRING_CLASS) &&
-                            argumentTypes[markerOffset + 1].equals(OBJECT_CLASS)) {
-                            // MULTI-PARAM METHOD: debug(Marker?, String, Object p0, ...)
-                            checkFixedArityArgs(methodNode, logMessageFrames[i], lineNumber, methodInsn, markerOffset + 0,
-                                lengthWithoutMarker - 1);
-                        } else if ((lengthWithoutMarker == 1 || lengthWithoutMarker == 2) &&
-                            lengthWithoutMarker == 2 ? argumentTypes[markerOffset + 1].equals(THROWABLE_CLASS) : true) {
-                            // all the rest: debug(Marker?, (Message|MessageSupplier|CharSequence|Object|String|Supplier), Throwable?)
-                            checkFixedArityArgs(methodNode, logMessageFrames[i], lineNumber, methodInsn, markerOffset + 0, 0);
-                        } else {
-                            throw new IllegalStateException("Method invoked on " + LOGGER_CLASS.getClassName() +
-                                " that is not supported by logger usage checker");
-                        }
+                        verifyLoggerUsage(methodNode, logMessageFrames, arraySizeFrames, lineNumber, i,
+                            methodInsn, argumentTypes, markerOffset, lengthWithoutMarker);
                     }
                 } else if (insn.getOpcode() == Opcodes.INVOKESPECIAL) { // constructor invocation
                     MethodInsnNode methodInsn = (MethodInsnNode) insn;
@@ -343,7 +324,48 @@ public class ESLoggerUsageChecker {
                                 "Constructor: "+ Arrays.toString(argumentTypes)));
                         }
                     }
+                } else if (insn.getOpcode() == Opcodes.INVOKEVIRTUAL) {
+                    //using strings because this test do not depend on server
+
+                    MethodInsnNode methodInsn = (MethodInsnNode) insn;
+                    if (methodInsn.owner.equals("org/elasticsearch/common/logging/DeprecationLogger")) {
+                        if (methodInsn.name.equals("deprecate")) {
+                            Type[] argumentTypes = Type.getArgumentTypes(methodInsn.desc);
+                            int markerOffset = 1; // skip key
+
+                            int lengthWithoutMarker = argumentTypes.length - markerOffset;
+
+                            verifyLoggerUsage(methodNode, logMessageFrames, arraySizeFrames, lineNumber, i,
+                                methodInsn, argumentTypes, markerOffset, lengthWithoutMarker);
+                        }
+                    }
                 }
+            }
+        }
+
+        private void verifyLoggerUsage(MethodNode methodNode, Frame<BasicValue>[] logMessageFrames, Frame<BasicValue>[] arraySizeFrames,
+                                       int lineNumber, int i, MethodInsnNode methodInsn, Type[] argumentTypes,
+                                       int markerOffset, int lengthWithoutMarker) {
+            if (lengthWithoutMarker == 2 &&
+                argumentTypes[markerOffset + 0].equals(STRING_CLASS) &&
+                (argumentTypes[markerOffset + 1].equals(OBJECT_ARRAY_CLASS) ||
+                    argumentTypes[markerOffset + 1].equals(SUPPLIER_ARRAY_CLASS))) {
+                // VARARGS METHOD: debug(Marker?, String, (Object...|Supplier...))
+                checkArrayArgs(methodNode, logMessageFrames[i], arraySizeFrames[i], lineNumber, methodInsn, markerOffset + 0,
+                    markerOffset + 1);
+            } else if (lengthWithoutMarker >= 2 &&
+                argumentTypes[markerOffset + 0].equals(STRING_CLASS) &&
+                argumentTypes[markerOffset + 1].equals(OBJECT_CLASS)) {
+                // MULTI-PARAM METHOD: debug(Marker?, String, Object p0, ...)
+                checkFixedArityArgs(methodNode, logMessageFrames[i], lineNumber, methodInsn, markerOffset + 0,
+                    lengthWithoutMarker - 1);
+            } else if ((lengthWithoutMarker == 1 || lengthWithoutMarker == 2) &&
+                lengthWithoutMarker == 2 ? argumentTypes[markerOffset + 1].equals(THROWABLE_CLASS) : true) {
+                // all the rest: debug(Marker?, (Message|MessageSupplier|CharSequence|Object|String|Supplier), Throwable?)
+                checkFixedArityArgs(methodNode, logMessageFrames[i], lineNumber, methodInsn, markerOffset + 0, 0);
+            } else {
+                throw new IllegalStateException("Method invoked on " + LOGGER_CLASS.getClassName() +
+                    " that is not supported by logger usage checker");
             }
         }
 

--- a/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
+++ b/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.util.MessageSupplier;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.ESLogMessage;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.loggerusage.ESLoggerUsageChecker.WrongLoggerUsage;
 

--- a/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
+++ b/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
@@ -26,6 +26,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.MessageSupplier;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.SuppressLoggerChecks;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogMessage;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.loggerusage.ESLoggerUsageChecker.WrongLoggerUsage;
 
@@ -124,6 +126,7 @@ public class ESLoggerUsageTests extends ESTestCase {
     public void checkArraySizeForSubclasses() {
         logger.debug(new TestMessage("message {}", "x-opaque-id", 1));
     }
+
     public void checkFailArraySizeForSubclasses(Object... arr) {
         logger.debug(new TestMessage("message {}", "x-opaque-id", arr));
     }
@@ -241,6 +244,11 @@ public class ESLoggerUsageTests extends ESTestCase {
             args = new Object[] { "world", 43, "another argument" };
         }
         logger.info(message, args);
+    }
+
+    public void checkDeprecationLogger() {
+        DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+        deprecationLogger.deprecate("key","message {}", 123);
     }
 
 }

--- a/x-pack/plugin/async-search/qa/rest/src/main/java/org/elasticsearch/query/DeprecatedQueryBuilder.java
+++ b/x-pack/plugin/async-search/qa/rest/src/main/java/org/elasticsearch/query/DeprecatedQueryBuilder.java
@@ -54,7 +54,7 @@ public class DeprecatedQueryBuilder extends AbstractQueryBuilder<DeprecatedQuery
 
     @Override
     protected Query doToQuery(QueryShardContext context) {
-        deprecationLogger.deprecatedAndMaybeLog("to_query", "[deprecated] query");
+        deprecationLogger.deprecate("to_query", "[deprecated] query");
         return new MatchAllDocsQuery();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -350,7 +350,7 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
         if (Files.exists(config) == false) {
             Path legacyConfig = env.configFile().resolve("x-pack").resolve(name);
             if (Files.exists(legacyConfig)) {
-                deprecationLogger.deprecatedAndMaybeLog("config_file_path",
+                deprecationLogger.deprecate("config_file_path",
                     "Config file [" + name + "] is in a deprecated location. Move from " +
                     legacyConfig.toString() + " to " + config.toString());
                 return legacyConfig;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -348,7 +348,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder(datafeedConfig);
         if (jobId != null) {
             if (datafeedConfig.getJobId() != null && datafeedConfig.getJobId().equals(jobId) == false) {
-                deprecationLogger.deprecatedAndMaybeLog("update_datafeed_job_id", DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE);
+                deprecationLogger.deprecate("update_datafeed_job_id", DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE);
             }
             builder.setJobId(jobId);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -287,7 +287,7 @@ public final class IndicesPermission {
                             for (String privilegeName : group.privilege.name()) {
                                 if (PRIVILEGE_NAME_SET_BWC_ALLOW_MAPPING_UPDATE.contains(privilegeName)) {
                                     bwcDeprecationLogActions.add(() -> {
-                                        deprecationLogger.deprecatedAndMaybeLog("[" + indexOrAlias + "] mapping update for ingest " +
+                                        deprecationLogger.deprecate("[" + indexOrAlias + "] mapping update for ingest " +
                                                 "privilege [" + privilegeName + "]", "the index privilege [" + privilegeName + "] allowed" +
                                                 " the update mapping action [" + action + "] on index [" + indexOrAlias + "], this " +
                                                 "privilege will not permit mapping updates in the next major release - users who require " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -544,7 +544,7 @@ public class SSLService {
             // Client Authentication _should_ be required, but if someone turns it off, then this check is no longer relevant
             final SSLConfigurationSettings configurationSettings = SSLConfigurationSettings.withPrefix(prefix + ".");
             if (isConfigurationValidForServerUsage(configuration) == false) {
-                deprecationLogger.deprecatedAndMaybeLog("invalid_ssl_configuration", "invalid SSL configuration for " + prefix +
+                deprecationLogger.deprecate("invalid_ssl_configuration", "invalid SSL configuration for " + prefix +
                     " - server ssl configuration requires a key and certificate, but these have not been configured; you must set either " +
                     "[" + configurationSettings.x509KeyPair.keystorePath.getKey() + "], or both [" +
                     configurationSettings.x509KeyPair.keyPath.getKey() + "] and [" +
@@ -556,7 +556,7 @@ public class SSLService {
                 .sorted()
                 .collect(Collectors.toList());
             if (sslSettingNames.isEmpty() == false) {
-                deprecationLogger.deprecatedAndMaybeLog("invalid_ssl_configuration",
+                deprecationLogger.deprecate("invalid_ssl_configuration",
                     "invalid configuration for " + prefix + " - [" + enabledSetting +
                     "] is not set, but the following settings have been configured in elasticsearch.yml : [" +
                     Strings.collectionToCommaDelimitedString(sslSettingNames) + "]");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -117,11 +117,7 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
                 builder.field(TransformField.COUNT.getPreferredName(), invalidTransforms.size());
                 builder.field(TransformField.TRANSFORMS.getPreferredName(), invalidTransforms);
                 builder.endObject();
-                deprecationLogger.deprecatedAndMaybeLog(
-                    "invalid_transforms",
-                    INVALID_TRANSFORMS_DEPRECATION_WARNING,
-                    invalidTransforms.size()
-                );
+                deprecationLogger.deprecate("invalid_transforms", INVALID_TRANSFORMS_DEPRECATION_WARNING, invalidTransforms.size());
             }
 
             builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
@@ -86,7 +86,7 @@ public class PivotConfig implements Writeable, ToXContentObject {
         this.maxPageSearchSize = maxPageSearchSize;
 
         if (maxPageSearchSize != null) {
-            deprecationLogger.deprecatedAndMaybeLog(
+            deprecationLogger.deprecate(
                 TransformField.MAX_PAGE_SEARCH_SIZE.getPreferredName(),
                 "[max_page_search_size] is deprecated inside pivot please use settings instead"
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
@@ -93,7 +93,7 @@ public class MockDeprecatedAggregationBuilder extends ValuesSourceAggregationBui
     }
 
     public static MockDeprecatedAggregationBuilder fromXContent(XContentParser p) {
-        deprecationLogger.deprecatedAndMaybeLog("deprecated_mock", DEPRECATION_MESSAGE);
+        deprecationLogger.deprecate("deprecated_mock", DEPRECATION_MESSAGE);
         return new MockDeprecatedAggregationBuilder();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedQueryBuilder.java
@@ -47,7 +47,7 @@ public class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDepreca
 
     public static MockDeprecatedQueryBuilder fromXContent(XContentParser parser) {
         try {
-            deprecationLogger.deprecatedAndMaybeLog("deprecated_mock", DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("deprecated_mock", DEPRECATION_MESSAGE);
 
             return PARSER.apply(parser, null);
         } catch (IllegalArgumentException e) {

--- a/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -19,7 +19,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Setting;
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.common.logging.DeprecationLogger.WARNING_HEADER_PATTERN;
+import static org.elasticsearch.common.logging.HeaderWarning.WARNING_HEADER_PATTERN;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.elasticsearch.xpack.deprecation.TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1;
@@ -200,7 +200,7 @@ public class DeprecationHttpIT extends ESSingleNodeTestCase {
             assertThat(deprecatedWarning, matches(WARNING_HEADER_PATTERN.pattern()));
         }
         final List<String> actualWarningValues =
-                deprecatedWarnings.stream().map(s -> DeprecationLogger.extractWarningValueFromWarningHeader(s, true))
+                deprecatedWarnings.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, true))
                     .collect(Collectors.toList());
         for (Matcher<String> headerMatcher : headerMatchers) {
             assertThat(actualWarningValues, hasItem(headerMatcher));

--- a/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/TestDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/TestDeprecatedQueryBuilder.java
@@ -67,7 +67,7 @@ public class TestDeprecatedQueryBuilder extends AbstractQueryBuilder<TestDepreca
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        deprecationLogger.deprecatedAndMaybeLog(NAME, "[{}] query is deprecated, but used on [{}] index", NAME, context.index().getName());
+        deprecationLogger.deprecate(NAME, "[{}] query is deprecated, but used on [{}] index", NAME, context.index().getName());
 
         return Queries.newMatchAllQuery();
     }

--- a/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/TestDeprecationHeaderRestAction.java
+++ b/x-pack/plugin/deprecation/src/internalClusterTest/java/org/elasticsearch/xpack/deprecation/TestDeprecationHeaderRestAction.java
@@ -93,7 +93,7 @@ public class TestDeprecationHeaderRestAction extends BaseRestHandler {
             final Map<String, Object> source = parser.map();
 
             if (source.containsKey("deprecated_settings")) {
-                deprecationLogger.deprecatedAndMaybeLog("deprecated_settings", DEPRECATED_USAGE);
+                deprecationLogger.deprecate("deprecated_settings", DEPRECATED_USAGE);
 
                 settings = (List<String>)source.get("deprecated_settings");
             } else {

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -114,7 +114,7 @@ public class RestGraphAction extends XPackRestHandler {
         }
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("graph_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("graph_with_types", TYPES_DEPRECATION_MESSAGE);
             graphRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         }
         return channel -> client.es().execute(INSTANCE, graphRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -247,7 +247,7 @@ public class JobManager {
         Job job = jobBuilder.build(new Date());
 
         if (job.getDataDescription() != null && job.getDataDescription().getFormat() == DataDescription.DataFormat.DELIMITED) {
-            deprecationLogger.deprecatedAndMaybeLog("ml_create_job_delimited_data",
+            deprecationLogger.deprecate("ml_create_job_delimited_data",
                 "Creating jobs with delimited data format is deprecated. Please use xcontent instead.");
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
@@ -163,7 +163,7 @@ public final class DomainSplitFunction {
     public static List<String> domainSplit(String host, Map<String, Object> params) {
         // NOTE: we don't check SpecialPermission because this will be called (indirectly) from scripts
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            deprecationLogger.deprecatedAndMaybeLog("domainSplit",
+            deprecationLogger.deprecate("domainSplit",
                 "Method [domainSplit] taking params is deprecated. Remove the params argument.");
             return null;
         });

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -132,9 +132,9 @@ public class TransportPutRollupJobAction extends TransportMasterNodeAction<PutRo
         String timeZone = request.getConfig().getGroupConfig().getDateHistogram().getTimeZone();
         String modernTZ = DateUtils.DEPRECATED_LONG_TIMEZONES.get(timeZone);
         if (modernTZ != null) {
-            deprecationLogger.deprecatedAndMaybeLog("deprecated_timezone",
+            deprecationLogger.deprecate("deprecated_timezone",
                 "Creating Rollup job [" + request.getConfig().getId() + "] with timezone ["
-                + timeZone + "], but [" + timeZone + "] has been deprecated by the IANA.  Use [" + modernTZ +"] instead.");
+                    + timeZone + "], but [" + timeZone + "] has been deprecated by the IANA.  Use [" + modernTZ +"] instead.");
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -723,25 +723,22 @@ public class ApiKeyService {
         @Override
         public void usedDeprecatedName(String parserName, Supplier<XContentLocation> location, String usedName, String modernName) {
             String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-            deprecationLogger.deprecatedAndMaybeLog("api_key_field",
-                "{}Deprecated field [{}] used in api key [{}], expected [{}] instead",
-                prefix, usedName, apiKeyId, modernName);
+            deprecationLogger.deprecate("api_key_field",
+                "{}Deprecated field [{}] used in api key [{}], expected [{}] instead", prefix, usedName, apiKeyId, modernName);
         }
 
         @Override
         public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName, String replacedWith) {
             String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-            deprecationLogger.deprecatedAndMaybeLog("api_key_field",
-                "{}Deprecated field [{}] used in api key [{}], replaced by [{}]",
-                prefix, usedName, apiKeyId, replacedWith);
+            deprecationLogger.deprecate("api_key_field",
+                "{}Deprecated field [{}] used in api key [{}], replaced by [{}]", prefix, usedName, apiKeyId, replacedWith);
         }
 
         @Override
         public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName) {
             String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-            deprecationLogger.deprecatedAndMaybeLog("api_key_field",
-                "{}Deprecated field [{}] used in api key [{}], which is unused and will be removed entirely",
-                prefix, usedName);
+            deprecationLogger.deprecate("api_key_field",
+                "{}Deprecated field [{}] used in api key [{}], which is unused and will be removed entirely", prefix, usedName, apiKeyId);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -348,7 +348,7 @@ public class Realms implements Iterable<Realm> {
 
     private void logDeprecationIfFound(Set<String> missingOrderRealmSettingKeys, Map<String, Set<String>> orderToRealmOrderSettingKeys) {
         if (missingOrderRealmSettingKeys.size() > 0) {
-            deprecationLogger.deprecatedAndMaybeLog("unordered_realm_config", "Found realms without order config: [{}]. " +
+            deprecationLogger.deprecate("unordered_realm_config", "Found realms without order config: [{}]. " +
                     "In next major release, node will fail to start with missing realm order.",
                 String.join("; ", missingOrderRealmSettingKeys)
             );
@@ -360,7 +360,7 @@ public class Realms implements Iterable<Realm> {
             .sorted()
             .collect(Collectors.toList());
         if (false == duplicatedRealmOrderSettingKeys.isEmpty()) {
-            deprecationLogger.deprecatedAndMaybeLog("duplicate_realm_order",
+            deprecationLogger.deprecate("duplicate_realm_order",
                     "Found multiple realms configured with the same order: [{}]. " +
                     "In next major release, node will fail to start with duplicated realm order.",
                 String.join("; ", duplicatedRealmOrderSettingKeys));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
@@ -238,9 +238,9 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
     private void logDeprecatedUser(final User user){
         Map<String, Object> metadata = user.metadata();
         if (Boolean.TRUE.equals(metadata.get(MetadataUtils.DEPRECATED_METADATA_KEY))) {
-            deprecationLogger.deprecatedAndMaybeLog("deprecated_user-" + user.principal(), "The user [" + user.principal() +
-                "] is deprecated and will be removed in a future version of Elasticsearch. " +
-                metadata.get(MetadataUtils.DEPRECATED_REASON_METADATA_KEY));
+            deprecationLogger.deprecate("deprecated_user-" + user.principal(), "The user [" + user.principal() +
+                    "] is deprecated and will be removed in a future version of Elasticsearch. " +
+                    metadata.get(MetadataUtils.DEPRECATED_REASON_METADATA_KEY));
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
@@ -523,8 +523,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
             super(config, timeout, ignoreReferralErrors, logger, groupsResolver, metadataResolver, domainDN,
                     ActiveDirectorySessionFactorySettings.AD_UPN_USER_SEARCH_FILTER_SETTING, UPN_USER_FILTER, threadPool);
             if (userSearchFilter.contains("{0}")) {
-                new DeprecationLogger(logger).deprecatedAndMaybeLog("ldap_settings",
-                    "The use of the account name variable {0} in the setting ["
+                new DeprecationLogger(logger).deprecate("ldap_settings", "The use of the account name variable {0} in the setting ["
                     + RealmSettings.getFullSettingKey(config, ActiveDirectorySessionFactorySettings.AD_UPN_USER_SEARCH_FILTER_SETTING)
                     + "] has been deprecated and will be removed in a future version!");
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactory.java
@@ -159,12 +159,9 @@ public abstract class SessionFactory {
         } else if (hostnameVerificationExists) {
             final String fullSettingKey = RealmSettings.getFullSettingKey(config, SessionFactorySettings.HOSTNAME_VERIFICATION_SETTING);
             final String deprecationKey = "deprecated_setting_" + fullSettingKey.replace('.', '_');
-            new DeprecationLogger(logger).deprecatedAndMaybeLog(
-                deprecationKey,
-                "the setting [{}] has been deprecated and " + "will be removed in a future version. use [{}] instead",
-                fullSettingKey,
-                RealmSettings.getFullSettingKey(config, SSLConfigurationSettings.VERIFICATION_MODE_SETTING_REALM)
-            );
+            new DeprecationLogger(logger).deprecate(deprecationKey,
+                "the setting [{}] has been deprecated and will be removed in a future version. use [{}] instead",
+                fullSettingKey, RealmSettings.getFullSettingKey(config, SSLConfigurationSettings.VERIFICATION_MODE_SETTING_REALM));
             if (config.getSetting(SessionFactorySettings.HOSTNAME_VERIFICATION_SETTING)) {
                 options.setSSLSocketVerifier(new HostNameSSLSocketVerifier(true));
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -195,8 +195,8 @@ public class CompositeRolesStore {
             .forEach(rd -> {
                 String reason = Objects.toString(
                     rd.getMetadata().get(MetadataUtils.DEPRECATED_REASON_METADATA_KEY), "Please check the documentation");
-                deprecationLogger.deprecatedAndMaybeLog("deprecated_role-" + rd.getName(), "The role [" + rd.getName() +
-                    "] is deprecated and will be removed in a future version of Elasticsearch. " + reason);
+                deprecationLogger.deprecate("deprecated_role-" + rd.getName(), "The role [" + rd.getName() +
+                            "] is deprecated and will be removed in a future version of Elasticsearch. " + reason);
             });
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumer.java
@@ -206,7 +206,7 @@ public final class DeprecationRoleDescriptorConsumer implements Consumer<Collect
             if (false == inferiorIndexNames.isEmpty()) {
                 final String logMessage = String.format(Locale.ROOT, ROLE_PERMISSION_DEPRECATION_STANZA, roleDescriptor.getName(),
                         aliasName, String.join(", ", inferiorIndexNames));
-                deprecationLogger.deprecatedAndMaybeLog("index_permissions_on_alias", logMessage);
+                deprecationLogger.deprecate("index_permissions_on_alias", logMessage);
             }
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
@@ -296,7 +296,7 @@ public final class DeprecationRoleDescriptorConsumerTests extends ESTestCase {
     }
 
     private void verifyLogger(DeprecationLogger deprecationLogger, String roleName, String aliasName, String indexNames) {
-        verify(deprecationLogger).deprecatedAndMaybeLog("index_permissions_on_alias",
+        verify(deprecationLogger).deprecate("index_permissions_on_alias",
             "Role [" + roleName + "] contains index privileges covering the [" + aliasName
                 + "] alias but which do not cover some of the indices that it points to [" + indexNames + "]. Granting privileges over an"
                 + " alias and hence granting privileges over all the indices that the alias points to is deprecated and will be removed"

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
@@ -185,7 +185,7 @@ public class ShapeQueryBuilder extends AbstractGeometryQueryBuilder<ShapeQueryBu
 
         ShapeQueryBuilder builder;
         if (pgsqb.type != null) {
-            deprecationLogger.deprecatedAndMaybeLog(
+            deprecationLogger.deprecate(
                 "geo_share_query_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -81,7 +81,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            deprecationLogger.deprecatedAndMaybeLog("sparse_vector", DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("sparse_vector", DEPRECATION_MESSAGE);
             SparseVectorFieldMapper.Builder builder = new SparseVectorFieldMapper.Builder(name);
             return builder;
         }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
@@ -80,7 +80,7 @@ public class ScoreScriptUtils {
                 docValues = (DenseVectorScriptDocValues) scoreScript.getDoc().get(fieldName);
             } else if (field instanceof DenseVectorScriptDocValues) {
                 docValues = (DenseVectorScriptDocValues) field;
-                deprecationLogger.deprecatedAndMaybeLog("vector_function_signature", DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("vector_function_signature", DEPRECATION_MESSAGE);
             } else {
                 throw new IllegalArgumentException("For vector functions, the 'field' argument must be of type String or " +
                     "VectorScriptDocValues");
@@ -238,13 +238,13 @@ public class ScoreScriptUtils {
                 docValues = (SparseVectorScriptDocValues) scoreScript.getDoc().get(fieldName);
             } else if (field instanceof SparseVectorScriptDocValues) {
                 docValues = (SparseVectorScriptDocValues) field;
-                deprecationLogger.deprecatedAndMaybeLog("vector_function_signature", DEPRECATION_MESSAGE);
+                deprecationLogger.deprecate("vector_function_signature", DEPRECATION_MESSAGE);
             } else {
                 throw new IllegalArgumentException("For vector functions, the 'field' argument must be of type String or " +
                     "VectorScriptDocValues");
             }
 
-            deprecationLogger.deprecatedAndMaybeLog("sparse_vector_function", SparseVectorFieldMapper.DEPRECATION_MESSAGE);
+            deprecationLogger.deprecate("sparse_vector_function", SparseVectorFieldMapper.DEPRECATION_MESSAGE);
         }
 
         BytesRef getEncodedVector() {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
@@ -166,7 +166,7 @@ public class IndexAction implements Action {
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 if (Field.DOC_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("watcher_index_action", TYPES_DEPRECATION_MESSAGE);
+                    deprecationLogger.deprecate("watcher_index_action", TYPES_DEPRECATION_MESSAGE);
                     docType = parser.text();
                 } else if (Field.DOC_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     docId = parser.text();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatcherStatsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatcherStatsAction.java
@@ -60,8 +60,7 @@ public class RestWatcherStatsAction extends WatcherRestHandler {
         }
 
         if (metrics.contains("pending_watches")) {
-            deprecationLogger.deprecatedAndMaybeLog("pending_watches",
-                "The pending_watches parameter is deprecated, use queued_watches instead");
+            deprecationLogger.deprecate("pending_watches", "The pending_watches parameter is deprecated, use queued_watches instead");
         }
 
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -209,7 +209,7 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                         }
                     }
                 } else if (TYPES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("watcher_search_input", TYPES_DEPRECATION_MESSAGE);
+                    deprecationLogger.deprecate("watcher_search_input", TYPES_DEPRECATION_MESSAGE);
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {
                             types.add(parser.textOrNull());
@@ -285,7 +285,7 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                     String indicesStr = parser.text();
                     indices.addAll(Arrays.asList(Strings.delimitedListToStringArray(indicesStr, ",", " \t")));
                 } else if (TYPES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("watcher_search_input", TYPES_DEPRECATION_MESSAGE);
+                    deprecationLogger.deprecate("watcher_search_input", TYPES_DEPRECATION_MESSAGE);
                     String typesStr = parser.text();
                     types.addAll(Arrays.asList(Strings.delimitedListToStringArray(typesStr, ",", " \t")));
                 } else if (SEARCH_TYPE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {


### PR DESCRIPTION
Splitting DeprecationLogger into two. HeaderWarningLogger - responsible for adding a response warning headers and ThrottlingLogger - responsible for limiting the duplicated log entries for the same key (previously deprecateAndMaybeLog).
Introducing A ThrottlingAndHeaderWarningLogger which is a base for other common logging usages where both response warning header and logging throttling was needed.

relates #55699
relates #52369

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
