### PR TITLE
[7.9] Fix wrong pipeline name in debug log (#58817)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.bulk;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.ElasticsearchParseException;
@@ -79,6 +78,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -702,8 +702,6 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
     static final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
 
-        private static final Logger logger = LogManager.getLogger(BulkRequestModifier.class);
-
         final BulkRequest bulkRequest;
         final SparseFixedBitSet failedSlots;
         final List<BulkItemResponse> itemResponses;
@@ -784,7 +782,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
         synchronized void markItemAsFailed(int slot, Exception e) {
             IndexRequest indexRequest = getIndexWriteRequest(bulkRequest.requests().get(slot));
-            logger.debug(() -> new ParameterizedMessage("failed to execute pipeline [{}] for document [{}/{}/{}]",
+            logger.debug(String.format(Locale.ROOT, "failed to execute pipeline [%s] for document [%s/%s/%s]",
                 indexRequest.getPipeline(), indexRequest.index(), indexRequest.type(), indexRequest.id()), e);
 
             // We hit a error during preprocessing a request, so we:

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.ingest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
@@ -528,6 +529,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 String originalIndex = indexRequest.indices()[0];
                 innerExecute(slot, indexRequest, pipeline, onDropped, e -> {
                     if (e != null) {
+                        logger.debug(() -> new ParameterizedMessage("failed to execute pipeline [{}] for document [{}/{}]",
+                            pipelineId, indexRequest.index(), indexRequest.id()), e);
                         onFailure.accept(slot, e);
                     }
 
@@ -567,6 +570,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     }
                 });
             } catch (Exception e) {
+                logger.debug(() -> new ParameterizedMessage("failed to execute pipeline [{}] for document [{}/{}]",
+                    pipelineId, indexRequest.index(), indexRequest.id()), e);
                 onFailure.accept(slot, e);
                 if (counter.decrementAndGet() == 0) {
                     onCompletion.accept(originalThread, null);


### PR DESCRIPTION
Relates to #58478.

When the ingest pipeline processes failed in bulk API, we can find a debug log which prints `failed to execute pipeline [_none] for document...`, the pipeline name is always `_none`. That's because  `pipeline` in `indexRequest` is set to `_none` when executing the ingest pipeline: https://github.com/elastic/elasticsearch/blob/cc3bd3974fac25c1deca4699a1a2129cc2f601ef/server/src/main/java/org/elasticsearch/ingest/IngestService.java#L366.

The main point of this PR is moving the logging to IngestService#executePipelines(), so we can get the real pipeline name when printing the debug log. 

Backport of #58817 
