### PR TITLE
Rework output normalization in build-tools func tests (#61706) (7.x backport)

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -57,12 +57,10 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     String normalizedOutput(String input) {
+        String normalizedPathPrefix = testProjectDir.root.canonicalPath.replace('\\', '/')
         return input.readLines()
-                .collect { it.replaceAll("\\\\", "/") }
-                .collect {
-                    it.replaceAll(
-                            testProjectDir.root.canonicalPath.replaceAll('\\\\', '/'), ".")
-                }
+                .collect { it.replace('\\', '/') }
+                .collect {it.replace(normalizedPathPrefix , '.') }
                 .join("\n")
     }
 


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch/pull/61706