### PR TITLE
[7.x] Drop assertion that rest client header warnings conform to RFC 7234 (#61365)

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -100,22 +100,6 @@ public class Response {
         return response.getEntity();
     }
 
-    private static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
-            "299 " + // warn code
-            "Elasticsearch-" + // warn agent
-            "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
-            "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
-            "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
-            // quoted RFC 1123 date format
-            "\"" + // opening quote
-            "(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), " + // weekday
-            "\\d{2} " + // 2-digit day
-            "(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) " + // month
-            "\\d{4} " + // 4-digit year
-            "\\d{2}:\\d{2}:\\d{2} " + // (two-digit hour):(two-digit minute):(two-digit second)
-            "GMT" + // GMT
-            "\")?"); // closing quote (optional, since an older version can still send a warn-date)
-
     /**
      * Optimized regular expression to test if a string matches the RFC 1123 date
      * format (with quotes and leading space). Start/end of line characters and
@@ -182,18 +166,7 @@ public class Response {
         final int firstQuote = warningHeader.indexOf('\"');
         final int lastQuote = warningHeader.length() - 1;
         final String warningValue = warningHeader.substring(firstQuote + 1, lastQuote);
-        assert assertWarningValue(s, warningValue);
         return warningValue;
-    }
-
-    /**
-     * Refer to org.elasticsearch.common.logging.DeprecationLogger
-     */
-    private static boolean assertWarningValue(final String s, final String warningValue) {
-        final Matcher matcher = WARNING_HEADER_PATTERN.matcher(s);
-        final boolean matches = matcher.matches();
-        assert matches;
-        return matcher.group(1).equals(warningValue);
     }
 
     /**


### PR DESCRIPTION
This removes the assertion that the header warnings we parse in the
rest client reponses conform to RFC 7234	because we are not in full control
of the warnings that could be present in the responses (ie. proxies might
emit warnings that don't comply).

We still maintain this assertion on the ES side (see `HeaderWarning#addWarning`)
for the warnings we emit.

(cherry picked from commit 1259a46cbe84d32e85cd1a7455012d177b809702)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #61365 