### PR TITLE
Mention audit logs are sent to stdout when using Docker

### DIFF
--- a/x-pack/docs/en/security/auditing/enable-audit-logging.asciidoc
+++ b/x-pack/docs/en/security/auditing/enable-audit-logging.asciidoc
@@ -19,6 +19,9 @@ To enable enable audit logging:
 When audit logging is enabled, <<audit-event-types, security events>> are persisted to 
 a dedicated `<clustername>_audit.json` file on the host's file system (on each node).
 
+NOTE: the official Elasticsearch Docker image outputs security events on the standard
+output (`stdout`) by default, instead of using a dedicated `<clustername>_audit.json` file.
+
 You can configure additional options to control what events are logged and 
 what information is included in the audit log. 
 For more information, see <<auditing-settings>>.


### PR DESCRIPTION
Since https://github.com/elastic/elasticsearch/pull/42671 (7.3.0), audit logs are sent to stdout when running Elasticsearch from its official Docker image.

However the audit logging documentation still mentions:

```
When audit logging is enabled, security events are persisted to a dedicated <clustername>_audit.json file on the host's file system (on each node).
```

This commit adds a note to mention audit logs will appear on stdout when using
the official Docker image.

I'm not sure what's the right process to backport this to other versions of the documentation (7.3.0+, 8.0).