### PR TITLE
[7.x] Add runtimeJavaDetails property in BuildParams (#61901)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/BuildParams.java
@@ -38,6 +38,7 @@ public class BuildParams {
     private static JavaVersion minimumRuntimeVersion;
     private static JavaVersion gradleJavaVersion;
     private static JavaVersion runtimeJavaVersion;
+    private static String runtimeJavaDetails;
     private static Boolean inFipsJvm;
     private static String gitRevision;
     private static String gitOrigin;
@@ -87,6 +88,10 @@ public class BuildParams {
 
     public static JavaVersion getRuntimeJavaVersion() {
         return value(runtimeJavaVersion);
+    }
+
+    public static String getRuntimeJavaDetails() {
+        return value(runtimeJavaDetails);
     }
 
     public static Boolean isInFipsJvm() {
@@ -196,6 +201,10 @@ public class BuildParams {
 
         public void setRuntimeJavaVersion(JavaVersion runtimeJavaVersion) {
             BuildParams.runtimeJavaVersion = requireNonNull(runtimeJavaVersion);
+        }
+
+        public void setRuntimeJavaDetails(String runtimeJavaDetails) {
+            BuildParams.runtimeJavaDetails = runtimeJavaDetails;
         }
 
         public void setInFipsJvm(boolean inFipsJvm) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -105,6 +105,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setRuntimeJavaHome(runtimeJavaHome);
             params.setRuntimeJavaVersion(determineJavaVersion("runtime java.home", runtimeJavaHome, minimumRuntimeVersion));
             params.setIsRutimeJavaHomeSet(Jvm.current().getJavaHome().equals(runtimeJavaHome) == false);
+            params.setRuntimeJavaDetails(getJavaInstallation(runtimeJavaHome).getImplementationName());
             params.setJavaVersions(getAvailableJavaVersions(minimumCompilerVersion));
             params.setMinimumCompilerVersion(minimumCompilerVersion);
             params.setMinimumRuntimeVersion(minimumRuntimeVersion);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add runtimeJavaDetails property in BuildParams (#61901)