### PR TITLE
[DOCS] Remove Outdated Snapshot Docs

### DIFF
--- a/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
+++ b/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
@@ -149,8 +149,7 @@ detailed insight into the current state of the recovery process by using <<indic
 [discrete]
 [[get-snapshot-stop-snapshot]]
 === Stop snapshot and restore operations
-The snapshot and restore framework allows running only one snapshot or one restore operation at a time. If a currently
-running snapshot was started by mistake, or takes unusually long, it can be stopped using the <<delete-snapshot-api,delete snapshot API>>.
+If a currently running snapshot was started by mistake, or takes unusually long, it can be stopped using the <<delete-snapshot-api,delete snapshot API>>.
 This operation checks whether the deleted snapshot is currently running. If it is, the delete snapshot operation stops
 that snapshot before deleting the snapshot data from the repository.
 

--- a/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
+++ b/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
@@ -149,7 +149,8 @@ detailed insight into the current state of the recovery process by using <<indic
 [discrete]
 [[get-snapshot-stop-snapshot]]
 === Stop snapshot and restore operations
-If a currently running snapshot was started by mistake, or takes unusually long, it can be stopped using the <<delete-snapshot-api,delete snapshot API>>.
+To stop a currently running snapshot that was started by mistake or is taking unusually long, use
+the <<delete-snapshot-api,delete snapshot API>>.
 This operation checks whether the deleted snapshot is currently running. If it is, the delete snapshot operation stops
 that snapshot before deleting the snapshot data from the repository.
 

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -80,8 +80,7 @@ Besides creating a copy of each data stream and index, the snapshot process can 
 cluster settings and templates. The transient settings and registered snapshot repositories are not stored as part of
 the snapshot.
 
-Only one snapshot process can be started in the cluster at any time. While a
-snapshot of a particular shard is being
+While a snapshot of a particular shard is being
 created, this shard cannot be moved to another node, which can interfere with rebalancing and allocation
 filtering. {es} can only move a shard to another node (according to the current allocation
 filtering settings and rebalancing algorithm) after the snapshot process

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -194,9 +194,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     }
 
     private void startNewSnapshots(SnapshotsInProgress snapshotsInProgress) {
-        // For now we will be mostly dealing with a single snapshot at a time but might have multiple simultaneously running
-        // snapshots in the future
-        // Now go through all snapshots and update existing or create missing
         final String localNodeId = clusterService.localNode().getId();
         for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
             final State entryState = entry.state();


### PR DESCRIPTION
Removing some now outdated statements that refer to a time
when snapshot operations could not run concurrently.

Closes #61680

Backports:

* 7.x #61728
* 7.9 #61733