### PR TITLE
Use int for number of parts in blob store

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
@@ -27,21 +27,21 @@ import java.io.InputStream;
  *  A {@link SlicedInputStream} is a logical
  * concatenation one or more input streams. In contrast to the JDKs
  * {@link java.io.SequenceInputStream} this stream doesn't require the instantiation
- * of all logical sub-streams ahead of time. Instead, {@link #openSlice(long)} is called
+ * of all logical sub-streams ahead of time. Instead, {@link #openSlice(int)} is called
  * if a new slice is required. Each slice is closed once it's been fully consumed or if
  * close is called before.
  */
 public abstract class SlicedInputStream extends InputStream {
-    private long slice = 0;
+    private int slice = 0;
     private InputStream currentStream;
-    private final long numSlices;
+    private final int numSlices;
     private boolean initialized = false;
 
     /**
      * Creates a new SlicedInputStream
      * @param numSlices the number of slices to consume
      */
-    protected SlicedInputStream(final long numSlices) {
+    protected SlicedInputStream(final int numSlices) {
         this.numSlices = numSlices;
     }
 
@@ -60,7 +60,7 @@ public abstract class SlicedInputStream extends InputStream {
     /**
      * Called for each logical slice given a zero based slice ordinal.
      */
-    protected abstract InputStream openSlice(long slice) throws IOException;
+    protected abstract InputStream openSlice(int slice) throws IOException;
 
     private InputStream currentStream() throws IOException {
         if (currentStream == null) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2083,7 +2083,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         } else {
                             try (InputStream stream = maybeRateLimitRestores(new SlicedInputStream(fileInfo.numberOfParts()) {
                                 @Override
-                                protected InputStream openSlice(long slice) throws IOException {
+                                protected InputStream openSlice(int slice) throws IOException {
                                     return container.readBlob(fileInfo.partName(slice));
                                 }
                             })) {

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -169,6 +169,5 @@ public class FileInfoTests extends ESTestCase {
             }
             assertEquals(numBytes, metadata.length());
         }
-
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -60,10 +60,9 @@ public class SlicedInputStreamTests extends ESTestCase {
         }
 
         SlicedInputStream input = new SlicedInputStream(parts) {
-
             @Override
-            protected InputStream openSlice(long slice) throws IOException {
-                return streams[(int)slice];
+            protected InputStream openSlice(int slice) throws IOException {
+                return streams[slice];
             }
         };
         random = new Random(seed);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -439,7 +439,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                 final IndexInput input = openInput(file.physicalName(), CachedBlobContainerIndexInput.CACHE_WARMING_CONTEXT);
                 assert input instanceof CachedBlobContainerIndexInput : "expected cached index input but got " + input.getClass();
 
-                final int numberOfParts = Math.toIntExact(file.numberOfParts());
+                final int numberOfParts = file.numberOfParts();
                 final StepListener<Collection<Void>> fileCompletionListener = new StepListener<>();
                 fileCompletionListener.whenComplete(voids -> input.close(), e -> IOUtils.closeWhileHandlingException(input));
                 fileCompletionListener.whenComplete(voids -> completionListener.onResponse(null), completionListener::onFailure);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
@@ -105,18 +105,18 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     @Override
     protected void readInternal(ByteBuffer b) throws IOException {
         ensureOpen();
-        if (fileInfo.numberOfParts() == 1L) {
+        if (fileInfo.numberOfParts() == 1) {
             readInternalBytes(0, position, b, b.remaining());
         } else {
             while (b.hasRemaining()) {
                 int currentPart = Math.toIntExact(position / fileInfo.partSize().getBytes());
-                int remainingBytesInPart;
+                long remainingBytesInPart;
                 if (currentPart < (fileInfo.numberOfParts() - 1)) {
-                    remainingBytesInPart = toIntBytes(((currentPart + 1L) * fileInfo.partSize().getBytes()) - position);
+                    remainingBytesInPart = ((currentPart + 1) * fileInfo.partSize().getBytes()) - position;
                 } else {
                     remainingBytesInPart = toIntBytes(fileInfo.length() - position);
                 }
-                final int read = Math.min(b.remaining(), remainingBytesInPart);
+                final int read = toIntBytes(Math.min(b.remaining(), remainingBytesInPart));
                 readInternalBytes(currentPart, position % fileInfo.partSize().getBytes(), b, read);
             }
         }
@@ -211,8 +211,8 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         // it and keep it open for future reads
         final InputStream inputStream = openBlobStream(part, pos, streamLength);
         streamForSequentialReads = new StreamForSequentialReads(new FilterInputStream(inputStream) {
-            private LongAdder bytesRead = new LongAdder();
-            private LongAdder timeNanos = new LongAdder();
+            private final LongAdder bytesRead = new LongAdder();
+            private final LongAdder timeNanos = new LongAdder();
 
             private int onOptimizedRead(CheckedSupplier<Integer, IOException> read) throws IOException {
                 final long startTimeNanos = stats.currentTimeNanos();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
@@ -79,18 +79,18 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
             onReadBlob.run();
 
             final InputStream stream;
-            if (fileInfo.numberOfParts() == 1L) {
+            if (fileInfo.numberOfParts() == 1) {
                 assertThat("Unexpected blob name [" + name + "]", name, equalTo(fileInfo.name()));
                 stream = new ByteArrayInputStream(input, toIntBytes(position), toIntBytes(length));
 
             } else {
                 assertThat("Unexpected blob name [" + name + "]", name, allOf(startsWith(fileInfo.name()), containsString(".part")));
 
-                long partNumber = Long.parseLong(name.substring(name.indexOf(".part") + ".part".length()));
+                int partNumber = Integer.parseInt(name.substring(name.indexOf(".part") + ".part".length()));
                 assertThat(
                     "Unexpected part number [" + partNumber + "] for [" + name + "]",
                     partNumber,
-                    allOf(greaterThanOrEqualTo(0L), lessThan(fileInfo.numberOfParts()))
+                    allOf(greaterThanOrEqualTo(0), lessThan(fileInfo.numberOfParts()))
                 );
 
                 stream = new ByteArrayInputStream(input, toIntBytes(partNumber * partSize + position), toIntBytes(length));


### PR DESCRIPTION
Today we use `long` to represent the number of parts of a blob. There's
no need for this extra range, it forces us to do some casting elsewhere,
and indeed when snapshotting we iterate over the parts using an `int`
which would be an infinite loop in case of overflow anyway:

    for (int i = 0; i < fileInfo.numberOfParts(); i++) {

This commit changes the representation of the number of parts of a blob
to an `int`.