### PR TITLE
[DOCS] Updated target_field description of the json ingest processor

### DIFF
--- a/docs/reference/ingest/processors/json.asciidoc
+++ b/docs/reference/ingest/processors/json.asciidoc
@@ -11,8 +11,8 @@ Converts a JSON string into a structured JSON object.
 [options="header"]
 |======
 | Name           | Required  | Default  | Description
-| `field`        | yes       | -        | The field to be parsed
-| `target_field` | no        | `field`  | The field to insert the converted structured object into
+| `field`        | yes       | -        | The field to be parsed.
+| `target_field` | no        | `field`  | The field to insert the converted structured object into, overwriting everything that is in this object already.
 | `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
 include::common-options.asciidoc[]
 |======

--- a/docs/reference/ingest/processors/json.asciidoc
+++ b/docs/reference/ingest/processors/json.asciidoc
@@ -12,7 +12,7 @@ Converts a JSON string into a structured JSON object.
 |======
 | Name           | Required  | Default  | Description
 | `field`        | yes       | -        | The field to be parsed.
-| `target_field` | no        | `field`  | The field to insert the converted structured object into, overwriting everything that is in this object already.
+| `target_field` | no        | `field`  | The field that the converted structured object will be written into. Any existing content in this field will be overwritten.
 | `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
 include::common-options.asciidoc[]
 |======


### PR DESCRIPTION
to make it more clear it's overwriting the content of the target object if there is anything in there already. 

Tagging @danhermann because we talked about this. 