### PR TITLE
[7.9] [DOCS] Document dynamic cluster settings (#61760)

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -6,52 +6,52 @@ cluster restarts.
 
 The following _static_ settings, which must be set on every master node,
 control how long a freshly elected master should wait before it tries to
-recover the cluster state and the cluster's data:
+recover the cluster state and the cluster's data.
+
+NOTE: These settings only take effect on a full cluster restart.
 
 `gateway.expected_nodes`::
-
-    deprecated:[7.7.0, This setting will be removed in 8.0. You should use `gateway.expected_data_nodes` instead.]
-    The number of (data or master) nodes that are expected to be in the cluster.
-    Recovery of local shards will start as soon as the expected number of
-    nodes have joined the cluster. Defaults to `0`
+(<<static-cluster-setting,Static>>)
+deprecated:[7.7.0, This setting will be removed in 8.0. Use `gateway.expected_data_nodes` instead.]
+Number of data or master nodes expected in the cluster.
+Recovery of local shards begins when the expected number of
+nodes join the cluster. Defaults to `0`.
 
 `gateway.expected_master_nodes`::
-
-    deprecated:[7.7.0, This setting will be removed in 8.0. You should use `gateway.expected_data_nodes` instead.]
-    The number of master nodes that are expected to be in the cluster.
-    Recovery of local shards will start as soon as the expected number of
-    master nodes have joined the cluster. Defaults to `0`
+(<<static-cluster-setting,Static>>)
+deprecated:[7.7.0, This setting will be removed in 8.0. Use `gateway.expected_data_nodes` instead.]
+Number of master nodes expected in the cluster.
+Recovery of local shards begins when the expected number of
+master nodes join the cluster. Defaults to `0`.
 
 `gateway.expected_data_nodes`::
-
-    The number of data nodes that are expected to be in the cluster.
-    Recovery of local shards will start as soon as the expected number of
-    data nodes have joined the cluster. Defaults to `0`
+(<<static-cluster-setting,Static>>)
+Number of data nodes expected in the cluster.
+Recovery of local shards begins when the expected number of
+data nodes join the cluster. Defaults to `0`.
 
 `gateway.recover_after_time`::
-
-    If the expected number of nodes is not achieved, the recovery process waits
-    for the configured amount of time before trying to recover regardless.
-    Defaults to `5m` if one of the `expected_nodes` settings is configured.
-
+(<<static-cluster-setting,Static>>)
+If the expected number of nodes is not achieved, the recovery process waits
+for the configured amount of time before trying to recover.
+Defaults to `5m` if one of the `expected_nodes` settings is configured.
++
 Once the `recover_after_time` duration has timed out, recovery will start
 as long as the following conditions are met:
 
 `gateway.recover_after_nodes`::
-
-    deprecated:[7.7.0, This setting will be removed in 8.0. You should use `gateway.recover_after_data_nodes` instead.]
-    Recover as long as this many data or master nodes have joined the cluster.
+(<<static-cluster-setting,Static>>)
+deprecated:[7.7.0, This setting will be removed in 8.0. Use `gateway.recover_after_data_nodes` instead.]
+Recover as long as this many data or master nodes have joined the cluster.
 
 `gateway.recover_after_master_nodes`::
-
-    deprecated:[7.7.0, This setting will be removed in 8.0. You should use `gateway.recover_after_data_nodes` instead.]
-    Recover as long as this many master nodes have joined the cluster.
+(<<static-cluster-setting,Static>>)
+deprecated:[7.7.0, This setting will be removed in 8.0. Use `gateway.recover_after_data_nodes` instead.]
+Recover as long as this many master nodes have joined the cluster.
 
 `gateway.recover_after_data_nodes`::
-
-    Recover as long as this many data nodes have joined the cluster.
-
-NOTE: These settings only take effect on a full cluster restart.
+(<<static-cluster-setting,Static>>)
+Recover as long as this many data nodes have joined the cluster.
 
 [[dangling-indices]]
 ==== Dangling indices

--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -22,13 +22,18 @@ The following setting is _static_ and must be configured on every data node in
 the cluster:
 
 `indices.queries.cache.size`::
-    Controls the memory size for the filter cache , defaults to `10%`. Accepts
-    either a percentage value, like `5%`, or an exact value, like `512mb`.
+(<<static-cluster-setting,Static>>)
+Controls the memory size for the filter cache. Accepts
+either a percentage value, like `5%`, or an exact value, like `512mb`. Defaults to `10%`.
+
+[[query-cache-index-settings]]
+==== Query cache index settings
 
 The following setting is an _index_ setting that can be configured on a 
 per-index basis. Can only be set at index creation time or on a
 <<indices-open-close,closed index>>:
 
 `index.queries.cache.enabled`::
-    Controls whether to enable query caching. Accepts `true` (default) or
-    `false`.
+(<<index-modules-settings,Static>>)
+Controls whether to enable query caching. Accepts `true` (default) or
+`false`.

--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -6,7 +6,7 @@ limits.
 
 [[indices-query-bool-max-clause-count]]
 `indices.query.bool.max_clause_count`::
-(integer)
+(<<static-cluster-setting,Static>>, integer)
 Maximum number of clauses a Lucene BooleanQuery can contain. Defaults to `1024`.
 +
 This setting limits the number of clauses a Lucene BooleanQuery can have. The

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -17,6 +17,7 @@ Never expose an unprotected node to the public internet.
 ==== Commonly used network settings
 
 `network.host`::
+(<<static-cluster-setting,Static>>)
 The node will bind to this hostname or IP address and _publish_ (advertise)
 this host to other nodes in the cluster. Accepts an IP address, hostname, a
 <<network-interface-values,special value>>, or an array of any combination of
@@ -29,6 +30,7 @@ same effect as the value `0.0.0.0`.
 Defaults to `_local_`.
 
 `discovery.seed_hosts`::
+(<<static-cluster-setting,Static>>)
 In order to join a cluster, a node needs to know the hostname or IP address of
 at least some of the other nodes in the cluster.  This setting provides the
 initial list of addresses this node will try to contact. Accepts IP addresses
@@ -43,6 +45,7 @@ caching>>).
 Defaults to `["127.0.0.1", "[::1]"]`.
 
 `http.port`::
