### PR TITLE
Calculate precise cardinality upper bounds (backport of #61529)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -67,7 +67,7 @@ public class NestedAggregator extends BucketsAggregator implements SingleBucketA
             : Queries.newNonNestedFilter(context.mapperService().getIndexSettings().getIndexVersionCreated());
         this.parentFilter = context.bitsetFilterCache().getBitSetProducer(parentFilter);
         this.childFilter = childObjectMapper.nestedTypeFilter();
-        this.collectsFromSingleBucket = cardinality != CardinalityUpperBound.MANY;
+        this.collectsFromSingleBucket = cardinality.map(estimate -> estimate < 2);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
@@ -34,7 +34,7 @@ public abstract class BytesKeyedBucketOrds implements Releasable {
      * Build a {@link LongKeyedBucketOrds}.
      */
     public static BytesKeyedBucketOrds build(BigArrays bigArrays, CardinalityUpperBound cardinality) {
-        return cardinality == CardinalityUpperBound.ONE ? new FromSingle(bigArrays) : new FromMany(bigArrays);
+        return cardinality.map(estimate -> estimate < 2 ? new FromSingle(bigArrays) : new FromMany(bigArrays));
     }
 
     private BytesKeyedBucketOrds() {}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -106,10 +106,12 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         if (remapGlobalOrds) {
             this.collectionStrategy = new RemapGlobalOrds(cardinality);
         } else {
-            if (cardinality == CardinalityUpperBound.MANY) {
-                throw new AggregationExecutionException("Dense ords don't know how to collect from many buckets");
-            }
-            this.collectionStrategy = new DenseGlobalOrds();
+            this.collectionStrategy = cardinality.map(estimate -> {
+                if (estimate > 1) {
+                    throw new AggregationExecutionException("Dense ords don't know how to collect from many buckets");
+                }
+                return new DenseGlobalOrds();
+            });
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -33,8 +33,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
      * Build a {@link LongKeyedBucketOrds}.
      */
     public static LongKeyedBucketOrds build(BigArrays bigArrays, CardinalityUpperBound cardinality) {
-        // TODO nothing NONE?
-        return cardinality != CardinalityUpperBound.MANY ? new FromSingle(bigArrays) : new FromMany(bigArrays);
+        return cardinality.map(estimate -> estimate < 2 ? new FromSingle(bigArrays) : new FromMany(bigArrays));
     }
 
     private LongKeyedBucketOrds() {}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/CardinalityUpperBoundTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/CardinalityUpperBoundTests.java
@@ -22,20 +22,47 @@ package org.elasticsearch.search.aggregations;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class CardinalityUpperBoundTests extends ESTestCase {
     public void testNoneMultiply() {
-        assertThat(CardinalityUpperBound.NONE.multiply(randomInt()), equalTo(CardinalityUpperBound.NONE));
+        assertThat(CardinalityUpperBound.NONE.multiply(randomInt()), sameInstance(CardinalityUpperBound.NONE));
+    }
+
+    public void testNoneMap() {
+        assertThat(CardinalityUpperBound.NONE.map(i -> i), equalTo(0));
     }
 
     public void testOneMultiply() {
-        assertThat(CardinalityUpperBound.ONE.multiply(0), equalTo(CardinalityUpperBound.NONE));
-        assertThat(CardinalityUpperBound.ONE.multiply(1), equalTo(CardinalityUpperBound.ONE));
-        assertThat(CardinalityUpperBound.ONE.multiply(between(2, Integer.MAX_VALUE)), equalTo(CardinalityUpperBound.MANY));
+        assertThat(CardinalityUpperBound.ONE.multiply(0), sameInstance(CardinalityUpperBound.NONE));
+        assertThat(CardinalityUpperBound.ONE.multiply(1), sameInstance(CardinalityUpperBound.ONE));
+        assertThat(CardinalityUpperBound.ONE.multiply(Integer.MAX_VALUE), sameInstance(CardinalityUpperBound.MANY));
+    }
+
+    public void testOneMap() {
+        assertThat(CardinalityUpperBound.ONE.map(i -> i), equalTo(1));
+    }
+
+    public void testLargerKnownValues() {
+        int estimate = between(2, Short.MAX_VALUE);
+        CardinalityUpperBound known = CardinalityUpperBound.ONE.multiply(estimate);
+        assertThat(known.map(i -> i), equalTo(estimate));
+
+        assertThat(known.multiply(0), sameInstance(CardinalityUpperBound.NONE));
+        assertThat(known.multiply(1), sameInstance(known));
+        int minOverflow = (int) Math.ceil((double) Integer.MAX_VALUE / estimate);
+        assertThat(known.multiply(between(minOverflow, Integer.MAX_VALUE)), sameInstance(CardinalityUpperBound.MANY));
+
+        int multiplier = between(2, Short.MAX_VALUE - 1);
+        assertThat(known.multiply(multiplier).map(i -> i), equalTo(estimate * multiplier));
     }
 
     public void testManyMultiply() {
-        assertThat(CardinalityUpperBound.MANY.multiply(0), equalTo(CardinalityUpperBound.NONE));
-        assertThat(CardinalityUpperBound.MANY.multiply(between(1, Integer.MAX_VALUE)), equalTo(CardinalityUpperBound.MANY));
+        assertThat(CardinalityUpperBound.MANY.multiply(0), sameInstance(CardinalityUpperBound.NONE));
+        assertThat(CardinalityUpperBound.MANY.multiply(between(1, Integer.MAX_VALUE)), sameInstance(CardinalityUpperBound.MANY));
+    }
+
+    public void testManyMap() {
+        assertThat(CardinalityUpperBound.MANY.map(i -> i), equalTo(Integer.MAX_VALUE));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -289,9 +289,9 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         simpleTestCase(aggregationBuilder, new MatchAllDocsQuery(), range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             InternalAggCardinality pc = ranges.get(0).getAggregations().get("c");
-            assertThat(pc.cardinality(), equalTo(CardinalityUpperBound.MANY));
+            assertThat(pc.cardinality().map(i -> i), equalTo(2));
             pc = ranges.get(1).getAggregations().get("c");
-            assertThat(pc.cardinality(), equalTo(CardinalityUpperBound.MANY));
+            assertThat(pc.cardinality().map(i -> i), equalTo(2));
         });
     }
 


### PR DESCRIPTION
This reworks `CardinalityUpperBound` to support precise estimates while
maintaining most of the public API. This will allow us to make more
informed choices about the data structures that we use in aggregations.
None of those interesting choices come as part of this change, but they
are more possible with it.
