### PR TITLE
[ML] Update reindexing task progress before persisting job progress

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -119,6 +119,7 @@ public class TransportGetDataFrameAnalyticsStatsAction
             }, listener::onFailure
         );
 
+        // We must update the progress of the reindexing task as it might be stale
         task.updateReindexTaskProgress(reindexingProgressListener);
     }
 


### PR DESCRIPTION
This fixes a bug introduced by #61782. In that PR I thought I could
simplify the persistence of progress by using the progress straight
from the stats holder in the task instead of calling the get
stats action. However, I overlooked that it is then possible to
have stale progress for the reindexing task as that is only updated
when the get stats API is called.

In this commit this is fixed by updating reindexing task progress
before persisting the job progress. This seems to be much more
lightweight than calling the get stats request.

Closes #61852
