### PR TITLE
[DOCS] Fix capitalization in HLRC ML APIs

### DIFF
--- a/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
@@ -6,13 +6,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Expired Data API
+=== Delete expired data API
 Delete expired {ml} data.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Expired Data Request
+==== Delete expired data request
 
 A `DeleteExpiredDataRequest` object does not require any arguments.
 
@@ -28,7 +28,7 @@ include-tagged::{doc-tests-file}[{api}-request]
     to run before they are canceled. Default value is `8h` (8 hours).
 
 [id="{upid}-{api}-response"]
-==== Delete Expired Data Response
+==== Delete expired data response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-filter.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Filter API
+=== Delete filter API
 Delete a {ml} filter.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Filter Request
+==== Delete filter request
 
 A +{request}+ object requires a non-null `filterId`.
 
@@ -22,7 +22,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request referencing an existing filter
 
 [id="{upid}-{api}-response"]
-==== Delete Filter Response
+==== Delete filter response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-forecast.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-forecast.asciidoc
@@ -5,15 +5,15 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Forecast API
+=== Delete forecast API
 
-The Delete Forecast API provides the ability to delete a {ml} job's
+The delete forecast API provides the ability to delete a {ml} job's
 forecast in the cluster.
 It accepts a +{request}+ object and responds
 with an +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Forecast Request
+==== Delete forecast request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing an existing `jobId`
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -39,7 +39,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 request finds no forecasts. It defaults to `true`
 
 [id="{upid}-{api}-response"]
-==== Delete Forecast Response
+==== Delete forecast response
 
 An +{response}+ contains an acknowledgement of the forecast(s) deletion
 

--- a/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
@@ -5,10 +5,10 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Model Snapshot API
+=== Delete model snapshot API
 
 [id="{upid}-{api}-request"]
-==== Delete Model Snapshot Request
+==== Delete model snapshot request
 
 A +{request}+ object requires both a non-null `jobId` and a non-null `snapshotId`.
 
@@ -21,7 +21,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Delete Model Snapshot Response
+==== Delete model snapshot response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-model.asciidoc
@@ -5,30 +5,30 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Trained Model API
+=== Delete trained model API
 
 experimental[]
 
-Deletes a previously saved Trained Model.
+Deletes a previously saved trained model.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Delete Trained Model request
+==== Delete trained model request
 
-A +{request}+ requires a valid Trained Model ID.
+A +{request}+ requires a valid trained model ID.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new DELETE request referencing an existing Trained Model
+<1> Constructing a new DELETE request referencing an existing trained model
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ object acknowledges the Trained Model deletion.
+The returned +{response}+ object acknowledges the trained model deletion.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
@@ -5,7 +5,7 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Explain {dfanalytics}} API
+=== Explain {dfanalytics} API
 
 Explains the following about a {dataframe-analytics-config}:
 

--- a/docs/java-rest/high-level/ml/flush-job.asciidoc
+++ b/docs/java-rest/high-level/ml/flush-job.asciidoc
@@ -5,15 +5,15 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Flush Job API
+=== Flush job API
 
-The Flush Job API provides the ability to flush a {ml} job's 
+The flush job API provides the ability to flush a {ml} job's 
 datafeed in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Flush Job Request
+==== Flush job request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing an existing `jobId`
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -41,7 +41,7 @@ to calculate interim results (requires `calc_interim` to be `true`)
 <5> Set the skip time to skip a particular time value
 
 [id="{upid}-{api}-response"]
-==== Flush Job Response
+==== Flush job response
 
 A +{response}+ contains an acknowledgement and an optional end date for the
 last finalized bucket

--- a/docs/java-rest/high-level/ml/forecast-job.asciidoc
+++ b/docs/java-rest/high-level/ml/forecast-job.asciidoc
@@ -5,15 +5,15 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Forecast Job API
+=== Forecast job API
 
