### PR TITLE
Standardize runtime field emit methods

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -184,17 +184,17 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
     }
 
     private static final Map<String, String> PAINLESS_TO_EMIT = Map.ofEntries(
-        Map.entry(BooleanFieldMapper.CONTENT_TYPE, "value(parse(value));"),
-        Map.entry(DateFieldMapper.CONTENT_TYPE, "millis(parse(value.toString()));"),
+        Map.entry(BooleanFieldMapper.CONTENT_TYPE, "emitValue(parse(value));"),
+        Map.entry(DateFieldMapper.CONTENT_TYPE, "emitValue(parse(value.toString()));"),
         Map.entry(
             NumberType.DOUBLE.typeName(),
-            "value(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
+            "emitValue(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));"
         ),
-        Map.entry(KeywordFieldMapper.CONTENT_TYPE, "value(value.toString());"),
-        Map.entry(IpFieldMapper.CONTENT_TYPE, "stringValue(value.toString());"),
+        Map.entry(KeywordFieldMapper.CONTENT_TYPE, "emitValue(value.toString());"),
+        Map.entry(IpFieldMapper.CONTENT_TYPE, "emitValue(value.toString());"),
         Map.entry(
             NumberType.LONG.typeName(),
-            "value(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
+            "emitValue(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
         )
     );
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
@@ -49,7 +49,7 @@ public abstract class AbstractLongScriptFieldScript extends AbstractScriptFieldS
         return count;
     }
 
