### PR TITLE
[DOCS] Fix allow_no_match description for model APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -56,7 +56,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `allow_no_match`::
 (Optional, boolean) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-models]
 
 `from`::
 (Optional, integer) 

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -57,7 +57,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `allow_no_match`::
 (Optional, boolean) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-models]
 
 `decompress_definition`::
 (Optional, boolean)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -62,6 +62,21 @@ when there are no matches or only partial matches.
 --
 end::allow-no-match[]
 
+tag::allow-no-match-models[]
+Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no models that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty array when there are no
+matches and the subset of results when there are partial matches. If this
+parameter is `false`, the request returns a `404` status code when there are no
+matches or only partial matches.
+--
+end::allow-no-match-models[]
+
 tag::analysis[]
 Defines the type of {dfanalytics} you want to perform on your source index. For
 example: `outlier_detection`. See <<ml-dfa-analysis-objects>>.


### PR DESCRIPTION
The [get inference trained model stats API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-stats.html) and the [get inference trained model API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference.html) have an allow_no_match option. The API documentation incorrectly refers to matching job IDs instead of model IDs. This PR creates the appropriate shared description.

### Preview

* https://elasticsearch_62008.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference-stats.html#ml-get-inference-stats-query-params
* https://elasticsearch_62008.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference.html#ml-get-inference-path-params