### PR TITLE
[7.x] Fix wrong result when executing bulk requests with and without pipeline

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/90_pipeline.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/90_pipeline.yml
@@ -1,0 +1,25 @@
+---
+"One request has pipeline and another not":
+  - skip:
+      version: " - 7.99.99"
+      reason: "change after backporting"
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_index", "_id": "test_id1"}}'
+          - '{"f1": "v1", "f2": 42}'
+          - '{"index": {"_index": "test_index", "_id": "test_id2", "pipeline": "mypipeline"}}'
+          - '{"f1": "v2", "f2": 47}'
+
+  - match: { errors: true }
+  - match: { items.0.index.result: created }
+  - match: { items.1.index.status: 400 }
+  - match: { items.1.index.error.type: illegal_argument_exception }
+  - match: { items.1.index.error.reason: "pipeline with id [mypipeline] does not exist" }
+
+  - do:
+      count:
+        index: test_index
+
+  - match: {count: 1}

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -473,6 +473,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                             onCompletion.accept(originalThread, null);
                         }
                         assert counter.get() >= 0;
+                        i++;
                         continue;
                     }
 
@@ -495,6 +496,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                             onCompletion.accept(originalThread, null);
                         }
                         assert counter.get() >= 0;
+                        i++;
                         continue;
                     }
 


### PR DESCRIPTION
Closes #60437 .

When executing bulk api, if one request has no ingest pipeline and others have ingest pipeline, then the response is not correct, that's because in `IngestService#executeBulkRequest()` method, the cursor `i` doesn't move to next if the request has no ingest pipeline.

The main changes are:
1. fix the bug in `IngestService#executeBulkRequest()`.
2. add some unit tests.
3. add a yaml test.

Backport of #60818 
