### PR TITLE
Remove usage of IndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -256,7 +256,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 }
                 hi = Math.round(Math.floor(dValue));
             }
-            Query query = NumberFieldMapper.NumberType.LONG.rangeQuery(name(), lo, hi, true, true, hasDocValues(), context);
+            Query query = NumberFieldMapper.NumberType.LONG.rangeQuery(name(), lo, hi, true, true, hasDocValues());
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
             }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -91,8 +91,8 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             Double u = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
             boolean includeLower = randomBoolean();
             boolean includeUpper = randomBoolean();
-            Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false, MOCK_QSC);
-            Query scaledFloatQ = ft.rangeQuery(l, u, includeLower, includeUpper, MOCK_QSC);
+            Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false);
+            Query scaledFloatQ = ft.rangeQuery(l, u, includeLower, includeUpper, null);
             assertEquals(searcher.count(doubleQ), searcher.count(scaledFloatQ));
         }
         IOUtils.close(reader, dir);
@@ -103,17 +103,17 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, MOCK_QSC);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 7999]", scaledFloatQ.toString());
     }
 
@@ -122,15 +122,15 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, MOCK_QSC);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, null);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, null);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, null);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, null);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, null);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -227,14 +227,13 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testExtractRanges() throws Exception {
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
         addQueryFieldMappings();
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
         Query rangeQuery1 = mapperService.fieldType("number_field1")
-            .rangeQuery(10, 20, true, true, null, null, null, context);
+            .rangeQuery(10, 20, true, true, null, null, null, null);
         bq.add(rangeQuery1, Occur.MUST);
         Query rangeQuery2 = mapperService.fieldType("number_field1")
-            .rangeQuery(15, 20, true, true, null, null, null, context);
+            .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
@@ -266,7 +265,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq = new BooleanQuery.Builder();
         bq.add(rangeQuery1, Occur.MUST);
         rangeQuery2 = mapperService.fieldType("number_field2")
-            .rangeQuery(15, 20, true, true, null, null, null, context);
+            .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
         parseContext = new ParseContext.InternalParseContext(settings,

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -171,11 +171,6 @@ public final class IndexSortConfig {
         return sortSpecs.length > 0;
     }
 
-    public boolean hasPrimarySortOnField(String field) {
-        return sortSpecs.length > 0
-            && sortSpecs[0].field.equals(field);
-    }
-
     /**
      * Builds the {@link Sort} order from the settings for this index
      * or returns null if this index has no sort.

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
-import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
@@ -390,17 +389,11 @@ public final class DateFieldMapper extends FieldMapper {
                     --u;
                 }
             }
-
             Query query = LongPoint.newRangeQuery(name(), l, u);
             if (hasDocValues()) {
                 Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
                 query = new IndexOrDocValuesQuery(query, dvQuery);
-
-                if (context.indexSortedOnField(name())) {
-                    query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
-                }
             }
-
             if (nowUsed[0]) {
                 query = new DateRangeIncludingNowQuery(query);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -35,7 +35,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
-import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -229,8 +228,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
                 float l = Float.NEGATIVE_INFINITY;
                 float u = Float.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
@@ -326,8 +325,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
                 float l = Float.NEGATIVE_INFINITY;
                 float u = Float.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
@@ -345,8 +344,8 @@ public class NumberFieldMapper extends FieldMapper {
                 Query query = FloatPoint.newRangeQuery(field, l, u);
                 if (hasDocValues) {
                     Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field,
-                        NumericUtils.floatToSortableInt(l),
-                        NumericUtils.floatToSortableInt(u));
+                            NumericUtils.floatToSortableInt(l),
+                            NumericUtils.floatToSortableInt(u));
                     query = new IndexOrDocValuesQuery(query, dvQuery);
                 }
                 return query;
@@ -412,8 +411,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
                 double l = Double.NEGATIVE_INFINITY;
                 double u = Double.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
@@ -506,9 +505,9 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
-                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues, context);
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
+                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues);
             }
 
             @Override
@@ -563,9 +562,9 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
-                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues, context);
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
+                return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues);
             }
 
             @Override
@@ -640,8 +639,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
                 int l = Integer.MIN_VALUE;
                 int u = Integer.MAX_VALUE;
                 if (lowerTerm != null) {
@@ -675,9 +674,6 @@ public class NumberFieldMapper extends FieldMapper {
                 if (hasDocValues) {
                     Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field, l, u);
                     query = new IndexOrDocValuesQuery(query, dvQuery);
-                    if (context.indexSortedOnField(field)) {
-                        query = new IndexSortSortedNumericDocValuesRangeQuery(field, l, u, query);
-                    }
                 }
                 return query;
             }
@@ -762,8 +758,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                    boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                             boolean includeLower, boolean includeUpper,
+                             boolean hasDocValues) {
                 long l = Long.MIN_VALUE;
                 long u = Long.MAX_VALUE;
                 if (lowerTerm != null) {
@@ -797,9 +793,6 @@ public class NumberFieldMapper extends FieldMapper {
                 if (hasDocValues) {
                     Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field, l, u);
                     query = new IndexOrDocValuesQuery(query, dvQuery);
-                    if (context.indexSortedOnField(field)) {
-                        query = new IndexSortSortedNumericDocValuesRangeQuery(field, l, u, query);
-                    }
                 }
                 return query;
             }
@@ -840,8 +833,8 @@ public class NumberFieldMapper extends FieldMapper {
         public abstract Query termQuery(String field, Object value);
         public abstract Query termsQuery(String field, List<Object> values);
         public abstract Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
-                                         boolean includeLower, boolean includeUpper,
-                                         boolean hasDocValues, QueryShardContext context);
+                                  boolean includeLower, boolean includeUpper,
+                                  boolean hasDocValues);
         public abstract Number parse(XContentParser parser, boolean coerce) throws IOException;
         public abstract Number parse(Object value, boolean coerce);
         public abstract Number parsePoint(byte[] value);
@@ -955,7 +948,7 @@ public class NumberFieldMapper extends FieldMapper {
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
             failIfNotIndexed();
-            Query query = type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues(), context);
+            Query query = type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues());
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
             }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -347,11 +346,6 @@ public class QueryShardContext extends QueryRewriteContext {
      */
     public boolean indexMatches(String pattern) {
         return indexNameMatcher.test(pattern);
-    }
-
-    public boolean indexSortedOnField(String field) {
-        IndexSortConfig indexSortConfig = indexSettings.getIndexSortConfig();
-        return indexSortConfig.hasPrimarySortOnField(field);
     }
 
     public ParsedQuery toQuery(QueryBuilder queryBuilder) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -29,7 +29,6 @@ import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
-import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
@@ -40,9 +39,9 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
-import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
@@ -215,36 +214,6 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> unsearchable.rangeQuery(date1, date2, true, true, null, null, null, context));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
-    }
-
-    public void testRangeQueryWithIndexSort() {
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-            .put("index.sort.field", "field")
-            .build();
-
-        IndexMetadata indexMetadata = new IndexMetadata.Builder("index")
-            .settings(settings)
-            .build();
-        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
-
-        QueryShardContext context = new QueryShardContext(0, indexSettings,
-            BigArrays.NON_RECYCLING_INSTANCE, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, () -> 0L, null, null, () -> true, null);
-
-        MappedFieldType ft = new DateFieldType("field");
-        String date1 = "2015-10-12T14:10:55";
-        String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date1)).toInstant().toEpochMilli();
-        long instant2 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date2)).toInstant().toEpochMilli() + 999;
-
-        Query pointQuery = LongPoint.newRangeQuery("field", instant1, instant2);
-        Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2);
-        Query expected = new IndexSortSortedNumericDocValuesRangeQuery("field",  instant1, instant2,
-            new IndexOrDocValuesQuery(pointQuery, dvQuery));
-        assertEquals(expected, ft.rangeQuery(date1, date2, true, true, null, null, null, context));
     }
 
     public void testDateNanoDocValues() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -32,26 +32,16 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.MultiValueMode;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -141,106 +131,106 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
     public void testRangeQueryWithNegativeBounds() {
         MappedFieldType ftInt = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER);
