### PR TITLE
Enable searchable snapshot feature for integTest clusters

### DIFF
--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -43,7 +43,7 @@ artifacts {
   testArtifacts testJar
 }
 
-test {
+testClusters.integTest {
   if (BuildParams.isSnapshotBuild() == false) {
     systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
   }


### PR DESCRIPTION
One of our build job `release-tests` started to fail recently on CI for integration tests of the following package:
org.elasticsearch.xpack.searchablesnapshots

Build scans:
https://gradle-enterprise.elastic.co/s/5tyix4dniwqxm
https://gradle-enterprise.elastic.co/s/ijkfq3lsqovee

I suspect that this is related to #61802, which recently change some build plugins, and the consequence is that
```
test {
  if (BuildParams.isSnapshotBuild() == false) {
    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
  }
}
```

is not applied to integration tests. Or maybe #54987 wasn't complete since the beginning. 

This pull request tries to correct that.