### PR TITLE
Throws IndexNotFoundException in TransportGetAction for unknown indices (#61785)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -116,7 +116,7 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
     @Override
     protected String getExecutor(GetRequest request, ShardId shardId) {
         final ClusterState clusterState = clusterService.state();
-        if (clusterState.metadata().index(shardId.getIndex()).isSystem()) {
+        if (clusterState.metadata().getIndexSafe(shardId.getIndex()).isSystem()) {
             return ThreadPool.Names.SYSTEM_READ;
         } else if (indicesService.indexServiceSafe(shardId.getIndex()).getIndexSettings().isSearchThrottled()) {
             return ThreadPool.Names.SEARCH_THROTTLED;


### PR DESCRIPTION
Backport of #61785 for 7.10.0

The change #57936 introduced a dedicated thread pool for reads in system indices. 
It also introduced a potential NPE in the case the index to read in not yet present in 
the cluster state. This commit fixes that bug by using the getIndexSafe() instead of 
just index() method when retrieving the index's metadata so that an INFE is thrown 
if the index does not exist.