### PR TITLE
Fix jvm options expansion on windows (#61743) (7.x backport)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -528,7 +528,13 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private boolean canUseSharedDistribution() {
-        return extraJarFiles.size() == 0 && modules.size() == 0 && plugins.size() == 0 && requiresAddingXPack() == false;
+        // using original location can be too long due to MAX_PATH restrictions on windows CI
+        // TODO revisit when moving to shorter paths on CI by using Teamcity
+        return OS.current() != OS.WINDOWS
+            && extraJarFiles.size() == 0
+            && modules.size() == 0
+            && plugins.size() == 0
+            && requiresAddingXPack() == false;
     }
 
     private void logToProcessStdout(String message) {
@@ -1208,7 +1214,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 if (!content.contains(origin)) {
                     throw new IOException("template property " + origin + " not found in template.");
                 }
-                content = content.replaceAll(origin, expansions.get(origin));
+                content = content.replace(origin, expansions.get(origin));
             }
             Files.write(jvmOptions, content.getBytes());
         } catch (IOException ioException) {
@@ -1220,12 +1226,16 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         Map<String, String> expansions = new HashMap<>();
         Version version = getVersion();
         String heapDumpOrigin = getVersion().onOrAfter("6.3.0") ? "-XX:HeapDumpPath=data" : "-XX:HeapDumpPath=/heap/dump/path";
-        expansions.put(heapDumpOrigin, "-XX:HeapDumpPath=" + confPathLogs.toString());
+        Path relativeLogPath = workingDir.relativize(confPathLogs);
+        expansions.put(heapDumpOrigin, "-XX:HeapDumpPath=" + relativeLogPath.toString());
         if (version.onOrAfter("6.2.0")) {
-            expansions.put("logs/gc.log", confPathLogs.resolve("gc.log").toString());
+            expansions.put("logs/gc.log", relativeLogPath.resolve("gc.log").toString());
         }
         if (getVersion().getMajor() >= 7) {
-            expansions.put("-XX:ErrorFile=logs/hs_err_pid%p.log", "-XX:ErrorFile=" + confPathLogs.resolve("hs_err_pid%p.log").toString());
+            expansions.put(
+                "-XX:ErrorFile=logs/hs_err_pid%p.log",
+                "-XX:ErrorFile=" + relativeLogPath.resolve("hs_err_pid%p.log").toString()
+            );
         }
         return expansions;
     }


### PR DESCRIPTION
* Fix jvm options expansion on windows
* Avoid long paths on windows
* Relativize paths in jvmoptions against working dir

backports #61743 to 7.x branch