### PR TITLE
[7.x] [DOCS] Fix typo in nodes stats docs (#61601)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1875,7 +1875,7 @@ Total number of HTTP connections opened for the node.
 ======
 
 [[cluster-nodes-stats-api-response-body-breakers]]
-`beakers`::
+`breakers`::
 (object)
 Contains circuit breaker statistics for the node.
 +


### PR DESCRIPTION
7.x backport of #61601