### PR TITLE
Search - add case insensitive flag for "term" family of queries

### DIFF
--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -41,6 +41,10 @@ provided `<field>`.
 (Optional, string) Method used to rewrite the query. For valid values and more
 information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
+`case_insensitive`::
+(Optional, boolean) allows ASCII case insensitive matching of the
+value with the indexed field values when set to true. Setting to false is disallowed.
+
 [[prefix-query-notes]]
 ==== Notes
 

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -62,6 +62,10 @@ Boost values are relative to the default value of `1.0`. A boost value between
 `0` and `1.0` decreases the relevance score. A value greater than `1.0`
 increases the relevance score.
 
+`case_insensitive`::
+(Optional, boolean) allows ASCII case insensitive matching of the
+value with the indexed field values when set to true. Setting to false is disallowed.
+
 [[term-query-notes]]
 ==== Notes
 
@@ -84,7 +88,7 @@ The `term` query does *not* analyze the search term. The `term` query only
 searches for the *exact* term you provide. This means the `term` query may
 return poor or no results when searching `text` fields.
 
-To see the difference in search results, try the following example.  
+To see the difference in search results, try the following example.
 
 . Create an index with a `text` field called `full_text`.
 +

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -52,7 +52,7 @@ This parameter supports two wildcard operators:
 
 WARNING: Avoid beginning patterns with `*` or `?`. This can increase
 the iterations needed to find matching terms and slow search performance.
--- 
+--
 
 `boost`::
 (Optional, float) Floating point number used to decrease or increase the
@@ -68,6 +68,10 @@ increases the relevance score.
 `rewrite`::
 (Optional, string) Method used to rewrite the query. For valid values and more information, see the
 <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
