### PR TITLE
[ML] Assert mappings match templates in Upgrade tests 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
@@ -13,6 +13,9 @@ import org.elasticsearch.common.ParseField;
 public final class InferenceIndexConstants {
 
     /**
+     * When incrementing the index version please also update
+     * any use of the constant in x-pack/qa/
+     *
      * version: 7.8.0:
      *  - adds inference_config definition to trained model config
      *

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/persistence/TransformInternalIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/persistence/TransformInternalIndexConstants.java
@@ -19,6 +19,7 @@ public final class TransformInternalIndexConstants {
      *
      *    - XPackRestTestConstants
      *    - yaml tests under x-pack/qa/
+     *    - upgrade tests under x-pack/qa/rolling-upgrade
      *
      * (pro-tip: grep for the constant)
      */

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -334,6 +334,9 @@
       "max_num_threads" : {
         "type" : "integer"
       },
+      "model_memory_limit": {
+        "type" : "keyword"
+      },
       "model_plot_config" : {
         "properties" : {
           "enabled" : {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -280,7 +280,7 @@ public final class TransformInternalIndex {
                         .field(TYPE, KEYWORD)
                     .endObject()
                     .startObject(SourceConfig.QUERY.getPreferredName())
-                        .field(ENABLED, "false")
+                        .field(ENABLED, false)
                     .endObject()
                 .endObject()
             .endObject()

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -11,14 +11,24 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.test.SecuritySettingsSourceField;
 import org.junit.Before;
 
+import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.test.SecuritySettingsSourceField.basicAuthHeaderValue;
 
@@ -115,5 +125,131 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
                 fail("Some expected templates are missing: " + missingTemplates + ". The templates that exist are: " + templates + "");
             }
         });
+    }
+
+    /**
+     * Compares the mappings from the template and the index and asserts they
+     * are the same.
+     *
+     * The test is intended to catch cases where an index mapping has been
+     * updated dynamically or a write occurred before the template was put.
+     * The assertion error message details the differences in the mappings.
+     *
+     * The Mappings, which are maps of maps, are flattened with the keys built
+     * from the keys of the sub-maps appended to the parent key.
+     * This makes diffing the 2 maps easier and diffs more comprehensible.
+     *
+     * @param templateName The template
+     * @param indexName The index
+     * @throws IOException Yes
+     */
+    @SuppressWarnings("unchecked")
+    public void assertLegacyTemplateMatchesIndexMappings(String templateName,
+                                                         String indexName) throws IOException {
+
+        Request getTemplate = new Request("GET", "_template/" + templateName);
+        Response templateResponse = client().performRequest(getTemplate);
+        assertEquals("missing template [" + templateName + "]", 200, templateResponse.getStatusLine().getStatusCode());
+
+        Map<String, Object> templateMappings = (Map<String, Object>) XContentMapValues.extractValue(entityAsMap(templateResponse),
+            templateName, "mappings");
+
+        Request getIndexMapping = new Request("GET", indexName + "/_mapping");
+        Response indexMappingResponse = client().performRequest(getIndexMapping);
+        assertEquals("error getting mappings for index [" + indexName + "]",
+            200, indexMappingResponse.getStatusLine().getStatusCode());
+
+        Map<String, Object> indexMappings = (Map<String, Object>) XContentMapValues.extractValue(entityAsMap(indexMappingResponse),
+            indexName, "mappings");
+
+        // We cannot do a simple comparison of mappings e.g
+        // Objects.equals(indexMappings, templateMappings) because some
+        // templates use strings for the boolean values - "true" and "false"
+        // which are automatically converted to Booleans causing the equality
+        // to fail.
+        boolean isEqual = true;
+
+        // flatten the map of maps
+        Map<String, Object> flatTemplateMap = flattenMap(templateMappings);
+        Map<String, Object> flatIndexMap = flattenMap(indexMappings);
+
+        Set<String> keysMissingFromIndex = new HashSet<>(flatTemplateMap.keySet());
+        keysMissingFromIndex.removeAll(flatIndexMap.keySet());
+
+        Set<String> keysMissingFromTemplate = new HashSet<>(flatIndexMap.keySet());
+        keysMissingFromTemplate.removeAll(flatTemplateMap.keySet());
+
+        // In the case of object fields the 'type: object' mapping is set by default.
+        // If this does not explicitly appear in the template it is not an error
+        // as ES has added the default to the index mappings
+        keysMissingFromTemplate.removeIf(key -> key.endsWith(".type") && "object".equals(flatIndexMap.get(key)));
+
+        StringBuilder errorMesssage = new StringBuilder("Error the template mappings [")
+            .append(templateName)
+            .append("] and index mappings [")
+            .append(indexName)
+            .append("] are not the same")
+            .append(System.lineSeparator());
+
+        if (keysMissingFromIndex.isEmpty() == false) {
+            isEqual = false;
+            errorMesssage.append("Keys in the template missing from the index mapping: ")
+                .append(keysMissingFromIndex)
+                .append(System.lineSeparator());
+        }
+
+        if (keysMissingFromTemplate.isEmpty() == false) {
+            isEqual = false;
+            errorMesssage.append("Keys in the index missing from the template mapping: ")
+                .append(keysMissingFromTemplate)
+                .append(System.lineSeparator());
+        }
+
+        // find values that are different for the same key
+        Set<String> commonKeys = new TreeSet<>(flatIndexMap.keySet());
+        commonKeys.retainAll(flatTemplateMap.keySet());
+        for (String key : commonKeys) {
+            Object template = flatTemplateMap.get(key);
+            Object index = flatIndexMap.get(key);
+            if (Objects.equals(template, index) ==  false) {
+                // Both maybe be booleans but different representations
+                if (index instanceof Boolean && template instanceof String) {
+                    if (index.equals(Boolean.parseBoolean((String)template))) {
+                        continue;
+                    }
+                }
+
+                isEqual = false;
+
+                errorMesssage.append("Values for key [").append(key).append("] are different").append(System.lineSeparator());
+                errorMesssage.append("    template value [").append(template).append("] ").append(template.getClass().getSimpleName())
+                    .append(System.lineSeparator());
+                errorMesssage.append("    index value [").append(index).append("] ").append(index.getClass().getSimpleName())
+                    .append(System.lineSeparator());
+            }
+        }
+
+        if (isEqual == false) {
+            fail(errorMesssage.toString());
+        }
+    }
+
+    private Map<String, Object> flattenMap(Map<String, Object> map) {
+        return new TreeMap<>(flatten("", map).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private Stream<Map.Entry<String, Object>> flatten(String path, Map<String, Object> map) {
+        return map.entrySet()
+            .stream()
+            .flatMap((e) -> extractValue(path, e));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Stream<Map.Entry<String, Object>> extractValue(String path, Map.Entry<String, Object> entry) {
+        if (entry.getValue() instanceof Map<?, ?>) {
+            return flatten(path + "." + entry.getKey(), (Map<String, Object>) entry.getValue());
+        } else {
+            return Stream.of(new AbstractMap.SimpleEntry<>(path + "." + entry.getKey(), entry.getValue()));
+        }
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -248,10 +248,8 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
             Object index = flatIndexMap.get(key);
             if (Objects.equals(template, index) ==  false) {
                 // Both maybe be booleans but different representations
-                if (index instanceof Boolean && template instanceof String) {
-                    if (index.equals(Boolean.parseBoolean((String)template))) {
-                        continue;
-                    }
+                if (areBooleanObjectsAndEqual(index, template)) {
+                    continue;
                 }
 
                 mappingsAreTheSame = false;
@@ -272,6 +270,37 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     protected void assertLegacyTemplateMatchesIndexMappings(String templateName,
                                                             String indexName) throws IOException {
         assertLegacyTemplateMatchesIndexMappings(templateName, indexName, false, Collections.emptySet());
+    }
+
+    private boolean areBooleanObjectsAndEqual(Object a, Object b) {
+        Boolean left;
+        Boolean right;
+
+        if (a instanceof Boolean) {
+            left = (Boolean)a;
+        } else if (a instanceof String && isBooleanValueString((String)a)) {
+            left = Boolean.parseBoolean((String)a);
+        } else {
+            return false;
+        }
+
+        if (b instanceof Boolean) {
+            right = (Boolean)b;
+        } else if (b instanceof String && isBooleanValueString((String)b)) {
+            right = Boolean.parseBoolean((String)b);
+        } else {
+            return false;
+        }
+
+        return left.equals(right);
+    }
+
+    /* Boolean.parseBoolean is not strict anything that isn't
+     * "true" is returned as false. Here we want to know if
+     * s is a boolean.
+     */
+    private boolean isBooleanValueString(String s) {
+        return s.equalsIgnoreCase("true") || s.equalsIgnoreCase("false");
     }
 
     private Map<String, Object> flattenMap(Map<String, Object> map) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -161,6 +161,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
 
         Map<String, Object> templateMappings = (Map<String, Object>) XContentMapValues.extractValue(entityAsMap(templateResponse),
             templateName, "mappings");
+        assertNotNull(templateMappings);
 
         Request getIndexMapping = new Request("GET", indexName + "/_mapping");
         Response indexMappingResponse;
@@ -178,6 +179,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
 
         Map<String, Object> indexMappings = (Map<String, Object>) XContentMapValues.extractValue(entityAsMap(indexMappingResponse),
             indexName, "mappings");
+        assertNotNull(indexMappings);
 
         // ignore the _meta field
         indexMappings.remove("_meta");
@@ -194,10 +196,10 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
         Map<String, Object> flatTemplateMap = flattenMap(templateMappings);
         Map<String, Object> flatIndexMap = flattenMap(indexMappings);
 
-        Set<String> keysMissingFromIndex = new HashSet<>(flatTemplateMap.keySet());
+        SortedSet<String> keysMissingFromIndex = new TreeSet<>(flatTemplateMap.keySet());
         keysMissingFromIndex.removeAll(flatIndexMap.keySet());
 
-        Set<String> keysMissingFromTemplate = new HashSet<>(flatIndexMap.keySet());
+        SortedSet<String> keysMissingFromTemplate = new TreeSet<>(flatIndexMap.keySet());
         keysMissingFromTemplate.removeAll(flatTemplateMap.keySet());
 
         // In the case of object fields the 'type: object' mapping is set by default.

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -188,7 +188,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
         // templates use strings for the boolean values - "true" and "false"
         // which are automatically converted to Booleans causing the equality
         // to fail.
-        boolean isEqual = true;
+        boolean mappingsAreTheSame = true;
 
         // flatten the map of maps
         Map<String, Object> flatTemplateMap = flattenMap(templateMappings);
@@ -203,7 +203,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
         // In the case of object fields the 'type: object' mapping is set by default.
         // If this does not explicitly appear in the template it is not an error
         // as ES has added the default to the index mappings
-        keysMissingFromTemplate.removeIf(key -> key.endsWith(".type") && "object".equals(flatIndexMap.get(key)));
+        keysMissingFromTemplate.removeIf(key -> key.endsWith("type") && "object".equals(flatIndexMap.get(key)));
 
         StringBuilder errorMesssage = new StringBuilder("Error the template mappings [")
             .append(templateName)
@@ -213,14 +213,14 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
             .append(System.lineSeparator());
 
         if (keysMissingFromIndex.isEmpty() == false) {
-            isEqual = false;
+            mappingsAreTheSame = false;
             errorMesssage.append("Keys in the template missing from the index mapping: ")
                 .append(keysMissingFromIndex)
                 .append(System.lineSeparator());
         }
 
         if (keysMissingFromTemplate.isEmpty() == false) {
-            isEqual = false;
+            mappingsAreTheSame = false;
             errorMesssage.append("Keys in the index missing from the template mapping: ")
                 .append(keysMissingFromTemplate)
                 .append(System.lineSeparator());
@@ -240,7 +240,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
                     }
                 }
 
-                isEqual = false;
+                mappingsAreTheSame = false;
 
                 errorMesssage.append("Values for key [").append(key).append("] are different").append(System.lineSeparator());
                 errorMesssage.append("    template value [").append(template).append("] ").append(template.getClass().getSimpleName())
@@ -250,7 +250,7 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
             }
         }
 
-        if (isEqual == false) {
+        if (mappingsAreTheSame == false) {
             fail(errorMesssage.toString());
         }
     }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -18,8 +18,10 @@ import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +31,10 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.extrac
 public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
+
+    private static final List<String> INDICES_TO_WATCH = Collections.unmodifiableList(
+        Arrays.asList(".transform-internal-005")
+    );
 
     @Override
     protected Collection<String> templatesToWaitFor() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -18,10 +18,8 @@ import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,10 +29,6 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.extrac
 public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
-
-    private static final List<String> INDICES_TO_WATCH = Collections.unmodifiableList(
-        Arrays.asList(".transform-internal-005")
-    );
 
     @Override
     protected Collection<String> templatesToWaitFor() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
@@ -152,6 +152,7 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
             case UPGRADED:
                 client().performRequest(waitForYellow);
                 verifyContinuousTransformHandlesData(3);
+                assertLegacyTemplateMatchesIndexMappings(".transform-internal-005", ".transform-internal-005");
                 cleanUpTransforms();
                 break;
             default:


### PR DESCRIPTION
At the end of the rolling upgrade tests check the mappings of the concrete `.ml` and `.transform-internal` indices match the mappings in the templates. When the templates change, the tests should prove that the mappings have been updated or the new template added before the index is written to during rolling upgrade.

- Where concrete versioned indices are used e.g. `.ml-inference-000003` the test must be updated to use the latest version of the index.
- In the case where dynamic mappings are disabled (transforms) the test should at least prove the mappings have been updated before any write.
- `.ml-annotations-6` does not use templates and cannot be tested
- `.ml-anomalies-shared` mapping is updated with fields from the job so will not match the template