### PR TITLE
Set timeout of auto put-follow request to unbounded

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -571,6 +571,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
             request.getParameters().setMaxWriteBufferSize(pattern.getMaxWriteBufferSize());
             request.getParameters().setMaxRetryDelay(pattern.getMaxRetryDelay());
             request.getParameters().setReadPollTimeout(pattern.getReadPollTimeout());
+            request.masterNodeTimeout(TimeValue.MAX_VALUE);
 
             // Execute if the create and follow api call succeeds:
             Runnable successHandler = () -> {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -148,6 +148,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                 assertThat(followRequest.getRemoteCluster(), equalTo("remote"));
                 assertThat(followRequest.getLeaderIndex(), equalTo("logs-20190101"));
                 assertThat(followRequest.getFollowerIndex(), equalTo("logs-20190101"));
+                assertThat(followRequest.masterNodeTimeout(), equalTo(TimeValue.MAX_VALUE));
                 successHandler.run();
             }
 
@@ -296,6 +297,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                 assertThat(followRequest.getRemoteCluster(), equalTo("remote"));
                 assertThat(followRequest.getLeaderIndex(), equalTo("logs-20190101"));
                 assertThat(followRequest.getFollowerIndex(), equalTo("logs-20190101"));
+                assertThat(followRequest.masterNodeTimeout(), equalTo(TimeValue.MAX_VALUE));
                 successHandler.run();
             }
 
@@ -500,6 +502,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                 void createAndFollow(Map<String, String> headers, PutFollowAction.Request request,
                                      Runnable successHandler, Consumer<Exception> failureHandler) {
                     assertThat(request.getRemoteCluster(), equalTo(remoteCluster));
+                    assertThat(request.masterNodeTimeout(), equalTo(TimeValue.MAX_VALUE));
                     assertThat(request.getFollowerIndex(), startsWith("copy-"));
                     followedIndices.add(request.getLeaderIndex());
                     successHandler.run();
@@ -615,6 +618,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                                  Runnable successHandler,
                                  Consumer<Exception> failureHandler) {
                 assertThat(followRequest.getRemoteCluster(), equalTo("remote"));
+                assertThat(followRequest.masterNodeTimeout(), equalTo(TimeValue.MAX_VALUE));
                 assertThat(followRequest.getLeaderIndex(), equalTo("logs-20190101"));
                 assertThat(followRequest.getFollowerIndex(), equalTo("logs-20190101"));
                 failureHandler.accept(failure);


### PR DESCRIPTION
> auto-follow stats : {"number_of_failed_follow_indices":3,"number_of_failed_remote_cluster_state_requests":0,"number_of_successful_follow_indices":11,"recent_auto_follow_errors":[{"leader_index":"my-pattern:logs-9","timestamp":1598039586196,"auto_follow_exception":{"type":"process_cluster_event_timeout_exception","reason":"failed to process cluster event (restore_snapshot[_latest_]) within 30s"}}],"auto_followed_clusters":[{"cluster_name":"leader_cluster","time_since_last_check_millis":0,"last_seen_metadata_version":29}]}

If the master node of the follower cluster is busy, then the auto-follower will fail to [initialize](https://github.com/elastic/elasticsearch/blob/0425ad6f0898e2b970aaa12b0523df9e46ff5e1d/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java#L152-L165) the following process. This also occurs when an auto-follow pattern matches multiple indices. We should set the timeout of put-follow requests issued by the auto-follower to unbounded to avoid this problem.

Closes #56891