### PR TITLE
Adapt SearchableSnapshotsBlobStoreCacheIntegTests to Lucene 8.7.0

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -214,12 +214,8 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             new SearchableSnapshotsStatsRequest()
         ).actionGet().getStats()) {
             for (final SearchableSnapshotShardStats.CacheIndexInputStats indexInputStats : shardStats.getStats()) {
-                final boolean mayReadMoreThanHeader
                 // we read the header of each file contained within the .cfs file, which could be anywhere
-                    = indexInputStats.getFileName().endsWith(".cfs")
-                        // we read a couple of longs at the end of the .fdt file (see https://issues.apache.org/jira/browse/LUCENE-9456)
-                        // TODO revisit this when this issue is addressed in Lucene
-                        || indexInputStats.getFileName().endsWith(".fdt");
+                final boolean mayReadMoreThanHeader = indexInputStats.getFileName().endsWith(".cfs");
                 if (indexInputStats.getFileLength() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE * 2
                     || mayReadMoreThanHeader == false) {
                     assertThat(Strings.toString(indexInputStats), indexInputStats.getBlobStoreBytesRequested().getCount(), equalTo(0L));


### PR DESCRIPTION
Elasticsearch now uses #61957 which includes https://issues.apache.org/jira/browse/LUCENE-9456. We can now remove the corresponding `//TODO` in `SearchableSnapshotsBlobStoreCacheIntegTests`.