### PR TITLE
[DOCS] Fix typo in JVM options

### DIFF
--- a/docs/reference/setup/jvm-options.asciidoc
+++ b/docs/reference/setup/jvm-options.asciidoc
@@ -11,7 +11,7 @@ files. When installing from the tar or zip distributions, the root `jvm.options`
 configuration file is `config/jvm.options` and custom JVM options files can be
 added to `config/jvm.options.d/`. When installing from the Debian or RPM
 packages, the root `jvm.options` configuration file is
-``/etc/elasticsearch/jvm.options` and custom JVM options files can be added to
+`/etc/elasticsearch/jvm.options` and custom JVM options files can be added to
 `/etc/elasticsearch/jvm.options.d/`. When using the <<docker, Docker
 distribution of {es}>> you can bind mount custom JVM options files into
 `/usr/share/elasticsearch/config/jvm.options.d/`. You should never need to


### PR DESCRIPTION
Typo, there's an extra ` hurts my eye 😛 