+(<<static-cluster-setting,Static>>)
 Port to bind to for incoming HTTP requests. Accepts a single value or a range.
 If a range is specified, the node will bind to the first available port in the
 range.
@@ -50,6 +53,7 @@ range.
 Defaults to `9200-9300`.
 
 `transport.port`::
+(<<static-cluster-setting,Static>>)
 Port to bind for communication between nodes. Accepts a single value or a
 range. If a range is specified, the node will bind to the first available port
 in the range.
@@ -126,6 +130,7 @@ Any component that uses TCP (like the <<modules-http,HTTP>> and
 <<modules-transport,transport>> layers) share the following settings:
 
 `network.tcp.no_delay`::
+(<<static-cluster-setting,Static>>)
 Enable or disable the {wikipedia}/Nagle%27s_algorithm[TCP no delay]
 setting. Defaults to `true`.
 
@@ -134,14 +139,17 @@ Enable or disable https://en.wikipedia.org/wiki/Keepalive[TCP keep alive].
 Defaults to `true`.
 
 `network.tcp.reuse_address`::
+(<<static-cluster-setting,Static>>)
 Should an address be reused or not. Defaults to `true` on non-windows
 machines.
 
 `network.tcp.send_buffer_size`::
+(<<static-cluster-setting,Static>>)
 The size of the TCP send buffer (specified with <<size-units,size units>>).
 By default not explicitly set.
 
 `network.tcp.receive_buffer_size`::
+(<<static-cluster-setting,Static>>)
 The size of the TCP receive buffer (specified with <<size-units,size units>>).
 By default not explicitly set.
 

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -15,38 +15,50 @@ of a <<modules-remote-clusters,remote cluster>>, and also by the
 The internal transport communicates over TCP. You can configure it with the
 following settings:
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Setting |Description
-|`transport.port` |A bind port range. Defaults to `9300-9400`.
+`transport.port`::
+(<<static-cluster-setting,Static>>)
+A bind port range. Defaults to `9300-9400`.
 
-|`transport.publish_port` |The port that other nodes in the cluster
+`transport.publish_port`::
+(<<static-cluster-setting,Static>>)
+The port that other nodes in the cluster
 should use when communicating with this node. Useful when a cluster node
 is behind a proxy or firewall and the `transport.port` is not directly
 addressable from the outside. Defaults to the actual port assigned via
 `transport.port`.
 