-    protected void collectValue(long v) {
+    protected final void emitValue(long v) {
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
@@ -66,7 +66,7 @@ public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript
         return falses;
     }
 
-    private void collectValue(boolean v) {
+    protected final void emitValue(boolean v) {
         if (v) {
             trues++;
         } else {
@@ -78,15 +78,15 @@ public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript
         return Booleans.parseBoolean(str.toString());
     }
 
-    public static class Value {
+    public static class EmitValue {
         private final BooleanScriptFieldScript script;
 
-        public Value(BooleanScriptFieldScript script) {
+        public EmitValue(BooleanScriptFieldScript script) {
             this.script = script;
         }
 
         public void value(boolean v) {
-            script.collectValue(v);
+            script.emitValue(v);
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
@@ -44,30 +44,22 @@ public abstract class DateScriptFieldScript extends AbstractLongScriptFieldScrip
         this.formatter = formatter;
     }
 
-    public static class Millis {
-        private final DateScriptFieldScript script;
-
-        public Millis(DateScriptFieldScript script) {
-            this.script = script;
-        }
-
-        public void millis(long v) {
-            script.collectValue(v);
-        }
+    public static long toEpochMilli(TemporalAccessor v) {
+        // TemporalAccessor is a nanos API so we have to convert.
+        long millis = Math.multiplyExact(v.getLong(ChronoField.INSTANT_SECONDS), 1000);
+        millis = Math.addExact(millis, v.get(ChronoField.NANO_OF_SECOND) / 1_000_000);
+        return millis;
     }
 
-    public static class Date {
+    public static class EmitValue {
         private final DateScriptFieldScript script;
 
-        public Date(DateScriptFieldScript script) {
+        public EmitValue(DateScriptFieldScript script) {
             this.script = script;
         }
 
-        public void date(TemporalAccessor v) {
-            // TemporalAccessor is a nanos API so we have to convert.
-            long millis = Math.multiplyExact(v.getLong(ChronoField.INSTANT_SECONDS), 1000);
-            millis = Math.addExact(millis, v.get(ChronoField.NANO_OF_SECOND) / 1_000_000);
-            script.collectValue(millis);
+        public void emitValue(long v) {
+            script.emitValue(v);
         }
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -68,22 +68,22 @@ public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript 
         return count;
     }
 
-    private void collectValue(double v) {
+    protected final void emitValue(double v) {
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }
         values[count++] = v;
     }
 
-    public static class Value {
+    public static class EmitValue {
         private final DoubleScriptFieldScript script;
 
-        public Value(DoubleScriptFieldScript script) {
+        public EmitValue(DoubleScriptFieldScript script) {
             this.script = script;
         }
 
-        public void value(double v) {
-            script.collectValue(v);
+        public void emitValue(double v) {
+            script.emitValue(v);
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
@@ -92,22 +92,22 @@ public abstract class IpScriptFieldScript extends AbstractScriptFieldScript {
         return count;
     }
 
-    private void collectValue(String v) {
+    protected final void emitValue(String v) {
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }
         values[count++] = new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)));
     }
 
-    public static class StringValue {
+    public static class EmitValue {
         private final IpScriptFieldScript script;
 
-        public StringValue(IpScriptFieldScript script) {
+        public EmitValue(IpScriptFieldScript script) {
             this.script = script;
         }
 
-        public void stringValue(String v) {
-            script.collectValue(v);
+        public void emitValue(String v) {
+            script.emitValue(v);
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
@@ -38,15 +38,15 @@ public abstract class LongScriptFieldScript extends AbstractLongScriptFieldScrip
         super(params, searchLookup, ctx);
     }
 
-    public static class Value {
+    public static class EmitValue {
         private final LongScriptFieldScript script;
 
-        public Value(LongScriptFieldScript script) {
+        public EmitValue(LongScriptFieldScript script) {
             this.script = script;
         }
 
-        public void value(long v) {
-            script.collectValue(v);
+        public void emitValue(long v) {
+            script.emitValue(v);
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
@@ -54,15 +54,19 @@ public abstract class StringScriptFieldScript extends AbstractScriptFieldScript 
         return results;
     }
 
-    public static class Value {
+    protected final void emitValue(String v) {
+        results.add(v);
+    }
+
+    public static class EmitValue {
         private final StringScriptFieldScript script;
 
-        public Value(StringScriptFieldScript script) {
+        public EmitValue(StringScriptFieldScript script) {
             this.script = script;
         }
 
-        public void value(String v) {
-            script.results.add(v);
+        public void emitValue(String v) {
+            script.emitValue(v);
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
@@ -6,15 +6,16 @@
 
 # The whitelist for boolean-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript @no_import {
-
+}
+class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void value(org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript, boolean) bound_to org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Value
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript, boolean) bound_to org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$EmitValue
+    # Parse a value from the source to a boolean
     boolean parse(def) from_class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript
 }
 
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Factory @no_import {
-}

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
@@ -6,15 +6,20 @@
 
 # The whitelist for date-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void millis(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Millis
-    void date(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, TemporalAccessor) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Date
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$EmitValue
+    # Parse a value from the source to millis since epoch
     long parse(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, def) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Parse
+    # Add an easy method to convert temporalAccessors to millis since epoch.
+    long toEpochMilli(java.time.temporal.TemporalAccessor) from_class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript
 }
 
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Factory @no_import {
-}
+
+

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
@@ -6,13 +6,14 @@
 
 # The whitelist for double-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void value(org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript, double) bound_to org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Value
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript, double) bound_to org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$EmitValue
 }
 
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Factory @no_import {
-}

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/ip_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/ip_whitelist.txt
@@ -6,13 +6,13 @@
 
 # The whitelist for ip-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.IpScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void stringValue(org.elasticsearch.xpack.runtimefields.IpScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$StringValue
-}
-
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$Factory @no_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.IpScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$EmitValue
 }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
@@ -6,13 +6,13 @@
 
 # The whitelist for long-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void value(org.elasticsearch.xpack.runtimefields.LongScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Value
-}
-
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Factory @no_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.LongScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$EmitValue
 }

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/string_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/string_whitelist.txt
@@ -6,13 +6,13 @@
 
 # The whitelist for string-valued runtime fields
 
+# These two whitelists are required for painless to find the classes
 class org.elasticsearch.xpack.runtimefields.StringScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$Factory @no_import {
 }
 
 static_import {
-    void value(org.elasticsearch.xpack.runtimefields.StringScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$Value
-}
-
-# This import is required to make painless happy and it isn't 100% clear why
-class org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$Factory @no_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.StringScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$EmitValue
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
@@ -16,7 +16,7 @@ public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<Boo
     ) {
         @Override
         public void execute() {
-            new BooleanScriptFieldScript.Value(this).value(false);
+            emitValue(false);
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
@@ -17,7 +17,7 @@ public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateSc
     ) {
         @Override
         public void execute() {
-            new DateScriptFieldScript.Millis(this).millis(1595431354874L);
+            emitValue(1595431354874L);
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -16,7 +16,7 @@ public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<Doub
     ) {
         @Override
         public void execute() {
-            new DoubleScriptFieldScript.Value(this).value(1.0);
+            emitValue(1.0);
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
@@ -12,7 +12,7 @@ public class IpScriptFieldScriptTests extends ScriptFieldScriptTestCase<IpScript
     public static final IpScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new IpScriptFieldScript(params, lookup, ctx) {
         @Override
         public void execute() {
-            new IpScriptFieldScript.StringValue(this).stringValue("192.168.0.1");
+            emitValue("192.168.0.1");
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
@@ -12,7 +12,7 @@ public class LongScriptFieldScriptTests extends ScriptFieldScriptTestCase<LongSc
     public static final LongScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new LongScriptFieldScript(params, lookup, ctx) {
         @Override
         public void execute() {
-            new LongScriptFieldScript.Value(this).value(1);
+            emitValue(1);
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
@@ -16,7 +16,7 @@ public class StringScriptFieldScriptTests extends ScriptFieldScriptTestCase<Stri
     ) {
         @Override
         public void execute() {
-            new StringScriptFieldScript.Value(this).value("foo");
+            emitValue("foo");
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
@@ -413,7 +413,7 @@ public class ScriptBooleanMappedFieldTypeTests extends AbstractNonTextScriptMapp
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new BooleanScriptFieldScript.Value(this).value(parse(foo));
+                                            emitValue(parse(foo));
                                         }
                                     }
                                 };
@@ -422,9 +422,7 @@ public class ScriptBooleanMappedFieldTypeTests extends AbstractNonTextScriptMapp
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new BooleanScriptFieldScript.Value(this).value(
-                                                (Boolean) foo ^ ((Boolean) getParams().get("param"))
-                                            );
+                                            emitValue((Boolean) foo ^ ((Boolean) getParams().get("param")));
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
@@ -440,7 +440,7 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                     public void execute() {
                                         for (Object timestamp : (List<?>) getSource().get("timestamp")) {
                                             DateScriptFieldScript.Parse parse = new DateScriptFieldScript.Parse(this);
-                                            new DateScriptFieldScript.Millis(this).millis(parse.parse(timestamp));
+                                            emitValue(parse.parse(timestamp));
                                         }
                                     }
                                 };
@@ -452,7 +452,7 @@ public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                             long epoch = (Long) timestamp;
                                             ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
                                             dt = dt.plus(((Number) params.get("days")).longValue(), ChronoUnit.DAYS);
-                                            new DateScriptFieldScript.Date(this).date(dt);
+                                            emitValue(toEpochMilli(dt));
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
@@ -272,7 +272,7 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new DoubleScriptFieldScript.Value(this).value(((Number) foo).doubleValue());
+                                            emitValue(((Number) foo).doubleValue());
                                         }
                                     }
                                 };
@@ -281,9 +281,7 @@ public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappe
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new DoubleScriptFieldScript.Value(this).value(
-                                                ((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue()
-                                            );
+                                            emitValue(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldTypeTests.java
@@ -301,7 +301,7 @@ public class ScriptIpMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new IpScriptFieldScript.StringValue(this).stringValue(foo.toString());
+                                            emitValue(foo.toString());
                                         }
                                     }
                                 };
@@ -310,9 +310,7 @@ public class ScriptIpMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new IpScriptFieldScript.StringValue(this).stringValue(
-                                                foo.toString() + getParams().get("param")
-                                            );
+                                            emitValue(foo.toString() + getParams().get("param"));
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
@@ -375,7 +375,7 @@ public class ScriptKeywordMappedFieldTypeTests extends AbstractScriptMappedField
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new StringScriptFieldScript.Value(this).value(foo.toString());
+                                            emitValue(foo.toString());
                                         }
                                     }
                                 };
@@ -384,9 +384,7 @@ public class ScriptKeywordMappedFieldTypeTests extends AbstractScriptMappedField
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new StringScriptFieldScript.Value(this).value(
-                                                foo.toString() + getParams().get("param").toString()
-                                            );
+                                            emitValue(foo.toString() + getParams().get("param").toString());
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
@@ -271,7 +271,7 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new LongScriptFieldScript.Value(this).value(((Number) foo).longValue());
+                                            emitValue(((Number) foo).longValue());
                                         }
                                     }
                                 };
@@ -280,9 +280,7 @@ public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            new LongScriptFieldScript.Value(this).value(
-                                                ((Number) foo).longValue() + ((Number) getParams().get("param")).longValue()
-                                            );
+                                            emitValue(((Number) foo).longValue() + ((Number) getParams().get("param")).longValue());
                                         }
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
@@ -91,7 +91,7 @@ public class LongScriptFieldDistanceFeatureQueryTests extends AbstractScriptFiel
                         @Override
                         public void execute() {
                             for (Object timestamp : (List<?>) getSource().get("timestamp")) {
-                                new DateScriptFieldScript.Millis(this).millis(((Number) timestamp).longValue());
+                                emitValue(((Number) timestamp).longValue());
                             }
                         }
                     };

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -21,7 +21,7 @@ setup:
                 type: runtime_script
                 runtime_type: keyword
                 script: |
-                  value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+                  emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
               # Test fetching from _source
               day_of_week_from_source:
                 type: runtime_script
@@ -29,7 +29,7 @@ setup:
                 script: |
                   Instant instant = Instant.ofEpochMilli(source['timestamp']);
                   ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
-                  value(dt.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ROOT));
+                  emitValue(dt.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ROOT));
               # Test fetching many values
               day_of_week_letters:
                 type: runtime_script
@@ -37,7 +37,7 @@ setup:
                 script: |
                   for (String dow: doc['day_of_week']) {
                     for (int i = 0; i < dow.length(); i++) {
-                      value(dow.charAt(i).toString());
+                      emitValue(dow.charAt(i).toString());
                     }
                   }
               prefixed_node:
@@ -46,7 +46,7 @@ setup:
                 script:
                   source: |
                     for (String node : doc['node']) {
-                      value(params.prefix + node);
+                      emitValue(params.prefix + node);
                     }
                   params:
                     prefix: node_
@@ -78,7 +78,7 @@ setup:
   - match: {sensor.mappings.properties.day_of_week.runtime_type: keyword }
   - match:
       sensor.mappings.properties.day_of_week.script.source: |
-        value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+        emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
   - match: {sensor.mappings.properties.day_of_week.script.lang: painless }
 
 ---
@@ -94,7 +94,7 @@ setup:
         runtime_type: keyword
         script:
           source: |
-            value(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+            emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
           lang: painless
         meta: {}
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -23,7 +23,7 @@ setup:
                 script:
                   source: |
                     for (double v : doc['voltage']) {
-                      value((long)(v * params.multiplier));
+                      emitValue((long)(v * params.multiplier));
                     }
                   params:
                     multiplier: 10
@@ -33,7 +33,7 @@ setup:
                 runtime_type: long
                 script:
                   source: |
-                    value((long)(source['voltage'] * params.multiplier));
+                    emitValue((long)(source['voltage'] * params.multiplier));
                   params:
                     multiplier: 10
               # Test fetching many values
@@ -45,7 +45,7 @@ setup:
                     for (long temperature : doc['temperature']) {
                       long t = temperature;
                       while (t != 0) {
-                        value(t % 10);
+                        emitValue(t % 10);
                         t /= 10;
                       }
                     }
@@ -78,7 +78,7 @@ setup:
   - match:
       sensor.mappings.properties.voltage_times_ten.script.source: |
         for (double v : doc['voltage']) {
-          value((long)(v * params.multiplier));
+          emitValue((long)(v * params.multiplier));
         }
   - match: {sensor.mappings.properties.voltage_times_ten.script.params: {multiplier: 10} }
   - match: {sensor.mappings.properties.voltage_times_ten.script.lang: painless }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
@@ -23,7 +23,7 @@ setup:
                 script:
                   source: |
                     for (double v : doc['voltage']) {
-                      value(v / params.max);
+                      emitValue(v / params.max);
                     }
                   params:
                     max: 5.8
@@ -33,7 +33,7 @@ setup:
                 runtime_type: double
                 script:
                   source: |
-                    value(source['voltage'] / params.max);
+                    emitValue(source['voltage'] / params.max);
                   params:
                     max: 5.8
               # Test fetching many values
@@ -45,7 +45,7 @@ setup:
                     for (double voltage : doc['voltage']) {
                       double v = voltage;
                       while (v > 1.2) {
-                        value(v);
+                        emitValue(v);
                         v = Math.sqrt(v);
                       }
                     }
@@ -78,7 +78,7 @@ setup:
   - match:
       sensor.mappings.properties.voltage_percent.script.source: |
         for (double v : doc['voltage']) {
-          value(v / params.max);
+          emitValue(v / params.max);
         }
   - match: {sensor.mappings.properties.voltage_percent.script.params: {max: 5.8} }
   - match: {sensor.mappings.properties.voltage_percent.script.lang: painless }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -23,7 +23,7 @@ setup:
                 script:
                   source: |
                     for (def dt : doc['timestamp']) {
-                      date(dt.plus(params.days, ChronoUnit.DAYS));
+                      emitValue(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
                     }
                   params:
                     days: 1
@@ -35,7 +35,7 @@ setup:
                   source: |
                     Instant instant = Instant.ofEpochMilli(parse(source['timestamp']));
                     ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
-                    date(dt.plus(1, ChronoUnit.DAYS));
+                    emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
               # Test returning millis
               the_past:
                 type: runtime_script
@@ -43,7 +43,7 @@ setup:
                 script:
                   source: |
                     for (def dt : doc['timestamp']) {
-                      millis(dt.toInstant().toEpochMilli() - 1000);
+                      emitValue(dt.toInstant().toEpochMilli() - 1000);
                     }
               # Test fetching many values
               all_week:
@@ -53,7 +53,7 @@ setup:
                   source: |
                     for (def dt : doc['timestamp']) {
                       for (int i = 0; i < 7; i++) {
-                        date(dt.plus(i, ChronoUnit.DAYS));
+                        emitValue(toEpochMilli(dt.plus(i, ChronoUnit.DAYS)));
                       }
                     }
               # Test format parameter
@@ -63,7 +63,7 @@ setup:
                 format: yyyy-MM-dd
                 script: |
                   for (def dt : doc['timestamp']) {
-                    date(dt.plus(1, ChronoUnit.DAYS));
+                    emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
                   }
 
   - do:
@@ -94,7 +94,7 @@ setup:
   - match:
       sensor.mappings.properties.tomorrow.script.source: |
         for (def dt : doc['timestamp']) {
-          date(dt.plus(params.days, ChronoUnit.DAYS));
+          emitValue(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
         }
   - match: {sensor.mappings.properties.tomorrow.script.params: {days: 1} }
   - match: {sensor.mappings.properties.tomorrow.script.lang: painless }
@@ -104,7 +104,7 @@ setup:
   - match:
       sensor.mappings.properties.formatted_tomorrow.script.source: |
         for (def dt : doc['timestamp']) {
-          date(dt.plus(1, ChronoUnit.DAYS));
+          emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
         }
   - match: {sensor.mappings.properties.formatted_tomorrow.script.lang: painless }
   - match: {sensor.mappings.properties.formatted_tomorrow.format: yyyy-MM-dd }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -20,7 +20,7 @@ setup:
                   source: |
                     String m = doc["message"].value;
                     int end = m.indexOf(" ");
-                    stringValue(m.substring(0, end));
+                    emitValue(m.substring(0, end));
               # Test fetching from _source
               ip_from_source:
                 type: runtime_script
@@ -29,7 +29,7 @@ setup:
                   source: |
                     String m = source["message"];
                     int end = m.indexOf(" ");
-                    stringValue(m.substring(0, end));
+                    emitValue(m.substring(0, end));
               # Test emitting many values
               ip_many:
                 type: runtime_script
@@ -41,7 +41,7 @@ setup:
                     end = m.lastIndexOf(".", end);
                     String stem = m.substring(0, end + 1);
                     for (int i = 0; i < 5; i++) {
-                      stringValue(stem + i);
+                      emitValue(stem + i);
                     }
   - do:
       bulk:
@@ -73,7 +73,7 @@ setup:
       http_logs.mappings.properties.ip.script.source: |
         String m = doc["message"].value;
         int end = m.indexOf(" ");
-        stringValue(m.substring(0, end));
+        emitValue(m.substring(0, end));
   - match: {http_logs.mappings.properties.ip.script.lang: painless }
 
 ---

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
@@ -23,7 +23,7 @@ setup:
                 script:
                   source: |
                     for (def v : doc['voltage']) {
-                      value(v >= params.min_v);
+                      emitValue(v >= params.min_v);
                     }
                   params:
                     min_v: 5.0
@@ -33,7 +33,7 @@ setup:
                 runtime_type: boolean
                 script:
                   source: |
-                    value(source['voltage'] >= 5.0);
+                    emitValue(source['voltage'] >= 5.0);
               # Test many booleans
               big_vals:
                 type: runtime_script
@@ -41,13 +41,11 @@ setup:
                 script:
                   source: |
                     for (def v : doc['temperature']) {
-                      value(v >= 200);
+                      emitValue(v >= 200);
                     }
                     for (def v : doc['voltage']) {
-                      value(v >= 5.0);
+                      emitValue(v >= 5.0);
                     }
-
-
 
   - do:
       bulk:
@@ -77,7 +75,7 @@ setup:
   - match:
       sensor.mappings.properties.over_v.script.source: |
         for (def v : doc['voltage']) {
-          value(v >= params.min_v);
+          emitValue(v >= params.min_v);
         }
   - match: {sensor.mappings.properties.over_v.script.params: {min_v: 5.0} }
   - match: {sensor.mappings.properties.over_v.script.lang: painless }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/90_loops.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/90_loops.yml
@@ -20,23 +20,23 @@ setup:
               tight_loop:
                 type: runtime_script
                 runtime_type: keyword
-                script: value(doc['tight_loop'].value)
+                script: emitValue(doc['tight_loop'].value)
               loose_loop:
                 type: runtime_script
                 runtime_type: keyword
-                script: value(doc['lla'].value)
+                script: emitValue(doc['lla'].value)
               lla:
                 type: runtime_script
                 runtime_type: keyword
-                script: value(doc['llb'].value)
+                script: emitValue(doc['llb'].value)
               llb:
                 type: runtime_script
                 runtime_type: keyword
-                script: value(doc['llc'].value)
+                script: emitValue(doc['llc'].value)
               llc:
                 type: runtime_script
                 runtime_type: keyword
-                script: value(doc['loose_loop'].value)
+                script: emitValue(doc['loose_loop'].value)
 
   - do:
       bulk:


### PR DESCRIPTION
This standardizes that name for all of the "emit value" methods used by
runtime field scripts to `emitValue`. To make dates possible this adds a
a `toEpochMilli` method to convert from `TemporalAccessor` into millis
since epoch.
