### PR TITLE
[ML] Increase wait for templates timeout in tests

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -70,6 +70,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -125,7 +126,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
             ClusterState state = client().admin().cluster().prepareState().get().getState();
             assertTrue("Timed out waiting for the ML templates to be installed",
                     MachineLearning.allTemplatesInstalled(state));
-        });
+        }, 20, TimeUnit.SECONDS);
     }
 
     protected Job.Builder createJob(String id) {


### PR DESCRIPTION
Recently there has been a number of ML tests failing with the message "Timed out waiting for the ML templates to be installed"

https://build-stats.elastic.co/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-30d,mode:quick,to:now))&_a=(columns:!(message,test,class),index:e58bf320-7efd-11e8-bf69-63c8ef516157,interval:auto,query:(language:lucene,query:'%22Timed%20out%20waiting%20for%20the%20ML%20templates%20to%20be%20installed%22'),sort:!(time,desc))

This happens more often with multi-node tests and drilling down into the logs we can see the fault is an overworked machine. 
For example the failure in https://gradle-enterprise.elastic.co/s/dn5rorbsbk3ba takes 16 seconds install all the ml templates. 


```
[2020-08-27T08:47:33,124][INFO ][o.e.x.m.i.BasicDistributedJobsIT] [testMlStateAndResultsIndicesNotAvailable] before test
[2020-08-27T08:47:33,124][INFO ][o.e.x.m.i.BasicDistributedJobsIT] [testMlStateAndResultsIndicesNotAvailable] [BasicDistributedJobsIT#testMlStateAndResultsIndicesNotAvailable]: setting up test
....
[2020-08-27T08:47:49,125][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t0] adding template [.ml-meta] for index patterns [.ml-meta]
[2020-08-27T08:47:49,445][INFO ][o.e.x.m.i.BasicDistributedJobsIT] [testMlStateAndResultsIndicesNotAvailable] [BasicDistributedJobsIT#testMlStateAndResultsIndicesNotAvailable]: Cleaning up datafeeds and jobs after test
```