### PR TITLE
[ML] Update ML mappings upgrade test and extend to config index

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
+
 public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
@@ -48,7 +50,9 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
                 // We don't know whether the job is on an old or upgraded node, so cannot assert that the mappings have been upgraded
                 break;
             case UPGRADED:
-                assertUpgradedMappings();
+                assertUpgradedResultsMappings();
+                closeAndReopenTestJob();
+                assertUpgradedConfigMappings();
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
@@ -77,8 +81,21 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
+    // Doing this should force the config index mappings to be upgraded,
+    // when the finished time is cleared on reopening the job
+    private void closeAndReopenTestJob() throws IOException {
+
+        Request closeJob = new Request("POST", "_ml/anomaly_detectors/" + JOB_ID + "/_close");
+        Response response = client().performRequest(closeJob);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Request openJob = new Request("POST", "_ml/anomaly_detectors/" + JOB_ID + "/_open");
+        response = client().performRequest(openJob);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
     @SuppressWarnings("unchecked")
-    private void assertUpgradedMappings() throws Exception {
+    private void assertUpgradedResultsMappings() throws Exception {
 
         assertBusy(() -> {
             Request getMappings = new Request("GET", XPackRestTestHelper.resultsWriteAlias(JOB_ID) + "/_mappings");
@@ -97,17 +114,34 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
                 }
             }
             assertNotNull(indexLevel);
-            Map<String, Object> mappingsLevel = (Map<String, Object>) indexLevel.get("mappings");
-            assertNotNull(mappingsLevel);
 
-            Map<String, Object> metaLevel = (Map<String, Object>) mappingsLevel.get("_meta");
-            assertEquals(Collections.singletonMap("version", Version.CURRENT.toString()), metaLevel);
-            Map<String, Object> propertiesLevel = (Map<String, Object>) mappingsLevel.get("properties");
-            assertNotNull(propertiesLevel);
+            assertEquals(Version.CURRENT.toString(), extractValue("mappings._meta.version", indexLevel));
+
             // TODO: as the years go by, the field we assert on here should be changed
             // to the most recent field we've added that is NOT of type "keyword"
-            Map<String, Object> fieldLevel = (Map<String, Object>) propertiesLevel.get("multi_bucket_impact");
-            assertEquals(Collections.singletonMap("type", "double"), fieldLevel);
+            assertEquals("Incorrect type for peak_model_bytes in " + responseLevel, "long",
+                extractValue("mappings.properties.model_size_stats.properties.peak_model_bytes.type", indexLevel));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertUpgradedConfigMappings() throws Exception {
+
+        assertBusy(() -> {
+            Request getMappings = new Request("GET", ".ml-config/_mappings");
+            Response response = client().performRequest(getMappings);
+
+            Map<String, Object> responseLevel = entityAsMap(response);
+            assertNotNull(responseLevel);
+            Map<String, Object> indexLevel = (Map<String, Object>) responseLevel.get(".ml-config");
+            assertNotNull(indexLevel);
+
+            assertEquals(Version.CURRENT.toString(), extractValue("mappings._meta.version", indexLevel));
+
+            // TODO: as the years go by, the field we assert on here should be changed
+            // to the most recent field we've added that is NOT of type "keyword"
+            assertEquals("Incorrect type for annotations_enabled in " + responseLevel, "boolean",
+                extractValue("mappings.properties.model_plot_config.properties.annotations_enabled.type", indexLevel));
         });
     }
 }


### PR DESCRIPTION
The ML mappings upgrade test had become useless as it was
checking a field that has been the same since 6.5. This
commit switches to a field that was changed in 7.9.

Additionally, the test only used to check the results index
mappings.  This commit also adds checking for the config
index.

Backport of #61340