### PR TITLE
[DOC] Use correct get document API example

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -110,7 +110,7 @@ Note that the handling of other error types is unaffected by the `"conflicts"` p
 If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
-{es} creates a record of this task as a document at `.tasks/task/${taskId}`.
+{es} creates a record of this task as a document at `.tasks/_doc/${taskId}`.
 When you are done with a task, you should delete the task document so
 {es} can reclaim the space.
 


### PR DESCRIPTION
The documentation refers to a deprecated get document API call (it uses document `type`).
