### PR TITLE
[7.9] [DOCS] Remove 7.9.1 coming tag (#61929)

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.9.1]]
 == {es} version 7.9.1
 
-coming[7.9.1]
-
 Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 
 [[feature-7.9.1]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Remove 7.9.1 coming tag (#61929)