### PR TITLE
[7.x] Add test for item-level error when no write index defined for an alias in bulk API (#55503)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -207,6 +207,9 @@
         index: new_index_not_created
 ---
 "Return item-level error when no write index defined for an alias":
+  - skip:
+      version: " - 7.8.99"
+      reason: "supporting code added in 7.9.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -205,3 +205,33 @@
       catch: missing
       indices.get:
         index: new_index_not_created
+---
+"Return item-level error when no write index defined for an alias":
+
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+
+  - do:
+      indices.put_alias:
+        index: test_index1
+        name: test_index
+  - do:
+      indices.put_alias:
+        index: test_index2
+        name: test_index
+
+  - do:
+      bulk:
+        body:
+          - '{"index": {"_index": "test_index"}}'
+          - '{"field": "test"}'
+
+  - match: { errors: true }
+  - match: { items.0.index.status: 400 }
+  - match: { items.0.index.error.type: illegal_argument_exception }
+  - match: { items.0.index.error.reason: "no write index is defined for alias [test_index]. The write index may be explicitly disabled using is_write_index=false or the alias points to multiple indices without one being designated as a write index" }
+


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add test for item-level error when no write index defined for an alias in bulk API (#55503)