### PR TITLE
Search - regex case insensitive version fix after backport to 7.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -97,7 +97,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         syntaxFlagsValue = in.readVInt();
         maxDeterminizedStates = in.readVInt();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             caseInsensitive = in.readBoolean();
         }
     }
@@ -109,7 +109,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         out.writeVInt(syntaxFlagsValue);
         out.writeVInt(maxDeterminizedStates);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeBoolean(caseInsensitive);
         }
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -110,8 +110,8 @@ setup:
 "Case insensitive query":
   - skip:
       features: headers
-      version: " - 7.10.99"
-      reason: "temporary master constraint until case insensitive regex backported to 7.10"
+      version: " - 7.9.99"
+      reason: "Case insensitive flag added in 7.10"
   - do:
       search:
         body:


### PR DESCRIPTION
Changing master's supported version numbers now that backport PR https://github.com/elastic/elasticsearch/pull/61532 is merged.

Closes #59235