### PR TITLE
[DOCS] [7.9] Update audit-settings.asciidoc

### DIFF
--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -14,7 +14,7 @@ on each node in the cluster. For more information, see <<enable-audit-logging>>.
 ==== General Auditing Settings
 [[xpack-security-audit-enabled]]
 // tag::xpack-security-audit-enabled-tag[]
-`xpack.security.audit.enabled` {ece-icon}::
+`xpack.security.audit.enabled`::
 Set to `true` to enable auditing on the node. The default value is `false`.
 This puts the auditing events in a dedicated file named `<clustername>_audit.json`
 on each node.
@@ -28,7 +28,7 @@ by using the following settings:
 
 [[xpack-sa-lf-events-include]]
 // tag::xpack-sa-lf-events-include-tag[]
-`xpack.security.audit.logfile.events.include` {ece-icon}::
+`xpack.security.audit.logfile.events.include`::
 Specifies which events to include in the auditing output. The default value is:
 `access_denied, access_granted, anonymous_access_denied, authentication_failed,
 connection_denied, tampered_request, run_as_denied, run_as_granted`.
@@ -36,14 +36,14 @@ connection_denied, tampered_request, run_as_denied, run_as_granted`.
 
 [[xpack-sa-lf-events-exclude]]
 // tag::xpack-sa-lf-events-exclude-tag[]
-`xpack.security.audit.logfile.events.exclude` {ece-icon}::
+`xpack.security.audit.logfile.events.exclude`::
 Excludes the specified events from the output. By default, no events are
 excluded.
 // end::xpack-sa-lf-events-exclude-tag[]
 
 [[xpack-sa-lf-events-emit-request]]
 // tag::xpack-sa-lf-events-emit-request-tag[]
-`xpack.security.audit.logfile.events.emit_request_body` {ece-icon}::
+`xpack.security.audit.logfile.events.emit_request_body`::
 Specifies whether to include the request body from REST requests on certain
 event types such as `authentication_failed`. The default value is `false`.
 +
@@ -59,28 +59,28 @@ audited in plain text when including the request body in audit events.
 
 [[xpack-sa-lf-emit-node-name]]
 // tag::xpack-sa-lf-emit-node-name-tag[]
-`xpack.security.audit.logfile.emit_node_name` {ece-icon}::
+`xpack.security.audit.logfile.emit_node_name`::
 Specifies whether to include the <<node.name,node name>> as a field in
 each audit event. The default value is `false`.
 // end::xpack-sa-lf-emit-node-name-tag[]
 
 [[xpack-sa-lf-emit-node-host-address]]
 // tag::xpack-sa-lf-emit-node-host-address-tag[]
-`xpack.security.audit.logfile.emit_node_host_address` {ece-icon}::
+`xpack.security.audit.logfile.emit_node_host_address`::
 Specifies whether to include the node's IP address as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-address-tag[]
 
 [[xpack-sa-lf-emit-node-host-name]]
 // tag::xpack-sa-lf-emit-node-host-name-tag[]
-`xpack.security.audit.logfile.emit_node_host_name` {ece-icon}::
+`xpack.security.audit.logfile.emit_node_host_name`::
 Specifies whether to include the node's host name as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-name-tag[]
 
 [[xpack-sa-lf-emit-node-id]]
 // tag::xpack-sa-lf-emit-node-id-tag[]
-`xpack.security.audit.logfile.emit_node_id` {ece-icon}::
+`xpack.security.audit.logfile.emit_node_id`::
 Specifies whether to include the node id as a field in each audit event.
 This is available for the new format only. That is to say, this information
 does not exist in the `<clustername>_access.log` file.
@@ -101,21 +101,21 @@ and not printed.
 
 [[xpack-sa-lf-events-ignore-users]]
 // tag::xpack-sa-lf-events-ignore-users-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.users` {ece-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.users`::
 A list of user names or wildcards. The specified policy will
 not print audit events for users matching these values.
 // end::xpack-sa-lf-events-ignore-users-tag[]
 
 [[xpack-sa-lf-events-ignore-realms]]
 // tag::xpack-sa-lf-events-ignore-realms-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.realms` {ece-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.realms`::
 A list of authentication realm names or wildcards. The specified policy will
 not print audit events for users in these realms.
 // end::xpack-sa-lf-events-ignore-realms-tag[]
 
 [[xpack-sa-lf-events-ignore-roles]]
 // tag::xpack-sa-lf-events-ignore-roles-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.roles` {ece-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.roles`::
 A list of role names or wildcards. The specified policy will
 not print audit events for users that have these roles. If the user has several
 roles, some of which are *not* covered by the policy, the policy will
@@ -124,7 +124,7 @@ roles, some of which are *not* covered by the policy, the policy will
 
 [[xpack-sa-lf-events-ignore-indices]]
 // tag::xpack-sa-lf-events-ignore-indices-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.indices` {ece-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.indices`::
 A list of index names or wildcards. The specified policy will
 not print audit events when all the indices in the event match
 these values. If the event concerns several indices, some of which are

--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -14,7 +14,7 @@ on each node in the cluster. For more information, see <<enable-audit-logging>>.
 ==== General Auditing Settings
 [[xpack-security-audit-enabled]]
 // tag::xpack-security-audit-enabled-tag[]
-`xpack.security.audit.enabled`::
+`xpack.security.audit.enabled` {ece-icon}::
 Set to `true` to enable auditing on the node. The default value is `false`.
 This puts the auditing events in a dedicated file named `<clustername>_audit.json`
 on each node.
@@ -28,7 +28,7 @@ by using the following settings:
 
 [[xpack-sa-lf-events-include]]
 // tag::xpack-sa-lf-events-include-tag[]
-`xpack.security.audit.logfile.events.include` {ess-icon}::
+`xpack.security.audit.logfile.events.include` {ece-icon}::
 Specifies which events to include in the auditing output. The default value is:
 `access_denied, access_granted, anonymous_access_denied, authentication_failed,
 connection_denied, tampered_request, run_as_denied, run_as_granted`.
@@ -36,14 +36,14 @@ connection_denied, tampered_request, run_as_denied, run_as_granted`.
 
 [[xpack-sa-lf-events-exclude]]
 // tag::xpack-sa-lf-events-exclude-tag[]
-`xpack.security.audit.logfile.events.exclude` {ess-icon}::
+`xpack.security.audit.logfile.events.exclude` {ece-icon}::
 Excludes the specified events from the output. By default, no events are
 excluded.
 // end::xpack-sa-lf-events-exclude-tag[]
 
 [[xpack-sa-lf-events-emit-request]]
 // tag::xpack-sa-lf-events-emit-request-tag[]
-`xpack.security.audit.logfile.events.emit_request_body` {ess-icon}::
+`xpack.security.audit.logfile.events.emit_request_body` {ece-icon}::
 Specifies whether to include the request body from REST requests on certain
 event types such as `authentication_failed`. The default value is `false`.
 +
@@ -59,28 +59,28 @@ audited in plain text when including the request body in audit events.
 
 [[xpack-sa-lf-emit-node-name]]
 // tag::xpack-sa-lf-emit-node-name-tag[]
-`xpack.security.audit.logfile.emit_node_name` {ess-icon}::
+`xpack.security.audit.logfile.emit_node_name` {ece-icon}::
 Specifies whether to include the <<node.name,node name>> as a field in
 each audit event. The default value is `false`.
 // end::xpack-sa-lf-emit-node-name-tag[]
 
 [[xpack-sa-lf-emit-node-host-address]]
 // tag::xpack-sa-lf-emit-node-host-address-tag[]
-`xpack.security.audit.logfile.emit_node_host_address` {ess-icon}::
+`xpack.security.audit.logfile.emit_node_host_address` {ece-icon}::
 Specifies whether to include the node's IP address as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-address-tag[]
 
 [[xpack-sa-lf-emit-node-host-name]]
 // tag::xpack-sa-lf-emit-node-host-name-tag[]
-`xpack.security.audit.logfile.emit_node_host_name` {ess-icon}::
+`xpack.security.audit.logfile.emit_node_host_name` {ece-icon}::
 Specifies whether to include the node's host name as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-name-tag[]
 
 [[xpack-sa-lf-emit-node-id]]
 // tag::xpack-sa-lf-emit-node-id-tag[]
-`xpack.security.audit.logfile.emit_node_id` {ess-icon}::
+`xpack.security.audit.logfile.emit_node_id` {ece-icon}::
 Specifies whether to include the node id as a field in each audit event.
 This is available for the new format only. That is to say, this information
 does not exist in the `<clustername>_access.log` file.
@@ -101,21 +101,21 @@ and not printed.
 
 [[xpack-sa-lf-events-ignore-users]]
 // tag::xpack-sa-lf-events-ignore-users-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.users` {ess-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.users` {ece-icon}::
 A list of user names or wildcards. The specified policy will
 not print audit events for users matching these values.
 // end::xpack-sa-lf-events-ignore-users-tag[]
 
 [[xpack-sa-lf-events-ignore-realms]]
 // tag::xpack-sa-lf-events-ignore-realms-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.realms` {ess-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.realms` {ece-icon}::
 A list of authentication realm names or wildcards. The specified policy will
 not print audit events for users in these realms.
 // end::xpack-sa-lf-events-ignore-realms-tag[]
 
 [[xpack-sa-lf-events-ignore-roles]]
 // tag::xpack-sa-lf-events-ignore-roles-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.roles` {ess-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.roles` {ece-icon}::
 A list of role names or wildcards. The specified policy will
 not print audit events for users that have these roles. If the user has several
 roles, some of which are *not* covered by the policy, the policy will
@@ -124,7 +124,7 @@ roles, some of which are *not* covered by the policy, the policy will
 
 [[xpack-sa-lf-events-ignore-indices]]
 // tag::xpack-sa-lf-events-ignore-indices-tag[]
-`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.indices` {ess-icon}::
+`xpack.security.audit.logfile.events.ignore_filters.<policy_name>.indices` {ece-icon}::
 A list of index names or wildcards. The specified policy will
 not print audit events when all the indices in the event match
 these values. If the event concerns several indices, some of which are


### PR DESCRIPTION
"I think" all `{ess-icon}` should be replaced by `{ece-icon}` because:
- audit logging is not allowed on ESS, as per https://www.elastic.co/guide/en/cloud/current/ec-add-user-settings.html and https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security
- audit logging is allowed setting on ECE, as per https://www.elastic.co/guide/en/cloud-enterprise/current/ece-enable-auditing.html

I've also added one more `{ece-icon}` for the setting `xpack.security.audit.enabled` which is used to enable them all. I believe this is necessary.

Please also make changes to other applicable versions.