### PR TITLE
[7.8] [DOCS] Remove placeholder for 7.8.2 release notes (#61653)

### DIFF
--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -1,9 +1,3 @@
-[[release-notes-7.8.2]]
-== {es} version 7.8.2
-
-coming::[7.8.2]
-
-
 [[release-notes-7.8.1]]
 == {es} version 7.8.1
 


### PR DESCRIPTION
7.8 backport of #61653