### PR TITLE
Ensure audit request tracking id sticks when context changes

### DIFF
--- a/docs/changelog/61759.yaml
+++ b/docs/changelog/61759.yaml
@@ -1,0 +1,5 @@
+pr: 61759
+summary: Ensure audit request tracking id sticks when context changes
+area: Audit
+type: enhancement
+issues: []

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -44,7 +44,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.tasks.Task;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.transport.NettyAllocator;
 
 import java.io.Closeable;
@@ -77,7 +77,7 @@ class Netty4HttpClient implements Closeable {
     static Collection<String> returnOpaqueIds(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
         for (HttpResponse response : responses) {
-            list.add(response.headers().get(Task.X_OPAQUE_ID));
+            list.add(response.headers().get(ThreadContext.X_OPAQUE_ID));
         }
         return list;
     }

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.nio.BytesChannelContext;
 import org.elasticsearch.nio.ChannelFactory;
@@ -53,7 +54,6 @@ import org.elasticsearch.nio.NioServerSocketChannel;
 import org.elasticsearch.nio.NioSocketChannel;
 import org.elasticsearch.nio.SocketChannelContext;
 import org.elasticsearch.nio.WriteOperation;
-import org.elasticsearch.tasks.Task;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -82,7 +82,7 @@ class NioHttpClient implements Closeable {
     static Collection<String> returnOpaqueIds(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
         for (HttpResponse response : responses) {
-            list.add(response.headers().get(Task.X_OPAQUE_ID));
+            list.add(response.headers().get(ThreadContext.X_OPAQUE_ID));
         }
         return list;
     }
@@ -105,7 +105,7 @@ class NioHttpClient implements Closeable {
         for (int i = 0; i < uris.length; i++) {
             final HttpRequest httpRequest = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, uris[i]);
             httpRequest.headers().add(HOST, "localhost");
-            httpRequest.headers().add(Task.X_OPAQUE_ID, String.valueOf(i));
+            httpRequest.headers().add(ThreadContext.X_OPAQUE_ID, String.valueOf(i));
             requests.add(httpRequest);
         }
         return sendRequests(remoteAddress, requests);

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -89,7 +88,7 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testDeprecatedMessage() throws Exception {
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "someId");
+            threadContext.putHeader(ThreadContext.X_OPAQUE_ID, "someId");
             final DeprecationLogger testLogger = DeprecationLogger.getLogger("test");
             testLogger.deprecate("someKey", "deprecated message1");
 
@@ -340,7 +339,7 @@ public class JsonLoggerTests extends ESTestCase {
 
         // For the same key and X-Opaque-ID deprecation should be once
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "ID1");
+            threadContext.putHeader(ThreadContext.X_OPAQUE_ID, "ID1");
             deprecationLogger.deprecate("key", "message1");
             deprecationLogger.deprecate("key", "message2");
             assertWarnings("message1", "message2");
@@ -368,7 +367,7 @@ public class JsonLoggerTests extends ESTestCase {
         // For the same key and different X-Opaque-ID should be multiple times per key/x-opaque-id
         //continuing with message1-ID1 in logs already, adding a new deprecation log line with message2-ID2
         withThreadContext(threadContext -> {
-            threadContext.putHeader(Task.X_OPAQUE_ID, "ID2");
+            threadContext.putHeader(ThreadContext.X_OPAQUE_ID, "ID2");
             deprecationLogger.deprecate("key", "message1");
             deprecationLogger.deprecate("key", "message2");
             assertWarnings("message1", "message2");

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
@@ -349,7 +350,7 @@ public class TasksIT extends ESIntegTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         Map<String, String> headers = new HashMap<>();
-        headers.put(Task.X_OPAQUE_ID, "my_id");
+        headers.put(ThreadContext.X_OPAQUE_ID, "my_id");
         headers.put("Foo-Header", "bar");
         headers.put("Custom-Task-Header", "my_value");
         assertSearchResponse(
@@ -396,7 +397,7 @@ public class TasksIT extends ESIntegTestCase {
         int maxSize = Math.toIntExact(SETTING_HTTP_MAX_HEADER_SIZE.getDefault(Settings.EMPTY).getBytes() / 2 + 1);
 
         Map<String, String> headers = new HashMap<>();
-        headers.put(Task.X_OPAQUE_ID, "my_id");
+        headers.put(ThreadContext.X_OPAQUE_ID, "my_id");
         headers.put("Custom-Task-Header", randomAlphaOfLengthBetween(maxSize, maxSize + 100));
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
@@ -407,7 +408,7 @@ public class TasksIT extends ESIntegTestCase {
 
     private void assertTaskHeaders(TaskInfo taskInfo) {
         assertThat(taskInfo.getHeaders().keySet(), hasSize(2));
-        assertEquals("my_id", taskInfo.getHeaders().get(Task.X_OPAQUE_ID));
+        assertEquals("my_id", taskInfo.getHeaders().get(ThreadContext.X_OPAQUE_ID));
         assertEquals("my_value", taskInfo.getHeaders().get("Custom-Task-Header"));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -244,6 +244,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.gateway.TransportNodesListGatewayMetaState;
 import org.elasticsearch.gateway.TransportNodesListGatewayStartedShards;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
@@ -381,7 +382,6 @@ import org.elasticsearch.rest.action.search.RestExplainAction;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.usage.UsageService;
 
@@ -437,7 +437,7 @@ public class ActionModule extends AbstractModule {
         destructiveOperations = new DestructiveOperations(settings, clusterSettings);
         Set<RestHeaderDefinition> headers = Stream.concat(
             actionPlugins.stream().flatMap(p -> p.getRestHeaders().stream()),
-            Stream.of(new RestHeaderDefinition(Task.X_OPAQUE_ID, false))
+            Stream.of(new RestHeaderDefinition(ThreadContext.X_OPAQUE_ID, false))
         ).collect(Collectors.toSet());
         UnaryOperator<RestHandler> restWrapper = null;
         for (ActionPlugin plugin : actionPlugins) {

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.logging;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.tasks.Task;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -315,9 +314,9 @@ public class HeaderWarning {
 
     public static String getXOpaqueId() {
         return THREAD_CONTEXT.stream()
-            .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
+            .filter(t -> t.getHeader(ThreadContext.X_OPAQUE_ID) != null)
             .findFirst()
-            .map(t -> t.getHeader(Task.X_OPAQUE_ID))
+            .map(t -> t.getHeader(ThreadContext.X_OPAQUE_ID))
             .orElse("");
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpTransportSettings;
-import org.elasticsearch.tasks.Task;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -89,6 +88,10 @@ public final class ThreadContext implements Writeable {
      * Name for the {@link #stashWithOrigin origin} attribute.
      */
     public static final String ACTION_ORIGIN_TRANSIENT_NAME = "action.origin";
+    /**
+     * The request header to mark tasks with specific ids
+     */
+    public static final String X_OPAQUE_ID = "X-Opaque-Id";
 
     private static final Logger logger = LogManager.getLogger(ThreadContext.class);
     private static final ThreadContextStruct DEFAULT_CONTEXT = new ThreadContextStruct();
@@ -119,9 +122,9 @@ public final class ThreadContext implements Writeable {
          * This is needed so the DeprecationLogger in another thread can see the value of X-Opaque-ID provided by a user.
          * Otherwise when context is stash, it should be empty.
          */
-        if (context.requestHeaders.containsKey(Task.X_OPAQUE_ID)) {
+        if (context.requestHeaders.containsKey(X_OPAQUE_ID)) {
             ThreadContextStruct threadContextStruct =
-                DEFAULT_CONTEXT.putHeaders(Map.of(Task.X_OPAQUE_ID, context.requestHeaders.get(Task.X_OPAQUE_ID)));
+                DEFAULT_CONTEXT.putHeaders(Map.of(X_OPAQUE_ID, context.requestHeaders.get(X_OPAQUE_ID)));
             threadLocal.set(threadContextStruct);
         } else {
             threadLocal.set(DEFAULT_CONTEXT);

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.tasks.Task.X_OPAQUE_ID;
+import static org.elasticsearch.common.util.concurrent.ThreadContext.X_OPAQUE_ID;
 
 /**
  * The default rest channel for incoming requests. This class implements the basic logic for sending a rest

--- a/server/src/main/java/org/elasticsearch/http/HttpTracer.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTracer.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
@@ -66,7 +66,7 @@ class HttpTracer {
     HttpTracer maybeTraceRequest(RestRequest restRequest, @Nullable Exception e) {
         if (logger.isTraceEnabled() && TransportService.shouldTraceAction(restRequest.uri(), tracerLogInclude, tracerLogExclude)) {
             logger.trace(new ParameterizedMessage("[{}][{}][{}][{}] received request from [{}]", restRequest.getRequestId(),
-                restRequest.header(Task.X_OPAQUE_ID), restRequest.method(), restRequest.uri(), restRequest.getHttpChannel()), e);
+                restRequest.header(ThreadContext.X_OPAQUE_ID), restRequest.method(), restRequest.uri(), restRequest.getHttpChannel()), e);
             return this;
         }
         return null;
@@ -78,7 +78,7 @@ class HttpTracer {
      * @param restResponse  RestResponse
      * @param httpChannel   HttpChannel the response was sent on
      * @param contentLength Value of the response content length header
-     * @param opaqueHeader  Value of HTTP header {@link Task#X_OPAQUE_ID}
+     * @param opaqueHeader  Value of HTTP header {@link ThreadContext#X_OPAQUE_ID}
      * @param requestId     Request id as returned by {@link RestRequest#getRequestId()}
      * @param success       Whether the response was successfully sent
      */

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -28,10 +28,10 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.tasks.Task;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -173,7 +173,7 @@ public final class SearchSlowLog implements SearchOperationListener {
                 messageFields.put("source", "{}");
             }
 
-            messageFields.put("id", context.getTask().getHeader(Task.X_OPAQUE_ID));
+            messageFields.put("id", context.getTask().getHeader(ThreadContext.X_OPAQUE_ID));
             return messageFields;
         }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -87,6 +87,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.discovery.Discovery;
@@ -160,7 +161,6 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.SnapshotShardsService;
 import org.elasticsearch.snapshots.SnapshotsService;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.tasks.TaskResultsService;
 import org.elasticsearch.threadpool.ExecutorBuilder;
@@ -539,7 +539,7 @@ public class Node implements Closeable {
             final Transport transport = networkModule.getTransportSupplier().get();
             Set<String> taskHeaders = Stream.concat(
                 pluginsService.filterPlugins(ActionPlugin.class).stream().flatMap(p -> p.getTaskHeaders().stream()),
-                Stream.of(Task.X_OPAQUE_ID)
+                Stream.of(ThreadContext.X_OPAQUE_ID)
             ).collect(Collectors.toSet());
             final TransportService transportService = newTransportService(settings, transport, threadPool,
                 networkModule.getTransportInterceptor(), localNodeFactory, settingsModule.getClusterSettings(), taskHeaders);

--- a/server/src/main/java/org/elasticsearch/search/SearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchPhase.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.search;
 
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.tasks.Task;
 
 /**
  * Represents a phase of a search request e.g. query, fetch etc.
@@ -56,8 +56,8 @@ public interface SearchPhase {
                 builder.append("source[], ");
             }
             if (searchContext.getTask() != null &&
-                    searchContext.getTask().getHeader(Task.X_OPAQUE_ID) != null) {
-                builder.append("id[").append(searchContext.getTask().getHeader(Task.X_OPAQUE_ID)).append("], ");
+                    searchContext.getTask().getHeader(ThreadContext.X_OPAQUE_ID) != null) {
+                builder.append("id[").append(searchContext.getTask().getHeader(ThreadContext.X_OPAQUE_ID)).append("], ");
             } else {
                 builder.append("id[], ");
             }

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -34,11 +34,6 @@ import java.util.Map;
  */
 public class Task {
 
-    /**
-     * The request header to mark tasks with specific ids
-     */
-    public static final String X_OPAQUE_ID = "X-Opaque-Id";
-
     private final long id;
 
     private final String type;

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -21,7 +21,6 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.tasks.Task;
 
 import java.util.Arrays;
 
@@ -63,7 +62,7 @@ public enum Transports {
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
         assert threadContext.getRequestHeadersOnly().isEmpty() ||
-            threadContext.getRequestHeadersOnly().size() == 1 && threadContext.getRequestHeadersOnly().containsKey(Task.X_OPAQUE_ID) :
+            threadContext.getRequestHeadersOnly().size() == 1 && threadContext.getRequestHeadersOnly().containsKey(ThreadContext.X_OPAQUE_ID) :
             "expected empty context but was " + threadContext.getRequestHeadersOnly() + " on " + Thread.currentThread().getName();
         return true;
     }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -42,12 +42,31 @@ public class ThreadContextTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(build);
         threadContext.putHeader("foo", "bar");
         threadContext.putTransient("ctx.foo", 1);
+        boolean hasOpaqueId = randomBoolean();
+        if (hasOpaqueId) {
+            threadContext.putHeader(ThreadContext.X_OPAQUE_ID, "opaque_id_value");
+        }
+        boolean hasRequestId = randomBoolean();
+        if (hasRequestId) {
+            threadContext.putHeader(ThreadContext.TRACE_REQUEST_ID, "request_id_value");
+        }
         assertEquals("bar", threadContext.getHeader("foo"));
         assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
         try (ThreadContext.StoredContext ctx = threadContext.stashContext()) {
             assertNull(threadContext.getHeader("foo"));
             assertNull(threadContext.getTransient("ctx.foo"));
+            assertEquals("1", threadContext.getHeader("default"));
+            if (hasOpaqueId) {
+                assertEquals("opaque_id_value", threadContext.getHeader(ThreadContext.X_OPAQUE_ID));
+            } else {
+                assertNull(threadContext.getHeader(ThreadContext.X_OPAQUE_ID));
+            }
+            if (hasRequestId) {
+                assertEquals("request_id_value", threadContext.getHeader(ThreadContext.TRACE_REQUEST_ID));
+            } else {
+                assertNull(threadContext.getHeader(ThreadContext.TRACE_REQUEST_ID));
+            }
             assertEquals("1", threadContext.getHeader("default"));
         }
 

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -260,7 +259,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 final FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
                     .withMethod(RestRequest.Method.OPTIONS)
                     .withPath("/internal/test")
-                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .withHeaders(Collections.singletonMap(ThreadContext.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                     .withInboundException(inboundException)
                     .build();
 
@@ -276,7 +275,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 final FakeRestRequest fakeRestRequestExcludedPath = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
                     .withMethod(RestRequest.Method.OPTIONS)
                     .withPath("/internal/testNotSeen")
-                    .withHeaders(Collections.singletonMap(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .withHeaders(Collections.singletonMap(ThreadContext.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                     .withInboundException(inboundExceptionExcludedPath)
                     .build();
 

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -39,7 +40,6 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -186,7 +186,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     public void testHeadersSet() {
         Settings settings = Settings.builder().build();
         final TestRequest httpRequest = new TestRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");
-        httpRequest.getHeaders().put(Task.X_OPAQUE_ID, Collections.singletonList("abc"));
+        httpRequest.getHeaders().put(ThreadContext.X_OPAQUE_ID, Collections.singletonList("abc"));
         final RestRequest request = RestRequest.request(xContentRegistry(), httpRequest, httpChannel);
         HttpHandlingSettings handlingSettings = HttpHandlingSettings.fromSettings(settings);
 
@@ -206,7 +206,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         Map<String, List<String>> headers = httpResponse.headers;
         assertNull(headers.get("non-existent-header"));
         assertEquals(customHeaderValue, headers.get(customHeader).get(0));
-        assertEquals("abc", headers.get(Task.X_OPAQUE_ID).get(0));
+        assertEquals("abc", headers.get(ThreadContext.X_OPAQUE_ID).get(0));
         assertEquals(Integer.toString(resp.content().length()), headers.get(DefaultRestChannel.CONTENT_LENGTH).get(0));
         assertEquals(resp.contentType(), headers.get(DefaultRestChannel.CONTENT_TYPE).get(0));
     }
@@ -214,7 +214,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     public void testCookiesSet() {
         Settings settings = Settings.builder().put(HttpTransportSettings.SETTING_HTTP_RESET_COOKIES.getKey(), true).build();
         final TestRequest httpRequest = new TestRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");
-        httpRequest.getHeaders().put(Task.X_OPAQUE_ID, Collections.singletonList("abc"));
+        httpRequest.getHeaders().put(ThreadContext.X_OPAQUE_ID, Collections.singletonList("abc"));
         final RestRequest request = RestRequest.request(xContentRegistry(), httpRequest, httpChannel);
         HttpHandlingSettings handlingSettings = HttpHandlingSettings.fromSettings(settings);
 

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -33,12 +33,12 @@ import org.elasticsearch.common.logging.MockAppender;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.TestSearchContext;
 import org.hamcrest.Matchers;
@@ -253,7 +253,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         searchContext.request().source(source);
         searchContext.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null,
-            Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+            Collections.singletonMap(ThreadContext.X_OPAQUE_ID, "my_id")));
 
         ESLogMessage p = SearchSlowLog.SearchSlowLogMessage.of(searchContext, 10);
         assertThat(p.get("stats"), equalTo("[\\\"group1\\\"]"));
@@ -262,7 +262,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         searchContext.request().source(source);
         searchContext.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null,
-            Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+            Collections.singletonMap(ThreadContext.X_OPAQUE_ID, "my_id")));
         p = SearchSlowLog.SearchSlowLogMessage.of(searchContext, 10);
         assertThat(p.get("stats"), equalTo("[\\\"group1\\\", \\\"group2\\\"]"));
     }
@@ -463,7 +463,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
         ctx.request().source(source);
         ctx.setTask(new SearchShardTask(0, "n/a", "n/a", "test", null,
-            Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+            Collections.singletonMap(ThreadContext.X_OPAQUE_ID, "my_id")));
         return ctx;
     }
 }

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -225,7 +226,7 @@ public abstract class AbstractEqlBlockingIntegTestCase extends AbstractEqlIntegT
     protected TaskInfo getTaskInfoWithXOpaqueId(String id, String action) {
         ListTasksResponse tasks = client().admin().cluster().prepareListTasks().setActions(action).get();
         for (TaskInfo task : tasks.getTasks()) {
-            if (id.equals(task.getHeaders().get(Task.X_OPAQUE_ID))) {
+            if (id.equals(task.getHeaders().get(ThreadContext.X_OPAQUE_ID))) {
                 return task;
             }
         }

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
@@ -20,11 +20,11 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
@@ -168,7 +168,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(ThreadContext.X_OPAQUE_ID, opaqueId))
             .execute(EqlSearchAction.INSTANCE, request).get();
         assertThat(response.isRunning(), is(true));
         assertThat(response.isPartial(), is(true));
@@ -219,7 +219,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
         String opaqueId = randomAlphaOfLength(10);
         logger.trace("Starting async search");
-        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, opaqueId))
+        EqlSearchResponse response = client().filterWithHeader(Collections.singletonMap(ThreadContext.X_OPAQUE_ID, opaqueId))
             .execute(EqlSearchAction.INSTANCE, request).get();
         assertThat(response.isRunning(), is(true));
         assertThat(response.isPartial(), is(true));

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.eql.action;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.tasks.Task;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.junit.After;
 
@@ -63,7 +63,7 @@ public class EqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
         logger.trace("Preparing search");
         // We might perform field caps on the same thread if it is local client, so we cannot use the standard mechanism
         Future<EqlSearchResponse> future = executorService.submit(() ->
-            client().filterWithHeader(Collections.singletonMap(Task.X_OPAQUE_ID, id)).execute(EqlSearchAction.INSTANCE, request).get()
+            client().filterWithHeader(Collections.singletonMap(ThreadContext.X_OPAQUE_ID, id)).execute(EqlSearchAction.INSTANCE, request).get()
         );
         logger.trace("Waiting for block to be established");
         if (cancelDuringSearch) {

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskInfo;
@@ -105,7 +106,7 @@ public class RestEqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
 
         Request request = new Request("GET", "/test/_eql/search");
         request.setJsonEntity(Strings.toString(eqlSearchRequest));
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(Task.X_OPAQUE_ID, id));
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(ThreadContext.X_OPAQUE_ID, id));
         logger.trace("Preparing search");
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
@@ -21,8 +21,6 @@ import java.util.Set;
 
 public class AuditUtil {
 
-    private static final String AUDIT_REQUEST_ID = "_xpack_audit_request_id";
-
     public static String restRequestContent(RestRequest request) {
         if (request.hasContent()) {
             try {
@@ -67,11 +65,11 @@ public class AuditUtil {
         }
         final String requestId = UUIDs.randomBase64UUID(Randomness.get());
         // Store as a header (not transient) so that it is passed over the network if this request requires execution on other nodes
-        threadContext.putHeader(AUDIT_REQUEST_ID, requestId);
+        threadContext.putHeader(ThreadContext.TRACE_REQUEST_ID, requestId);
         return requestId;
     }
 
     public static String extractRequestId(ThreadContext threadContext) {
-        return threadContext.getHeader(AUDIT_REQUEST_ID);
+        return threadContext.getHeader(ThreadContext.TRACE_REQUEST_ID);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
@@ -813,7 +812,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         }
 
         LogEntryBuilder withOpaqueId(ThreadContext threadContext) {
-            final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID);
+            final String opaqueId = threadContext.getHeader(ThreadContext.X_OPAQUE_ID);
             if (opaqueId != null) {
                 logEntry.with(OPAQUE_ID_FIELD_NAME, opaqueId);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest.Builder;
@@ -212,7 +211,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         commonFields = new LoggingAuditTrail.EntryCommonFields(settings, localNode).commonFields;
         threadContext = new ThreadContext(Settings.EMPTY);
         if (randomBoolean()) {
-            threadContext.putHeader(Task.X_OPAQUE_ID, randomAlphaOfLengthBetween(1, 4));
+            threadContext.putHeader(ThreadContext.X_OPAQUE_ID, randomAlphaOfLengthBetween(1, 4));
         }
         if (randomBoolean()) {
             threadContext.putHeader(AuditTrail.X_FORWARDED_FOR_HEADER,
@@ -1483,7 +1482,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     private static void opaqueId(ThreadContext threadContext, MapBuilder<String, String> checkedFields) {
-        final String opaqueId = threadContext.getHeader(Task.X_OPAQUE_ID);
+        final String opaqueId = threadContext.getHeader(ThreadContext.X_OPAQUE_ID);
         if (opaqueId != null) {
             checkedFields.put(LoggingAuditTrail.OPAQUE_ID_FIELD_NAME, opaqueId);
         }


### PR DESCRIPTION
The `request.id` audit event attribute is used to link together the related audit events of the same client request. It is similar to the `X-Opaque-Id` request header, but its value is automatically generated internally by ES Security and cannot be submitted in a request header by the client.

But unlike the `X-Opaque-Id`, the internal `request.id` was not preserved upon context stashing (i.e. `ClientHelper#executeAsyncWithOrigin`). This amounted to commonly loosing the linkage information, so that related actions appeared independent.

NB: A great many code changes are about the `Task.X_OPAQUE_ID` -> `ThreadContext.X_OPAQUE_ID` refactoring. `ThreadContext` now "owns" the headers that it maintains on `stash`.