+
+`case_insensitive`::
+(Optional, boolean) allows case insensitive matching of the
+pattern with the indexed field values when set to true. Setting to false is disallowed.
 
 [[wildcard-query-notes]]
 ==== Notes

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -281,11 +281,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
             if (prefixField == null || prefixField.termLengthWithinBounds(value.length()) == false) {
-                return super.prefixQuery(value, method, context);
+                return super.prefixQuery(value, method, caseInsensitive, context);
             } else {
-                final Query query = prefixField.prefixQuery(value, method, context);
+                final Query query = prefixField.prefixQuery(value, method, caseInsensitive, context);
                 if (method == null
                     || method == MultiTermQuery.CONSTANT_SCORE_REWRITE
                     || method == MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE) {
@@ -365,8 +365,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
             if (value.length() >= minChars) {
+                if(caseInsensitive) {
+                    return super.termQueryCaseInsensitive(value, context);
+                }
                 return super.termQuery(value, context);
             }
             List<Automaton> automata = new ArrayList<>();
@@ -507,11 +510,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
             if (prefixFieldType == null || prefixFieldType.termLengthWithinBounds(value.length()) == false) {
-                return super.prefixQuery(value, method, context);
+                return super.prefixQuery(value, method, caseInsensitive, context);
             } else {
-                final Query query = prefixFieldType.prefixQuery(value, method, context);
+                final Query query = prefixFieldType.prefixQuery(value, method, caseInsensitive, context);
                 if (method == null
                     || method == MultiTermQuery.CONSTANT_SCORE_REWRITE
                     || method == MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE) {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -136,13 +136,15 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, 
+            boolean caseInsensitive, QueryShardContext context) {
             throw new UnsupportedOperationException("[prefix] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query wildcardQuery(String value,
                                    @Nullable MultiTermQuery.RewriteMethod method,
+                                   boolean caseInsensitive,
                                    QueryShardContext context) {
             throw new UnsupportedOperationException("[wildcard] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -879,4 +879,18 @@ public class Strings {
             return sb.toString();
         }
     }
+    
+    public static String toLowercaseAscii(String in) {
+        StringBuilder out = new StringBuilder();
+        Iterator<Integer> iter = in.codePoints().iterator();
+        while (iter.hasNext()) {
+            int codepoint = iter.next();
+            if (codepoint > 128) {
+                out.appendCodePoint(codepoint);
+            } else {
+                out.appendCodePoint(Character.toLowerCase(codepoint));
+            }
+        }
+        return out.toString();
+    }    
 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.search;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.AutomatonQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.MinimizationOperations;
+import org.apache.lucene.util.automaton.Operations;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Helper functions for creating various forms of {@link AutomatonQuery}
+ */
+public class AutomatonQueries  {
+
+
+    
+    /** Build an automaton query accepting all terms with the specified prefix, ASCII case insensitive. */
+    public static Automaton caseInsensitivePrefix(String s) {
+        List<Automaton> list = new ArrayList<>();
+        Iterator<Integer> iter = s.codePoints().iterator();
+        while (iter.hasNext()) {
+            list.add(toCaseInsensitiveChar(iter.next(), Integer.MAX_VALUE));
+        }
+        list.add(Automata.makeAnyString());
+
+        Automaton a = Operations.concatenate(list);
+        a = MinimizationOperations.minimize(a, Integer.MAX_VALUE);
+        return a;
+    } 
+    
+    
+    /** Build an automaton query accepting all terms with the specified prefix, ASCII case insensitive. */
+    public static AutomatonQuery caseInsensitivePrefixQuery(Term prefix) {
+        return new AutomatonQuery(prefix, caseInsensitivePrefix(prefix.text()));
+    }    
+    
+    /** Build an automaton accepting all terms ASCII case insensitive. */
+    public static AutomatonQuery caseInsensitiveTermQuery(Term term) {
+        BytesRef prefix = term.bytes();
+        return new AutomatonQuery(term, toCaseInsensitiveString(prefix,Integer.MAX_VALUE));
+    }    
+
+    
+    /** Build an automaton matching a wildcard pattern, ASCII case insensitive. */
+    public static AutomatonQuery caseInsensitiveWildcardQuery(Term wildcardquery) {
+        return new AutomatonQuery(wildcardquery, toCaseInsensitiveWildcardAutomaton(wildcardquery,Integer.MAX_VALUE));
+    }    
+    
+    
+    /** String equality with support for wildcards */
+    public static final char WILDCARD_STRING = '*';
+
+    /** Char equality with support for wildcards */
+    public static final char WILDCARD_CHAR = '?';
+
+    /** Escape character */
+    public static final char WILDCARD_ESCAPE = '\\';    
+    /**
+     * Convert Lucene wildcard syntax into an automaton.
+     */
+    @SuppressWarnings("fallthrough")
+    public static Automaton toCaseInsensitiveWildcardAutomaton(Term wildcardquery, int maxDeterminizedStates) {
+      List<Automaton> automata = new ArrayList<>();
+      
+      String wildcardText = wildcardquery.text();
+      
+      for (int i = 0; i < wildcardText.length();) {
+        final int c = wildcardText.codePointAt(i);
+        int length = Character.charCount(c);
+        switch(c) {
+          case WILDCARD_STRING: 
+            automata.add(Automata.makeAnyString());
+            break;
+          case WILDCARD_CHAR:
+            automata.add(Automata.makeAnyChar());
+            break;
+          case WILDCARD_ESCAPE:
+            // add the next codepoint instead, if it exists
+            if (i + length < wildcardText.length()) {
+              final int nextChar = wildcardText.codePointAt(i + length);
+              length += Character.charCount(nextChar);
+              automata.add(Automata.makeChar(nextChar));
+              break;
+            } // else fallthru, lenient parsing with a trailing \
+          default:
+            automata.add(toCaseInsensitiveChar(c, maxDeterminizedStates));
+        }
+        i += length;
+      }
+      
+      return Operations.concatenate(automata);
+    }    
+
+    protected static Automaton toCaseInsensitiveString(BytesRef br, int maxDeterminizedStates) {
+        return toCaseInsensitiveString(br.utf8ToString(), maxDeterminizedStates);
+    }
+    
+    public static Automaton toCaseInsensitiveString(String s, int maxDeterminizedStates) {
+        List<Automaton> list = new ArrayList<>();
+        Iterator<Integer> iter = s.codePoints().iterator();
+        while (iter.hasNext()) {
+            list.add(toCaseInsensitiveChar(iter.next(), maxDeterminizedStates));
+        }
+
+        Automaton a = Operations.concatenate(list);
+        a = MinimizationOperations.minimize(a, maxDeterminizedStates);
+        return a;
+ 
+    
+    }
+
+    protected static Automaton toCaseInsensitiveChar(int codepoint, int maxDeterminizedStates) {
+        Automaton case1 = Automata.makeChar(codepoint);
+        // For now we only work with ASCII characters
+        if (codepoint > 128) {
+            return case1;
+        }
+        int altCase = Character.isLowerCase(codepoint) ? Character.toUpperCase(codepoint) : Character.toLowerCase(codepoint);
+        Automaton result;
+        if (altCase != codepoint) {
+            result = Operations.union(case1, Automata.makeChar(altCase));
+            result = MinimizationOperations.minimize(result, maxDeterminizedStates);
+        } else {
+            result = case1;
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/regex/Regex.java
+++ b/server/src/main/java/org/elasticsearch/common/regex/Regex.java
@@ -79,15 +79,39 @@ public class Regex {
      * Match a String against the given pattern, supporting the following simple
      * pattern styles: "xxx*", "*xxx", "*xxx*" and "xxx*yyy" matches (with an
      * arbitrary number of pattern parts), as well as direct equality.
+     * Matching is case sensitive.
      *
      * @param pattern the pattern to match against
      * @param str     the String to match
      * @return whether the String matches the given pattern
      */
     public static boolean simpleMatch(String pattern, String str) {
+        return simpleMatch(pattern, str, false);
+    }
+    
+    
+    /**
+     * Match a String against the given pattern, supporting the following simple
+     * pattern styles: "xxx*", "*xxx", "*xxx*" and "xxx*yyy" matches (with an
+     * arbitrary number of pattern parts), as well as direct equality.
+     *
+     * @param pattern the pattern to match against
+     * @param str     the String to match
+     * @param caseInsensitive  true if ASCII case differences should be ignored
+     * @return whether the String matches the given pattern
+     */
+    public static boolean simpleMatch(String pattern, String str, boolean caseInsensitive) {
         if (pattern == null || str == null) {
             return false;
         }
+        if (caseInsensitive) {
+            pattern = Strings.toLowercaseAscii(pattern);
+            str = Strings.toLowercaseAscii(str);
+        }
+        return simpleMatchWithNormalizedStrings(pattern, str);
+    }
+    
+    private static boolean simpleMatchWithNormalizedStrings(String pattern, String str) {
         final int firstIndex = pattern.indexOf('*');
         if (firstIndex == -1) {
             return pattern.equals(str);
@@ -102,12 +126,12 @@ public class Regex {
                 return str.regionMatches(str.length() - pattern.length() + 1, pattern, 1, pattern.length() - 1);
             } else if (nextIndex == 1) {
                 // Double wildcard "**" - skipping the first "*"
-                return simpleMatch(pattern.substring(1), str);
+                return simpleMatchWithNormalizedStrings(pattern.substring(1), str);
             }
             final String part = pattern.substring(1, nextIndex);
             int partIndex = str.indexOf(part);
             while (partIndex != -1) {
-                if (simpleMatch(pattern.substring(nextIndex), str.substring(partIndex + part.length()))) {
+                if (simpleMatchWithNormalizedStrings(pattern.substring(nextIndex), str.substring(partIndex + part.length()))) {
                     return true;
                 }
                 partIndex = str.indexOf(part, partIndex + 1);
@@ -116,9 +140,9 @@ public class Regex {
         }
         return str.regionMatches(0, pattern, 0, firstIndex)
             && (firstIndex == pattern.length() - 1 // only wildcard in pattern is at the end, so no need to look at the rest of the string
-                || simpleMatch(pattern.substring(firstIndex), str.substring(firstIndex)));
-    }
-
+                || simpleMatchWithNormalizedStrings(pattern.substring(firstIndex), str.substring(firstIndex)));
+    }    
+    
     /**
      * Match a String against the given patterns, supporting the following simple
      * pattern styles: "xxx*", "*xxx", "*xxx*" and "xxx*yyy" matches (with an

--- a/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
@@ -59,7 +59,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
      * Return whether the constant value of this field matches the provided {@code pattern}
      * as documented in {@link Regex#simpleMatch}.
      */
-    protected abstract boolean matches(String pattern, QueryShardContext context);
+    protected abstract boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context);
 
     private static String valueToString(Object value) {
         return value instanceof BytesRef
@@ -70,7 +70,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     @Override
     public final Query termQuery(Object value, QueryShardContext context) {
         String pattern = valueToString(value);
-        if (matches(pattern, context)) {
+        if (matches(pattern, false, context)) {
             return Queries.newMatchAllQuery();
         } else {
             return new MatchNoDocsQuery();
@@ -78,23 +78,34 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     @Override
+    public final Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        String pattern = valueToString(value);
+        if (matches(pattern, true, context)) {
+            return Queries.newMatchAllQuery();
+        } else {
+            return new MatchNoDocsQuery();
+        }
+    }
+    
+    @Override
     public final Query termsQuery(List<?> values, QueryShardContext context) {
         for (Object value : values) {
             String pattern = valueToString(value);
-            if (matches(pattern, context)) {
+            if (matches(pattern, false, context)) {
                 // `terms` queries are a disjunction, so one matching term is enough
                 return Queries.newMatchAllQuery();
             }
         }
         return new MatchNoDocsQuery();
-    }
+    }    
 
     @Override
     public final Query prefixQuery(String prefix,
                              @Nullable MultiTermQuery.RewriteMethod method,
+                             boolean caseInsensitive, 
                              QueryShardContext context) {
         String pattern = prefix + "*";
-        if (matches(pattern, context)) {
+        if (matches(pattern, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
         } else {
             return new MatchNoDocsQuery();
@@ -104,8 +115,9 @@ public abstract class ConstantFieldType extends MappedFieldType {
     @Override
     public final Query wildcardQuery(String value,
                                @Nullable MultiTermQuery.RewriteMethod method,
+                               boolean caseInsensitive, 
                                QueryShardContext context) {
-        if (matches(value, context)) {
+        if (matches(value, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
         } else {
             return new MatchNoDocsQuery();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -52,7 +53,12 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        protected boolean matches(String pattern, QueryShardContext context) {
+        protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
+            if (caseInsensitive) {
+                // Thankfully, all index names are lower-cased so we don't have to pass a case_insensitive mode flag
+                // down to all the index name-matching logic. We just lower-case the search string
+                pattern = Strings.toLowercaseAscii(pattern);
+            }            
             return context.indexMatches(pattern);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -176,6 +176,13 @@ public abstract class MappedFieldType {
      */
     // TODO: Standardize exception types
     public abstract Query termQuery(Object value, @Nullable QueryShardContext context);
+    
+    
+    // Case insensitive form of term query (not supported by all fields so must be overridden to enable)
+    public Query termQueryCaseInsensitive(Object value, @Nullable QueryShardContext context) {
+        throw new QueryShardException(context, "[" + name + "] field which is of type [" + typeName() + 
+            "], does not support case insensitive term queries");
+    }    
 
     /** Build a constant-scoring query that matches all values. The default implementation uses a
      * {@link ConstantScoreQuery} around a {@link BooleanQuery} whose {@link Occur#SHOULD} clauses
@@ -206,14 +213,27 @@ public abstract class MappedFieldType {
             + "] which is of type [" + typeName() + "]");
     }
 
-    public Query prefixQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+    // Case sensitive form of prefix query
+    public final Query prefixQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        return prefixQuery(value, method, false, context);
+    }    
+    
+    public Query prefixQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, boolean caseInsensitve, 
+        QueryShardContext context) {
         throw new QueryShardException(context, "Can only use prefix queries on keyword, text and wildcard fields - not on [" + name
             + "] which is of type [" + typeName() + "]");
     }
 
+    // Case sensitive form of wildcard query
+    public final Query wildcardQuery(String value,
+        @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context
+    ) {
+        return wildcardQuery(value, method, false, context);
+    }
+    
     public Query wildcardQuery(String value,
                                @Nullable MultiTermQuery.RewriteMethod method,
-                               QueryShardContext context) {
+                               boolean caseInsensitve, QueryShardContext context) {
         throw new QueryShardException(context, "Can only use wildcard queries on keyword, text and wildcard fields - not on [" + name
             + "] which is of type [" + typeName() + "]");
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -32,6 +33,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.support.QueryParsers;
@@ -68,13 +70,21 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[prefix] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false. For optimised prefix queries on text " +
                     "fields please enable [index_prefixes].");
         }
         failIfNotIndexed();
+        if (caseInsensitive) {
+            AutomatonQuery query = AutomatonQueries.caseInsensitivePrefixQuery((new Term(name(), indexedValueForSearch(value))));
+            if (method != null) {
+                query.setRewriteMethod(method);
+            }
+            return query;
+            
+        }
         PrefixQuery query = new PrefixQuery(new Term(name(), indexedValueForSearch(value)));
         if (method != null) {
             query.setRewriteMethod(method);
@@ -113,7 +123,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
         failIfNotIndexed();
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[wildcard] queries cannot be executed when '" +
@@ -127,7 +137,11 @@ public abstract class StringFieldType extends TermBasedFieldType {
         } else {
             term = new Term(name(), indexedValueForSearch(value));
         }
-
+        if (caseInsensitive) {
+            AutomatonQuery query = AutomatonQueries.caseInsensitiveWildcardQuery(term);
+            QueryParsers.setRewriteMethod(query, method);
+            return query;            
+        }
         WildcardQuery query = new WildcardQuery(term);
         QueryParsers.setRewriteMethod(query, method);
         return query;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.util.List;
@@ -44,6 +45,16 @@ abstract class TermBasedFieldType extends SimpleMappedFieldType {
      *  query factory methods such as {@link #termQuery}. */
     protected BytesRef indexedValueForSearch(Object value) {
         return BytesRefs.toBytesRef(value);
+    }
+
+    @Override
+    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        failIfNotIndexed();
+        Query query = AutomatonQueries.caseInsensitiveTermQuery(new Term(name(), indexedValueForSearch(value)));
+        if (boost() != 1f) {
+            query = new BoostQuery(query, boost());
+        }
+        return query;            
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -77,7 +77,10 @@ public class TypeFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        protected boolean matches(String pattern, QueryShardContext context) {
+        protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
+            if (caseInsensitive) {
+                return pattern.equalsIgnoreCase(MapperService.SINGLE_MAPPING_NAME);
+            }
             return pattern.equals(MapperService.SINGLE_MAPPING_NAME);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -152,18 +152,23 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
         builder.startObject(getName());
         builder.startObject(fieldName);
         builder.field(VALUE_FIELD.getPreferredName(), maybeConvertToString(this.value));
+        addExtraXContent(builder, params);
         printBoostAndQueryName(builder);
         builder.endObject();
         builder.endObject();
     }
+    
+    protected void addExtraXContent(XContentBuilder builder, Params params) throws IOException {
+        // Do nothing but allows subclasses to override.
+    }
 
     @Override
-    protected final int doHashCode() {
+    protected int doHashCode() {
         return Objects.hash(fieldName, value);
     }
 
     @Override
-    protected final boolean doEquals(QB other) {
+    protected boolean doEquals(QB other) {
         return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(value, other.value);
     }

--- a/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.common.regex;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Locale;
 import java.util.Random;
 import java.util.regex.Pattern;
 
@@ -54,13 +55,17 @@ public class RegexTests extends ESTestCase {
 
     public void testDoubleWildcardMatch() {
         assertTrue(Regex.simpleMatch("ddd", "ddd"));
+        assertTrue(Regex.simpleMatch("ddd", "Ddd", true));
+        assertFalse(Regex.simpleMatch("ddd", "Ddd"));
         assertTrue(Regex.simpleMatch("d*d*d", "dadd"));
         assertTrue(Regex.simpleMatch("**ddd", "dddd"));
+        assertTrue(Regex.simpleMatch("**ddD", "dddd", true));
         assertFalse(Regex.simpleMatch("**ddd", "fff"));
         assertTrue(Regex.simpleMatch("fff*ddd", "fffabcddd"));
         assertTrue(Regex.simpleMatch("fff**ddd", "fffabcddd"));
         assertFalse(Regex.simpleMatch("fff**ddd", "fffabcdd"));
         assertTrue(Regex.simpleMatch("fff*******ddd", "fffabcddd"));
+        assertTrue(Regex.simpleMatch("fff*******ddd", "FffAbcdDd", true));
         assertFalse(Regex.simpleMatch("fff******ddd", "fffabcdd"));
     }
 
@@ -76,6 +81,8 @@ public class RegexTests extends ESTestCase {
                 pattern = pattern.substring(0, shrinkStart) + "*" + pattern.substring(shrinkEnd);
             }
             assertTrue("[" + pattern + "] should match [" + matchingString + "]", Regex.simpleMatch(pattern, matchingString));
+            assertTrue("[" + pattern + "] should match [" + matchingString.toUpperCase(Locale.ROOT) + "]", 
+                Regex.simpleMatch(pattern, matchingString.toUpperCase(Locale.ROOT), true));
 
             // construct a pattern that does not match this string by inserting a non-matching character (a digit)
             final int insertPos = between(0, pattern.length());

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -46,7 +46,9 @@ public class IndexFieldTypeTests extends ESTestCase {
         MappedFieldType ft = IndexFieldMapper.IndexFieldType.INSTANCE;
 
         assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("ind*x", null, createContext()));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("iNd*x", null, true, createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("other_ind*x", null, createContext()));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("Other_ind*x", null, true, createContext()));
     }
 
     public void testRegexpQuery() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper.RangeFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -480,5 +481,15 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         boolean includeUpper = true;
         assertEquals(getExpectedRangeQuery(relation, value, value, includeLower, includeUpper),
             ft.termQuery(value, context));
+    }
+    
+    public void testCaseInsensitiveQuery() throws Exception {
+        QueryShardContext context = createContext();
+        RangeFieldType ft = createDefaultFieldType(FIELDNAME);
+
+        Object value = nextFrom();
+        QueryShardException ex = expectThrows(QueryShardException.class,
+            () ->   ft.termQueryCaseInsensitive(value, context));
+        assertTrue(ex.getMessage().contains("does not support case insensitive term queries"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
@@ -35,7 +35,15 @@ public class TypeFieldTypeTests extends ESTestCase {
         Query query = ft.termQuery("_doc", context);
         assertEquals(new MatchAllDocsQuery(), query);
 
+        query = ft.termQueryCaseInsensitive("_dOc", context);
+        assertEquals(new MatchAllDocsQuery(), query);
+        
+        
         query = ft.termQuery("other_type", context);
         assertEquals(new MatchNoDocsQuery(), query);
+
+        query = ft.termQueryCaseInsensitive("other_Type", context);
+        assertEquals(new MatchNoDocsQuery(), query);
+    
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -44,6 +44,13 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         if (randomBoolean()) {
             query.rewrite(getRandomRewriteMethod());
         }
+        //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
+        // 1) Commit PR 61596 with this code commented out in master
+        // 2) Backport PR 61596 to 7.x, uncommented
+        // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.
+//        if (randomBoolean()) {
+//            query.caseInsensitive(true);
+//        }         
         return query;
     }
 
@@ -101,7 +108,14 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     public void testFromJson() throws IOException {
         String json =
-                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\", \"boost\" : 2.0 } }}";
+                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\", \"boost\" : 2.0 "
+            //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
+            // 1) Commit PR 61596 with this code commented out in master
+            // 2) Backport PR 61596 to 7.x, uncommented
+            // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.                
+//            "      \"case_insensitive\" : true\n" +
+            
+                + "} }}";
 
         PrefixQueryBuilder parsed = (PrefixQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -41,6 +41,13 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         if (randomBoolean()) {
             query.rewrite(randomFrom(getRandomRewriteMethod()));
         }
+        //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
+        // 1) Commit PR 61596 with this code commented out in master
+        // 2) Backport PR 61596 to 7.x, uncommented
+        // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.
+//        if (randomBoolean()) {
+//            query.caseInsensitive(true);
+//        }         
         return query;
     }
 
@@ -103,7 +110,14 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     public void testFromJson() throws IOException {
-        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\", \"boost\" : 2.0 } }}";
+        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\", \"boost\" : 2.0"
+            //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
+            // 1) Commit PR 61596 with this code commented out in master
+            // 2) Backport PR 61596 to 7.x, uncommented
+            // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.                
+//            "      \"case_insensitive\" : true\n" +
+            
+            + " } }}";
         WildcardQueryBuilder parsed = (WildcardQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
         assertEquals(json, "ki*y", parsed.value());

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -147,11 +147,11 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected boolean matches(String pattern, QueryShardContext context) {
+        protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
             if (value == null) {
                 return false;
             }
-            return Regex.simpleMatch(pattern, value);
+            return Regex.simpleMatch(pattern, value, caseInsensitive);
         }
 
         @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
@@ -21,9 +21,12 @@ public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
     public void testTermQuery() {
         ConstantKeywordFieldType ft = new ConstantKeywordFieldType("f", "foo");
         assertEquals(new MatchAllDocsQuery(), ft.termQuery("foo", null));
+        assertEquals(new MatchAllDocsQuery(), ft.termQueryCaseInsensitive("fOo", null));
         assertEquals(new MatchNoDocsQuery(), ft.termQuery("bar", null));
+        assertEquals(new MatchNoDocsQuery(), ft.termQueryCaseInsensitive("bAr", null));
         ConstantKeywordFieldType bar = new ConstantKeywordFieldType("f", "bar");
         assertEquals(new MatchNoDocsQuery(), bar.termQuery("foo", null));
+        assertEquals(new MatchNoDocsQuery(), bar.termQueryCaseInsensitive("fOo", null));
     }
 
     public void testTermsQuery() {
@@ -39,18 +42,24 @@ public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
 
     public void testWildcardQuery() {
         ConstantKeywordFieldType bar = new ConstantKeywordFieldType("f", "bar");
-        assertEquals(new MatchNoDocsQuery(), bar.wildcardQuery("f*o", null, null));
+        assertEquals(new MatchNoDocsQuery(), bar.wildcardQuery("f*o", null, false, null));
+        assertEquals(new MatchNoDocsQuery(), bar.wildcardQuery("F*o", null, true, null));
         ConstantKeywordFieldType ft = new ConstantKeywordFieldType("f", "foo");
-        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("f*o", null, null));
-        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("b*r", null, null));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("f*o", null, false, null));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("F*o", null, true, null));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("b*r", null, false, null));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("B*r", null, true, null));
     }
 
     public void testPrefixQuery() {
         ConstantKeywordFieldType bar = new ConstantKeywordFieldType("f", "bar");
-        assertEquals(new MatchNoDocsQuery(), bar.prefixQuery("fo", null, null));
+        assertEquals(new MatchNoDocsQuery(), bar.prefixQuery("fo", null, false, null));
+        assertEquals(new MatchNoDocsQuery(), bar.prefixQuery("fO", null, true, null));
         ConstantKeywordFieldType ft = new ConstantKeywordFieldType("f", "foo");
-        assertEquals(new MatchAllDocsQuery(), ft.prefixQuery("fo", null, null));
-        assertEquals(new MatchNoDocsQuery(), ft.prefixQuery("ba", null, null));
+        assertEquals(new MatchAllDocsQuery(), ft.prefixQuery("fo", null, false, null));
+        assertEquals(new MatchAllDocsQuery(), ft.prefixQuery("fO", null, true, null));
+        assertEquals(new MatchNoDocsQuery(), ft.prefixQuery("ba", null, false, null));
+        assertEquals(new MatchNoDocsQuery(), ft.prefixQuery("Ba", null, true, null));
     }
 
     public void testExistsQuery() {

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -20,6 +21,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -302,11 +304,23 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         @Override
         public Query wildcardQuery(String value,
                                    MultiTermQuery.RewriteMethod method,
+                                   boolean caseInsensitive,
                                    QueryShardContext context) {
             throw new UnsupportedOperationException("[wildcard] queries are not currently supported on keyed " +
                 "[" + CONTENT_TYPE + "] fields.");
         }
+        
+        
 
+        @Override
+        public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+            Query query = AutomatonQueries.caseInsensitiveTermQuery(new Term(name(), indexedValueForSearch(value)));
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+        
         @Override
         public BytesRef indexedValueForSearch(Object value) {
             if (value == null) {

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/RootFlatObjectFieldTypeTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/RootFlatObjectFieldTypeTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
@@ -43,6 +44,10 @@ public class RootFlatObjectFieldTypeTests extends FieldTypeTestCase {
         Query expected = new TermQuery(new Term("field", "value"));
         assertEquals(expected, ft.termQuery("value", null));
 
+        expected = AutomatonQueries.caseInsensitiveTermQuery(new Term("field", "Value"));
+        assertEquals(expected, ft.termQueryCaseInsensitive("Value", null));
+        
+        
         RootFlatObjectFieldType unsearchable = new RootFlatObjectFieldType("field", false, true,
             Collections.emptyMap(), false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -133,12 +133,12 @@ abstract class AbstractScriptMappedFieldType<LeafFactory> extends MappedFieldTyp
     }
 
     @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
         throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
     }
 
     @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
         throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
@@ -88,9 +88,14 @@ public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFiel
     }
 
     @Override
-    public Query prefixQuery(String value, RewriteMethod method, org.elasticsearch.index.query.QueryShardContext context) {
+    public Query prefixQuery(
+        String value,
+        RewriteMethod method,
+        boolean caseInsensitive,
+        org.elasticsearch.index.query.QueryShardContext context
+    ) {
         checkAllowExpensiveQueries(context);
-        return new StringScriptFieldPrefixQuery(script, leafFactory(context), name(), value);
+        return new StringScriptFieldPrefixQuery(script, leafFactory(context), name(), value, caseInsensitive);
     }
 
     @Override
@@ -128,13 +133,27 @@ public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFiel
         if (matchFlags != 0) {
             throw new IllegalArgumentException("Match flags not yet implemented [" + matchFlags + "]");
         }
-        return new StringScriptFieldRegexpQuery(script, leafFactory(context), name(), value, syntaxFlags, maxDeterminizedStates);
+        return new StringScriptFieldRegexpQuery(
+            script,
+            leafFactory(context),
+            name(),
+            value,
+            syntaxFlags,
+            matchFlags,
+            maxDeterminizedStates
+        );
+    }
+
+    @Override
+    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldTermQuery(script, leafFactory(context), name(), BytesRefs.toString(Objects.requireNonNull(value)),true);
     }
 
     @Override
     public Query termQuery(Object value, QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new StringScriptFieldTermQuery(script, leafFactory(context), name(), BytesRefs.toString(Objects.requireNonNull(value)));
+        return new StringScriptFieldTermQuery(script, leafFactory(context), name(), BytesRefs.toString(Objects.requireNonNull(value)), false);
     }
 
     @Override
@@ -145,8 +164,8 @@ public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFiel
     }
 
     @Override
-    public Query wildcardQuery(String value, RewriteMethod method, QueryShardContext context) {
+    public Query wildcardQuery(String value, RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new StringScriptFieldWildcardQuery(script, leafFactory(context), name(), value);
+        return new StringScriptFieldWildcardQuery(script, leafFactory(context), name(), value, caseInsensitive);
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
@@ -147,13 +147,25 @@ public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFiel
     @Override
     public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new StringScriptFieldTermQuery(script, leafFactory(context), name(), BytesRefs.toString(Objects.requireNonNull(value)),true);
+        return new StringScriptFieldTermQuery(
+            script,
+            leafFactory(context),
+            name(),
+            BytesRefs.toString(Objects.requireNonNull(value)),
+            true
+        );
     }
 
     @Override
     public Query termQuery(Object value, QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new StringScriptFieldTermQuery(script, leafFactory(context), name(), BytesRefs.toString(Objects.requireNonNull(value)), false);
+        return new StringScriptFieldTermQuery(
+            script,
+            leafFactory(context),
+            name(),
+            BytesRefs.toString(Objects.requireNonNull(value)),
+            false
+        );
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQuery.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.runtimefields.query;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.xpack.runtimefields.mapper.StringFieldScript;
 
@@ -18,26 +20,63 @@ import java.util.Objects;
 
 public class StringScriptFieldPrefixQuery extends AbstractStringScriptFieldQuery {
     private final String prefix;
+    private final boolean caseInsensitive;
 
-    public StringScriptFieldPrefixQuery(Script script, StringFieldScript.LeafFactory leafFactory, String fieldName, String prefix) {
+    public StringScriptFieldPrefixQuery(
+        Script script,
+        StringFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String prefix,
+        boolean caseInsensitive
+    ) {
         super(script, leafFactory, fieldName);
         this.prefix = Objects.requireNonNull(prefix);
+        this.caseInsensitive = caseInsensitive;
     }
 
     @Override
     protected boolean matches(List<String> values) {
         for (String value : values) {
-            if (value != null && value.startsWith(prefix)) {
+            if (startsWith(value, prefix, caseInsensitive)) {
                 return true;
             }
         }
         return false;
     }
 
+    /**
+     * <p>Check if a String starts with a specified prefix (optionally case insensitive).</p>
+     *
+     * @see java.lang.String#startsWith(String)
+     * @param str  the String to check, may be null
+     * @param prefix the prefix to find, may be null
+     * @param ignoreCase inidicates whether the compare should ignore case
+     *  (case insensitive) or not.
+     * @return <code>true</code> if the String starts with the prefix or
+     *  both <code>null</code>
+     */
+    private static boolean startsWith(String str, String prefix, boolean ignoreCase) {
+        if (str == null || prefix == null) {
+            return (str == null && prefix == null);
+        }
+        if (prefix.length() > str.length()) {
+            return false;
+        }
+        return str.regionMatches(ignoreCase, 0, prefix, 0, prefix.length());
+    }
+
     @Override
     public void visit(QueryVisitor visitor) {
         if (visitor.acceptField(fieldName())) {
-            visitor.consumeTermsMatching(this, fieldName(), () -> new ByteRunAutomaton(PrefixQuery.toAutomaton(new BytesRef(prefix))));
+            visitor.consumeTermsMatching(this, fieldName(), () -> new ByteRunAutomaton(buildAutomaton(new BytesRef(prefix))));
+        }
+    }
+
+    Automaton buildAutomaton(BytesRef prefix) {
+        if (caseInsensitive) {
+            return AutomatonQueries.caseInsensitivePrefix(prefix.utf8ToString());
+        } else {
+            return PrefixQuery.toAutomaton(prefix);
         }
     }
 
@@ -51,7 +90,7 @@ public class StringScriptFieldPrefixQuery extends AbstractStringScriptFieldQuery
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), prefix);
+        return Objects.hash(super.hashCode(), prefix, caseInsensitive);
     }
 
     @Override
@@ -60,10 +99,14 @@ public class StringScriptFieldPrefixQuery extends AbstractStringScriptFieldQuery
             return false;
         }
         StringScriptFieldPrefixQuery other = (StringScriptFieldPrefixQuery) obj;
-        return prefix.equals(other.prefix);
+        return prefix.equals(other.prefix) && caseInsensitive == other.caseInsensitive;
     }
 
     String prefix() {
         return prefix;
+    }
+
+    boolean caseInsensitive() {
+        return caseInsensitive;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
@@ -15,24 +15,27 @@ import java.util.Objects;
 
 public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutomatonQuery {
     private final String pattern;
-    private final int flags;
+    private final int syntaxFlags;
+    private final int matchFlags;
 
     public StringScriptFieldRegexpQuery(
         Script script,
         StringFieldScript.LeafFactory leafFactory,
         String fieldName,
         String pattern,
-        int flags,
+        int syntaxFlags,
+        int matchFlags,
         int maxDeterminizedStates
     ) {
         super(
             script,
             leafFactory,
             fieldName,
-            new ByteRunAutomaton(new RegExp(Objects.requireNonNull(pattern), flags).toAutomaton(maxDeterminizedStates))
+            new ByteRunAutomaton(new RegExp(Objects.requireNonNull(pattern), syntaxFlags, matchFlags).toAutomaton(maxDeterminizedStates))
         );
         this.pattern = pattern;
-        this.flags = flags;
+        this.syntaxFlags = syntaxFlags;
+        this.matchFlags = matchFlags;
     }
 
     @Override
@@ -46,7 +49,7 @@ public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutom
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), pattern, flags);
+        return Objects.hash(super.hashCode(), pattern, syntaxFlags, matchFlags);
     }
 
     @Override
@@ -55,14 +58,18 @@ public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutom
             return false;
         }
         StringScriptFieldRegexpQuery other = (StringScriptFieldRegexpQuery) obj;
-        return pattern.equals(other.pattern) && flags == other.flags;
+        return pattern.equals(other.pattern) && syntaxFlags == other.syntaxFlags && matchFlags == other.matchFlags;
     }
 
     String pattern() {
         return pattern;
     }
 
-    int flags() {
-        return flags;
+    int syntaxFlags() {
+        return syntaxFlags;
+    }
+
+    int matchFlags() {
+        return matchFlags;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQuery.java
@@ -16,16 +16,28 @@ import java.util.Objects;
 
 public class StringScriptFieldTermQuery extends AbstractStringScriptFieldQuery {
     private final String term;
+    private final boolean caseInsensitive;
 
-    public StringScriptFieldTermQuery(Script script, StringFieldScript.LeafFactory leafFactory, String fieldName, String term) {
+    public StringScriptFieldTermQuery(
+        Script script,
+        StringFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String term,
+        boolean caseInsensitive
+    ) {
         super(script, leafFactory, fieldName);
         this.term = Objects.requireNonNull(term);
+        this.caseInsensitive = caseInsensitive;
     }
 
     @Override
     protected boolean matches(List<String> values) {
         for (String value : values) {
-            if (term.equals(value)) {
+            if (caseInsensitive) {
+                if (term.equalsIgnoreCase(value)) {
+                    return true;
+                }
+            } else if (term.equals(value)) {
                 return true;
             }
         }
@@ -47,7 +59,7 @@ public class StringScriptFieldTermQuery extends AbstractStringScriptFieldQuery {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), term);
+        return Objects.hash(super.hashCode(), term, caseInsensitive);
     }
 
     @Override
@@ -56,10 +68,14 @@ public class StringScriptFieldTermQuery extends AbstractStringScriptFieldQuery {
             return false;
         }
         StringScriptFieldTermQuery other = (StringScriptFieldTermQuery) obj;
-        return term.equals(other.term);
+        return term.equals(other.term) && caseInsensitive == other.caseInsensitive;
     }
 
     String term() {
         return term;
+    }
+
+    boolean caseInsensitive() {
+        return caseInsensitive;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
@@ -8,7 +8,9 @@ package org.elasticsearch.xpack.runtimefields.query;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.xpack.runtimefields.mapper.StringFieldScript;
 
@@ -16,15 +18,30 @@ import java.util.Objects;
 
 public class StringScriptFieldWildcardQuery extends AbstractStringScriptFieldAutomatonQuery {
     private final String pattern;
+    private final boolean caseInsensitive;
 
-    public StringScriptFieldWildcardQuery(Script script, StringFieldScript.LeafFactory leafFactory, String fieldName, String pattern) {
+    public StringScriptFieldWildcardQuery(
+        Script script,
+        StringFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String pattern,
+        boolean caseInsensitive
+    ) {
         super(
             script,
             leafFactory,
             fieldName,
-            new ByteRunAutomaton(WildcardQuery.toAutomaton(new Term(fieldName, Objects.requireNonNull(pattern))))
+            new ByteRunAutomaton(buildAutomaton(new Term(fieldName, Objects.requireNonNull(pattern)), caseInsensitive))
         );
         this.pattern = pattern;
+        this.caseInsensitive = caseInsensitive;
+    }
+
+    private static Automaton buildAutomaton(Term term, boolean caseInsensitive) {
+        if (caseInsensitive) {
+            return AutomatonQueries.toCaseInsensitiveWildcardAutomaton(term, Integer.MAX_VALUE);
+        }
+        return WildcardQuery.toAutomaton(term);
     }
 
     @Override
@@ -37,7 +54,7 @@ public class StringScriptFieldWildcardQuery extends AbstractStringScriptFieldAut
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), pattern);
+        return Objects.hash(super.hashCode(), pattern, caseInsensitive);
     }
 
     @Override
@@ -46,10 +63,14 @@ public class StringScriptFieldWildcardQuery extends AbstractStringScriptFieldAut
             return false;
         }
         StringScriptFieldWildcardQuery other = (StringScriptFieldWildcardQuery) obj;
-        return pattern.equals(other.pattern);
+        return pattern.equals(other.pattern) && caseInsensitive == other.caseInsensitive;
     }
 
     String pattern() {
         return pattern;
+    }
+
+    boolean caseInsensitive() {
+        return caseInsensitive;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldTypeTests.java
@@ -267,7 +267,7 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
     }
 
     private Query randomRegexpQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.regexpQuery(randomAlphaOfLengthBetween(1, 1000), randomInt(0xFFFF), 0, Integer.MAX_VALUE, null, ctx);
+        return ft.regexpQuery(randomAlphaOfLengthBetween(1, 1000), randomInt(0xFF), 0, Integer.MAX_VALUE, null, ctx);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
@@ -23,12 +23,12 @@ import static org.hamcrest.Matchers.equalTo;
 public class StringScriptFieldTermQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldTermQuery> {
     @Override
     protected StringScriptFieldTermQuery createTestInstance() {
-        return new StringScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+        return new StringScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6), randomBoolean());
     }
 
     @Override
     protected StringScriptFieldTermQuery copy(StringScriptFieldTermQuery orig) {
-        return new StringScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term());
+        return new StringScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term(), orig.caseInsensitive());
     }
 
     @Override
@@ -36,7 +36,8 @@ public class StringScriptFieldTermQueryTests extends AbstractStringScriptFieldQu
         Script script = orig.script();
         String fieldName = orig.fieldName();
         String term = orig.term();
-        switch (randomInt(2)) {
+        boolean caseInsensitive = orig.caseInsensitive();
+        switch (randomInt(3)) {
             case 0:
                 script = randomValueOtherThan(script, this::randomScript);
                 break;
@@ -46,18 +47,27 @@ public class StringScriptFieldTermQueryTests extends AbstractStringScriptFieldQu
             case 2:
                 term += "modified";
                 break;
+            case 3:
+                caseInsensitive = !caseInsensitive;
+                break;
             default:
                 fail();
         }
-        return new StringScriptFieldTermQuery(script, leafFactory, fieldName, term);
+        return new StringScriptFieldTermQuery(script, leafFactory, fieldName, term, caseInsensitive);
     }
 
     @Override
     public void testMatches() {
-        StringScriptFieldTermQuery query = new StringScriptFieldTermQuery(randomScript(), leafFactory, "test", "foo");
+        StringScriptFieldTermQuery query = new StringScriptFieldTermQuery(randomScript(), leafFactory, "test", "foo", false);
         assertTrue(query.matches(List.of("foo")));
+        assertFalse(query.matches(List.of("foO")));
         assertFalse(query.matches(List.of("bar")));
         assertTrue(query.matches(List.of("foo", "bar")));
+
+        StringScriptFieldTermQuery ciQuery = new StringScriptFieldTermQuery(randomScript(), leafFactory, "test", "foo", true);
+        assertTrue(ciQuery.matches(List.of("Foo")));
+        assertTrue(ciQuery.matches(List.of("fOo", "bar")));
+
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
@@ -17,12 +17,18 @@ import static org.hamcrest.Matchers.equalTo;
 public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldWildcardQuery> {
     @Override
     protected StringScriptFieldWildcardQuery createTestInstance() {
-        return new StringScriptFieldWildcardQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+        return new StringScriptFieldWildcardQuery(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(6),
+            randomBoolean()
+        );
     }
 
     @Override
     protected StringScriptFieldWildcardQuery copy(StringScriptFieldWildcardQuery orig) {
-        return new StringScriptFieldWildcardQuery(orig.script(), leafFactory, orig.fieldName(), orig.pattern());
+        return new StringScriptFieldWildcardQuery(orig.script(), leafFactory, orig.fieldName(), orig.pattern(), orig.caseInsensitive());
     }
 
     @Override
@@ -30,7 +36,8 @@ public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFie
         Script script = orig.script();
         String fieldName = orig.fieldName();
         String pattern = orig.pattern();
-        switch (randomInt(2)) {
+        boolean caseInsensitive = orig.caseInsensitive();
+        switch (randomInt(3)) {
             case 0:
                 script = randomValueOtherThan(script, this::randomScript);
                 break;
@@ -40,22 +47,31 @@ public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFie
             case 2:
                 pattern += "modified";
                 break;
+            case 3:
+                caseInsensitive = !caseInsensitive;
+                break;
             default:
                 fail();
         }
-        return new StringScriptFieldWildcardQuery(script, leafFactory, fieldName, pattern);
+        return new StringScriptFieldWildcardQuery(script, leafFactory, fieldName, pattern, caseInsensitive);
     }
 
     @Override
     public void testMatches() {
-        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b", false);
         assertTrue(query.matches(List.of("astuffb")));
+        assertFalse(query.matches(List.of("Astuffb")));
         assertFalse(query.matches(List.of("fffff")));
         assertFalse(query.matches(List.of("a")));
         assertFalse(query.matches(List.of("b")));
         assertFalse(query.matches(List.of("aasdf")));
         assertFalse(query.matches(List.of("dsfb")));
         assertTrue(query.matches(List.of("astuffb", "fffff")));
+
+        StringScriptFieldWildcardQuery ciQuery = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b", true);
+        assertTrue(ciQuery.matches(List.of("Astuffb")));
+        assertTrue(ciQuery.matches(List.of("astuffB", "fffff")));
+
     }
 
     @Override
@@ -65,7 +81,7 @@ public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFie
 
     @Override
     public void testVisit() {
-        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b", false);
         ByteRunAutomaton automaton = visitForSingleAutomata(query);
         BytesRef term = new BytesRef("astuffb");
         assertTrue(automaton.run(term.bytes, term.offset, term.length));

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -40,6 +40,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -218,7 +219,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String wildcardPattern, RewriteMethod method, QueryShardContext context) {
+        public Query wildcardQuery(String wildcardPattern, RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
 
             String ngramIndexPattern = addLineEndChars(toLowerCase(wildcardPattern));
 
@@ -276,7 +277,11 @@ public class WildcardFieldMapper extends FieldMapper {
                 clauseCount++;
             }
             Supplier<Automaton> deferredAutomatonSupplier = () -> {
-                return WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
+                if(caseInsensitive) {
+                    return AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term(name(), wildcardPattern), Integer.MAX_VALUE);
+                } else {
+                    return WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
+                }
             };
             AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), wildcardPattern, deferredAutomatonSupplier);
             if (clauseCount > 0) {
@@ -845,7 +850,7 @@ public class WildcardFieldMapper extends FieldMapper {
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
             String searchTerm = BytesRefs.toString(value);
-            return wildcardQuery(escapeWildcardSyntax(searchTerm),  MultiTermQuery.CONSTANT_SCORE_REWRITE, context);
+            return wildcardQuery(escapeWildcardSyntax(searchTerm),  MultiTermQuery.CONSTANT_SCORE_REWRITE, false, context);
         }
         
         private String escapeWildcardSyntax(String term) {
@@ -862,10 +867,16 @@ public class WildcardFieldMapper extends FieldMapper {
             }
             return result.toString();
         }
+        
+        @Override
+        public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+            String searchTerm = BytesRefs.toString(value);
+            return wildcardQuery(escapeWildcardSyntax(searchTerm), MultiTermQuery.CONSTANT_SCORE_REWRITE, true, context);
+        }        
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
-            return wildcardQuery(escapeWildcardSyntax(value) + "*", method, context);
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+            return wildcardQuery(escapeWildcardSyntax(value) + "*", method, caseInsensitive, context);
         }
 
         @Override
@@ -876,7 +887,7 @@ public class WildcardFieldMapper extends FieldMapper {
             }
             return new ConstantScoreQuery(bq.build());
         }
-
+        
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -264,18 +264,21 @@ public class WildcardFieldMapperTests extends ESTestCase {
             switch (randomInt(4)) {
             case 0:
                 pattern = getRandomWildcardPattern();
-                wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery(pattern, null, MOCK_QSC);
-                keywordFieldQuery = keywordFieldType.fieldType().wildcardQuery(pattern, null, MOCK_QSC);
+                boolean caseInsensitive = randomBoolean();
+                wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery(pattern, null, caseInsensitive, MOCK_QSC);
+                keywordFieldQuery = keywordFieldType.fieldType().wildcardQuery(pattern, null, caseInsensitive, MOCK_QSC);
                 break;
             case 1:
                 pattern = getRandomRegexPattern(values);
-                wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(pattern, RegExp.ALL, 0, 20000, null, MOCK_QSC);
-                keywordFieldQuery = keywordFieldType.fieldType().regexpQuery(pattern, RegExp.ALL, 0,20000, null, MOCK_QSC);
+                int matchFlags = randomBoolean()? 0 : RegExp.ASCII_CASE_INSENSITIVE;
+                wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(pattern, RegExp.ALL, matchFlags, 20000, null, MOCK_QSC);
+                keywordFieldQuery = keywordFieldType.fieldType().regexpQuery(pattern, RegExp.ALL, matchFlags,20000, null, MOCK_QSC);
                 break;
             case 2:
                 pattern = randomABString(5);
-                wildcardFieldQuery = wildcardFieldType.fieldType().prefixQuery(pattern, null, MOCK_QSC);
-                keywordFieldQuery = keywordFieldType.fieldType().prefixQuery(pattern, null, MOCK_QSC);
+                boolean caseInsensitivePrefix = randomBoolean();
+                wildcardFieldQuery = wildcardFieldType.fieldType().prefixQuery(pattern, null, caseInsensitivePrefix, MOCK_QSC);
+                keywordFieldQuery = keywordFieldType.fieldType().prefixQuery(pattern, null, caseInsensitivePrefix, MOCK_QSC);
                 break;
             case 3:
                 int edits = randomInt(2);


### PR DESCRIPTION
Adds case insensitive option to term, terms, terms_in_set,  prefix, wildcard queries
First cut.
Closes #61546
