### PR TITLE
[ML] Check and install the latest template in the DFA executor

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -242,7 +242,7 @@ public final class MlIndexAndAlias {
         String templateName = templateConfig.getTemplateName();
 
         // The check for existence of the template is against the cluster state, so very cheap
-        if (haveIndexTemplate(clusterState, templateName)) {
+        if (hasIndexTemplate(clusterState, templateName)) {
             listener.onResponse(true);
             return;
         }
@@ -254,7 +254,7 @@ public final class MlIndexAndAlias {
         ActionListener<AcknowledgedResponse> innerListener = ActionListener.wrap(
             response ->  {
                 if (response.isAcknowledged() == false) {
-                    logger.error("error adding legacy template [{}], request was not acknowledged", templateName);
+                    logger.warn("error adding legacy template [{}], request was not acknowledged", templateName);
                 }
                 listener.onResponse(response.isAcknowledged());
             },
@@ -264,7 +264,7 @@ public final class MlIndexAndAlias {
             client.admin().indices()::putTemplate);
     }
 
-    static boolean haveIndexTemplate(ClusterState state, String templateName) {
+    private static boolean hasIndexTemplate(ClusterState state, String templateName) {
         return state.getMetadata().getTemplates().containsKey(templateName);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
@@ -25,6 +26,9 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -214,5 +218,53 @@ public final class MlIndexAndAlias {
                 resp -> listener.onResponse(resp.isAcknowledged()),
                 listener::onFailure),
             client.admin().indices()::aliases);
+    }
+
+    /**
+     * Installs the index template specified by {@code templateConfig} if it is not in already
+     * installed in {@code clusterState}.
+     *
+     * The check for presence is simple and will return the listener on
+     * the calling thread if successful. If the template has to be installed
+     * an async call will be made.
+     *
+     * @param clusterState The cluster state
+     * @param client For putting the template
+     * @param templateConfig The config
+     * @param listener Async listener
+     */
+    public static void installIndexTemplateIfRequired(
+        ClusterState clusterState,
+        Client client,
+        IndexTemplateConfig templateConfig,
+        ActionListener<Void> listener
+    ) {
+        String templateName = templateConfig.getTemplateName();
+
+        // The check for existence of the template is against the cluster state, so very cheap
+        if (haveIndexTemplate(clusterState, templateName)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        PutIndexTemplateRequest request = new PutIndexTemplateRequest(templateName)
+            .source(templateConfig.loadBytes(), XContentType.JSON);
+        request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+
+        ActionListener<AcknowledgedResponse> innerListener = ActionListener.wrap(
+            response ->  {
+                if (response.isAcknowledged() == false) {
+                    logger.error("error adding legacy template [{}], request was not acknowledged", templateName);
+                }
+                listener.onResponse(null);
+            },
+            listener::onFailure);
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, request, innerListener,
+            client.admin().indices()::putTemplate);
+    }
+
+    static boolean haveIndexTemplate(ClusterState state, String templateName) {
+        return state.getMetadata().getTemplates().containsKey(templateName);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -237,13 +237,13 @@ public final class MlIndexAndAlias {
         ClusterState clusterState,
         Client client,
         IndexTemplateConfig templateConfig,
-        ActionListener<Void> listener
+        ActionListener<Boolean> listener
     ) {
         String templateName = templateConfig.getTemplateName();
 
         // The check for existence of the template is against the cluster state, so very cheap
         if (haveIndexTemplate(clusterState, templateName)) {
-            listener.onResponse(null);
+            listener.onResponse(true);
             return;
         }
 
@@ -256,7 +256,7 @@ public final class MlIndexAndAlias {
                 if (response.isAcknowledged() == false) {
                     logger.error("error adding legacy template [{}], request was not acknowledged", templateName);
                 }
-                listener.onResponse(null);
+                listener.onResponse(response.isAcknowledged());
             },
             listener::onFailure);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -28,12 +28,15 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -88,6 +91,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         doAnswer(withResponse(new CreateIndexResponse(true, true, FIRST_CONCRETE_INDEX))).when(indicesAdminClient).create(any(), any());
         when(indicesAdminClient.prepareAliases()).thenReturn(new IndicesAliasesRequestBuilder(client, IndicesAliasesAction.INSTANCE));
         doAnswer(withResponse(new AcknowledgedResponse(true))).when(indicesAdminClient).aliases(any(), any());
+        doAnswer(withResponse(new AcknowledgedResponse(true))).when(indicesAdminClient).putTemplate(any(), any());
 
         clusterAdminClient = mock(ClusterAdminClient.class);
         doAnswer(invocationOnMock -> {
@@ -114,6 +118,34 @@ public class MlIndexAndAliasTests extends ESTestCase {
     @After
     public void verifyNoMoreInteractionsWithMocks() {
         verifyNoMoreInteractions(indicesAdminClient, listener);
+    }
+
+    public void testInstallIndexTemplateIfRequired_TemplateExist() {
+        ClusterState clusterState = createClusterState(Collections.emptyMap(),
+            Collections.singletonMap(InferenceIndexConstants.LATEST_INDEX_NAME,
+                createIndexTemplateMetaData(InferenceIndexConstants.LATEST_INDEX_NAME,
+                    Collections.singletonList(InferenceIndexConstants.LATEST_INDEX_NAME))));
+
+        IndexTemplateConfig inferenceTemplate = new IndexTemplateConfig(InferenceIndexConstants.LATEST_INDEX_NAME,
+            "not_a_real_file.json", Version.CURRENT.id, "xpack.ml.version",
+            Collections.singletonMap("xpack.ml.version.id", String.valueOf(Version.CURRENT.id)));
+
+        MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, inferenceTemplate, listener);
+        verify(listener).onResponse(true);
+        verifyNoMoreInteractions(client);
+    }
+
+    public void testInstallIndexTemplateIfRequired() {
+        ClusterState clusterState = createClusterState(Collections.emptyMap());
+
+        IndexTemplateConfig inferenceTemplate = new IndexTemplateConfig(InferenceIndexConstants.LATEST_INDEX_NAME,
+            "/org/elasticsearch/xpack/core/ml/inference_index_template.json", Version.CURRENT.id, "xpack.ml.version",
+            Collections.singletonMap("xpack.ml.version.id", String.valueOf(Version.CURRENT.id)));
+
+        MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, inferenceTemplate, listener);
+        InOrder inOrder = inOrder(indicesAdminClient, listener);
+        inOrder.verify(indicesAdminClient).putTemplate(any(), any());
+        inOrder.verify(listener).onResponse(true);
     }
 
     public void testCreateStateIndexAndAliasIfNecessary_CleanState() {
@@ -261,9 +293,15 @@ public class MlIndexAndAliasTests extends ESTestCase {
     }
 
     private static ClusterState createClusterState(Map<String, IndexMetadata> indices) {
+        return createClusterState(indices, Collections.emptyMap());
+    }
+
+    private static ClusterState createClusterState(Map<String, IndexMetadata> indices, Map<String, IndexTemplateMetadata> templates) {
         return ClusterState.builder(ClusterName.DEFAULT)
             .metadata(Metadata.builder()
-                .indices(ImmutableOpenMap.<String, IndexMetadata>builder().putAll(indices).build()).build())
+                .indices(ImmutableOpenMap.<String, IndexMetadata>builder().putAll(indices).build())
+                .templates(ImmutableOpenMap.<String, IndexTemplateMetadata>builder().putAll(templates).build())
+                .build())
             .build();
     }
 
@@ -273,6 +311,10 @@ public class MlIndexAndAliasTests extends ESTestCase {
 
     private static IndexMetadata createIndexMetadataWithAlias(String indexName) {
         return createIndexMetadata(indexName, true);
+    }
+
+    private static IndexTemplateMetadata createIndexTemplateMetaData(String templateName, List<String> patterns) {
+        return IndexTemplateMetadata.builder(templateName).patterns(patterns).build();
     }
 
     private static IndexMetadata createIndexMetadata(String indexName, boolean withAlias) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -120,7 +120,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         verifyNoMoreInteractions(indicesAdminClient, listener);
     }
 
-    public void testInstallIndexTemplateIfRequired_TemplateExist() {
+    public void testInstallIndexTemplateIfRequired_GivenTemplateExists() {
         ClusterState clusterState = createClusterState(Collections.emptyMap(),
             Collections.singletonMap(InferenceIndexConstants.LATEST_INDEX_NAME,
                 createIndexTemplateMetaData(InferenceIndexConstants.LATEST_INDEX_NAME,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -789,7 +789,8 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                     memoryTracker.get(), client, expressionResolver),
                 new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedManager.get(), expressionResolver),
                 new TransportStartDataFrameAnalyticsAction.TaskExecutor(settings, client, clusterService, dataFrameAnalyticsManager.get(),
-                    dataFrameAnalyticsAuditor.get(), memoryTracker.get(), expressionResolver)
+                    dataFrameAnalyticsAuditor.get(), memoryTracker.get(), expressionResolver,
+                    MlIndexTemplateRegistry.INFERENCE_TEMPLATE)
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -52,7 +52,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private static final IndexTemplateConfig CONFIG_TEMPLATE = configTemplate();
 
-    private static final IndexTemplateConfig INFERENCE_TEMPLATE = new IndexTemplateConfig(InferenceIndexConstants.LATEST_INDEX_NAME,
+    public static final IndexTemplateConfig INFERENCE_TEMPLATE = new IndexTemplateConfig(InferenceIndexConstants.LATEST_INDEX_NAME,
         ROOT_RESOURCE_PATH + "inference_index_template.json", Version.CURRENT.id, VERSION_PATTERN,
         Collections.singletonMap(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id)));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -706,7 +706,10 @@ public class TransportStartDataFrameAnalyticsAction
             ActionListener<Boolean> templateCheckListener = ActionListener.wrap(
                 ok -> executeTask(analyticsTaskState, task),
                 error -> {
-
+                    Throwable cause = ExceptionsHelper.unwrapCause(error);
+                    String msg = "Failed to create internal index template [" + inferenceIndexTemplate.getTemplateName() + "]";
+                    logger.error(msg, cause);
+                    task.markAsFailed(error);
                 }
             );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -67,7 +67,9 @@ import org.elasticsearch.xpack.core.ml.dataframe.analyses.RequiredField;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
+import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
@@ -599,6 +601,7 @@ public class TransportStartDataFrameAnalyticsAction
         private final DataFrameAnalyticsAuditor auditor;
         private final MlMemoryTracker memoryTracker;
         private final IndexNameExpressionResolver resolver;
+        private final IndexTemplateConfig inferenceIndexTemplate;
 
         private volatile int maxMachineMemoryPercent;
         private volatile int maxLazyMLNodes;
@@ -606,7 +609,8 @@ public class TransportStartDataFrameAnalyticsAction
         private volatile ClusterState clusterState;
 
         public TaskExecutor(Settings settings, Client client, ClusterService clusterService, DataFrameAnalyticsManager manager,
-                            DataFrameAnalyticsAuditor auditor, MlMemoryTracker memoryTracker, IndexNameExpressionResolver resolver) {
+                            DataFrameAnalyticsAuditor auditor, MlMemoryTracker memoryTracker, IndexNameExpressionResolver resolver,
+                            IndexTemplateConfig inferenceIndexTemplate) {
             super(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, MachineLearning.UTILITY_THREAD_POOL_NAME);
             this.client = Objects.requireNonNull(client);
             this.clusterService = Objects.requireNonNull(clusterService);
@@ -614,6 +618,7 @@ public class TransportStartDataFrameAnalyticsAction
             this.auditor = Objects.requireNonNull(auditor);
             this.memoryTracker = Objects.requireNonNull(memoryTracker);
             this.resolver = Objects.requireNonNull(resolver);
+            this.inferenceIndexTemplate = Objects.requireNonNull(inferenceIndexTemplate);
             this.maxMachineMemoryPercent = MachineLearning.MAX_MACHINE_MEMORY_PERCENT.get(settings);
             this.maxLazyMLNodes = MachineLearning.MAX_LAZY_ML_NODES.get(settings);
             this.maxOpenJobs = MAX_OPEN_JOBS_PER_NODE.get(settings);
@@ -698,6 +703,17 @@ public class TransportStartDataFrameAnalyticsAction
                 return;
             }
 
+            ActionListener<Void> templateCheckListener = ActionListener.wrap(
+                ok -> executeTask(analyticsTaskState, task),
+                error -> {
+
+                }
+            );
+
+            MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, inferenceIndexTemplate, templateCheckListener);
+        }
+
+        private void executeTask(DataFrameAnalyticsTaskState analyticsTaskState, AllocatedPersistentTask task) {
             if (analyticsTaskState == null) {
                 DataFrameAnalyticsTaskState startedState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.STARTED,
                     task.getAllocationId(), null);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -703,7 +703,7 @@ public class TransportStartDataFrameAnalyticsAction
                 return;
             }
 
-            ActionListener<Void> templateCheckListener = ActionListener.wrap(
+            ActionListener<Boolean> templateCheckListener = ActionListener.wrap(
                 ok -> executeTask(analyticsTaskState, task),
                 error -> {
 


### PR DESCRIPTION
After an upgrade new templates are installed by the master node. During a rolling upgrade it is possible that a worker node will be upgraded before the master in which case the required templates will not have been installed. If the worker creates the new index it will be created without any mappings as the matching template has not bee installed yet.

Before a DFA task starts check that the latest template is installed and install it if necessary. 

Non issue as this addresses a problem in unreleased code