### PR TITLE
[DOCS] Add 7.9.1 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.9.1>>
 * <<release-notes-7.9.0>>
 * <<release-notes-7.8.1>>
 * <<release-notes-7.8.0>>


### PR DESCRIPTION
It was not added on e0efcb50f5ec313bd8a369d31b2d31dc973de5ae / #61861

See https://www.elastic.co/guide/en/elasticsearch/reference/7.9/es-release-notes.html : 7.9.1 is missing from there.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
Yes