### PR TITLE
[7.x] Fix passing params to template or script failed in watcher (#58559)

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/mustache/60_template_with_params.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/mustache/60_template_with_params.yml
@@ -1,0 +1,67 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+teardown:
+  - do:
+      watcher.delete_watch:
+        id: "test_watch"
+        ignore: 404
+
+---
+"Test executing logging action using template with params":
+  - do:
+      put_script:
+        id: log-action
+        body: >
+          {
+            "script":
+            {
+              "lang": "mustache",
+              "source": "{{color}} alert"
+            }
+          }
+
+  - do:
+      watcher.put_watch:
+        id: "test_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "interval": "1m" }
+            },
+            "input": {
+              "simple": {
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+              "log" : {
+                "logging" : {
+                  "text" : {
+                    "id": "log-action",
+                    "params": {
+                      "color": "yellow"
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - match: { _id: "test_watch" }
+  - match: { created: true }
+
+  - do:
+      watcher.execute_watch:
+        id: "test_watch"
+
+  - match: { watch_record.watch_id: "test_watch" }
+  - match: { watch_record.result.actions.0.id: "log" }
+  - match: { watch_record.result.actions.0.type: "logging" }
+  - match: { watch_record.result.actions.0.status: "success" }
+  - match: { watch_record.result.actions.0.logging.logged_text: "yellow alert" }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
@@ -248,3 +248,61 @@
   - match: { "watch_record.result.actions.0.type" : "email" }
   - match: { "watch_record.result.actions.0.email.message.subject" : "404 recently encountered" }
 
+---
+"Test executing logging action using scripts with params":
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      put_script:
+        id: log-action
+        body: >
+          {
+            "script":
+            {
+              "lang": "painless",
+              "source": "params.color + \" alert\""
+            }
+          }
+
+  - do:
+      watcher.put_watch:
+        id: "test_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "interval": "1m" }
+            },
+            "input": {
+              "simple": {
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+              "log" : {
+                "logging" : {
+                  "text" : {
+                    "id": "log-action",
+                    "params": {
+                      "color": "yellow"
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - match: { _id: "test_watch" }
+  - match: { created: true }
+
+  - do:
+      watcher.execute_watch:
+        id: "test_watch"
+
+  - match: { watch_record.watch_id: "test_watch" }
+  - match: { watch_record.result.actions.0.id: "log" }
+  - match: { watch_record.result.actions.0.type: "logging" }
+  - match: { watch_record.result.actions.0.status: "success" }
+  - match: { watch_record.result.actions.0.logging.logged_text: "yellow alert" }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/text/TextTemplateEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/text/TextTemplateEngine.java
@@ -55,7 +55,7 @@ public class TextTemplateEngine {
         Script script = new Script(textTemplate.getType(),
                 textTemplate.getType() == ScriptType.STORED ? null : "mustache", template, options, mergedModel);
         TemplateScript.Factory compiledTemplate = service.compile(script, Watcher.SCRIPT_TEMPLATE_CONTEXT);
-        return compiledTemplate.newInstance(model).execute();
+        return compiledTemplate.newInstance(mergedModel).execute();
     }
 
     private String trimContentType(TextTemplate textTemplate) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix passing params to template or script failed in watcher (#58559)