### PR TITLE
[DOCS] Fix old NodeSelector field in Low Level REST Client

### DIFF
--- a/docs/java-rest/low-level/usage.asciidoc
+++ b/docs/java-rest/low-level/usage.asciidoc
@@ -292,7 +292,7 @@ header because the client will automatically set that from the `HttpEntity`
 attached to the request.
 
 You can set the `NodeSelector` which controls which nodes will receive
-requests. `NodeSelector.NOT_MASTER_ONLY` is a good choice.
+requests. `NodeSelector.SKIP_DEDICATED_MASTERS` is a good choice.
 
 You can also customize the response consumer used to buffer the asynchronous
 responses. The default consumer will buffer up to 100MB of response on the


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->

Hi.
Seems `NodeSelector.NOT_MASTER_ONLY` has been renamed to `NodeSelector.SKIP_DEDICATED_MASTERS` by #31471

Related docs:
- https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-low-usage-requests.html
- https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.9/java-rest-low-usage-requests.html
- https://www.elastic.co/guide/en/elasticsearch/client/java-rest/6.8/java-rest-low-usage-requests.html
