### PR TITLE
[DOCS] Clarify enabling monitoring features

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -18,12 +18,8 @@ legacy collection methods; do not use both.
 Learn more about <<configuring-metricbeat>>.
 =========================
 
-If you enable the Elastic {monitor-features} in your cluster, you can
-optionally collect metrics about {es}. By default, monitoring is enabled but
-data collection is disabled.
-
-This method involves sending the metrics to the monitoring cluster by using
-exporters. For the recommended method, see <<configuring-metricbeat>>.
+This method for collecting metrics about {es} involves sending the metrics to
+the monitoring cluster by using exporters. For the recommended method, see <<configuring-metricbeat>>.
 
 Advanced monitoring settings enable you to control how frequently data is
 collected, configure timeouts, and set the retention period for locally-stored


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/61673

This PR removes the sentence "By default, monitoring is enabled but data collection is disabled" from the legacy monitoring documentation. It was unclear and was related to the `xpack.monitoring.enabled` setting, which was deprecated in 7.8.0 and no longer has an effect on monitoring behaviour.

### Preview

https://elasticsearch_61758.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/collecting-monitoring-data.html