### PR TITLE
[DOCS] Fix JSON spec link for PIT API

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1142,3 +1142,9 @@ See <<joining-queries-notes>>.
 === Percolate query notes
 
 See <<percolate-query-notes>>.
+
+[role="exclude",id="point-in-time"]
+=== Point in time API
+
+See <<point-in-time-api>>.
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/close_point_in_time.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/close_point_in_time.json
@@ -1,7 +1,7 @@
 {
   "close_point_in_time":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html",
       "description":"Close a point in time"
     },
     "stability":"stable",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/open_point_in_time.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/open_point_in_time.json
@@ -1,7 +1,7 @@
 {
   "open_point_in_time":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html",
       "description":"Open a point in time that can be used in subsequent searches"
     },
     "stability":"stable",


### PR DESCRIPTION
Fixes docs link in the point in time API's JSON spec. 

This caused a broken link in the ES JS docs.