### PR TITLE
Several minor Painless fixes

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/BlockNode.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/BlockNode.java
@@ -44,7 +44,6 @@ public class BlockNode extends StatementNode {
     /* ---- end tree structure, begin node data ---- */
 
     private boolean doAllEscape;
-    private int statementCount;
 
     public void setAllEscape(boolean doAllEscape) {
         this.doAllEscape = doAllEscape;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/BlockNode.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/BlockNode.java
@@ -54,14 +54,6 @@ public class BlockNode extends StatementNode {
         return doAllEscape;
     }
 
-    public void setStatementCount(int statementCount) {
-        this.statementCount = statementCount;
-    }
-
-    public int getStatementCount() {
-        return statementCount;
-    }
-
     /* ---- end node data, begin visitor ---- */
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/ClassNode.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ir/ClassNode.java
@@ -111,7 +111,6 @@ public class ClassNode extends IRNode {
         clinitBlockNode = new BlockNode();
         clinitBlockNode.setLocation(new Location("internal$clinit$blocknode", 0));
         clinitBlockNode.setAllEscape(true);
-        clinitBlockNode.setStatementCount(1);
     }
 
     public byte[] write() {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -402,7 +402,7 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
                 }
 
                 scope.accept(irLeftConstantNode);
-            } else if (operation == Operation.OR) {
+            } else if (operation == Operation.BWOR) {
                 if (type == int.class) {
                     irLeftConstantNode.setConstant((int)irLeftConstantNode.getConstant() | (int)irRightConstantNode.getConstant());
                 } else if (type == long.class) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -308,7 +308,7 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
                 semanticScope.replicateCondition(userStatementNode, userBlockNode, LoopEscape.class);
 
                 if (allEscape) {
-                    semanticScope.setCondition(userStatementNode, AllEscape.class);
+                    semanticScope.setCondition(userBlockNode, AllEscape.class);
                 }
             } else {
                 if (allEscape) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -265,7 +265,6 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
             BlockNode blockNode = new BlockNode();
             blockNode.setLocation(internalLocation);
             blockNode.setAllEscape(true);
-            blockNode.setStatementCount(1);
 
             irFunctionNode.setBlockNode(blockNode);
 
@@ -1454,7 +1453,6 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
 
         BlockNode irBlockNode = new BlockNode();
         irBlockNode.setAllEscape(true);
-        irBlockNode.setStatementCount(1);
         irBlockNode.addStatementNode(irReturnNode);
 
         FunctionNode irFunctionNode = new FunctionNode();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -199,7 +199,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
         BlockNode irBlockNode = new BlockNode();
         irBlockNode.setLocation(internalLocation);
         irBlockNode.setAllEscape(true);
-        irBlockNode.setStatementCount(1);
 
         irFunctionNode.setBlockNode(irBlockNode);
 
@@ -230,7 +229,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
         irBlockNode = new BlockNode();
         irBlockNode.setLocation(internalLocation);
         irBlockNode.setAllEscape(true);
-        irBlockNode.setStatementCount(1);
 
         irFunctionNode.setBlockNode(irBlockNode);
 
@@ -261,7 +259,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
         irBlockNode = new BlockNode();
         irBlockNode.setLocation(internalLocation);
         irBlockNode.setAllEscape(true);
-        irBlockNode.setStatementCount(1);
 
         irFunctionNode.setBlockNode(irBlockNode);
 
@@ -333,7 +330,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
             BlockNode irBlockNode = new BlockNode();
             irBlockNode.setLocation(internalLocation);
             irBlockNode.setAllEscape(true);
-            irBlockNode.setStatementCount(1);
 
             irFunctionNode.setBlockNode(irBlockNode);
 
@@ -379,7 +375,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
             BlockNode irCatchBlockNode = new BlockNode();
             irCatchBlockNode.setLocation(internalLocation);
             irCatchBlockNode.setAllEscape(true);
-            irCatchBlockNode.setStatementCount(1);
 
             irCatchNode.setBlockNode(irCatchBlockNode);
 
@@ -467,7 +462,6 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
                 irCatchBlockNode = new BlockNode();
                 irCatchBlockNode.setLocation(internalLocation);
                 irCatchBlockNode.setAllEscape(true);
-                irCatchBlockNode.setStatementCount(1);
 
                 irCatchNode.setBlockNode(irCatchBlockNode);
 
@@ -530,9 +524,8 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
             }
 
             irBlockNode = new BlockNode();
-            irBlockNode.setLocation(irBlockNode.getLocation());
-            irBlockNode.setAllEscape(irBlockNode.doAllEscape());
-            irBlockNode.setStatementCount(irBlockNode.getStatementCount());
+            irBlockNode.setLocation(internalLocation);
+            irBlockNode.setAllEscape(true);
             irBlockNode.addStatementNode(irTryNode);
 
             irFunctionNode.setBlockNode(irBlockNode);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ConstantFoldingTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ConstantFoldingTests.java
@@ -54,13 +54,13 @@ public class ConstantFoldingTests extends ScriptTestCase {
         assertBytecodeExists("4L>>1L", "LDC 2");
         assertBytecodeExists("4>>>1", "ICONST_2");
         assertBytecodeExists("4L>>>1L", "LDC 2");
-        assertBytecodeExists("3&1", "ICONST_1");
-        assertBytecodeExists("3L&1L", "LDC 1");
+        assertBytecodeExists("5&3", "ICONST_1");
+        assertBytecodeExists("5L&3L", "LDC 1");
         assertBytecodeExists("true^false", "ICONST_1");
-        assertBytecodeExists("3^1", "ICONST_2");
-        assertBytecodeExists("3L^1L", "LDC 2");
-        assertBytecodeExists("3|1", "ICONST_3");
-        assertBytecodeExists("3L|1L", "LDC 3");
+        assertBytecodeExists("5^3", "BIPUSH 6");
+        assertBytecodeExists("5L^3L", "LDC 6");
+        assertBytecodeExists("5|3", "BIPUSH 7");
+        assertBytecodeExists("5L|3L", "LDC 7");
     }
 
     public void testStringConcatenation() {


### PR DESCRIPTION
This fixes the following based on bytecode comparisons between Painless in ES 7.x and 8.0:
1. Remove statement count from BlockNode as it's no longer used anywhere.
2. Fix the block node to properly decorate itself with all paths escape. This was adding extra unreachable gotos and labels.
3. Fix the block node generation for wrapping scripts with our standard exceptions. It was pulling data from itself which was the defaults rather than appropriately generated data.
4. Fix constant folding to actually look at bitwise or instead of boolean or in binary math operations. This comes with updated tests which weren't working due to not using unique constants so we were finding the right byte code doing the wrong operation.