### PR TITLE
add hlrc_rest_total_hits_as_int parameter in scroll request

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -409,8 +409,14 @@ final class RequestConverters {
         }
     }
 
+    private static void addSearchScrollRequestParams(Params params) {
+        params.putParam(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
+    }
+
     static Request searchScroll(SearchScrollRequest searchScrollRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_search/scroll");
+        Params params = new Params(request);
+        addSearchScrollRequestParams(params);
         request.setEntity(createEntity(searchScrollRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1150,10 +1150,14 @@ public class RequestConvertersTests extends ESTestCase {
         if (randomBoolean()) {
             searchScrollRequest.scroll(randomPositiveTimeValue());
         }
+        Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
+
         Request request = RequestConverters.searchScroll(searchScrollRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_search/scroll", request.getEndpoint());
-        assertEquals(0, request.getParameters().size());
+        assertEquals(1, request.getParameters().size());
+        assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(searchScrollRequest, request.getEntity());
         assertEquals(REQUEST_BODY_CONTENT_TYPE.mediaTypeWithoutParameters(), request.getEntity().getContentType().getValue());
     }


### PR DESCRIPTION
This commit adds a parameter called rest_total_hits_as_int to all HLRC's scroll search requests (__search/scroll_). This makes 6.8 HLRC client's compatible with ES clusters (>= 7.0.0 version).
fix #61677 
