### PR TITLE
Faster _source lookups.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchDirectoryReader.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.lucene.index;
 
+import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -63,8 +64,11 @@ public final class ElasticsearchDirectoryReader extends FilterDirectoryReader {
 
     /**
      * Wraps the given reader in a {@link org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader} as
-     * well as all it's sub-readers in {@link org.elasticsearch.common.lucene.index.ElasticsearchLeafReader} to
+     * well as all it's sub-readers in {@link org.elasticsearch.common.lucene.index.ElasticsearchCodecReader} to
      * expose the given shard Id.
+     *
+     * This uses codec readers on leaves rather than plain leaf readers in order to give a chance for SourceLookup
+     * to optimize for sequential access by using the logic that is normally reserved to merges.
      *
      * @param reader the reader to wrap
      * @param shardId the shard ID to expose via the elasticsearch internal reader wrappers.
@@ -80,7 +84,7 @@ public final class ElasticsearchDirectoryReader extends FilterDirectoryReader {
         }
         @Override
         public LeafReader wrap(LeafReader reader) {
-            return new ElasticsearchLeafReader(reader, shardId);
+            return new ElasticsearchCodecReader((CodecReader) reader, shardId);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
@@ -23,7 +23,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
-import org.elasticsearch.common.lucene.index.ElasticsearchLeafReader;
+import org.elasticsearch.common.lucene.index.ElasticsearchCodecReader;
 
 public final class ShardUtils {
 
@@ -35,7 +35,7 @@ public final class ShardUtils {
      */
     @Nullable
     public static ShardId extractShardId(LeafReader reader) {
-        final ElasticsearchLeafReader esReader = ElasticsearchLeafReader.getElasticsearchLeafReader(reader);
+        final ElasticsearchCodecReader esReader = ElasticsearchCodecReader.getElasticsearchCodecReader(reader);
         if (esReader != null) {
             assert reader.getRefCount() > 0 : "ElasticsearchLeafReader is already closed";
             return esReader.shardId();


### PR DESCRIPTION
As we're making it easier to create fields that read information
dynamically from `_source`, I've been trying to think about ways that we
could make stored field access less terrible. Today, Lucene's stored
fields optimize for random access: if your use-case is to fetch stored
fields for your top hits, it's very unlikely that two of them will come
from the same block, so Lucene makes no effort to keep state in order to
not decompress the same data multiple times because two documents might
be in the same compressed block. It only does this for merges, which is
the only time when stored fields are expected to be accessed
sequentially. So this PR introduces a little hack that uses the merging
logic for source lookups.

Note that the optimization in this PR doesn't apply if DLS or FLS are
enabled, as these features introduce LeafReader wrappers that would hide
the CodecReader.

FYI the speedup is not trivial. I played with a `nginx.access` dataset
and fetching 10M docs sequentially goes down from 8+ minutes to 1 minute
and 40 seconds.
