### PR TITLE
Fix invalid flag setting for RegExp

### DIFF
--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
@@ -59,7 +59,7 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
                 pattern += "modified";
                 break;
             case 3:
-                flags = randomValueOtherThan(flags, () -> randomInt(0xFFFF));
+                flags = randomValueOtherThan(flags, () -> randomInt(RegExp.ALL));
                 break;
             default:
                 fail();


### PR DESCRIPTION
This test failure is a side effect of the upgrade to a new Lucene snapshot

relates #61957