### PR TITLE
Fix bwc of HLRC scroll search requests

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -411,6 +411,8 @@ final class RequestConverters {
 
     static Request searchScroll(SearchScrollRequest searchScrollRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_search/scroll");
+        Params params = new Params(request);
+        params.putParam(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         request.setEntity(createEntity(searchScrollRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1150,10 +1150,12 @@ public class RequestConvertersTests extends ESTestCase {
         if (randomBoolean()) {
             searchScrollRequest.scroll(randomPositiveTimeValue());
         }
+        Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         Request request = RequestConverters.searchScroll(searchScrollRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_search/scroll", request.getEndpoint());
-        assertEquals(0, request.getParameters().size());
+        assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(searchScrollRequest, request.getEntity());
         assertEquals(REQUEST_BODY_CONTENT_TYPE.mediaTypeWithoutParameters(), request.getEntity().getContentType().getValue());
     }


### PR DESCRIPTION
This change sets the rest_total_hits_as_int option automatically
in scroll search requests emitted by the Java high level rest client.
This option is already set for normal search requests but was missing
for scrolls in 6.x.

Closes #61677