### PR TITLE
[TEST] Don't specify a type unless needed

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/300_sequence_numbers.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/300_sequence_numbers.yml
@@ -6,7 +6,6 @@ setup:
   - do:
       index:
           index:  test_1
-          type:   test
           id:     1
           body:   { foo: foo }
 
@@ -14,7 +13,6 @@ setup:
   - do:
       index:
         index:  test_1
-        type:   test
         id:     1
         body:   { foo: bar }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yml
@@ -19,14 +19,12 @@ setup:
   - do:
       index:
           index:  test_1
-          type:   test
           id:     1
           body:   { foo: bar }
 
   - do:
       index:
           index:  test_2
-          type:   test
           id:     1
           body:   { foo: bar }
 


### PR DESCRIPTION
We have a couple of yaml tests that index documents under a 'test' type, while they could omit it. We do want to still test that specifying the type is still allowed in 7.x but we already have specific tests for that, and other tests should use the endpoint that don't require specifying a type.