-        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, null),
+                ftInt.rangeQuery(-3.5, -2.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, null),
+                ftInt.rangeQuery(-3.5, -2.5, false, false, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, null),
+                ftInt.rangeQuery(-0.5, 0.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, null),
+                ftInt.rangeQuery(-0.5, 0.5, false, false, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, null),
+                ftInt.rangeQuery(0.5, 2.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, null),
+                ftInt.rangeQuery(0.5, 2.5, false, false, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, null),
+                ftInt.rangeQuery(-0.5, 2.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, null),
+                ftInt.rangeQuery(-0.5, 2.5, false, false, null, null, null, null));
 
-        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, null),
+                ftInt.rangeQuery(-2.5, 0.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, null),
+                ftInt.rangeQuery(-2.5, 0.5, false, false, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, null),
+                ftInt.rangeQuery(-2.5, -0.5, true, true, null, null, null, null));
+        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, null),
+                ftInt.rangeQuery(-2.5, -0.5, false, false, null, null, null, null));
 
         MappedFieldType ftLong = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG);
-        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, null),
+                ftLong.rangeQuery(-3.5, -2.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, null),
+                ftLong.rangeQuery(-3.5, -2.5, false, false, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, null),
+                ftLong.rangeQuery(-0.5, 0.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, null),
+                ftLong.rangeQuery(-0.5, 0.5, false, false, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, null),
+                ftLong.rangeQuery(0.5, 2.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, null),
+                ftLong.rangeQuery(0.5, 2.5, false, false, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, null),
+                ftLong.rangeQuery(-0.5, 2.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, null),
+                ftLong.rangeQuery(-0.5, 2.5, false, false, null, null, null, null));
 
