### PR TITLE
[7.x] Correct the query dsl for watching elasticsearch version (#58321)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
@@ -36,7 +36,7 @@
                       "filter": [
                         {
                           "term": {
-                            "_id": "{{ctx.metadata.xpack.cluster_uuid}}"
+                            "cluster_uuid": "{{ctx.metadata.xpack.cluster_uuid}}"
                           }
                         },
                         {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Correct the query dsl for watching elasticsearch version (#58321)