### PR TITLE
Improve Snapshot State Machine Performance

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -205,8 +205,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     // Add all new shards to start processing on
                     final ShardId shardId = shard.key;
                     final ShardSnapshotStatus shardSnapshotStatus = shard.value;
-                    if (localNodeId.equals(shardSnapshotStatus.nodeId())
-                        && shardSnapshotStatus.state() == ShardState.INIT
+                    if (shardSnapshotStatus.state() == ShardState.INIT
+                        && localNodeId.equals(shardSnapshotStatus.nodeId())
                         && snapshotShards.containsKey(shardId) == false) {
                         logger.trace("[{}] - Adding shard to the queue", shardId);
                         if (startedShards == null) {

--- a/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusRequest.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusRequest.java
@@ -41,7 +41,7 @@ public class UpdateIndexShardSnapshotStatusRequest extends MasterNodeRequest<Upd
         super(in);
         snapshot = new Snapshot(in);
         shardId = new ShardId(in);
-        status = new SnapshotsInProgress.ShardSnapshotStatus(in);
+        status = SnapshotsInProgress.ShardSnapshotStatus.readFrom(in);
     }
 
     public UpdateIndexShardSnapshotStatusRequest(Snapshot snapshot, ShardId shardId, SnapshotsInProgress.ShardSnapshotStatus status) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -73,8 +73,10 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                 ShardId shardId = new ShardId(idx, j);
                 String nodeId = randomAlphaOfLength(10);
                 ShardState shardState = randomFrom(ShardState.values());
-                builder.put(shardId, new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState,
-                    shardState.failed() ? randomAlphaOfLength(10) : null, "1"));
+                builder.put(shardId,
+                        shardState == ShardState.QUEUED ? SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED :
+                                new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState,
+                                        shardState.failed() ? randomAlphaOfLength(10) : null, "1"));
             }
         }
         ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = builder.build();


### PR DESCRIPTION
Just a few random things to optimize motivated by somewhat sub-standard performance and the fact that the clone API will make some of these computations even heavier for large snapshot cluster states with many concurrent snapshots observed in production.