### PR TITLE
[DOCS] Adds filter aggregation example link to painless examples

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -341,9 +341,13 @@ date which results in the duration of the session.
 == Counting HTTP responses by using scripted metric aggregation
 
 You can count the different HTTP response types in a web log data set by using 
-scripted metric aggregation as part of the {transform}. The example below 
-assumes that the HTTP response codes are stored as keywords in the `response` 
-field of the documents.
+scripted metric aggregation as part of the {transform}. You can achieve the same 
+function with filter aggregations, check the 
+{ref}/transform-examples.html#example-clientips[Finding suspicious client IPs] 
+example for details.
+
+The example below assumes that the HTTP response codes are stored as keywords in 
+the `response` field of the documents.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -3,7 +3,7 @@
 [[transform-painless-examples]]
 = Painless examples for {transforms}
 ++++
-<titleabbrev>Painless examples for {transforms}</titleabbrev>
+<titleabbrev>Painless examples</titleabbrev>
 ++++
 
 These examples demonstrate how to use Painless in {transforms}. You can learn 


### PR DESCRIPTION
## Overview

This PR adds a link to the `Counting HTTP responses...` painless example that points to the `Finding suspicious client IPs` example. This way users can check how the same function can be achieved by using painless or filter aggregations in transforms.

It also makes the page name shorter in the RHS navigation by using `titleabbrev`.

### Preview

[Counting HTTP responses](https://elasticsearch_61890.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-painless-examples.html#painless-count-http)