-The Forecast Job API provides the ability to forecast a {ml} job's behavior based
+The forecast job API provides the ability to forecast a {ml} job's behavior based
 on historical data.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Forecast Job Request
+==== Forecast job request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing an existing `jobId`
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -40,7 +40,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
     automatically reduced to below that number.
 
 [id="{upid}-{api}-response"]
-==== Forecast Job Response
+==== Forecast job response
 
 A +{response}+ contains an acknowledgement and the forecast ID
 

--- a/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
@@ -5,18 +5,18 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get Trained Models Stats API
+=== Get trained models stats API
 
 experimental[]
 
-Retrieves one or more Trained Model statistics.
+Retrieves one or more trained model statistics.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Trained Models Stats request
+==== Get trained models stats request
 
-A +{request}+ requires either a Trained Model ID, a comma-separated list of
-IDs, or the special wildcard `_all` to get stats for all Trained Models.
+A +{request}+ requires either a trained model ID, a comma-separated list of
+IDs, or the special wildcard `_all` to get stats for all trained models.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -24,8 +24,8 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new GET request referencing an existing Trained Model
 <2> Set the paging parameters
-<3> Allow empty response if no Trained Models match the provided ID patterns.
-    If false, an error will be thrown if no Trained Models match the
+<3> Allow empty response if no trained models match the provided ID patterns.
+    If false, an error will be thrown if no trained models match the
     ID patterns.
 
 include::../execution.asciidoc[]
@@ -34,7 +34,7 @@ include::../execution.asciidoc[]
 ==== Response
 
 The returned +{response}+ contains the statistics
-for the requested Trained Model.
+for the requested trained model.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/get-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models.asciidoc
@@ -5,18 +5,18 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get Trained Models API
+=== Get trained models API
 
 experimental[]
 
-Retrieves one or more Trained Models.
+Retrieves one or more trained models.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Trained Models request
+==== Get trained models request
 
-A +{request}+ requires either a Trained Model ID, a comma-separated list of
-IDs, or the special wildcard `_all` to get all Trained Models.
+A +{request}+ requires either a trained model ID, a comma-separated list of
+IDs, or the special wildcard `_all` to get all trained models.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
@@ -5,14 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Post Calendar Event API
+=== Post calendar event API
 Adds new ScheduledEvents to an existing {ml} calendar.
 
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Post Calendar Event Request
+==== Post calendar event request
 
 A +{request}+ is constructed with a calendar ID object
 and a non-empty list of scheduled events.
@@ -26,7 +26,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 
 
 [id="{upid}-{api}-response"]
-==== Post Calendar Event Response
+==== Post calendar event response
 
 The returned +{response}+ contains the added `ScheduledEvent` objects:
 

--- a/docs/java-rest/high-level/ml/post-data.asciidoc
+++ b/docs/java-rest/high-level/ml/post-data.asciidoc
@@ -5,15 +5,15 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Post Data API
+=== Post data API
 
-The Post Data API provides the ability to post data to an open
+The post data API provides the ability to post data to an open
  {ml} job in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Post Data Request
+==== Post data request
 
 A +{request}+ object gets created with an existing non-null `jobId`
 and the `XContentType` being sent. Individual docs can be added
@@ -34,7 +34,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <3> Add a new document as a serialized JSON formatted String.
 <4> Constructing a new request referencing an opened `jobId`, and a JsonBuilder
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -48,7 +48,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Post Data Response
+==== Post data response
 
 A +{response}+ contains current data processing statistics.
 

--- a/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
@@ -5,14 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Preview Datafeed API
+=== Preview datafeed API
 
-The Preview Datafeed API provides the ability to preview a {ml} datafeed's data
+The preview datafeed API provides the ability to preview a {ml} datafeed's data
 in the cluster. It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Preview Datafeed Request
+==== Preview datafeed request
 
 A +{request}+ object is created referencing a non-null `datafeedId`.
 