-|`transport.bind_host` |The host address to bind the transport service to. Defaults to `transport.host` (if set) or `network.bind_host`.
+`transport.bind_host`::
+(<<static-cluster-setting,Static>>)
+The host address to bind the transport service to. Defaults to
+`transport.host` (if set) or `network.bind_host`.
 
-|`transport.publish_host` |The host address to publish for nodes in the cluster to connect to. Defaults to `transport.host` (if set) or `network.publish_host`.
+`transport.publish_host`::
+(<<static-cluster-setting,Static>>)
+The host address to publish for nodes in the cluster to connect to.
+Defaults to `transport.host` (if set) or `network.publish_host`.
 
-|`transport.host` |Used to set the `transport.bind_host` and the `transport.publish_host`.
+`transport.host`::
+(<<static-cluster-setting,Static>>)
+Used to set the `transport.bind_host` and the `transport.publish_host`.
 
-
-|`transport.connect_timeout` |The connect timeout for initiating a new connection (in
+`transport.connect_timeout`::
+(<<static-cluster-setting,Static>>)
+The connect timeout for initiating a new connection (in
 time setting format). Defaults to `30s`.
 
-|`transport.compress` |Set to `true` to enable compression (`DEFLATE`) between
+`transport.compress`::
+(<<static-cluster-setting,Static>>)
+Set to `true` to enable compression (`DEFLATE`) between
 all nodes. Defaults to `false`.
 
-|`transport.ping_schedule` | Schedule a regular application-level ping message
+`transport.ping_schedule`::
+(<<static-cluster-setting,Static>>)
+Schedule a regular application-level ping message
 to ensure that transport connections between nodes are kept alive. Defaults to
 `5s` in the transport client and `-1` (disabled) elsewhere. It is preferable
 to correctly configure TCP keep-alives instead of using this feature, because
 TCP keep-alives apply to all kinds of long-lived connections and not just to
 transport connections.
-
-|=======================================================================
 
 It also uses the common
 <<modules-network,network settings>>.

--- a/docs/reference/settings/license-settings.asciidoc
+++ b/docs/reference/settings/license-settings.asciidoc
@@ -7,6 +7,7 @@ For more information, see
 {kibana-ref}/managing-licenses.html[License management].
 
 `xpack.license.self_generated.type`::
+(<<static-cluster-setting,Static>>)
 Set to `basic` (default) to enable basic {xpack} features. +
 +
 --

--- a/docs/reference/settings/slm-settings.asciidoc
+++ b/docs/reference/settings/slm-settings.asciidoc
@@ -13,13 +13,13 @@ These are the settings available for configuring
 
 [[slm-history-index-enabled]]
 `slm.history_index_enabled`::
-(boolean)
+(<<static-cluster-setting,Static>>, boolean)
 Controls whether {slm-init} records the history of actions taken as part of {slm-init} policies
 to the `slm-history-*` indices. Defaults to `true`.
 
 [[slm-retention-schedule]]
 `slm.retention_schedule`::
-(<<cluster-update-settings,Dynamic>>, <<schedule-cron,cron scheduler value>>)
+(<<dynamic-cluster-setting,Dynamic>>, <<schedule-cron,cron scheduler value>>)
 Controls when the <<slm-retention,retention task>> runs.
 Can be a periodic or absolute time schedule.
 Supports all values supported by the <<schedule-cron,cron scheduler>>.
@@ -27,12 +27,13 @@ Defaults to daily at 1:30am UTC: `0 30 1 * * ?`.
 
 [[slm-retention-duration]]
 `slm.retention_duration`::
-(<<cluster-update-settings,Dynamic>>, <<time-units,time value>>)
+(<<dynamic-cluster-setting,Dynamic>>, <<time-units,time value>>)
 Limits how long {slm-init} should spend deleting old snapshots.
 Defaults to one hour: `1h`.
 
 [[repositories-url-allowed]]
 // tag::repositories-url-allowed[]
 `repositories.url.allowed_urls` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Specifies the <<snapshots-read-only-repository,read-only URL repositories>> that snapshots can be restored from.
 // end::repositories-url-allowed[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Document dynamic cluster settings (#61760)