### PR TITLE
[7.x] [DOCS] Document static ILM settings (#61745)

### DIFF
--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -11,18 +11,18 @@ These are the settings available for configuring <<index-lifecycle-management, {
 ==== Cluster level settings
 
 `xpack.ilm.enabled`::
-(boolean)
+(<<static-cluster-setting,Static>>, boolean)
 deprecated:[7.8.0,Basic License features are always enabled] +
 This deprecated setting has no effect and will be removed in Elasticsearch 8.0.
 
 `indices.lifecycle.history_index_enabled`::
-(boolean)
+(<<static-cluster-setting,Static>>, boolean)
 Whether ILM's history index is enabled. If enabled, ILM will record the
 history of actions taken as part of ILM policies to the `ilm-history-*`
 indices. Defaults to `true`.
 
 `indices.lifecycle.poll_interval`::
-(<<cluster-update-settings,Dynamic>>, <<time-units, time unit value>>) 
+(<<dynamic-cluster-setting,Dynamic>>, <<time-units, time unit value>>) 
 How often {ilm} checks for indices that meet policy criteria. Defaults to `10m`.
 
 ==== Index level settings


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document static ILM settings (#61745)