### PR TITLE
Unmute TokenAuthIntegTests test

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -544,7 +544,6 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
         assertEquals("token has already been refreshed more than 30 seconds in the past", e.getHeader("error_description").get(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/55816")
     public void testRefreshingMultipleTimesWithinWindowSucceeds() throws Exception {
         final Clock clock = Clock.systemUTC();
         Client client = client().filterWithHeader(Collections.singletonMap("Authorization",
@@ -590,7 +589,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                             result.getTokenString(), result.getRefreshToken());
                     } else {
                         tokens.add(result.getTokenString() + result.getRefreshToken());
-                        client().filterWithHeader(Collections.singletonMap("Authorization", "Bearer " + result.getTokenString()))
+                        threadClient.filterWithHeader(Collections.singletonMap("Authorization", "Bearer " + result.getTokenString()))
                             .admin().cluster().health(new ClusterHealthRequest(), ActionListener.wrap(
                             r -> authStatuses.add(RestStatus.OK),
                             e -> authStatuses.add(RestStatus.BAD_REQUEST)));


### PR DESCRIPTION
@ywangd made an awesome analysis on why this test is failing, over
at https://github.com/elastic/elasticsearch/issues/55816#issuecomment-620913282

This change makes it so that we use the same client to perform a
refresh of a token, as we use to subsequently attempt to authenticate
with the refreshed token. This ensures the tests are failing and is
a good approximation of how we expect the same client doing the
refresh, to also perform the subsequent authentication in real life
uses.

The errors we were seeing from users have disappeared after #55114
so we deem our behavior safe.