### PR TITLE
[DOCS] Display point in time API docs

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -14,6 +14,7 @@ exception of the <<search-explain,explain API>>.
 * <<search-search>>
 * <<search-multi-search>>
 * <<async-search>>
+* <<point-in-time-api>>
 * <<scroll-api>>
 * <<clear-scroll-api>>
 * <<search-suggesters>>
@@ -50,6 +51,8 @@ For an overview of EQL and related tutorials, see <<eql>>.
 include::search/search.asciidoc[]
 
 include::search/async-search.asciidoc[]
+
+include::search/point-in-time-api.asciidoc[]
 
 include::search/scroll-api.asciidoc[]
 

--- a/docs/reference/search/point-in-time-api.asciidoc
+++ b/docs/reference/search/point-in-time-api.asciidoc
@@ -1,7 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
-[[point-in-time]]
-==== Point in time
+[[point-in-time-api]]
+=== Point in time API
+++++
+<titleabbrev>Point in time</titleabbrev>
+++++
 
 A search request by default executes against the most recent visible data of
 the target indices, which is called point in time. Elasticsearch pit (point in time)
@@ -55,7 +58,7 @@ return different `id`; thus always use the most recently received `id` for the
 next search request.
 
 [[point-in-time-keep-alive]]
-===== Keeping point in time alive
+==== Keeping point in time alive
 The `keep_alive` parameter, which is passed to a open point in time request and
 search request, extends the time to live of the corresponding point in time.
 The value (e.g. `1m`, see <<time-units>>) does not need to be long enough to
@@ -84,7 +87,8 @@ You can check how many point-in-times (i.e, search contexts) are open with the
 GET /_nodes/stats/indices/search
 ---------------------------------------
 
-===== Close point in time API
+[[close-point-in-time-api]]
+==== Close point in time API
 
 Point-in-time is automatically closed when its `keep_alive` has
 been elapsed. However keeping point-in-times has a cost, as discussed in the


### PR DESCRIPTION
#61062 added the point in time API docs, but they weren't included in any other files for
display.

This displays the docs and adjusts the headings accordingly.