### PR TITLE
[7.9] [DOCS] Change 'data type' to 'field type' (#61633)

### DIFF
--- a/docs/reference/mapping/types/alias.asciidoc
+++ b/docs/reference/mapping/types/alias.asciidoc
@@ -1,5 +1,5 @@
 [[alias]]
-=== Alias data type
+=== Alias field type
 ++++
 <titleabbrev>Alias</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/binary.asciidoc
+++ b/docs/reference/mapping/types/binary.asciidoc
@@ -1,5 +1,5 @@
 [[binary]]
-=== Binary data type
+=== Binary field type
 ++++
 <titleabbrev>Binary</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -1,5 +1,5 @@
 [[boolean]]
-=== Boolean data type
+=== Boolean field type
 ++++
 <titleabbrev>Boolean</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/constant-keyword.asciidoc
+++ b/docs/reference/mapping/types/constant-keyword.asciidoc
@@ -2,7 +2,7 @@
 [testenv="basic"]
 
 [[constant-keyword]]
-=== Constant keyword data type
+=== Constant keyword field type
 ++++
 <titleabbrev>Constant keyword</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -1,5 +1,5 @@
 [[date]]
-=== Date data type
+=== Date field type
 ++++
 <titleabbrev>Date</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -1,5 +1,5 @@
 [[date_nanos]]
-=== Date nanoseconds data type
+=== Date nanoseconds field type
 ++++
 <titleabbrev>Date nanoseconds</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[dense-vector]]
-=== Dense vector data type
+=== Dense vector field type
 ++++
 <titleabbrev>Dense vector</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/flattened.asciidoc
+++ b/docs/reference/mapping/types/flattened.asciidoc
@@ -2,7 +2,7 @@
 [testenv="basic"]
 
 [[flattened]]
-=== Flattened data type
+=== Flattened field type
 ++++
 <titleabbrev>Flattened</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -1,5 +1,5 @@
 [[geo-point]]
-=== Geo-point data type
+=== Geo-point field type
 ++++
 <titleabbrev>Geo-point</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -1,5 +1,5 @@
 [[geo-shape]]
-=== Geo-shape data type
+=== Geo-shape field type
 ++++
 <titleabbrev>Geo-shape</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[histogram]]
-=== Histogram data type
+=== Histogram field type
 ++++
 <titleabbrev>Histogram</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -1,5 +1,5 @@
 [[ip]]
-=== IP data type
+=== IP field type
 ++++
 <titleabbrev>IP</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -1,5 +1,5 @@
 [[keyword]]
-=== Keyword data type
+=== Keyword field type
 ++++
 <titleabbrev>Keyword</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -1,5 +1,5 @@
 [[nested]]
-=== Nested data type
+=== Nested field type
 ++++
 <titleabbrev>Nested</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -1,5 +1,5 @@
 [[number]]
-=== Numeric data types
+=== Numeric field types
 ++++
 <titleabbrev>Numeric</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -1,5 +1,5 @@
 [[object]]
-=== Object data type
+=== Object field type
 ++++
 <titleabbrev>Object</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -1,5 +1,5 @@
 [[parent-join]]
-=== Join data type
+=== Join field type
 ++++
 <titleabbrev>Join</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -1,5 +1,5 @@
 [[percolator]]
-=== Percolator type
+=== Percolator field type
 ++++
 <titleabbrev>Percolator</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/point.asciidoc
+++ b/docs/reference/mapping/types/point.asciidoc
@@ -1,7 +1,7 @@
 [[point]]
 [role="xpack"]
 [testenv="basic"]
-=== Point data type
+=== Point field type
 ++++
 <titleabbrev>Point</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -1,5 +1,5 @@
 [[range]]
-=== Range data types
+=== Range field types
 ++++
 <titleabbrev>Range</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/rank-feature.asciidoc
+++ b/docs/reference/mapping/types/rank-feature.asciidoc
@@ -1,5 +1,5 @@
 [[rank-feature]]
-=== Rank feature data type
+=== Rank feature field type
 ++++
 <titleabbrev>Rank feature</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/rank-features.asciidoc
+++ b/docs/reference/mapping/types/rank-features.asciidoc
@@ -1,5 +1,5 @@
 [[rank-features]]
-=== Rank features data type
+=== Rank features field type
 ++++
 <titleabbrev>Rank features</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/search-as-you-type.asciidoc
+++ b/docs/reference/mapping/types/search-as-you-type.asciidoc
@@ -1,5 +1,5 @@
 [[search-as-you-type]]
-=== Search-as-you-type data type
+=== Search-as-you-type field type
 ++++
 <titleabbrev>Search-as-you-type</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -1,7 +1,7 @@
 [[shape]]
 [role="xpack"]
 [testenv="basic"]
-=== Shape data type
+=== Shape field type
 ++++
 <titleabbrev>Shape</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -1,5 +1,5 @@
 [[text]]
-=== Text data type
+=== Text field type
 ++++
 <titleabbrev>Text</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/token-count.asciidoc
+++ b/docs/reference/mapping/types/token-count.asciidoc
@@ -1,5 +1,5 @@
 [[token-count]]
-=== Token count data type
+=== Token count field type
 ++++
 <titleabbrev>Token count</titleabbrev>
 ++++

--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[wildcard]]
-=== Wildcard data type
+=== Wildcard field type
 ++++
 <titleabbrev>Wildcard</titleabbrev>
 ++++


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Change 'data type' to 'field type' (#61633)