### PR TITLE
[7.x] [DOCS] Fix Gsub processor snippet (#61720)

### DIFF
--- a/docs/reference/ingest/processors/gsub.asciidoc
+++ b/docs/reference/ingest/processors/gsub.asciidoc
@@ -25,7 +25,7 @@ include::common-options.asciidoc[]
 {
   "gsub": {
     "field": "field1",
-    "pattern": "\.",
+    "pattern": "\\.",
     "replacement": "-"
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix Gsub processor snippet (#61720)