### PR TITLE
Convert more runtime field scripts to arrays

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -166,7 +166,7 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
             return null;
         }
         StringBuilder b = new StringBuilder();
-        if ("double".equals(type)) {
+        if (List.of("boolean", "date", "double", "long").contains(type)) {
             b.append("List result = new ArrayList();");
         }
         b.append("def v = source['").append(name).append("'];\n");
@@ -183,15 +183,15 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
         b.append("    ").append(emit).append("\n");
         b.append("  }\n");
         b.append("}\n");
-        if ("double".equals(type)) {
+        if (List.of("boolean", "date", "double", "long").contains(type)) {
             b.append("return result;");
         }
         return b.toString();
     }
 
     private static final Map<String, String> PAINLESS_TO_EMIT = Map.ofEntries(
-        Map.entry(BooleanFieldMapper.CONTENT_TYPE, "value(parse(value));"),
-        Map.entry(DateFieldMapper.CONTENT_TYPE, "millis(parse(value.toString()));"),
+        Map.entry(BooleanFieldMapper.CONTENT_TYPE, "result.add(parse(value));"),
+        Map.entry(DateFieldMapper.CONTENT_TYPE, "result.add(parse(value.toString()));"),
         Map.entry(
             NumberType.DOUBLE.typeName(),
             "result.add(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
@@ -200,7 +200,7 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
         Map.entry(IpFieldMapper.CONTENT_TYPE, "stringValue(value.toString());"),
         Map.entry(
             NumberType.LONG.typeName(),
-            "value(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
+            "result.add(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
         )
     );
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.runtimefields;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
@@ -16,45 +15,17 @@ import java.util.Map;
  * Common base class for script field scripts that return long values.
  */
 public abstract class AbstractLongScriptFieldScript extends AbstractScriptFieldScript {
-    private long[] values = new long[1];
-    private int count;
-
     public AbstractLongScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
         super(params, searchLookup, ctx);
     }
 
-    public abstract void execute();
+    public abstract long[] execute();
 
     /**
      * Execute the script for the provided {@code docId}.
      */
-    public final void runForDoc(int docId) {
-        count = 0;
+    public final long[] runForDoc(int docId) {
         setDocument(docId);
-        execute();
-    }
-
-    /**
-     * Values from the last time {@link #runForDoc(int)} was called. This array
-     * is mutable and will change with the next call of {@link #runForDoc(int)}.
-     * It is also oversized and will contain garbage at all indices at and
-     * above {@link #count()}.
-     */
-    public final long[] values() {
-        return values;
-    }
-
-    /**
-     * The number of results produced the last time {@link #runForDoc(int)} was called.
-     */
-    public final int count() {
-        return count;
-    }
-
-    protected void collectValue(long v) {
-        if (values.length < count + 1) {
-            values = ArrayUtil.grow(values, count + 1);
-        }
-        values[count++] = v;
+        return execute();
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
@@ -14,6 +14,7 @@ import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -38,15 +39,58 @@ public abstract class LongScriptFieldScript extends AbstractLongScriptFieldScrip
         super(params, searchLookup, ctx);
     }
 
-    public static class Value {
-        private final LongScriptFieldScript script;
+    public static long[] convertFromLong(long v) {
+        return new long[] { v };
+    }
 
-        public Value(LongScriptFieldScript script) {
-            this.script = script;
+    public static long[] convertFromCollection(Collection<?> v) {
+        long[] result = new long[v.size()];
+        int i = 0;
+        for (Object o : v) {
+            try {
+                result[i++] = convertCollectionElement(o);
+            } catch (ClassCastException e) {
+                throw new ClassCastException("Exception casting collection member [" + o + "]: " + e.getMessage());
+            }
         }
+        return result;
+    }
 
-        public void value(long v) {
-            script.collectValue(v);
+    public static long[] convertFromDef(Object o) {
+        if (o instanceof Long) {
+            return convertFromLong(((Long) o).longValue());
         }
+        if (o instanceof long[]) {
+            return (long[]) o;
+        }
+        if (o instanceof Integer) {
+            return convertFromLong(((Integer) o).longValue());
+        }
+        if (o instanceof Short) {
+            return convertFromLong(((Short) o).longValue());
+        }
+        if (o instanceof Byte) {
+            return convertFromLong(((Byte) o).longValue());
+        }
+        if (o instanceof Collection) {
+            return convertFromCollection((Collection<?>) o);
+        }
+        throw new ClassCastException("Can't cast [" + o.getClass().getName() + "] to long, long[], int, short, byte, or a collection");
+    }
+
+    private static long convertCollectionElement(Object o) {
+        if (o instanceof Long) {
+            return ((Long) o).longValue();
+        }
+        if (o instanceof Integer) {
+            return ((Integer) o).longValue();
+        }
+        if (o instanceof Short) {
+            return ((Short) o).longValue();
+        }
+        if (o instanceof Byte) {
+            return ((Byte) o).longValue();
+        }
+        throw new ClassCastException("Can't cast [" + o.getClass().getName() + "] to long, int, short, or byte");
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongDocValues.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 
 public final class ScriptLongDocValues extends AbstractSortedNumericDocValues {
     private final AbstractLongScriptFieldScript script;
+    private long[] values;
     private int cursor;
 
     ScriptLongDocValues(AbstractLongScriptFieldScript script) {
@@ -22,22 +23,22 @@ public final class ScriptLongDocValues extends AbstractSortedNumericDocValues {
 
     @Override
     public boolean advanceExact(int docId) {
-        script.runForDoc(docId);
-        if (script.count() == 0) {
+        values = script.runForDoc(docId);
+        if (values.length == 0) {
             return false;
         }
-        Arrays.sort(script.values(), 0, script.count());
+        Arrays.sort(values);
         cursor = 0;
         return true;
     }
 
     @Override
     public long nextValue() throws IOException {
-        return script.values()[cursor++];
+        return values[cursor++];
     }
 
     @Override
     public int docValueCount() {
-        return script.count();
+        return values.length;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQuery.java
@@ -36,10 +36,8 @@ abstract class AbstractBooleanScriptFieldQuery extends AbstractScriptFieldQuery 
 
     /**
      * Does the value match this query?
-     * @param trues the number of true values returned by the script
-     * @param falses the number of false values returned by the script
      */
-    protected abstract boolean matches(int trues, int falses);
+    protected abstract boolean matches(boolean[] values);
 
     @Override
     public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
@@ -56,8 +54,7 @@ abstract class AbstractBooleanScriptFieldQuery extends AbstractScriptFieldQuery 
                 TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
                     @Override
                     public boolean matches() throws IOException {
-                        script.runForDoc(approximation().docID());
-                        return AbstractBooleanScriptFieldQuery.this.matches(script.trues(), script.falses());
+                        return AbstractBooleanScriptFieldQuery.this.matches(script.runForDoc(approximation().docID()));
                     }
 
                     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQuery.java
@@ -41,7 +41,7 @@ abstract class AbstractLongScriptFieldQuery extends AbstractScriptFieldQuery {
     /**
      * Does the value match this query?
      */
-    protected abstract boolean matches(long[] values, int count);
+    protected abstract boolean matches(long[] values);
 
     @Override
     public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
@@ -58,8 +58,7 @@ abstract class AbstractLongScriptFieldQuery extends AbstractScriptFieldQuery {
                 TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
                     @Override
                     public boolean matches() throws IOException {
-                        script.runForDoc(approximation().docID());
-                        return AbstractLongScriptFieldQuery.this.matches(script.values(), script.count());
+                        return AbstractLongScriptFieldQuery.this.matches(script.runForDoc(approximation().docID()));
                     }
 
                     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQuery.java
@@ -15,8 +15,8 @@ public class BooleanScriptFieldExistsQuery extends AbstractBooleanScriptFieldQue
     }
 
     @Override
-    protected boolean matches(int trues, int falses) {
-        return (trues | falses) != 0;
+    protected boolean matches(boolean[] values) {
+        return values.length > 0;
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQuery.java
@@ -20,11 +20,21 @@ public class BooleanScriptFieldTermQuery extends AbstractBooleanScriptFieldQuery
     }
 
     @Override
-    protected boolean matches(int trues, int falses) {
+    protected boolean matches(boolean[] values) {
         if (term) {
-            return trues > 0;
+            for (boolean v : values) {
+                if (v) {
+                    return true;
+                }
+            }
+            return false;
         }
-        return falses > 0;
+        for (boolean v : values) {
+            if (false == v) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQuery.java
@@ -23,8 +23,8 @@ public class LongScriptFieldExistsQuery extends AbstractLongScriptFieldQuery {
     }
 
     @Override
-    protected boolean matches(long[] values, int count) {
-        return count > 0;
+    protected boolean matches(long[] values) {
+        return values.length > 0;
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
@@ -32,9 +32,9 @@ public class LongScriptFieldRangeQuery extends AbstractLongScriptFieldQuery {
     }
 
     @Override
-    protected boolean matches(long[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (lowerValue <= values[i] && values[i] <= upperValue) {
+    protected boolean matches(long[] values) {
+        for (long v : values) {
+            if (lowerValue <= v && v <= upperValue) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQuery.java
@@ -28,9 +28,9 @@ public class LongScriptFieldTermQuery extends AbstractLongScriptFieldQuery {
     }
 
     @Override
-    protected boolean matches(long[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (term == values[i]) {
+    protected boolean matches(long[] values) {
+        for (long v : values) {
+            if (term == v) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
@@ -30,9 +30,9 @@ public class LongScriptFieldTermsQuery extends AbstractLongScriptFieldQuery {
     }
 
     @Override
-    protected boolean matches(long[] values, int count) {
-        for (int i = 0; i < count; i++) {
-            if (terms.contains(values[i])) {
+    protected boolean matches(long[] values) {
+        for (long v : values) {
+            if (terms.contains(v)) {
                 return true;
             }
         }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
@@ -7,14 +7,12 @@
 # The whitelist for boolean-valued runtime fields
 
 class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript @no_import {
-
 }
 
 static_import {
-    void value(org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript, boolean) bound_to org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Value
     boolean parse(def) from_class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript
 }
 
-# This import is required to make painless happy and it isn't 100% clear why
+# This whitelist is required to allow painless to build the factory
 class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Factory @no_import {
 }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
@@ -10,11 +10,9 @@ class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript @no_import {
 }
 
 static_import {
-    void millis(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Millis
-    void date(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, TemporalAccessor) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Date
     long parse(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, def) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Parse
 }
 
-# This import is required to make painless happy and it isn't 100% clear why
+# This whitelist is required to allow painless to build the factory
 class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Factory @no_import {
 }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
@@ -9,10 +9,6 @@
 class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript @no_import {
 }
 
-static_import {
-    void value(org.elasticsearch.xpack.runtimefields.LongScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Value
-}
-
-# This import is required to make painless happy and it isn't 100% clear why
+# This whitelist is required to allow painless to build the factory
 class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Factory @no_import {
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
@@ -8,6 +8,10 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
 public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<BooleanScriptFieldScript.Factory> {
     public static final BooleanScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new BooleanScriptFieldScript(
         params,
@@ -15,8 +19,8 @@ public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<Boo
         ctx
     ) {
         @Override
-        public void execute() {
-            new BooleanScriptFieldScript.Value(this).value(false);
+        public boolean[] execute() {
+            return new boolean[] { false };
         }
     };
 
@@ -28,5 +32,22 @@ public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<Boo
     @Override
     protected BooleanScriptFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testConvertBoolean() {
+        boolean v = randomBoolean();
+        assertThat(BooleanScriptFieldScript.convertFromBoolean(v), equalTo(new boolean[] { v }));
+        assertThat(BooleanScriptFieldScript.convertFromDef(v), equalTo(new boolean[] { v }));
+    }
+
+    public void testConvertFromCollection() {
+        boolean[] result = new boolean[] { randomBoolean(), randomBoolean(), randomBoolean() };
+        assertThat(BooleanScriptFieldScript.convertFromCollection(List.of(result[0], result[1], result[2])), equalTo(result));
+        assertThat(BooleanScriptFieldScript.convertFromDef(List.of(result[0], result[1], result[2])), equalTo(result));
+    }
+
+    public void testConvertBooleanArrayFromDef() {
+        boolean[] result = new boolean[] { randomBoolean(), randomBoolean(), randomBoolean() };
+        assertThat(BooleanScriptFieldScript.convertFromDef(result), equalTo(result));
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
@@ -8,6 +8,11 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
+import java.time.Instant;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
 public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateScriptFieldScript.Factory> {
     public static final DateScriptFieldScript.Factory DUMMY = (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(
         params,
@@ -16,8 +21,8 @@ public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateSc
         ctx
     ) {
         @Override
-        public void execute() {
-            new DateScriptFieldScript.Millis(this).millis(1595431354874L);
+        public long[] execute() {
+            return new long[] { 1595431354874L };
         }
     };
 
@@ -29,5 +34,83 @@ public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateSc
     @Override
     protected DateScriptFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testConvertFromLong() {
+        long l = randomLong();
+        assertThat(DateScriptFieldScript.convertFromLong(l), equalTo(new long[] { l }));
+        assertThat(DateScriptFieldScript.convertFromDef(l), equalTo(new long[] { l }));
+    }
+
+    public void testConvertFromTemporalAccessor() {
+        Instant instant = randomInstant();
+        assertThat(DateScriptFieldScript.convertFromTemporalAccessor(instant), equalTo(new long[] { instant.toEpochMilli() }));
+        assertThat(DateScriptFieldScript.convertFromDef(instant), equalTo(new long[] { instant.toEpochMilli() }));
+    }
+
+    public void testConvertFromTemporalAccessorArray() {
+        Instant[] instants = new Instant[] { randomInstant(), randomInstant() };
+        long[] expected = new long[] { instants[0].toEpochMilli(), instants[1].toEpochMilli() };
+        assertThat(DateScriptFieldScript.convertFromTemporalAccessorArray(instants), equalTo(expected));
+        assertThat(DateScriptFieldScript.convertFromDef(instants), equalTo(expected));
+    }
+
+    private Instant randomInstant() {
+        return Instant.ofEpochMilli(randomLongBetween(0, 1595431354874L));
+    }
+
+    public void testConvertFromCollection() {
+        long l = randomLong();
+        int i = randomInt();
+        short s = randomShort();
+        byte b = randomByte();
+        Instant instant = randomInstant();
+        List<?> collection = List.of(l, i, s, b, instant);
+        long[] result = new long[] { l, i, s, b, instant.toEpochMilli() };
+        assertThat(DateScriptFieldScript.convertFromCollection(collection), equalTo(result));
+        assertThat(DateScriptFieldScript.convertFromDef(collection), equalTo(result));
+    }
+
+    public void testConvertFromCollectionBad() {
+        Exception e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromCollection(List.of(1.0)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef(List.of(1.0)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromCollection(List.of(1.0F)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef(List.of(1.0F)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromCollection(List.of("1.0")));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.String")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef(List.of("1.0")));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.String")));
+    }
+
+    private String badCollectionConversionMessage(String cls) {
+        return "Exception casting collection member [1.0]: Can't cast [" + cls + "] to long, TemporalAccessor, int, short, or byte";
+    }
+
+    public void testConvertFromLongArrayFromDef() {
+        long[] a = new long[] { 1, 2, 3 };
+        assertThat(DateScriptFieldScript.convertFromDef(a), equalTo(a));
+    }
+
+    public void testConvertFromNumberInDef() {
+        for (Number n : new Number[] { randomByte(), randomShort(), randomInt() }) {
+            assertThat(DateScriptFieldScript.convertFromDef(n), equalTo(new long[] { n.longValue() }));
+        }
+    }
+
+    public void testConvertFromDefBad() {
+        Exception e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef(1.0));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef(1.0F));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> DateScriptFieldScript.convertFromDef("1.0"));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.String")));
+    }
+
+    private String badDefConversionMessage(String cls) {
+        return "Can't cast [" + cls + "] to long, long[], TemporalAccessor, TemporalAccessor[], int, short, byte, or a collection";
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -34,7 +34,7 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
         return DUMMY;
     }
 
-    public void testConvertDouble() {
+    public void testConvertFromDouble() {
         double v = randomDouble();
         assertThat(DoubleScriptFieldScript.convertFromDouble(v), equalTo(new double[] { v }));
         assertThat(DoubleScriptFieldScript.convertFromDef(v), equalTo(new double[] { v }));
@@ -48,12 +48,12 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
         assertThat(DoubleScriptFieldScript.convertFromDef(List.of(d, l, i)), equalTo(new double[] { d, l, i }));
     }
 
-    public void testConvertDoubleArrayFromDef() {
+    public void testConvertFromDoubleArrayFromDef() {
         double[] a = new double[] { 1, 2, 3 };
         assertThat(DoubleScriptFieldScript.convertFromDef(a), equalTo(a));
     }
 
-    public void testConvertNumberFromDef() {
+    public void testConvertFromNumberInDef() {
         for (Number n : new Number[] { randomByte(), randomShort(), randomInt(), randomLong(), randomFloat() }) {
             assertThat(DoubleScriptFieldScript.convertFromDef(n), equalTo(new double[] { n.doubleValue() }));
         }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
@@ -8,11 +8,15 @@ package org.elasticsearch.xpack.runtimefields;
 
 import org.elasticsearch.script.ScriptContext;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
 public class LongScriptFieldScriptTests extends ScriptFieldScriptTestCase<LongScriptFieldScript.Factory> {
     public static final LongScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new LongScriptFieldScript(params, lookup, ctx) {
         @Override
-        public void execute() {
-            new LongScriptFieldScript.Value(this).value(1);
+        public long[] execute() {
+            return new long[] { 1 };
         }
     };
 
@@ -24,5 +28,65 @@ public class LongScriptFieldScriptTests extends ScriptFieldScriptTestCase<LongSc
     @Override
     protected LongScriptFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testConvertFromLong() {
+        long l = randomLong();
+        assertThat(LongScriptFieldScript.convertFromLong(l), equalTo(new long[] { l }));
+        assertThat(LongScriptFieldScript.convertFromDef(l), equalTo(new long[] { l }));
+    }
+
+    public void testConvertFromCollection() {
+        long l = randomLong();
+        int i = randomInt();
+        short s = randomShort();
+        byte b = randomByte();
+        List<?> collection = List.of(l, i, s, b);
+        long[] result = new long[] { l, i, s, b };
+        assertThat(LongScriptFieldScript.convertFromCollection(collection), equalTo(result));
+        assertThat(LongScriptFieldScript.convertFromDef(collection), equalTo(result));
+    }
+
+    public void testConvertFromCollectionBad() {
+        Exception e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromCollection(List.of(1.0)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef(List.of(1.0)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromCollection(List.of(1.0F)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef(List.of(1.0F)));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromCollection(List.of("1.0")));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.String")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef(List.of("1.0")));
+        assertThat(e.getMessage(), equalTo(badCollectionConversionMessage("java.lang.String")));
+    }
+
+    private String badCollectionConversionMessage(String cls) {
+        return "Exception casting collection member [1.0]: Can't cast [" + cls + "] to long, int, short, or byte";
+    }
+
+    public void testConvertFromLongArrayFromDef() {
+        long[] a = new long[] { 1, 2, 3 };
+        assertThat(LongScriptFieldScript.convertFromDef(a), equalTo(a));
+    }
+
+    public void testConvertFromNumberInDef() {
+        for (Number n : new Number[] { randomByte(), randomShort(), randomInt() }) {
+            assertThat(LongScriptFieldScript.convertFromDef(n), equalTo(new long[] { n.longValue() }));
+        }
+    }
+
+    public void testConvertFromDefBad() {
+        Exception e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef(1.0));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.Double")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef(1.0F));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.Float")));
+        e = expectThrows(ClassCastException.class, () -> LongScriptFieldScript.convertFromDef("1.0"));
+        assertThat(e.getMessage(), equalTo(badDefConversionMessage("java.lang.String")));
+    }
+
+    private String badDefConversionMessage(String cls) {
+        return "Can't cast [" + cls + "] to long, long[], int, short, byte, or a collection";
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
@@ -411,21 +411,27 @@ public class ScriptBooleanMappedFieldTypeTests extends AbstractNonTextScriptMapp
                             case "read_foo":
                                 return (params, lookup) -> (ctx) -> new BooleanScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new BooleanScriptFieldScript.Value(this).value(parse(foo));
+                                    public boolean[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        boolean[] results = new boolean[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = parse(foo);
                                         }
+                                        return results;
                                     }
                                 };
                             case "xor_param":
                                 return (params, lookup) -> (ctx) -> new BooleanScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new BooleanScriptFieldScript.Value(this).value(
-                                                (Boolean) foo ^ ((Boolean) getParams().get("param"))
-                                            );
+                                    public boolean[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        boolean[] results = new boolean[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = parse(foo) ^ ((Boolean) getParams().get("param"));
                                         }
+                                        return results;
                                     }
                                 };
                             default:

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
@@ -269,21 +269,27 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                             case "read_foo":
                                 return (params, lookup) -> (ctx) -> new LongScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new LongScriptFieldScript.Value(this).value(((Number) foo).longValue());
+                                    public long[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        long[] results = new long[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = ((Number) foo).longValue();
                                         }
+                                        return results;
                                     }
                                 };
                             case "add_param":
                                 return (params, lookup) -> (ctx) -> new LongScriptFieldScript(params, lookup, ctx) {
                                     @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new LongScriptFieldScript.Value(this).value(
-                                                ((Number) foo).longValue() + ((Number) getParams().get("param")).longValue()
-                                            );
+                                    public long[] execute() {
+                                        List<?> foos = (List<?>) getSource().get("foo");
+                                        long[] results = new long[foos.size()];
+                                        int i = 0;
+                                        for (Object foo : foos) {
+                                            results[i++] = ((Number) foo).longValue() + ((Number) getParams().get("param")).longValue();
                                         }
+                                        return results;
                                     }
                                 };
                             default:

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQueryTests.java
@@ -29,10 +29,10 @@ public class BooleanScriptFieldExistsQueryTests extends AbstractBooleanScriptFie
 
     @Override
     public void testMatches() {
-        assertTrue(createTestInstance().matches(between(1, Integer.MAX_VALUE), 0));
-        assertTrue(createTestInstance().matches(0, between(1, Integer.MAX_VALUE)));
-        assertTrue(createTestInstance().matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
-        assertFalse(createTestInstance().matches(0, 0));
+        assertTrue(createTestInstance().matches(new boolean[] { true }));
+        assertTrue(createTestInstance().matches(new boolean[] { false }));
+        assertTrue(createTestInstance().matches(new boolean[] { true, true }));
+        assertFalse(createTestInstance().matches(new boolean[] {}));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQueryTests.java
@@ -48,15 +48,15 @@ public class BooleanScriptFieldTermQueryTests extends AbstractBooleanScriptField
 
     @Override
     public void testMatches() {
-        assertTrue(createTestInstance(true).matches(between(1, Integer.MAX_VALUE), 0));
-        assertFalse(createTestInstance(true).matches(0, between(1, Integer.MAX_VALUE)));
-        assertTrue(createTestInstance(true).matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
+        assertTrue(createTestInstance(true).matches(new boolean[] { true }));
+        assertFalse(createTestInstance(true).matches(new boolean[] { false }));
+        assertTrue(createTestInstance(true).matches(new boolean[] { true, false }));
 
-        assertFalse(createTestInstance(false).matches(between(1, Integer.MAX_VALUE), 0));
-        assertTrue(createTestInstance(false).matches(0, between(1, Integer.MAX_VALUE)));
-        assertTrue(createTestInstance(false).matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
+        assertFalse(createTestInstance(false).matches(new boolean[] { true }));
+        assertTrue(createTestInstance(false).matches(new boolean[] { false }));
+        assertTrue(createTestInstance(false).matches(new boolean[] { true, false }));
 
-        assertFalse(createTestInstance().matches(0, 0));
+        assertFalse(createTestInstance().matches(new boolean[] {}));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
@@ -89,10 +89,14 @@ public class LongScriptFieldDistanceFeatureQueryTests extends AbstractScriptFiel
                 CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory =
                     ctx -> new DateScriptFieldScript(Map.of(), new SearchLookup(null, null), null, ctx) {
                         @Override
-                        public void execute() {
-                            for (Object timestamp : (List<?>) getSource().get("timestamp")) {
-                                new DateScriptFieldScript.Millis(this).millis(((Number) timestamp).longValue());
+                        public long[] execute() {
+                            List<?> timestamps = (List<?>) getSource().get("timestamp");
+                            long[] results = new long[timestamps.size()];
+                            int i = 0;
+                            for (Object timestamp : timestamps) {
+                                results[i++] = ((Number) timestamp).longValue();
                             }
+                            return results;
                         }
                     };
                 LongScriptFieldDistanceFeatureQuery query = new LongScriptFieldDistanceFeatureQuery(

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
@@ -29,9 +29,8 @@ public class LongScriptFieldExistsQueryTests extends AbstractLongScriptFieldQuer
 
     @Override
     public void testMatches() {
-        assertTrue(createTestInstance().matches(new long[0], randomIntBetween(1, Integer.MAX_VALUE)));
-        assertFalse(createTestInstance().matches(new long[0], 0));
-        assertFalse(createTestInstance().matches(new long[] { 1, 2, 3 }, 0));
+        assertTrue(createTestInstance().matches(new long[] { 1 }));
+        assertFalse(createTestInstance().matches(new long[] {}));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
@@ -65,13 +65,13 @@ public class LongScriptFieldRangeQueryTests extends AbstractLongScriptFieldQuery
     @Override
     public void testMatches() {
         LongScriptFieldRangeQuery query = new LongScriptFieldRangeQuery(randomScript(), leafFactory, "test", 1, 3);
-        assertTrue(query.matches(new long[] { 1 }, 1));
-        assertTrue(query.matches(new long[] { 2 }, 1));
-        assertTrue(query.matches(new long[] { 3 }, 1));
-        assertFalse(query.matches(new long[] { 1 }, 0));
-        assertFalse(query.matches(new long[] { 5 }, 1));
-        assertTrue(query.matches(new long[] { 1, 5 }, 2));
-        assertTrue(query.matches(new long[] { 5, 1 }, 2));
+        assertTrue(query.matches(new long[] { 1 }));
+        assertTrue(query.matches(new long[] { 2 }));
+        assertTrue(query.matches(new long[] { 3 }));
+        assertFalse(query.matches(new long[] {}));
+        assertFalse(query.matches(new long[] { 5 }));
+        assertTrue(query.matches(new long[] { 1, 5 }));
+        assertTrue(query.matches(new long[] { 5, 1 }));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQueryTests.java
@@ -46,10 +46,10 @@ public class LongScriptFieldTermQueryTests extends AbstractLongScriptFieldQueryT
     @Override
     public void testMatches() {
         LongScriptFieldTermQuery query = new LongScriptFieldTermQuery(randomScript(), leafFactory, "test", 1);
-        assertTrue(query.matches(new long[] { 1 }, 1));     // Match because value matches
-        assertFalse(query.matches(new long[] { 2 }, 1));    // No match because wrong value
-        assertFalse(query.matches(new long[] { 2, 1 }, 1)); // No match because value after count of values
-        assertTrue(query.matches(new long[] { 2, 1 }, 2));  // Match because one value matches
+        assertTrue(query.matches(new long[] { 1 }));
+        assertFalse(query.matches(new long[] { 2 }));
+        assertFalse(query.matches(new long[] {}));
+        assertTrue(query.matches(new long[] { 2, 1 }));
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
@@ -56,13 +56,13 @@ public class LongScriptFieldTermsQueryTests extends AbstractLongScriptFieldQuery
     @Override
     public void testMatches() {
         LongScriptFieldTermsQuery query = new LongScriptFieldTermsQuery(randomScript(), leafFactory, "test", LongHashSet.from(1, 2, 3));
-        assertTrue(query.matches(new long[] { 1 }, 1));
-        assertTrue(query.matches(new long[] { 2 }, 1));
-        assertTrue(query.matches(new long[] { 3 }, 1));
-        assertTrue(query.matches(new long[] { 1, 0 }, 2));
-        assertTrue(query.matches(new long[] { 0, 1 }, 2));
-        assertFalse(query.matches(new long[] { 0 }, 1));
-        assertFalse(query.matches(new long[] { 0, 1 }, 1));
+        assertTrue(query.matches(new long[] { 1 }));
+        assertTrue(query.matches(new long[] { 2 }));
+        assertTrue(query.matches(new long[] { 3 }));
+        assertTrue(query.matches(new long[] { 1, 0 }));
+        assertTrue(query.matches(new long[] { 0, 1 }));
+        assertFalse(query.matches(new long[] { 0 }));
+        assertFalse(query.matches(new long[] {}));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -22,18 +22,31 @@ setup:
                 runtime_type: long
                 script:
                   source: |
-                    for (double v : doc['voltage']) {
-                      value((long)(v * params.multiplier));
+                    def voltage = doc['voltage'];
+                    long[] result = new long[voltage.size()];
+                    int i = 0;
+                    for (double v : voltage) {
+                      result[i++] = (long)(v * params.multiplier);
                     }
+                    return result;
                   params:
                     multiplier: 10
-              # Test fetching from _source
+              # Test fetching from _source and def to long[] conversion
               voltage_times_ten_from_source:
                 type: runtime_script
                 runtime_type: long
                 script:
                   source: |
-                    value((long)(source['voltage'] * params.multiplier));
+                    Math.round(source['voltage'] * params.multiplier)
+                  params:
+                    multiplier: 10
+              # Test long to long[] conversion
+              voltage_times_ten_long_conversion:
+                type: runtime_script
+                runtime_type: long
+                script:
+                  source: |
+                    (long)(source['voltage'] * params.multiplier)
                   params:
                     multiplier: 10
               # Test fetching many values
@@ -42,13 +55,15 @@ setup:
                 runtime_type: long
                 script:
                   source: |
+                    List result = new ArrayList();
                     for (long temperature : doc['temperature']) {
                       long t = temperature;
                       while (t != 0) {
-                        value(t % 10);
+                        result.add(t % 10);
                         t /= 10;
                       }
                     }
+                    return result;
 
   - do:
       bulk:
@@ -77,9 +92,13 @@ setup:
   - match: {sensor.mappings.properties.voltage_times_ten.runtime_type: long }
   - match:
       sensor.mappings.properties.voltage_times_ten.script.source: |
-        for (double v : doc['voltage']) {
-          value((long)(v * params.multiplier));
+        def voltage = doc['voltage'];
+        long[] result = new long[voltage.size()];
+        int i = 0;
+        for (double v : voltage) {
+          result[i++] = (long)(v * params.multiplier);
         }
+        return result;
   - match: {sensor.mappings.properties.voltage_times_ten.script.params: {multiplier: 10} }
   - match: {sensor.mappings.properties.voltage_times_ten.script.lang: painless }
 
@@ -90,10 +109,15 @@ setup:
         index: sensor
         body:
           sort: timestamp
-          docvalue_fields: [voltage_times_ten, voltage_times_ten_from_source, temperature_digits]
+          docvalue_fields:
+            - voltage_times_ten
+            - voltage_times_ten_from_source
+            - voltage_times_ten_long_conversion
+            - temperature_digits
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_times_ten: [40] }
   - match: {hits.hits.0.fields.voltage_times_ten_from_source: [40] }
+  - match: {hits.hits.0.fields.voltage_times_ten_long_conversion: [40] }
   - match: {hits.hits.0.fields.temperature_digits: [0, 2, 2] }
   - match: {hits.hits.0.fields.voltage_times_ten: [40] }
   - match: {hits.hits.1.fields.voltage_times_ten: [42] }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -22,9 +22,11 @@ setup:
                 runtime_type: date
                 script:
                   source: |
+                    List result = new ArrayList();
                     for (def dt : doc['timestamp']) {
-                      date(dt.plus(params.days, ChronoUnit.DAYS));
+                      result.add(dt.plus(params.days, ChronoUnit.DAYS));
                     }
+                    return result;
                   params:
                     days: 1
               # Test fetching from _source and parsing
@@ -35,36 +37,38 @@ setup:
                   source: |
                     Instant instant = Instant.ofEpochMilli(parse(source['timestamp']));
                     ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
-                    date(dt.plus(1, ChronoUnit.DAYS));
+                    return dt.plus(1, ChronoUnit.DAYS);
               # Test returning millis
               the_past:
                 type: runtime_script
                 runtime_type: date
                 script:
                   source: |
-                    for (def dt : doc['timestamp']) {
-                      millis(dt.toInstant().toEpochMilli() - 1000);
-                    }
+                    doc['timestamp'].value.toInstant().toEpochMilli() - 1000;
               # Test fetching many values
               all_week:
                 type: runtime_script
                 runtime_type: date
                 script:
                   source: |
+                    List result = new ArrayList();
                     for (def dt : doc['timestamp']) {
                       for (int i = 0; i < 7; i++) {
-                        date(dt.plus(i, ChronoUnit.DAYS));
+                        result.add(dt.plus(i, ChronoUnit.DAYS));
                       }
                     }
+                    return result;
               # Test format parameter
               formatted_tomorrow:
                 type: runtime_script
                 runtime_type: date
                 format: yyyy-MM-dd
                 script: |
+                  List result = new ArrayList();
                   for (def dt : doc['timestamp']) {
-                    date(dt.plus(1, ChronoUnit.DAYS));
+                    result.add(dt.plus(1, ChronoUnit.DAYS));
                   }
+                  return result;
 
   - do:
       bulk:
@@ -93,9 +97,11 @@ setup:
   - match: {sensor.mappings.properties.tomorrow.runtime_type: date }
   - match:
       sensor.mappings.properties.tomorrow.script.source: |
+        List result = new ArrayList();
         for (def dt : doc['timestamp']) {
-          date(dt.plus(params.days, ChronoUnit.DAYS));
+          result.add(dt.plus(params.days, ChronoUnit.DAYS));
         }
+        return result;
   - match: {sensor.mappings.properties.tomorrow.script.params: {days: 1} }
   - match: {sensor.mappings.properties.tomorrow.script.lang: painless }
 
@@ -103,9 +109,11 @@ setup:
   - match: {sensor.mappings.properties.formatted_tomorrow.runtime_type: date }
   - match:
       sensor.mappings.properties.formatted_tomorrow.script.source: |
+        List result = new ArrayList();
         for (def dt : doc['timestamp']) {
-          date(dt.plus(1, ChronoUnit.DAYS));
+          result.add(dt.plus(1, ChronoUnit.DAYS));
         }
+        return result;
   - match: {sensor.mappings.properties.formatted_tomorrow.script.lang: painless }
   - match: {sensor.mappings.properties.formatted_tomorrow.format: yyyy-MM-dd }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
@@ -22,9 +22,13 @@ setup:
                 runtime_type: boolean
                 script:
                   source: |
-                    for (def v : doc['voltage']) {
-                      value(v >= params.min_v);
+                    def voltage = doc['voltage'];
+                    boolean[] result = new boolean[voltage.size()];
+                    int i = 0;
+                    for (double v : voltage) {
+                      result[i++] = v >= params.min_v;
                     }
+                    return result;
                   params:
                     min_v: 5.0
               # Test fetching from _source
@@ -33,21 +37,21 @@ setup:
                 runtime_type: boolean
                 script:
                   source: |
-                    value(source['voltage'] >= 5.0);
+                    source['voltage'] >= 5.0;
               # Test many booleans
               big_vals:
                 type: runtime_script
                 runtime_type: boolean
                 script:
                   source: |
+                    List results = new ArrayList();
                     for (def v : doc['temperature']) {
-                      value(v >= 200);
+                      results.add(v >= 200);
                     }
                     for (def v : doc['voltage']) {
-                      value(v >= 5.0);
+                      results.add(v >= 5.0);
                     }
-
-
+                    return results;
 
   - do:
       bulk:
@@ -76,9 +80,13 @@ setup:
   - match: {sensor.mappings.properties.over_v.runtime_type: boolean }
   - match:
       sensor.mappings.properties.over_v.script.source: |
-        for (def v : doc['voltage']) {
-          value(v >= params.min_v);
+        def voltage = doc['voltage'];
+        boolean[] result = new boolean[voltage.size()];
+        int i = 0;
+        for (double v : voltage) {
+          result[i++] = v >= params.min_v;
         }
+        return result;
   - match: {sensor.mappings.properties.over_v.script.params: {min_v: 5.0} }
   - match: {sensor.mappings.properties.over_v.script.lang: painless }
 


### PR DESCRIPTION
This converts more runtime field scripts from the callback mechanism to
return arrays which is more compatible with aggregation scripts. Its
`instanceof`-tastic, but some of those will go away #61389. Not all of
them, but some of them.