-        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, null),
+                ftLong.rangeQuery(-2.5, 0.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, null),
+                ftLong.rangeQuery(-2.5, 0.5, false, false, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, null),
+                ftLong.rangeQuery(-2.5, -0.5, true, true, null, null, null, null));
+        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, null),
+                ftLong.rangeQuery(-2.5, -0.5, false, false, null, null, null, null));
     }
 
     public void testByteRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, null));
     }
 
     public void testShortRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, null));
     }
 
     public void testIntegerRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, null));
     }
 
     public void testLongRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, null));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, null),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, null));
     }
 
     public void testRangeQuery() {
@@ -248,11 +238,11 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         Query expected = new IndexOrDocValuesQuery(
                 LongPoint.newRangeQuery("field", 1, 3),
                 SortedNumericDocValuesField.newSlowRangeQuery("field", 1, 3));
-        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, null));
 
         MappedFieldType unsearchable = new NumberFieldType("field", NumberType.LONG, false, true, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+                () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, null));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 
@@ -344,8 +334,8 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             float u = (randomFloat() * 2 - 1) * 65504;
             boolean includeLower = randomBoolean();
             boolean includeUpper = randomBoolean();
-            Query floatQ = NumberType.FLOAT.rangeQuery("float", l, u, includeLower, includeUpper, false, MOCK_QSC);
-            Query halfFloatQ = NumberType.HALF_FLOAT.rangeQuery("half_float", l, u, includeLower, includeUpper, false, MOCK_QSC);
+            Query floatQ = NumberType.FLOAT.rangeQuery("float", l, u, includeLower, includeUpper, false);
+            Query halfFloatQ = NumberType.HALF_FLOAT.rangeQuery("half_float", l, u, includeLower, includeUpper, false);
             assertEquals(searcher.count(floatQ), searcher.count(halfFloatQ));
         }
         IOUtils.close(reader, dir);
@@ -353,14 +343,14 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
     public void testNegativeZero() {
         assertEquals(
-                NumberType.DOUBLE.rangeQuery("field", null, -0d, true, true, false, MOCK_QSC),
-                NumberType.DOUBLE.rangeQuery("field", null, +0d, true, false, false, MOCK_QSC));
+                NumberType.DOUBLE.rangeQuery("field", null, -0d, true, true, false),
+                NumberType.DOUBLE.rangeQuery("field", null, +0d, true, false, false));
         assertEquals(
-                NumberType.FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_QSC),
-                NumberType.FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_QSC));
+                NumberType.FLOAT.rangeQuery("field", null, -0f, true, true, false),
+                NumberType.FLOAT.rangeQuery("field", null, +0f, true, false, false));
         assertEquals(
-                NumberType.HALF_FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_QSC),
-                NumberType.HALF_FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_QSC));
+                NumberType.HALF_FLOAT.rangeQuery("field", null, -0f, true, true, false),
+                NumberType.HALF_FLOAT.rangeQuery("field", null, +0f, true, false, false));
 
         assertFalse(NumberType.DOUBLE.termQuery("field", -0d).equals(NumberType.DOUBLE.termQuery("field", +0d)));
         assertFalse(NumberType.FLOAT.termQuery("field", -0f).equals(NumberType.FLOAT.termQuery("field", +0f)));
@@ -412,7 +402,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             Query query = type.rangeQuery("foo",
                     random().nextBoolean() ? null : valueSupplier.get(),
                     random().nextBoolean() ? null : valueSupplier.get(),
-                    randomBoolean(), randomBoolean(), true, MOCK_QSC);
+                    randomBoolean(), randomBoolean(), true);
             assertThat(query, instanceOf(IndexOrDocValuesQuery.class));
             IndexOrDocValuesQuery indexOrDvQuery = (IndexOrDocValuesQuery) query;
             assertEquals(
@@ -420,74 +410,6 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
                     searcher.count(indexOrDvQuery.getRandomAccessQuery()));
         }
         reader.close();