@@ -23,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request referencing an existing `datafeedId`
 
 [id="{upid}-{api}-response"]
-==== Preview Datafeed Response
+==== Preview datafeed response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/put-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/put-filter.asciidoc
@@ -5,14 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put Filter API
+=== Put filter API
 
-The Put Filter API can be used to create a new {ml} filter
+The put filter API can be used to create a new {ml} filter
 in the cluster. The API accepts a +{request}+ object
 as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put Filter Request
+==== Put filter request
 
 A +{request}+ requires the following argument:
 
@@ -23,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> The configuration of the {ml} filter to create as a `MlFilter`
 
 [id="{upid}-{api}-config"]
-==== Filter Configuration
+==== Filter configuration
 
 The `MlFilter` object contains all the details about the {ml} filter
 configuration.

--- a/docs/java-rest/high-level/ml/put-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put Trained Model API
+=== Put trained model API
 
 Creates a new trained model for inference.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put Trained Model request
+==== Put trained model request
 
 A +{request}+ requires the following argument:
 
@@ -19,10 +19,10 @@ A +{request}+ requires the following argument:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> The configuration of the {infer} Trained Model to create
+<1> The configuration of the {infer} trained model to create
 
 [id="{upid}-{api}-config"]
-==== Trained Model configuration
+==== Trained model configuration
 
 The `TrainedModelConfig` object contains all the details about the trained model
 configuration and contains the following arguments:

--- a/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
@@ -6,14 +6,14 @@
 [role="xpack"]
 
 [id="{upid}-{api}"]
-=== Revert Model Snapshot API
+=== Revert model snapshot API
 
-The Revert Model Snapshot API provides the ability to revert to a previous {ml} model snapshot.
+The revert model snapshot API provides the ability to revert to a previous {ml} model snapshot.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Revert Model Snapshot Request
+==== Revert model snapshot request
 
 A +{request}+ requires the following arguments:
 
@@ -23,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing existing `jobId` and `snapshotId` values.
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional:
 
@@ -37,7 +37,7 @@ include-tagged::{doc-tests-file}[{api}-delete-intervening-results]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Revert Job Response
+==== Revert job response
 
 A +{response}+ contains the full representation of the reverted `ModelSnapshot`.
 

--- a/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
+++ b/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
@@ -5,9 +5,9 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Set Upgrade Mode API
+=== Set upgrade mode API
 
-The Set Upgrade Mode API temporarily halts all {ml} job and {dfeed} tasks when `enabled=true`. Their
+The set upgrade mode API temporarily halts all {ml} job and {dfeed} tasks when `enabled=true`. Their
 reported states remain unchanged. Consequently, when exiting upgrade mode the halted {ml} jobs and
 {dfeeds} will return to their previous state.
 
@@ -17,7 +17,7 @@ When `enabled=true`, no new jobs can be opened, and no job or {dfeed} tasks will
 be running. Be sure to set `enabled=false` once upgrade actions are completed.
 
 [id="{upid}-{api}-request"]
-==== Set Upgrade Mode Request
+==== Set upgrade mode request
 
 A +{request}+ object gets created setting the desired `enabled` state.
 
@@ -30,7 +30,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 execution should wait.
 
 [id="{upid}-{api}-response"]
-==== Set Upgrade Mode Response
+==== Set upgrade mode response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
@@ -5,14 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Stop Datafeed API
+=== Stop datafeed API
 
-The Stop Datafeed API provides the ability to stop a {ml} datafeed in the cluster.
+The stop datafeed API provides the ability to stop a {ml} datafeed in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Stop Datafeed Request
+==== Stop datafeed request
 
 A +{request}+ object is created referencing any number of non-null `datafeedId` entries.
 Wildcards and `_all` are also accepted.
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing existing `datafeedId` entries.
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 


### PR DESCRIPTION
This PR fixes mismatched capitalization in the API reference information here: https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_machine_learning_apis.html