### PR TITLE
[DOCS] Add 7.9 breaking change for built-in templates

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -111,14 +111,18 @@ template for a data stream must specify:
 [IMPORTANT]
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
-patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
-templates to create data streams. If you use {agent}, assign your index
-templates a priority lower than `100` to avoid an override of the built-in
-templates.
+patterns, each with a priority of `100`.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. If you use {agent}, assign your index templates a priority
+lower than `100` to avoid overriding the built-in templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern, or assign your templates a `priority` higher or
-lower than `100`.
+non-overlapping index pattern or assign templates with an overlapping pattern a
+`priority` higher than `100`.
+
+For example, if you don't use {agent} and want to create a template for the
+`logs-*` index pattern, assign your template a priority of `200`. This ensures
+your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
 Every document indexed to a data stream must have a `@timestamp` field. This

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -170,14 +170,18 @@ the operation automatically creates the index and applies any matching
 [IMPORTANT]
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
-patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
-templates to create data streams. If you use {agent}, assign your index
-templates a priority lower than `100` to avoid an override of the built-in
-templates.
+patterns, each with a priority of `100`.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. If you use {agent}, assign your index templates a priority
+lower than `100` to avoid overriding the built-in templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern, or assign your templates a `priority` higher or
-lower than `100`.
+non-overlapping index pattern or assign templates with an overlapping pattern a
+`priority` higher than `100`.
+
+For example, if you don't use {agent} and want to create a template for the
+`logs-*` index pattern, assign your template a priority of `200`. This ensures
+your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
 If no mapping exists, the index operation

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -23,14 +23,18 @@ If a new data stream or index matches more than one index template, the index te
 [IMPORTANT]
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
-patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
-templates to create data streams. If you use {agent}, assign your index
-templates a priority lower than `100` to avoid an override of the built-in
-templates.
+patterns, each with a priority of `100`.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. If you use {agent}, assign your index templates a priority
+lower than `100` to avoid an overriding the built-in templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern, or assign your templates a `priority` higher or
-lower than `100`.
+non-overlapping index pattern or assign templates with an overlapping pattern a
+`priority` higher than `100`.
+
+For example, if you don't use {agent} and want to create a template for the
+`logs-*` index pattern, assign your template a priority of `200`. This ensures
+your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
 When a composable template matches a given index

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -87,10 +87,10 @@ used to match the names of data streams and indices during creation.
 [IMPORTANT]
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
-patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
-templates to create data streams. If you use {agent}, assign your index
-templates a priority lower than `100` to avoid overriding the built-in
-templates.
+patterns, each with a priority of `100`.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams. If you use {agent}, assign your index templates a priority
+lower than `100` to avoid an overriding the built-in templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
 non-overlapping index pattern or assign templates with an overlapping pattern a

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -89,12 +89,16 @@ used to match the names of data streams and indices during creation.
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
 patterns. {ingest-guide}/ingest-management-overview.html[{agent}] uses these
 templates to create data streams. If you use {agent}, assign your index
-templates a priority lower than `100` to avoid an override of the built-in
+templates a priority lower than `100` to avoid overriding the built-in
 templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern, or assign your templates a `priority` higher or
-lower than `100`.
+non-overlapping index pattern or assign templates with an overlapping pattern a
+`priority` higher than `100`.
+
+For example, if you don't use {agent} and want to create a template for the
+`logs-*` index pattern, assign your template a priority of `200`. This ensures
+your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
 [xpack]#`data_stream`#::

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -9,11 +9,40 @@ your application to {es} 7.9.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_79_indices_changes>>
 * <<breaking_79_script_cache_changes>>
 * <<breaking_79_settings_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+[discrete]
+[[breaking_79_indices_changes]]
+=== Indices changes
+.{es} includes built-in index templates for `logs-*-*` and `metrics-*-*`.
+
+[%collapsible]
+====
+*Details* +
+In 7.9, {es} added built-in index templates for the `metrics-*-*` and
+`logs-*-*` index patterns, each with a priority of `100`.
+{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+create data streams.
+
+*Impact* +
+If you use {agent}, assign your index templates a priority
+lower than `100` to avoid overriding the built-in templates.
+
+Otherwise, to avoid accidentally applying the built-in templates, use a
+non-overlapping index pattern or assign templates with an overlapping pattern a
+`priority` higher than `100`.
+
+For example, if you don't use {agent} and want to use a template for the
+`logs-*` index pattern, assign your template a priority of `200`. This ensures
+your template is applied instead of the built-in template for `logs-*-*`.
+====
+//end::notable-breaking-changes[]
 
 //tag::notable-breaking-changes[]
 [discrete]


### PR DESCRIPTION
Adds a breaking change for the built-in logs and metrics template.

Updates existing admons for the templates with stronger wording and an example.

Opening this initially on 7.9. Will backport to 7.x and master (excluding the breaking change on master).