-        dir.close();
-    }
-
-    public void testIndexSortIntRange() throws Exception {
-        doTestIndexSortRangeQueries(NumberType.INTEGER, random()::nextInt);
-    }
-
-    public void testIndexSortLongRange() throws Exception {
-        doTestIndexSortRangeQueries(NumberType.LONG, random()::nextLong);
-    }
-
-    public void doTestIndexSortRangeQueries(NumberType type, Supplier<Number> valueSupplier) throws IOException {
-        // Create index settings with an index sort.
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-            .put("index.sort.field", "field")
-            .build();
-
-        IndexMetadata indexMetadata = new IndexMetadata.Builder("index")
-            .settings(settings)
-            .build();
-        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
-
-        // Create an index writer configured with the same index sort.
-        NumberFieldType fieldType = new NumberFieldType("field", type);
-        IndexNumericFieldData fielddata = (IndexNumericFieldData) fieldType.fielddataBuilder("index")
-            .build(indexSettings, fieldType, null, null, null);
-        SortField sortField = fielddata.sortField(null, MultiValueMode.MIN, null, randomBoolean());
-
-        IndexWriterConfig writerConfig = new IndexWriterConfig();
-        writerConfig.setIndexSort(new Sort(sortField));
-
-        Directory dir = newDirectory();
-        IndexWriter w = new IndexWriter(dir, writerConfig);
-        final int numDocs = TestUtil.nextInt(random(), 100, 500);
-        for (int i = 0; i < numDocs; ++i) {
-            w.addDocument(type.createFields("field", valueSupplier.get(), true, true, false));
-        }
-
-        // Ensure that the optimized index sort query gives the same results as a points query.
-        DirectoryReader reader = DirectoryReader.open(w);
-        IndexSearcher searcher = newSearcher(reader);
-
-        QueryShardContext context = new QueryShardContext(0, indexSettings,
-            BigArrays.NON_RECYCLING_INSTANCE, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, () -> 0L, null, null, () -> true, null);
-
-        final int iters = 10;
-        for (int iter = 0; iter < iters; ++iter) {
-            Query query = type.rangeQuery("field",
-                random().nextBoolean() ? null : valueSupplier.get(),
-                random().nextBoolean() ? null : valueSupplier.get(),
-                randomBoolean(), randomBoolean(), true, context);
-            assertThat(query, instanceOf(IndexSortSortedNumericDocValuesRangeQuery.class));
-
-            Query fallbackQuery = ((IndexSortSortedNumericDocValuesRangeQuery) query).getFallbackQuery();
-            assertThat(fallbackQuery, instanceOf(IndexOrDocValuesQuery.class));
-
-            IndexOrDocValuesQuery indexOrDvQuery = (IndexOrDocValuesQuery) fallbackQuery;
-            assertEquals(
-                searcher.count(query),
-                searcher.count(indexOrDvQuery.getIndexQuery()));
-        }
-
-        reader.close();
-        w.close();
         dir.close();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.io.IOException;

--- a/server/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
@@ -134,28 +134,6 @@ public class QueryShardContextTests extends ESTestCase {
         assertThat(shardContext.getFullyQualifiedIndex().getUUID(), equalTo(indexUuid));
     }
 
-    public void testIndexSortedOnField() {
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-            .put("index.sort.field", "sort_field")
-            .build();
-        IndexMetadata indexMetadata = new IndexMetadata.Builder("index")
-            .settings(settings)
-            .build();
-
-        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
-        QueryShardContext context = new QueryShardContext(
-            0, indexSettings, BigArrays.NON_RECYCLING_INSTANCE, null, null,
-            null, null, null, NamedXContentRegistry.EMPTY, new NamedWriteableRegistry(Collections.emptyList()),
-            null, null, () -> 0L, null, null, () -> true, null);
-
-        assertTrue(context.indexSortedOnField("sort_field"));
-        assertFalse(context.indexSortedOnField("second_sort_field"));
-        assertFalse(context.indexSortedOnField("non_sort_field"));
-    }
-
     public static QueryShardContext createQueryShardContext(String indexUuid, String clusterAlias) {
         IndexMetadata.Builder indexMetadataBuilder = new IndexMetadata.Builder("index");
         indexMetadataBuilder.settings(Settings.builder().put("index.version.created", Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -178,29 +178,28 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testRangeQuery() {
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
-        Query rangeQuery = mapperService.fieldType("foo2").rangeQuery(2, 5, true, true, null, null, null, context);
+        Query rangeQuery = mapperService.fieldType("foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fieldType("nested1.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
+        rangeQuery = mapperService.fieldType("nested1.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fieldType("nested2.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
+        rangeQuery = mapperService.fieldType("nested2.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fieldType("nested3.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
+        rangeQuery = mapperService.fieldType("nested3.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));


### PR DESCRIPTION
This change reverts the optimization added in #56657. 
We found a [bug](https://github.com/elastic/elasticsearch/issues/61766) in
`IndexSortSortedNumericDocValuesRangeQuery` that can fail the entire shard search request so this commit removes the optimization and restore the old behavior (range query on points) in this release branch.

Relates #61766