### PR TITLE
Avoid listener call under SparseFileTracker#mutex

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
@@ -177,10 +177,10 @@ public class SparseFileTracker {
                 wrappedListener.onResponse(null);
                 break;
             case 1:
-                final ProgressListenableActionFuture requiredRange = requiredListeners.get(0);
-                requiredRange.addListener(
+                final ProgressListenableActionFuture requiredListener = requiredListeners.get(0);
+                requiredListener.addListener(
                     ActionListener.map(wrappedListener, progress -> null),
-                    Math.min(requiredRange.end, subRange.v2())
+                    Math.min(requiredListener.end, subRange.v2())
                 );
                 break;
             default:


### PR DESCRIPTION
Today we sometimes notify a listener of completion while holding
`SparseFileTracker#mutex`. This commit move all such calls out from
under the mutex and adds assertions that the mutex is not held in the
listener.

Closes #61520