### PR TITLE
[7.x] [DOCS] Fix typo in range query docs (#61722)

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -136,7 +136,7 @@ increases the relevance score.
 
 [[ranges-on-text-and-keyword]]
 ===== Using the `range` query with `text` and `keyword` fields
-Range queries on <<text, `text`>> or <<keyword, `keyword`>> files will not be executed if
+Range queries on <<text, `text`>> or <<keyword, `keyword`>> fields will not be executed if
 <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>> is set to false.
 
 [[ranges-on-dates]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo in range query docs (#61722)