### PR TITLE
Enable searchable snapshot feature for all test clusters

### DIFF
--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -43,7 +43,7 @@ artifacts {
   testArtifacts testJar
 }
 
-test {
+testClusters.integTest {
   if (BuildParams.isSnapshotBuild() == false) {
     systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
   }


### PR DESCRIPTION
This commit reenables the searchable snapshot feature for integration tests 
after #61802 which changed some build plugins.

Backport of #61888 for 7.10