### PR TITLE
[DOCS] Remove 7.9.1 coming tag

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 
-coming::[7.9.1]
-
 [[release-notes-7.9.0]]
 == {es} version 7.9.0
 


### PR DESCRIPTION
Removes the coming tag from the 7.9.1 ES RNs.