### PR TITLE
[7.9] [DOCS] Add placeholder for 7.9.1 release notes (#61652)

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -1,3 +1,10 @@
+[[release-notes-7.9.1]]
+== {es} version 7.9.1
+
+Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
+
+coming::[7.9.1]
+
 [[release-notes-7.9.0]]
 == {es} version 7.9.0
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Add placeholder for 7.9.1 release notes (#61652)