### PR TITLE
[DOCS] Makes example preface more accurate

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -341,8 +341,8 @@ date which results in the duration of the session.
 == Counting HTTP responses by using scripted metric aggregation
 
 You can count the different HTTP response types in a web log data set by using 
-scripted metric aggregation as part of the {transform}. You can achieve the same 
-function with filter aggregations, check the 
+scripted metric aggregation as part of the {transform}. You can achieve a 
+similar function with filter aggregations, check the 
 {ref}/transform-examples.html#example-clientips[Finding suspicious client IPs] 
 example for details.
 


### PR DESCRIPTION
## Overview

This PR fine-tunes the statement of a painless example preface text. The transform example mentioned in the statement does not achieve the same function, but a _similar_ one.