### PR TITLE
Log more information when mappings fail on index creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -395,7 +395,8 @@ public class MetadataCreateIndexService {
             try {
                 updateIndexMappingsAndBuildSortOrder(indexService, request, mappings, sourceMetadata);
             } catch (Exception e) {
-                logger.debug("failed on parsing mappings on index creation [{}]", request.index());
+                logger.log(silent ? Level.DEBUG : Level.INFO,
+                    "failed on parsing mappings on index creation [{}]: {}", request.index(), e.getMessage());
                 throw e;
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -396,7 +396,7 @@ public class MetadataCreateIndexService {
                 updateIndexMappingsAndBuildSortOrder(indexService, request, mappings, sourceMetadata);
             } catch (Exception e) {
                 logger.log(silent ? Level.DEBUG : Level.INFO,
-                    "failed on parsing mappings on index creation [{}]: {}", request.index(), e.getMessage());
+                    "failed on parsing mappings on index creation [{}]", request.index(), e);
                 throw e;
             }
 


### PR DESCRIPTION
Errors from bad mappings at index creation are currently logged at `DEBUG` level, which
can make it difficult to work out what's going on if the index is being auto-created.  This
commit ups the log level to `INFO` for auto-created indices, and includes some more 
information in the log message.