### PR TITLE
[7.9] Ensure domain_name setting for AD realm is present (#61859)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -78,7 +79,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
                             () -> config.getSetting(ActiveDirectorySessionFactorySettings.AD_DOMAIN_NAME_SETTING));
                 }, threadPool);
         String domainName = config.getSetting(ActiveDirectorySessionFactorySettings.AD_DOMAIN_NAME_SETTING);
-        if (domainName == null) {
+        if (Strings.isNullOrEmpty(domainName)) {
             throw new IllegalArgumentException("missing [" +
                     RealmSettings.getFullSettingKey(config, ActiveDirectorySessionFactorySettings.AD_DOMAIN_NAME_SETTING)
                     + "] setting for active directory");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/SecurityRealmSettingsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/SecurityRealmSettingsTests.java
@@ -67,6 +67,7 @@ public class SecurityRealmSettingsTests extends SecurityIntegTestCase {
                 .put("xpack.security.authc.realms.ldap.ldap1.user_dn_templates", "cn={0},dc=example,dc=com")
                 .put("xpack.security.authc.realms.active_directory.ad1.order", 4)
                 .put("xpack.security.authc.realms.active_directory.ad1.url", "ldap://127.0.0.1:389")
+                .put("xpack.security.authc.realms.active_directory.ad1.domain_name", "domain_name")
                 .put("xpack.security.authc.realms.pki.pki1.order", 5)
                 .put("xpack.security.authc.realms.saml.saml1.order", 6)
                 .put("xpack.security.authc.realms.saml.saml1.idp.metadata.path", samlIdpPath.toAbsolutePath())

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
@@ -366,6 +366,15 @@ public class ActiveDirectorySessionFactoryTests extends AbstractActiveDirectoryT
         }
     }
 
+    public void testADRealmMandatorySettings() throws Exception {
+        RealmConfig config = configureRealm("ad-test", LdapRealmSettings.AD_TYPE,
+            buildAdSettings(AD_LDAP_URL, randomBoolean() ? "" : null, false, true));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            getActiveDirectorySessionFactory(config, sslService, threadPool));
+        assertThat(e.getMessage(), containsString(getFullSettingKey(REALM_NAME,
+            ActiveDirectorySessionFactorySettings.AD_DOMAIN_NAME_SETTING)));
+    }
+
     private Settings buildAdSettings(String ldapUrl, String adDomainName, boolean hostnameVerification) {
         return buildAdSettings(ldapUrl, adDomainName, hostnameVerification, randomBoolean());
     }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Ensure domain_name setting for AD realm is present (#61859)