### PR TITLE
[7.x] [DOCS] Document dynamic index mgmt and buffer settings (#61753)

### DIFF
--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -1,23 +1,27 @@
 [[index-management-settings]]
 === Index management settings
 
-You can configure these index settings in the `elasticsearch.yml` file.
+You can use the following cluster settings to enable or disable index management
+features.
 
 [[auto-create-index]]
 // tag::auto-create-index-tag[]
 `action.auto_create_index` {ess-icon}::
-<<index-creation,Automatically create an index>> if it doesn't already exist and apply any configured index templates. Default: `true`.
+(<<dynamic-cluster-setting,Dynamic>>)
+<<index-creation,Automatically create an index>> if it doesn't already exist and apply any configured index templates. Defaults to `true`.
 // end::auto-create-index-tag[]
 
 [[action-destructive-requires-name]]
 // tag::action-destructive-requires-name-tag[]
 `action.destructive_requires_name` {ess-icon}::
+(<<dynamic-cluster-setting,Dynamic>>)
 When set to `true`, you must specify the index name to <<indices-delete-index,delete an index>>. It is not possible to delete all indices with `_all` or use wildcards.
 // end::action-destructive-requires-name-tag[]
 
 [[cluster-indices-close-enable]]
 // tag::cluster-indices-close-enable-tag[]
 `cluster.indices.close.enable` {ess-icon}::
+(<<dynamic-cluster-setting,Dynamic>>)
 Enables <<indices-open-close,opening of closed indices>> in {es}. You might enable this setting temporarily to change the analyzer configuration for an existing index. We strongly recommend leaving this set to `false` (the default) otherwise.
 +
 IMPORTANT: Closed indices are a data loss risk because they are not included when you make cluster configuration changes, such as scaling to a different capacity, failover, and many other operations. Additionally, closed indices can lead to inaccurate disk space counts.
@@ -25,5 +29,6 @@ IMPORTANT: Closed indices are a data loss risk because they are not included whe
 [[reindex-remote-whitelist]]
 // tag::reindex-remote-whitelist[]
 `reindex.remote.whitelist` {ess-icon}::
+(<<static-cluster-setting,Static>>)
 Specifies the hosts that can be <<reindex-from-remote,reindexed from remotely>>. Expects a YAML array of `host:port` strings. Consists of a comma-delimited list of `host:port` entries. Defaults to `["\*.io:*", "\*.com:*"]`.
 // end::reindex-remote-whitelist[]

--- a/docs/reference/modules/indices/indexing_buffer.asciidoc
+++ b/docs/reference/modules/indices/indexing_buffer.asciidoc
@@ -9,17 +9,17 @@ The following settings are _static_ and must be configured on every data node
 in the cluster:
 
 `indices.memory.index_buffer_size`::
-
-    Accepts either a percentage or a byte size value. It defaults to `10%`,
-    meaning that `10%` of the total heap allocated to a node will be used as the
-    indexing buffer size shared across all shards.
+(<<static-cluster-setting,Static>>)
+Accepts either a percentage or a byte size value. It defaults to `10%`,
+meaning that `10%` of the total heap allocated to a node will be used as the
+indexing buffer size shared across all shards.
 
 `indices.memory.min_index_buffer_size`::
-
-    If the `index_buffer_size` is specified as a percentage, then this
-    setting can be used to specify an absolute minimum.  Defaults to `48mb`.
+(<<static-cluster-setting,Static>>)
+If the `index_buffer_size` is specified as a percentage, then this
+setting can be used to specify an absolute minimum.  Defaults to `48mb`.
 
 `indices.memory.max_index_buffer_size`::
-
-    If the `index_buffer_size` is specified as a percentage, then this
-    setting can be used to specify an absolute maximum.  Defaults to unbounded.
+(<<static-cluster-setting,Static>>)
+If the `index_buffer_size` is specified as a percentage, then this
+setting can be used to specify an absolute maximum.  Defaults to unbounded.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document dynamic index mgmt and buffer settings (#61753)