### PR TITLE
Backport support for runtime fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeService.java
@@ -61,14 +61,16 @@ public class MetadataIndexUpgradeService {
     private final MapperRegistry mapperRegistry;
     private final IndexScopedSettings indexScopedSettings;
     private final SystemIndices systemIndices;
+    private final ScriptService scriptService;
 
     public MetadataIndexUpgradeService(Settings settings, NamedXContentRegistry xContentRegistry, MapperRegistry mapperRegistry,
-                                       IndexScopedSettings indexScopedSettings, SystemIndices systemIndices) {
+                                       IndexScopedSettings indexScopedSettings, SystemIndices systemIndices, ScriptService scriptService) {
         this.settings = settings;
         this.xContentRegistry = xContentRegistry;
         this.mapperRegistry = mapperRegistry;
         this.indexScopedSettings = indexScopedSettings;
         this.systemIndices = systemIndices;
+        this.scriptService = scriptService;
     }
 
     /**
@@ -188,7 +190,7 @@ public class MetadataIndexUpgradeService {
             try (IndexAnalyzers fakeIndexAnalzyers =
                      new IndexAnalyzers(analyzerMap, analyzerMap, analyzerMap)) {
                 MapperService mapperService = new MapperService(indexSettings, fakeIndexAnalzyers, xContentRegistry, similarityService,
-                        mapperRegistry, () -> null, () -> false);
+                        mapperRegistry, () -> null, () -> false, scriptService);
                 mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
             }
         } catch (Exception ex) {

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -505,7 +505,7 @@ public final class IndexModule {
             ScriptService scriptService) throws IOException {
         return new MapperService(indexSettings, analysisRegistry.build(indexSettings), xContentRegistry,
             new SimilarityService(indexSettings, scriptService, similarities), mapperRegistry,
-            () -> { throw new UnsupportedOperationException("no index query shard context available"); }, () -> false);
+            () -> { throw new UnsupportedOperationException("no index query shard context available"); }, () -> false, scriptService);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -193,16 +193,14 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             assert indexAnalyzers != null;
             this.mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
                 // we parse all percolator queries as they would be parsed on shard 0
-                () -> newQueryShardContext(0, null, System::currentTimeMillis, null), idFieldDataEnabled);
+                () -> newQueryShardContext(0, null, System::currentTimeMillis, null), idFieldDataEnabled, scriptService);
             this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService, mapperService);
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
                 // The sort order is validated right after the merge of the mapping later in the process.
                 this.indexSortSupplier = () -> indexSettings.getIndexSortConfig().buildIndexSort(
                     mapperService::fieldType,
-                    fieldType -> indexFieldData.getForField(fieldType, indexFieldData.index().getName(), () -> {
-                        throw new UnsupportedOperationException("search lookup not available for index sorting");
-                    })
+                    (fieldType, searchLookup) -> indexFieldData.getForField(fieldType, indexFieldData.index().getName(), searchLookup)
                 );
             } else {
                 this.indexSortSupplier = () -> null;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -481,25 +481,30 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         public int size() {
             return count;
         }
-
     }
 
-    public static final class Strings extends BinaryScriptDocValues<String> {
-
+    public static class Strings extends BinaryScriptDocValues<String> {
         public Strings(SortedBinaryDocValues in) {
             super(in);
         }
 
         @Override
-        public String get(int index) {
+        public final String get(int index) {
             if (count == 0) {
                 throw new IllegalStateException("A document doesn't have a value for a field! " +
                     "Use doc[<field>].size()==0 to check if a document is missing a field!");
             }
-            return values[index].get().utf8ToString();
+            return bytesToString(values[index].get());
         }
 
-        public String getValue() {
+        /**
+         * Convert the stored bytes to a String.
+         */
+        protected String bytesToString(BytesRef bytes) {
+            return bytes.utf8ToString();
+        }
+
+        public final String getValue() {
             return get(0);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
@@ -34,11 +34,11 @@ import java.util.Collections;
 /**
  * Specialization of {@link LeafNumericFieldData} for floating-point numerics.
  */
-abstract class LeafDoubleFieldData implements LeafNumericFieldData {
+public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
 
     private final long ramBytesUsed;
 
-    LeafDoubleFieldData(long ramBytesUsed) {
+    protected LeafDoubleFieldData(long ramBytesUsed) {
         this.ramBytesUsed = ramBytesUsed;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
@@ -29,7 +29,7 @@ import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 /**
  * Specialization of {@link LeafNumericFieldData} for integers.
  */
-abstract class LeafLongFieldData implements LeafNumericFieldData {
+public abstract class LeafLongFieldData implements LeafNumericFieldData {
 
     private final long ramBytesUsed;
     /**
@@ -37,7 +37,7 @@ abstract class LeafLongFieldData implements LeafNumericFieldData {
      */
     private final NumericType numericType;
 
-    LeafLongFieldData(long ramBytesUsed, NumericType numericType) {
+    protected LeafLongFieldData(long ramBytesUsed, NumericType numericType) {
         this.ramBytesUsed = ramBytesUsed;
         this.numericType = numericType;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -31,12 +31,12 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateMathParser;
@@ -63,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -343,60 +344,83 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
             DateMathParser parser = forcedDateParser == null
                     ? dateMathParser
                     : forcedDateParser;
+            return dateRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context, resolution, (l, u) -> {
+                Query query = LongPoint.newRangeQuery(name(), l, u);
+                if (hasDocValues()) {
+                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                    query = new IndexOrDocValuesQuery(query, dvQuery);
+
+                    if (context.indexSortedOnField(name())) {
+                        query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
+                    }
+                }
+                return query;
+            });
+        }
+
+        public static Query dateRangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            @Nullable ZoneId timeZone,
+            DateMathParser parser,
+            QueryShardContext context,
+            Resolution resolution,
+            BiFunction<Long, Long, Query> builder
+        ) {
+            return handleNow(context, nowSupplier -> {
+                long l, u;
+                if (lowerTerm == null) {
+                    l = Long.MIN_VALUE;
+                } else {
+                    l = parseToLong(lowerTerm, !includeLower, timeZone, parser, nowSupplier, resolution);
+                    if (includeLower == false) {
+                        ++l;
+                    }
+                }
+                if (upperTerm == null) {
+                    u = Long.MAX_VALUE;
+                } else {
+                    u = parseToLong(upperTerm, includeUpper, timeZone, parser, nowSupplier, resolution);
+                    if (includeUpper == false) {
+                        --u;
+                    }
+                }
+                return builder.apply(l, u);
+            });
+        }
+
+        /**
+         * Handle {@code now} in queries.
+         * @param context context from which to read the current time
+         * @param builder build the query
+         * @return the result of the builder, wrapped in {@link DateRangeIncludingNowQuery} if {@code now} was used.
+         */
+        public static Query handleNow(QueryShardContext context, Function<LongSupplier, Query> builder) {
             boolean[] nowUsed = new boolean[1];
             LongSupplier nowSupplier = () -> {
                 nowUsed[0] = true;
                 return context.nowInMillis();
             };
-            long l, u;
-            if (lowerTerm == null) {
-                l = Long.MIN_VALUE;
-            } else {
-                l = parseToLong(lowerTerm, !includeLower, timeZone, parser, nowSupplier);
-                if (includeLower == false) {
-                    ++l;
-                }
-            }
-            if (upperTerm == null) {
-                u = Long.MAX_VALUE;
-            } else {
-                u = parseToLong(upperTerm, includeUpper, timeZone, parser, nowSupplier);
-                if (includeUpper == false) {
-                    --u;
-                }
-            }
-
-            Query query = LongPoint.newRangeQuery(name(), l, u);
-            if (hasDocValues()) {
-                Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
-                query = new IndexOrDocValuesQuery(query, dvQuery);
-
-                if (context.indexSortedOnField(name())) {
-                    query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
-                }
-            }
-
-            if (nowUsed[0]) {
-                query = new DateRangeIncludingNowQuery(query);
-            }
-            return query;
+            Query query = builder.apply(nowSupplier);
+            return nowUsed[0] ? new DateRangeIncludingNowQuery(query) : query;
         }
 
-        public long parseToLong(Object value, boolean roundUp,
-                                @Nullable ZoneId zone, @Nullable DateMathParser forcedDateParser, LongSupplier now) {
-            DateMathParser dateParser = dateMathParser();
-            if (forcedDateParser != null) {
-                dateParser = forcedDateParser;
-            }
+        public long parseToLong(Object value, boolean roundUp, @Nullable ZoneId zone, DateMathParser dateParser, LongSupplier now) {
+            dateParser = dateParser == null ? dateMathParser() : dateParser;
+            return parseToLong(value, roundUp, zone, dateParser, now, resolution);
+        }
 
-            String strValue;
-            if (value instanceof BytesRef) {
-                strValue = ((BytesRef) value).utf8ToString();
-            } else {
-                strValue = value.toString();
-            }
-            Instant instant = dateParser.parse(strValue, now, roundUp, zone);
-            return resolution.convert(instant);
+        public static long parseToLong(
+            Object value,
+            boolean roundUp,
+            @Nullable ZoneId zone,
+            DateMathParser dateParser,
+            LongSupplier now,
+            Resolution resolution
+        ) {
+            return resolution.convert(dateParser.parse(BytesRefs.toString(value), now, roundUp, zone));
         }
 
         @Override
@@ -416,7 +440,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
             long fromInclusive = Long.MIN_VALUE;
             if (from != null) {
-                fromInclusive = parseToLong(from, !includeLower, timeZone, dateParser, context::nowInMillis);
+                fromInclusive = parseToLong(from, !includeLower, timeZone, dateParser, context::nowInMillis, resolution);
                 if (includeLower == false) {
                     if (fromInclusive == Long.MAX_VALUE) {
                         return Relation.DISJOINT;
@@ -427,7 +451,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
             long toInclusive = Long.MAX_VALUE;
             if (to != null) {
-                toInclusive = parseToLong(to, includeUpper, timeZone, dateParser, context::nowInMillis);
+                toInclusive = parseToLong(to, includeUpper, timeZone, dateParser, context::nowInMillis, resolution);
                 if (includeUpper == false) {
                     if (toInclusive == Long.MIN_VALUE) {
                         return Relation.DISJOINT;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
+import org.elasticsearch.script.ScriptService;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -54,13 +55,16 @@ public class DocumentMapperParser {
 
     private final Map<String, Mapper.TypeParser> typeParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> rootTypeParsers;
+    private final ScriptService scriptService;
 
     public DocumentMapperParser(IndexSettings indexSettings, MapperService mapperService, NamedXContentRegistry xContentRegistry,
-            SimilarityService similarityService, MapperRegistry mapperRegistry, Supplier<QueryShardContext> queryShardContextSupplier) {
+            SimilarityService similarityService, MapperRegistry mapperRegistry,
+            Supplier<QueryShardContext> queryShardContextSupplier, ScriptService scriptService) {
         this.mapperService = mapperService;
         this.xContentRegistry = xContentRegistry;
         this.similarityService = similarityService;
         this.queryShardContextSupplier = queryShardContextSupplier;
+        this.scriptService = scriptService;
         this.typeParsers = mapperRegistry.getMapperParsers();
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.rootTypeParsers = mapperRegistry.getMetadataMapperParsers(indexVersionCreated);
@@ -68,12 +72,12 @@ public class DocumentMapperParser {
 
     public Mapper.TypeParser.ParserContext parserContext() {
         return new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperService,
-                typeParsers::get, indexVersionCreated, queryShardContextSupplier, null);
+                typeParsers::get, indexVersionCreated, queryShardContextSupplier, null, scriptService);
     }
 
     public Mapper.TypeParser.ParserContext parserContext(DateFormatter dateFormatter) {
         return new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperService,
-            typeParsers::get, indexVersionCreated, queryShardContextSupplier, dateFormatter);
+            typeParsers::get, indexVersionCreated, queryShardContextSupplier, dateFormatter, scriptService);
     }
 
     public DocumentMapper parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.script.ScriptService;
 
 import java.util.Map;
 import java.util.Objects;
@@ -91,16 +92,19 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private final DateFormatter dateFormatter;
 
+            private final ScriptService scriptService;
+
             public ParserContext(Function<String, SimilarityProvider> similarityLookupService,
                                  MapperService mapperService, Function<String, TypeParser> typeParsers,
                                  Version indexVersionCreated, Supplier<QueryShardContext> queryShardContextSupplier,
-                                 DateFormatter dateFormatter) {
+                                 DateFormatter dateFormatter, ScriptService scriptService) {
                 this.similarityLookupService = similarityLookupService;
                 this.mapperService = mapperService;
                 this.typeParsers = typeParsers;
                 this.indexVersionCreated = indexVersionCreated;
                 this.queryShardContextSupplier = queryShardContextSupplier;
                 this.dateFormatter = dateFormatter;
+                this.scriptService = scriptService;
             }
 
             public IndexAnalyzers getIndexAnalyzers() {
@@ -146,6 +150,13 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             protected Function<String, SimilarityProvider> similarityLookupService() { return similarityLookupService; }
 
+            /**
+             * The {@linkplain ScriptService} to compile scripts needed by the {@linkplain Mapper}.
+             */
+            public ScriptService scriptService() {
+                return scriptService;
+            }
+
             public ParserContext createMultiFieldContext(ParserContext in) {
                 return new MultiFieldParserContext(in);
             }
@@ -153,7 +164,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             static class MultiFieldParserContext extends ParserContext {
                 MultiFieldParserContext(ParserContext in) {
                     super(in.similarityLookupService(), in.mapperService(), in.typeParsers(),
-                            in.indexVersionCreated(), in.queryShardContextSupplier(), in.getDateFormatter());
+                            in.indexVersionCreated(), in.queryShardContextSupplier(), in.getDateFormatter(), in.scriptService());
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -55,6 +55,7 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.InvalidTypeNameException;
 import org.elasticsearch.indices.mapper.MapperRegistry;
+import org.elasticsearch.script.ScriptService;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -151,12 +152,13 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public MapperService(IndexSettings indexSettings, IndexAnalyzers indexAnalyzers, NamedXContentRegistry xContentRegistry,
                          SimilarityService similarityService, MapperRegistry mapperRegistry,
-                         Supplier<QueryShardContext> queryShardContextSupplier, BooleanSupplier idFieldDataEnabled) {
+                         Supplier<QueryShardContext> queryShardContextSupplier, BooleanSupplier idFieldDataEnabled,
+                         ScriptService scriptService) {
         super(indexSettings);
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.indexAnalyzers = indexAnalyzers;
         this.documentParser = new DocumentMapperParser(indexSettings, this, xContentRegistry, similarityService, mapperRegistry,
-                queryShardContextSupplier);
+                queryShardContextSupplier, scriptService);
         this.indexAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultIndexAnalyzer(), MappedFieldType::indexAnalyzer);
         this.searchAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultSearchAnalyzer(),
             p -> p.getTextSearchInfo().getSearchAnalyzer());

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
+
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FloatPoint;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -367,28 +369,16 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
                                     boolean hasDocValues, QueryShardContext context) {
-                double l = Double.NEGATIVE_INFINITY;
-                double u = Double.POSITIVE_INFINITY;
-                if (lowerTerm != null) {
-                    l = parse(lowerTerm, false);
-                    if (includeLower == false) {
-                        l = DoublePoint.nextUp(l);
+                return doubleRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, (l, u) -> {
+                    Query query = DoublePoint.newRangeQuery(field, l, u);
+                    if (hasDocValues) {
+                        Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field,
+                                NumericUtils.doubleToSortableLong(l),
+                                NumericUtils.doubleToSortableLong(u));
+                        query = new IndexOrDocValuesQuery(query, dvQuery);
                     }
-                }
-                if (upperTerm != null) {
-                    u = parse(upperTerm, false);
-                    if (includeUpper == false) {
-                        u = DoublePoint.nextDown(u);
-                    }
-                }
-                Query query = DoublePoint.newRangeQuery(field, l, u);
-                if (hasDocValues) {
-                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field,
-                            NumericUtils.doubleToSortableLong(l),
-                            NumericUtils.doubleToSortableLong(u));
-                    query = new IndexOrDocValuesQuery(query, dvQuery);
-                }
-                return query;
+                    return query;
+                });
             }
 
             @Override
@@ -654,23 +644,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         LONG("long", NumericType.LONG) {
             @Override
             public Long parse(Object value, boolean coerce) {
-                if (value instanceof Long) {
-                    return (Long)value;
-                }
-
-                double doubleValue = objectToDouble(value);
-                // this check does not guarantee that value is inside MIN_VALUE/MAX_VALUE because values up to 9223372036854776832 will
-                // be equal to Long.MAX_VALUE after conversion to double. More checks ahead.
-                if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
-                    throw new IllegalArgumentException("Value [" + value + "] is out of range for a long");
-                }
-                if (!coerce && doubleValue % 1 != 0) {
-                    throw new IllegalArgumentException("Value [" + value + "] has a decimal part");
-                }
-
-                // longs need special handling so we don't lose precision while parsing
-                String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
-                return Numbers.toLong(stringValue, coerce);
+                return objectToLong(value, coerce);
             }
 
             @Override
@@ -717,44 +691,17 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
                                     boolean hasDocValues, QueryShardContext context) {
-                long l = Long.MIN_VALUE;
-                long u = Long.MAX_VALUE;
-                if (lowerTerm != null) {
-                    l = parse(lowerTerm, true);
-                    // if the lower bound is decimal:
-                    // - if the bound is positive then we increment it:
-                    //      if lowerTerm=1.5 then the (inclusive) bound becomes 2
-                    // - if the bound is negative then we leave it as is:
-                    //      if lowerTerm=-1.5 then the (inclusive) bound becomes -1 due to the call to longValue
-                    boolean lowerTermHasDecimalPart = hasDecimalPart(lowerTerm);
-                    if ((lowerTermHasDecimalPart == false && includeLower == false) ||
-                            (lowerTermHasDecimalPart && signum(lowerTerm) > 0)) {
-                        if (l == Long.MAX_VALUE) {
-                            return new MatchNoDocsQuery();
+                return longRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, (l, u) -> {
+                    Query query = LongPoint.newRangeQuery(field, l, u);
+                    if (hasDocValues) {
+                        Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field, l, u);
+                        query = new IndexOrDocValuesQuery(query, dvQuery);
+                        if (context.indexSortedOnField(field)) {
+                            query = new IndexSortSortedNumericDocValuesRangeQuery(field, l, u, query);
                         }
-                        ++l;
                     }
-                }
-                if (upperTerm != null) {
-                    u = parse(upperTerm, true);
-                    boolean upperTermHasDecimalPart = hasDecimalPart(upperTerm);
-                    if ((upperTermHasDecimalPart == false && includeUpper == false) ||
-                            (upperTermHasDecimalPart && signum(upperTerm) < 0)) {
-                        if (u == Long.MIN_VALUE) {
-                            return new MatchNoDocsQuery();
-                        }
-                        --u;
-                    }
-                }
-                Query query = LongPoint.newRangeQuery(field, l, u);
-                if (hasDocValues) {
-                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field, l, u);
-                    query = new IndexOrDocValuesQuery(query, dvQuery);
-                    if (context.indexSortedOnField(field)) {
-                        query = new IndexSortSortedNumericDocValuesRangeQuery(field, l, u, query);
-                    }
-                }
-                return query;
+                    return query;
+                });
             }
 
             @Override
@@ -812,7 +759,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         /**
          * Returns true if the object is a number and has a decimal part
          */
-        boolean hasDecimalPart(Object number) {
+        public static boolean hasDecimalPart(Object number) {
             if (number instanceof Number) {
                 double doubleValue = ((Number) number).doubleValue();
                 return doubleValue % 1 != 0;
@@ -829,7 +776,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         /**
          * Returns -1, 0, or 1 if the value is lower than, equal to, or greater than 0
          */
-        double signum(Object value) {
+        static double signum(Object value) {
             if (value instanceof Number) {
                 double doubleValue = ((Number) value).doubleValue();
                 return Math.signum(doubleValue);
@@ -843,7 +790,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         /**
          * Converts an Object to a double by checking it against known types first
          */
-        private static double objectToDouble(Object value) {
+        public static double objectToDouble(Object value) {
             double doubleValue;
 
             if (value instanceof Number) {
@@ -855,6 +802,95 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
             }
 
             return doubleValue;
+        }
+
+        /**
+         * Converts and Object to a {@code long} by checking it against known
+         * types and checking its range.
+         */
+        public static long objectToLong(Object value, boolean coerce) {
+            if (value instanceof Long) {
+                return (Long)value;
+            }
+
+            double doubleValue = objectToDouble(value);
+            // this check does not guarantee that value is inside MIN_VALUE/MAX_VALUE because values up to 9223372036854776832 will
+            // be equal to Long.MAX_VALUE after conversion to double. More checks ahead.
+            if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+                throw new IllegalArgumentException("Value [" + value + "] is out of range for a long");
+            }
+            if (!coerce && doubleValue % 1 != 0) {
+                throw new IllegalArgumentException("Value [" + value + "] has a decimal part");
+            }
+
+            // longs need special handling so we don't lose precision while parsing
+            String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
+            return Numbers.toLong(stringValue, coerce);
+        }
+
+        public static Query doubleRangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            BiFunction<Double, Double, Query> builder
+        ) {
+            double l = Double.NEGATIVE_INFINITY;
+            double u = Double.POSITIVE_INFINITY;
+            if (lowerTerm != null) {
+                l = objectToDouble(lowerTerm);
+                if (includeLower == false) {
+                    l = DoublePoint.nextUp(l);
+                }
+            }
+            if (upperTerm != null) {
+                u = objectToDouble(upperTerm);
+                if (includeUpper == false) {
+                    u = DoublePoint.nextDown(u);
+                }
+            }
+            return builder.apply(l, u);
+        }
+
+        /**
+         * Processes query bounds into {@code long}s and delegates the
+         * provided {@code builder} to build a range query.
+         */
+        public static Query longRangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            BiFunction<Long, Long, Query> builder
+        ) {
+            long l = Long.MIN_VALUE;
+            long u = Long.MAX_VALUE;
+            if (lowerTerm != null) {
+                l = objectToLong(lowerTerm, true);
+                // if the lower bound is decimal:
+                // - if the bound is positive then we increment it:
+                // if lowerTerm=1.5 then the (inclusive) bound becomes 2
+                // - if the bound is negative then we leave it as is:
+                // if lowerTerm=-1.5 then the (inclusive) bound becomes -1 due to the call to longValue
+                boolean lowerTermHasDecimalPart = hasDecimalPart(lowerTerm);
+                if ((lowerTermHasDecimalPart == false && includeLower == false) || (lowerTermHasDecimalPart && signum(lowerTerm) > 0)) {
+                    if (l == Long.MAX_VALUE) {
+                        return new MatchNoDocsQuery();
+                    }
+                    ++l;
+                }
+            }
+            if (upperTerm != null) {
+                u = objectToLong(upperTerm, true);
+                boolean upperTermHasDecimalPart = hasDecimalPart(upperTerm);
+                if ((upperTermHasDecimalPart == false && includeUpper == false) || (upperTermHasDecimalPart && signum(upperTerm) < 0)) {
+                    if (u == Long.MIN_VALUE) {
+                        return new MatchNoDocsQuery();
+                    }
+                    --u;
+                }
+            }
+            return builder.apply(l, u);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -210,6 +210,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
 
         // dates and time and geo need special handling
         parser.nextToken();
+        // TODO these ain't gonna work with runtime fields
         if (fieldType instanceof DateFieldMapper.DateFieldType) {
             return parseDateVariable(parser, context, fieldType, mode);
         } else if (fieldType instanceof GeoPointFieldType) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -550,7 +550,7 @@ public class Node implements Closeable {
                     .collect(Collectors.toList());
             final MetadataUpgrader metadataUpgrader = new MetadataUpgrader(indexTemplateMetadataUpgraders);
             final MetadataIndexUpgradeService metadataIndexUpgradeService = new MetadataIndexUpgradeService(settings, xContentRegistry,
-                indicesModule.getMapperRegistry(), settingsModule.getIndexScopedSettings(), systemIndices);
+                indicesModule.getMapperRegistry(), settingsModule.getIndexScopedSettings(), systemIndices, scriptService);
             clusterService.addListener(new SystemIndexMetadataUpgradeService(systemIndices, clusterService));
             new TemplateUpgradeService(client, clusterService, threadPool, indexTemplateMetadataUpgraders);
             final Transport transport = networkModule.getTransportSupplier().get();

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -42,7 +42,7 @@ public class ScriptCache {
 
     private static final Logger logger = LogManager.getLogger(ScriptService.class);
 
-    static final CompilationRate UNLIMITED_COMPILATION_RATE = new CompilationRate(0, TimeValue.ZERO);
+    public static final CompilationRate UNLIMITED_COMPILATION_RATE = new CompilationRate(0, TimeValue.ZERO);
 
     private final Cache<CacheKey, Object> cache;
     private final ScriptMetrics scriptMetrics;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
@@ -156,7 +156,8 @@ public class MetadataIndexUpgradeServiceTests extends ESTestCase {
             new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             new SystemIndices(Collections.singletonMap("system-plugin",
-                Collections.singletonList(new SystemIndexDescriptor(".system", "a system index"))))
+                Collections.singletonList(new SystemIndexDescriptor(".system", "a system index")))),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -159,7 +159,7 @@ public class GatewayMetaStateTests extends ESTestCase {
         private final boolean upgrade;
 
         MockMetadataIndexUpgradeService(boolean upgrade) {
-            super(Settings.EMPTY, null, null, null, null);
+            super(Settings.EMPTY, null, null, null, null, null);
             this.upgrade = upgrade;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -94,7 +94,7 @@ public class CodecTests extends ESTestCase {
         IndexAnalyzers indexAnalyzers = createTestAnalysis(settings, nodeSettings).indexAnalyzers;
         MapperRegistry mapperRegistry = new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER);
         MapperService service = new MapperService(settings, indexAnalyzers, xContentRegistry(), similarityService, mapperRegistry,
-                () -> null, () -> false);
+                () -> null, () -> false, null);
         return new CodecService(service, LogManager.getLogger("test"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalFieldMapperTests.java
@@ -75,7 +75,7 @@ public class ExternalFieldMapperTests extends ESSingleNodeTestCase {
             return indexService.newQueryShardContext(0, null, () -> { throw new UnsupportedOperationException(); }, null);
         };
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext);
+                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext, null);
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject(ExternalMetadataMapper.CONTENT_TYPE)
@@ -122,7 +122,7 @@ public class ExternalFieldMapperTests extends ESSingleNodeTestCase {
             return indexService.newQueryShardContext(0, null, () -> { throw new UnsupportedOperationException(); }, null);
         };
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext);
+                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext, null);
 
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 Strings
@@ -190,7 +190,7 @@ public class ExternalFieldMapperTests extends ESSingleNodeTestCase {
             return indexService.newQueryShardContext(0, null, () -> { throw new UnsupportedOperationException(); }, null);
         };
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext);
+                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext, null);
 
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 Strings

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -217,7 +217,7 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
                 return BinaryFieldMapper.PARSER;
             }
             return null;
-        }, version, () -> null, null);
+        }, version, () -> null, null, null);
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)
             .build(new Mapper.BuilderContext(Settings.EMPTY, new ContentPath(0)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -191,8 +191,7 @@ public class TypeParsersTests extends ESTestCase {
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         Mapper.TypeParser.ParserContext olderContext = new Mapper.TypeParser.ParserContext(
-            null, mapperService, type -> typeParser, Version.CURRENT, null, null);
-
+            null, mapperService, type -> typeParser, Version.CURRENT, null, null, null);
         TypeParsers.parseField(builder, "some-field", fieldNode, olderContext);
         assertWarnings("At least one multi-field, [sub-field], " +
             "was encountered that itself contains a multi-field. Defining multi-fields within a multi-field is deprecated " +

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -191,8 +191,14 @@ public class ClusterStateChanges {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             boundAddress -> DiscoveryNode.createLocal(SETTINGS, boundAddress.publishAddress(), UUIDs.randomBase64UUID()), clusterSettings,
             Collections.emptySet());
-        MetadataIndexUpgradeService metadataIndexUpgradeService =
-            new MetadataIndexUpgradeService(SETTINGS, xContentRegistry, null, null, null) {
+        MetadataIndexUpgradeService metadataIndexUpgradeService = new MetadataIndexUpgradeService(
+            SETTINGS,
+            xContentRegistry,
+            null,
+            null,
+            null,
+            null
+        ) {
             // metadata upgrader should do nothing
             @Override
             public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata, Version minimumIndexCompatibilityVersion) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1595,7 +1595,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         settings, namedXContentRegistry,
                         mapperRegistry,
                         indexScopedSettings,
-                        new SystemIndices(emptyMap())),
+                        new SystemIndices(emptyMap()),
+                        null),
                     clusterSettings,
                         shardLimitValidator
                 );

--- a/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
@@ -73,7 +73,7 @@ public class MapperTestUtils {
             xContentRegistry,
             similarityService,
             mapperRegistry,
-            () -> null, () -> false);
+            () -> null, () -> false, null);
     }
 
     public static void assertConflicts(String mapping1,

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -68,7 +68,7 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
         SimilarityService similarityService = new SimilarityService(indexSettings, null, emptyMap());
         MapperRegistry mapperRegistry = new IndicesModule(emptyList()).getMapperRegistry();
         mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
-                () -> null, () -> false);
+                () -> null, () -> false, null);
     }
 
     private DocumentMapperForType docMapper(String type) {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -45,6 +45,8 @@ import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
 
@@ -105,11 +107,15 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             .numberOfReplicas(0)
             .numberOfShards(1)
             .build();
-        IndexSettings indexSettings = new IndexSettings(meta, settings);
+        IndexSettings indexSettings = new IndexSettings(meta, Settings.EMPTY);
         MapperRegistry mapperRegistry = new IndicesModule(
             getPlugins().stream().filter(p -> p instanceof MapperPlugin).map(p -> (MapperPlugin) p).collect(toList())
         ).getMapperRegistry();
-        ScriptService scriptService = new ScriptService(settings, emptyMap(), emptyMap());
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            getPlugins().stream().filter(p -> p instanceof ScriptPlugin).map(p -> (ScriptPlugin) p).collect(toList())
+        );
+        ScriptService scriptService = new ScriptService(settings, scriptModule.engines, scriptModule.contexts);
         SimilarityService similarityService = new SimilarityService(indexSettings, scriptService, emptyMap());
         MapperService mapperService = new MapperService(
             indexSettings,
@@ -118,7 +124,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             similarityService,
             mapperRegistry,
             () -> { throw new UnsupportedOperationException(); },
-            () -> true
+            () -> true,
+            scriptService
         );
         merge(mapperService, mapping);
         return mapperService;

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.when;
  * Base class for testing {@link Mapper}s.
  */
 public abstract class MapperTestCase extends MapperServiceTestCase {
-
     protected abstract void minimalMapping(XContentBuilder b) throws IOException;
 
     public final void testEmptyName() {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -834,7 +834,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
     private class MockParserContext extends Mapper.TypeParser.ParserContext {
         MockParserContext() {
-            super(null, null, null, Version.CURRENT, null, null);
+            super(null, null, null, Version.CURRENT, null, null, null);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -360,7 +360,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             similarityService = new SimilarityService(idxSettings, null, Collections.emptyMap());
             MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
             mapperService = new MapperService(idxSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
-                    () -> createShardContext(null), () -> false);
+                    () -> createShardContext(null), () -> false, null);
             IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {
             });
             indexFieldDataService = new IndexFieldDataService(idxSettings, indicesFieldDataCache,

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
@@ -60,7 +60,12 @@ public class ClientYamlTestSection implements Comparable<ClientYamlTestSection> 
     private final SkipSection skipSection;
     private final List<ExecutableSection> executableSections;
 
-    ClientYamlTestSection(XContentLocation location, String name, SkipSection skipSection, List<ExecutableSection> executableSections) {
+    public ClientYamlTestSection(
+        XContentLocation location,
+        String name,
+        SkipSection skipSection,
+        List<ExecutableSection> executableSections
+    ) {
         this.location = location;
         this.name = name;
         this.skipSection = Objects.requireNonNull(skipSection, "skip section cannot be null");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -111,7 +111,7 @@ public class ClientYamlTestSuite {
     private final TeardownSection teardownSection;
     private final List<ClientYamlTestSection> testSections;
 
-    ClientYamlTestSuite(String api, String name, SetupSection setupSection, TeardownSection teardownSection,
+    public ClientYamlTestSuite(String api, String name, SetupSection setupSection, TeardownSection teardownSection,
                         List<ClientYamlTestSection> testSections) {
         this.api = api;
         this.name = name;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
@@ -70,7 +70,7 @@ public class SetupSection {
     private final SkipSection skipSection;
     private final List<ExecutableSection> executableSections;
 
-    SetupSection(SkipSection skipSection, List<ExecutableSection> executableSections) {
+    public SetupSection(SkipSection skipSection, List<ExecutableSection> executableSections) {
         this.skipSection = Objects.requireNonNull(skipSection, "skip section cannot be null");
         this.executableSections = Collections.unmodifiableList(executableSections);
     }

--- a/x-pack/plugin/runtime-fields/build.gradle
+++ b/x-pack/plugin/runtime-fields/build.gradle
@@ -1,0 +1,26 @@
+evaluationDependsOn(xpackModule('core'))
+
+apply plugin: 'elasticsearch.esplugin'
+
+esplugin {
+  name 'x-pack-runtime-fields'
+  description 'A module which adds support for runtime fields'
+  classname 'org.elasticsearch.xpack.runtimefields.RuntimeFields'
+  extendedPlugins = ['x-pack-core', 'lang-painless']
+}
+archivesBaseName = 'x-pack-runtime-fields'
+
+compileJava.options.compilerArgs << "-Xlint:-rawtypes"
+compileTestJava.options.compilerArgs << "-Xlint:-rawtypes"
+
+dependencies {
+  compileOnly project(":server")
+  compileOnly project(':modules:lang-painless:spi')
+  compileOnly project(path: xpackModule('core'), configuration: 'default')
+}
+
+dependencyLicenses {
+  ignoreSha 'x-pack-core'
+}
+
+integTest.enabled = false

--- a/x-pack/plugin/runtime-fields/qa/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/build.gradle
@@ -1,0 +1,1 @@
+// Empty project so we can pick up its subproject 

--- a/x-pack/plugin/runtime-fields/qa/rest/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/rest/build.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'elasticsearch.yaml-rest-test'
+
+restResources {
+  restApi {
+    includeXpack 'async_search', 'graph', '*_point_in_time'
+  }
+  restTests {
+    includeCore '*'
+    includeXpack 'async_search', 'graph'
+  }
+}
+
+testClusters.yamlRestTest {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.license.self_generated.type', 'trial'
+}
+
+yamlRestTest {
+  systemProperty 'tests.rest.suite',
+    [
+      'async_search',
+      'field_caps',
+      'graph',
+      'msearch',
+      'search',
+      'search.aggregation',
+      'search.highlight',
+      'search.inner_hits',
+      'search_shards',
+      'suggest',
+    ].join(',')
+  systemProperty 'tests.rest.blacklist',
+    [
+      /////// TO FIX ///////
+      'search/330_fetch_fields/*', // The whole API is not yet supported
+      'search.highlight/40_keyword_ignore/Plain Highligher should skip highlighting ignored keyword values', // The plain highlighter is incompatible with runtime fields. Worth fixing?
+      'search/115_multiple_field_collapsing/two levels fields collapsing', // Broken. Gotta fix.
+      'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
+      'search.aggregation/10_histogram/*', // runtime_script doesn't support sub-fields. Maybe it should?
+      'search/140_pre_filter_search_shards/pre_filter_shard_size with shards that have no hit',
+      /////// TO FIX ///////
+
+      /////// NOT SUPPORTED ///////
+      'search.aggregation/280_rare_terms/*', // Requires an index and we won't have it
+      // Runtime fields don't have global ords
+      'search.aggregation/20_terms/string profiler via global ordinals',
+      'search.aggregation/20_terms/Global ordinals are loaded with the global_ordinals execution hint',
+      //dynamic template causes a type _doc to be created, these tests use another type but only one type is allowed
+      'search.aggregation/51_filter_with_types/*',
+      'search/171_terms_query_with_types/*',
+      'msearch/12_basic_with_types/*'
+      /////// NOT SUPPORTED ///////
+    ].join(',')
+}

--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentLocation;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection;
+import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSuite;
+import org.elasticsearch.test.rest.yaml.section.DoSection;
+import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.elasticsearch.test.rest.yaml.section.SetupSection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
+    public CoreTestsWithRuntimeFieldsIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    /**
+     * Builds test parameters similarly to {@link ESClientYamlSuiteTestCase#createParameters()},
+     * replacing the body of index creation commands so that fields are {@code runtime_script}s
+     * that load from {@code source} instead of their original type. Test configurations that
+     * do are not modified to contain runtime fields are not returned as they are tested
+     * elsewhere.
+     */
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        Map<String, ClientYamlTestSuite> suites = new HashMap<>();
+        List<Object[]> result = new ArrayList<>();
+        for (Object[] orig : ESClientYamlSuiteTestCase.createParameters()) {
+            assert orig.length == 1;
+            ClientYamlTestCandidate candidate = (ClientYamlTestCandidate) orig[0];
+            ClientYamlTestSuite suite = suites.computeIfAbsent(candidate.getTestPath(), k -> modifiedSuite(candidate));
+            if (suite == null) {
+                // The setup section contains an unsupported option
+                continue;
+            }
+            if (false == modifySection(candidate.getTestSection().getExecutableSections())) {
+                // The test section contains an unsupported option
+                continue;
+            }
+            ClientYamlTestSection modified = new ClientYamlTestSection(
+                candidate.getTestSection().getLocation(),
+                candidate.getTestSection().getName(),
+                candidate.getTestSection().getSkipSection(),
+                candidate.getTestSection().getExecutableSections()
+            );
+            result.add(new Object[] { new ClientYamlTestCandidate(suite, modified) });
+        }
+        return result;
+    }
+
+    /**
+     * Modify the setup section to setup a dynamic template that replaces
+     * field configurations with scripts that load from source
+     * <strong>and</strong> replaces field configurations in {@code incides.create}
+     * with scripts that load from source.
+     */
+    private static ClientYamlTestSuite modifiedSuite(ClientYamlTestCandidate candidate) {
+        if (false == modifySection(candidate.getSetupSection().getExecutableSections())) {
+            return null;
+        }
+        List<ExecutableSection> setup = new ArrayList<>(candidate.getSetupSection().getExecutableSections().size() + 1);
+        setup.add(ADD_TEMPLATE);
+        setup.addAll(candidate.getSetupSection().getExecutableSections());
+        return new ClientYamlTestSuite(
+            candidate.getApi(),
+            candidate.getName(),
+            new SetupSection(candidate.getSetupSection().getSkipSection(), setup),
+            candidate.getTeardownSection(),
+            Collections.emptyList()
+        );
+    }
+
+    /**
+     * Replace field configuration in {@code indices.create} with scripts
+     * that load from the source.
+     */
+    private static boolean modifySection(List<ExecutableSection> executables) {
+        for (ExecutableSection section : executables) {
+            if (false == (section instanceof DoSection)) {
+                continue;
+            }
+            DoSection doSection = (DoSection) section;
+            if (false == doSection.getApiCallSection().getApi().equals("indices.create")) {
+                continue;
+            }
+            for (Map<?, ?> body : doSection.getApiCallSection().getBodies()) {
+                Object settings = body.get("settings");
+                if (settings instanceof Map && ((Map<?, ?>) settings).containsKey("sort.field")) {
+                    /*
+                     * You can't sort the index on a runtime_keyword and it is
+                     * hard to figure out if the sort was a runtime_keyword so
+                     * let's just skip this test.
+                     */
+                    continue;
+                }
+                Object mappings = body.get("mappings");
+                if (false == (mappings instanceof Map)) {
+                    continue;
+                }
+                Object properties = ((Map<?, ?>) mappings).get("properties");
+                if (false == (properties instanceof Map)) {
+                    continue;
+                }
+                for (Map.Entry<?, ?> property : ((Map<?, ?>) properties).entrySet()) {
+                    if (false == property.getValue() instanceof Map) {
+                        continue;
+                    }
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> propertyMap = (Map<String, Object>) property.getValue();
+                    String name = property.getKey().toString();
+                    String type = Objects.toString(propertyMap.get("type"));
+                    if ("nested".equals(type)) {
+                        // Our loading scripts can't be made to manage nested fields so we have to skip those tests.
+                        return false;
+                    }
+                    if ("false".equals(Objects.toString(propertyMap.get("doc_values")))) {
+                        // If doc_values is false we can't emulate with scripts. `null` and `true` are fine.
+                        continue;
+                    }
+                    if ("false".equals(Objects.toString(propertyMap.get("index")))) {
+                        // If index is false we can't emulate with scripts
+                        continue;
+                    }
+                    if ("true".equals(Objects.toString(propertyMap.get("store")))) {
+                        // If store is true we can't emulate with scripts
+                        continue;
+                    }
+                    if (propertyMap.containsKey("ignore_above")) {
+                        // Scripts don't support ignore_above so we skip those fields
+                        continue;
+                    }
+                    if (propertyMap.containsKey("ignore_malformed")) {
+                        // Our source reading script doesn't emulate ignore_malformed
+                        continue;
+                    }
+                    String toLoad = painlessToLoadFromSource(name, type);
+                    if (toLoad == null) {
+                        continue;
+                    }
+                    propertyMap.put("type", "runtime_script");
+                    propertyMap.put("runtime_type", type);
+                    propertyMap.put("script", toLoad);
+                    propertyMap.remove("store");
+                    propertyMap.remove("index");
+                    propertyMap.remove("doc_values");
+                }
+            }
+        }
+        return true;
+    }
+
+    private static String painlessToLoadFromSource(String name, String type) {
+        String emit = PAINLESS_TO_EMIT.get(type);
+        if (emit == null) {
+            return null;
+        }
+        StringBuilder b = new StringBuilder();
+        b.append("def v = params._source['").append(name).append("'];\n");
+        b.append("if (v instanceof Iterable) {\n");
+        b.append("  for (def vv : ((Iterable) v)) {\n");
+        b.append("    if (vv != null) {\n");
+        b.append("      def value = vv;\n");
+        b.append("      ").append(emit).append("\n");
+        b.append("    }\n");
+        b.append("  }\n");
+        b.append("} else {\n");
+        b.append("  if (v != null) {\n");
+        b.append("    def value = v;\n");
+        b.append("    ").append(emit).append("\n");
+        b.append("  }\n");
+        b.append("}\n");
+        return b.toString();
+    }
+
+    private static final Map<String, String> PAINLESS_TO_EMIT = org.elasticsearch.common.collect.Map.of(
+        BooleanFieldMapper.CONTENT_TYPE,
+        "emitValue(parse(value));",
+        DateFieldMapper.CONTENT_TYPE,
+        "emitValue(parse(value.toString()));",
+        NumberType.DOUBLE.typeName(),
+        "emitValue(value instanceof Number ? ((Number) value).doubleValue() : Double.parseDouble(value.toString()));",
+        KeywordFieldMapper.CONTENT_TYPE,
+        "emitValue(value.toString());",
+        IpFieldMapper.CONTENT_TYPE,
+        "emitValue(value.toString());",
+        NumberType.LONG.typeName(),
+        "emitValue(value instanceof Number ? ((Number) value).longValue() : Long.parseLong(value.toString()));"
+    );
+
+    private static final ExecutableSection ADD_TEMPLATE = new ExecutableSection() {
+        @Override
+        public XContentLocation getLocation() {
+            return new XContentLocation(-1, -1);
+        }
+
+        @Override
+        public void execute(ClientYamlTestExecutionContext executionContext) throws IOException {
+            Map<String, String> params = org.elasticsearch.common.collect.Map.of("name", "convert_to_source_only", "create", "true");
+            List<Map<String, Object>> dynamicTemplates = new ArrayList<>();
+            for (String type : PAINLESS_TO_EMIT.keySet()) {
+                if (type.equals("ip")) {
+                    // There isn't a dynamic template to pick up ips. They'll just look like strings.
+                    continue;
+                }
+                Map<String, Object> mapping = org.elasticsearch.common.collect.Map.of(
+                    "type",
+                    "runtime_script",
+                    "runtime_type",
+                    type,
+                    "script",
+                    painlessToLoadFromSource("{name}", type)
+                );
+                if (type.contentEquals("keyword")) {
+                    /*
+                     * For "string"-type dynamic mappings emulate our default
+                     * behavior with a top level text field and a `.keyword`
+                     * multi-field. But instead of the default, use a runtime
+                     * field for the multi-field.
+                     */
+                    mapping = org.elasticsearch.common.collect.Map.of(
+                        "type",
+                        "text",
+                        "fields",
+                        org.elasticsearch.common.collect.Map.of("keyword", mapping)
+                    );
+                    dynamicTemplates.add(
+                        org.elasticsearch.common.collect.Map.of(
+                            type,
+                            org.elasticsearch.common.collect.Map.of("match_mapping_type", "string", "mapping", mapping)
+                        )
+                    );
+                } else {
+                    dynamicTemplates.add(
+                        org.elasticsearch.common.collect.Map.of(
+                            type,
+                            org.elasticsearch.common.collect.Map.of("match_mapping_type", type, "mapping", mapping)
+                        )
+                    );
+                }
+            }
+            Map<String, Object> map = org.elasticsearch.common.collect.Map.of(
+                "index_patterns",
+                "*",
+                "priority",
+                Integer.MAX_VALUE - 1,
+                "template",
+                org.elasticsearch.common.collect.Map.of(
+                    "settings",
+                    Collections.emptyMap(),
+                    "mappings",
+                    org.elasticsearch.common.collect.Map.of("dynamic_templates", dynamicTemplates)
+                )
+            );
+
+            XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent()).map(map);
+            String string = Strings.toString(builder);
+            System.out.println(string);
+
+            List<Map<String, Object>> bodies = Collections.singletonList(
+                map
+            );
+            ClientYamlTestResponse response = executionContext.callApi(
+                "indices.put_index_template",
+                params,
+                bodies,
+                Collections.emptyMap()
+            );
+
+
+            assertThat(response.getStatusCode(), equalTo(200));
+            // There are probably some warning about overlapping templates. Ignore them.
+        }
+    };
+}

--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.runtimefields.rest;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentLocation;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
@@ -268,26 +264,21 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
                     );
                 }
             }
-            Map<String, Object> map = org.elasticsearch.common.collect.Map.of(
-                "index_patterns",
-                "*",
-                "priority",
-                Integer.MAX_VALUE - 1,
-                "template",
-                org.elasticsearch.common.collect.Map.of(
-                    "settings",
-                    Collections.emptyMap(),
-                    "mappings",
-                    org.elasticsearch.common.collect.Map.of("dynamic_templates", dynamicTemplates)
-                )
-            );
-
-            XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent()).map(map);
-            String string = Strings.toString(builder);
-            System.out.println(string);
 
             List<Map<String, Object>> bodies = Collections.singletonList(
-                map
+                org.elasticsearch.common.collect.Map.of(
+                    "index_patterns",
+                    "*",
+                    "priority",
+                    Integer.MAX_VALUE - 1,
+                    "template",
+                    org.elasticsearch.common.collect.Map.of(
+                        "settings",
+                        Collections.emptyMap(),
+                        "mappings",
+                        org.elasticsearch.common.collect.Map.of("dynamic_templates", dynamicTemplates)
+                    )
+                )
             );
             ClientYamlTestResponse response = executionContext.callApi(
                 "indices.put_index_template",
@@ -295,7 +286,6 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
                 bodies,
                 Collections.emptyMap()
             );
-
 
             assertThat(response.getStatusCode(), equalTo(200));
             // There are probably some warning about overlapping templates. Ignore them.

--- a/x-pack/plugin/runtime-fields/qa/with-security/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/with-security/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+
+dependencies {
+  testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+}
+
+def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
+                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+
+integTest {
+  systemProperty 'tests.rest.cluster.username', clusterCredentials.username
+  systemProperty 'tests.rest.cluster.password', clusterCredentials.password
+}
+
+testClusters.integTest {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.security.enabled', 'true'
+  setting 'xpack.watcher.enabled', 'false'
+  setting 'xpack.ml.enabled', 'false'
+  setting 'xpack.license.self_generated.type', 'trial'
+  extraConfigFile 'roles.yml', file('roles.yml')
+  user clusterCredentials
+  user username: "test", password: "x-pack-test-password", role: "test"
+}

--- a/x-pack/plugin/runtime-fields/qa/with-security/roles.yml
+++ b/x-pack/plugin/runtime-fields/qa/with-security/roles.yml
@@ -1,0 +1,13 @@
+test:
+  indices:
+    - names: [ 'dls' ]
+      privileges:
+        - read
+      query: "{\"match\": {\"year\": 2016}}"
+    - names: [ 'fls' ]
+      privileges:
+        - read
+      field_security:
+        grant: [ '*' ]
+        except: [ 'year', 'hidden' ]
+

--- a/x-pack/plugin/runtime-fields/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+
+public class PermissionsIT extends ESRestTestCase {
+
+    private static HighLevelClient highLevelClient;
+    private static HighLevelClient adminHighLevelClient;
+
+    @Override
+    protected Settings restClientSettings() {
+        String token = basicAuthHeaderValue("test", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Override
+    protected Settings restAdminSettings() {
+        String token = basicAuthHeaderValue("test_admin", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Before
+    public void initHighLevelClient() {
+        if (highLevelClient == null) {
+            highLevelClient = new HighLevelClient(client());
+            adminHighLevelClient = new HighLevelClient(adminClient());
+        }
+    }
+
+    @AfterClass
+    public static void closeHighLevelClients() throws IOException {
+        highLevelClient.close();
+        adminHighLevelClient.close();
+        highLevelClient = null;
+        adminHighLevelClient = null;
+    }
+
+    public void testDLS() throws IOException {
+        Request createIndex = new Request("PUT", "/dls");
+        createIndex.setJsonEntity(
+            "{\n"
+                + "    \"mappings\" : {\n"
+                + "        \"properties\" : {\n"
+                + "            \"date\" : {\"type\" : \"keyword\"},\n"
+                + "            \"year\" : {\n"
+                + "              \"type\" : \"runtime_script\", \n"
+                + "              \"runtime_type\" : \"keyword\",\n"
+                + "              \"script\" : \"emitValue(doc['date'].value.substring(0,4))\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n"
+        );
+        assertOK(adminClient().performRequest(createIndex));
+
+        Request indexDoc1 = new Request("PUT", "/dls/_doc/1");
+        indexDoc1.setJsonEntity("{\n" + "    \"date\" : \"2009-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc1));
+
+        Request indexDoc2 = new Request("PUT", "/dls/_doc/2");
+        indexDoc2.setJsonEntity("{\n" + "    \"date\" : \"2016-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc2));
+
+        Request indexDoc3 = new Request("PUT", "/dls/_doc/3");
+        indexDoc3.addParameter("refresh", "true");
+        indexDoc3.setJsonEntity("{\n" + "    \"date\" : \"2018-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc3));
+
+        SearchRequest searchRequest = new SearchRequest("dls");
+        {
+            SearchResponse searchResponse = adminHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+            assertEquals(3, searchResponse.getHits().getTotalHits().value);
+        }
+        {
+            SearchResponse searchResponse = highLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+            assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        }
+    }
+
+    public void testFLSProtectsData() throws IOException {
+        Request createIndex = new Request("PUT", "/fls");
+        createIndex.setJsonEntity(
+            "{\n"
+                + "    \"mappings\" : {\n"
+                + "        \"properties\" : {\n"
+                + "            \"hidden\" : {\"type\" : \"keyword\"},\n"
+                + "            \"hidden_values_count\" : {\n"
+                + "              \"type\" : \"runtime_script\", \n"
+                + "              \"runtime_type\" : \"long\",\n"
+                + "              \"script\" : \"emitValue(doc['hidden'].size())\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n"
+        );
+        assertOK(adminClient().performRequest(createIndex));
+
+        Request indexDoc1 = new Request("PUT", "/fls/_doc/1");
+        indexDoc1.setJsonEntity("{\n" + "    \"hidden\" : \"should not be read\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc1));
+
+        Request indexDoc2 = new Request("PUT", "/fls/_doc/2");
+        indexDoc2.setJsonEntity("{\n" + "    \"hidden\" : \"should not be read\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc2));
+
+        Request indexDoc3 = new Request("PUT", "/fls/_doc/3");
+        indexDoc3.addParameter("refresh", "true");
+        indexDoc3.setJsonEntity("{\n" + "    \"hidden\" : \"should not be read\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc3));
+
+        SearchRequest searchRequest = new SearchRequest("fls").source(new SearchSourceBuilder().docValueField("hidden_values_count"));
+        {
+            SearchResponse searchResponse = adminHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+            assertEquals(3, searchResponse.getHits().getTotalHits().value);
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                assertEquals(1, hit.getFields().size());
+                assertEquals(1, (int) hit.getFields().get("hidden_values_count").getValue());
+            }
+        }
+        {
+            SearchResponse searchResponse = highLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+            assertEquals(3, searchResponse.getHits().getTotalHits().value);
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                assertEquals(0, (int) hit.getFields().get("hidden_values_count").getValue());
+            }
+        }
+    }
+
+    public void testFLSOnRuntimeField() throws IOException {
+        Request createIndex = new Request("PUT", "/fls");
+        createIndex.setJsonEntity(
+            "{\n"
+                + "    \"mappings\" : {\n"
+                + "        \"properties\" : {\n"
+                + "            \"date\" : {\"type\" : \"keyword\"},\n"
+                + "            \"year\" : {\n"
+                + "              \"type\" : \"runtime_script\", \n"
+                + "              \"runtime_type\" : \"keyword\",\n"
+                + "              \"script\" : \"emitValue(doc['date'].value.substring(0,4))\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n"
+        );
+        assertOK(adminClient().performRequest(createIndex));
+
+        Request indexDoc1 = new Request("PUT", "/fls/_doc/1");
+        indexDoc1.setJsonEntity("{\n" + "    \"date\" : \"2009-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc1));
+
+        Request indexDoc2 = new Request("PUT", "/fls/_doc/2");
+        indexDoc2.setJsonEntity("{\n" + "    \"date\" : \"2016-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc2));
+
+        Request indexDoc3 = new Request("PUT", "/fls/_doc/3");
+        indexDoc3.addParameter("refresh", "true");
+        indexDoc3.setJsonEntity("{\n" + "    \"date\" : \"2018-11-15T14:12:12\"\n" + "}\n");
+        assertOK(adminClient().performRequest(indexDoc3));
+
+        // There is no FLS directly on runtime fields
+        SearchRequest searchRequest = new SearchRequest("fls").source(new SearchSourceBuilder().docValueField("year"));
+        SearchResponse searchResponse = highLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+        assertEquals(3, searchResponse.getHits().getTotalHits().value);
+        for (SearchHit hit : searchResponse.getHits().getHits()) {
+            Map<String, DocumentField> fields = hit.getFields();
+            assertEquals(1, fields.size());
+            switch (hit.getId()) {
+                case "1":
+                    assertEquals("2009", fields.get("year").getValue().toString());
+                    break;
+                case "2":
+                    assertEquals("2016", fields.get("year").getValue().toString());
+                    break;
+                case "3":
+                    assertEquals("2018", fields.get("year").getValue().toString());
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        {
+            FieldCapabilitiesRequest fieldCapsRequest = new FieldCapabilitiesRequest().indices("fls").fields("year");
+            FieldCapabilitiesResponse fieldCapabilitiesResponse = adminHighLevelClient.fieldCaps(fieldCapsRequest, RequestOptions.DEFAULT);
+            assertNotNull(fieldCapabilitiesResponse.get().get("year"));
+        }
+        {
+            // Though field_caps filters runtime fields out like ordinary fields
+            FieldCapabilitiesRequest fieldCapsRequest = new FieldCapabilitiesRequest().indices("fls").fields("year");
+            FieldCapabilitiesResponse fieldCapabilitiesResponse = highLevelClient.fieldCaps(fieldCapsRequest, RequestOptions.DEFAULT);
+            assertEquals(0, fieldCapabilitiesResponse.get().size());
+        }
+    }
+
+    private static class HighLevelClient extends RestHighLevelClient {
+        private HighLevelClient(RestClient restClient) {
+            super(restClient, (client) -> {}, Collections.emptyList());
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractLongScriptFieldScript.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.util.Map;
+
+/**
+ * Common base class for script field scripts that return long values.
+ */
+public abstract class AbstractLongScriptFieldScript extends AbstractScriptFieldScript {
+    private long[] values = new long[1];
+    private int count;
+
+    public AbstractLongScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}.
+     */
+    public final void runForDoc(int docId) {
+        count = 0;
+        setDocument(docId);
+        execute();
+    }
+
+    /**
+     * Values from the last time {@link #runForDoc(int)} was called. This array
+     * is mutable and will change with the next call of {@link #runForDoc(int)}.
+     * It is also oversized and will contain garbage at all indices at and
+     * above {@link #count()}.
+     */
+    public final long[] values() {
+        return values;
+    }
+
+    /**
+     * The number of results produced the last time {@link #runForDoc(int)} was called.
+     */
+    public final int count() {
+        return count;
+    }
+
+    protected final void emitValue(long v) {
+        if (values.length < count + 1) {
+            values = ArrayUtil.grow(values, count + 1);
+        }
+        values[count++] = v;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/AbstractScriptFieldScript.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.AggregationScript;
+import org.elasticsearch.script.DynamicMap;
+import org.elasticsearch.script.ScriptCache;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
+
+/**
+ * Abstract base for scripts to execute to build scripted fields. Inspired by
+ * {@link AggregationScript} but hopefully with less historical baggage.
+ */
+public abstract class AbstractScriptFieldScript {
+    public static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
+        return new ScriptContext<F>(
+            name + "_script_field",
+            factoryClass,
+            /*
+             * In an ideal world we wouldn't need the script cache at all
+             * because we have a hard reference to the script. The trouble
+             * is that we compile the scripts a few times when performing
+             * a mapping update. This is unfortunate, but we rely on the
+             * cache to speed this up.
+             */
+            100,
+            timeValueMillis(0),
+            /*
+             * Disable compilation rate limits for scripted fields so we
+             * don't prevent mapping updates because we've performed too
+             * many recently. That'd just be lame.
+             */
+            ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple()
+        );
+    }
+
+    private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.elasticsearch.common.collect.Map.of(
+        "_source",
+        value -> ((SourceLookup) value).loadSourceIfNeeded()
+    );
+
+    private final Map<String, Object> params;
+    private final LeafSearchLookup leafSearchLookup;
+
+    public AbstractScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        this.leafSearchLookup = searchLookup.getLeafSearchLookup(ctx);
+        params = new HashMap<>(params);
+        params.put("_source", leafSearchLookup.source());
+        params.put("_fields", leafSearchLookup.fields());
+        this.params = new DynamicMap(params, PARAMS_FUNCTIONS);
+    }
+
+    /**
+     * Set the document to run the script against.
+     */
+    public final void setDocument(int docId) {
+        this.leafSearchLookup.setDocument(docId);
+    }
+
+    /**
+     * Expose the {@code params} of the script to the script itself.
+     */
+    public final Map<String, Object> getParams() {
+        return params;
+    }
+
+    /**
+     * Expose the {@code _source} to the script.
+     */
+    @SuppressWarnings("unchecked")
+    protected final Map<String, Object> getSource() {
+        return leafSearchLookup.source();
+    }
+
+    /**
+     * Expose field data to the script as {@code doc}.
+     */
+    public final Map<String, ScriptDocValues<?>> getDoc() {
+        return leafSearchLookup.doc();
+    }
+
+    public abstract void execute();
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScript.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class BooleanScriptFieldScript extends AbstractScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("boolean_script_field", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(
+            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "boolean_whitelist.txt")
+        );
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        BooleanScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    private int trues;
+    private int falses;
+
+    public BooleanScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}.
+     */
+    public final void runForDoc(int docId) {
+        trues = 0;
+        falses = 0;
+        setDocument(docId);
+        execute();
+    }
+
+    /**
+     * How many {@code true} values were returned for this document.
+     */
+    public final int trues() {
+        return trues;
+    }
+
+    /**
+     * How many {@code false} values were returned for this document.
+     */
+    public final int falses() {
+        return falses;
+    }
+
+    protected final void emitValue(boolean v) {
+        if (v) {
+            trues++;
+        } else {
+            falses++;
+        }
+    }
+
+    public static boolean parse(Object str) {
+        return Booleans.parseBoolean(str.toString());
+    }
+
+    public static class EmitValue {
+        private final BooleanScriptFieldScript script;
+
+        public EmitValue(BooleanScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void value(boolean v) {
+            script.emitValue(v);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScript.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class DateScriptFieldScript extends AbstractLongScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("date", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "date_whitelist.txt"));
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup, DateFormatter formatter);
+    }
+
+    public interface LeafFactory {
+        DateScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    private final DateFormatter formatter;
+
+    public DateScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, DateFormatter formatter, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+        this.formatter = formatter;
+    }
+
+    public static long toEpochMilli(TemporalAccessor v) {
+        // TemporalAccessor is a nanos API so we have to convert.
+        long millis = Math.multiplyExact(v.getLong(ChronoField.INSTANT_SECONDS), 1000);
+        millis = Math.addExact(millis, v.get(ChronoField.NANO_OF_SECOND) / 1_000_000);
+        return millis;
+    }
+
+    public static class EmitValue {
+        private final DateScriptFieldScript script;
+
+        public EmitValue(DateScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void emitValue(long v) {
+            script.emitValue(v);
+        }
+    }
+
+    public static class Parse {
+        private final DateScriptFieldScript script;
+
+        public Parse(DateScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public long parse(Object str) {
+            return script.formatter.parseMillis(str.toString());
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScript.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class DoubleScriptFieldScript extends AbstractScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("double_script_field", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(
+            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "double_whitelist.txt")
+        );
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        DoubleScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    private double[] values = new double[1];
+    private int count;
+
+    public DoubleScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}.
+     */
+    public final void runForDoc(int docId) {
+        count = 0;
+        setDocument(docId);
+        execute();
+    }
+
+    /**
+     * Values from the last time {@link #runForDoc(int)} was called. This array
+     * is mutable and will change with the next call of {@link #runForDoc(int)}.
+     * It is also oversized and will contain garbage at all indices at and
+     * above {@link #count()}.
+     */
+    public final double[] values() {
+        return values;
+    }
+
+    /**
+     * The number of results produced the last time {@link #runForDoc(int)} was called.
+     */
+    public final int count() {
+        return count;
+    }
+
+    protected final void emitValue(double v) {
+        if (values.length < count + 1) {
+            values = ArrayUtil.grow(values, count + 1);
+        }
+        values[count++] = v;
+    }
+
+    public static class EmitValue {
+        private final DoubleScriptFieldScript script;
+
+        public EmitValue(DoubleScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void emitValue(double v) {
+            script.emitValue(v);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScript.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Script producing IP addresses. Unlike the other {@linkplain AbstractScriptFieldScript}s
+ * which deal with their native java objects this converts its values to the same format
+ * that Lucene uses to store its fields, {@link InetAddressPoint}. There are a few compelling
+ * reasons to do this:
+ * <ul>
+ * <li>{@link Inet4Address}es and {@link Inet6Address} are not comparable with one another.
+ * That is correct in some contexts, but not for our queries. Our queries must consider the
+ * IPv4 address equal to the address that it maps to in IPv6 <a href="https://tools.ietf.org/html/rfc4291">rfc4291</a>).
+ * <li>{@link InetAddress}es are not ordered, but we need to implement range queries with
+ * same same ordering as {@link IpFieldMapper}. That also uses {@link InetAddressPoint}
+ * so it saves us a lot of trouble to use the same representation.
+ * </ul>
+ */
+public abstract class IpScriptFieldScript extends AbstractScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("ip_script_field", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "ip_whitelist.txt"));
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        IpScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    private BytesRef[] values = new BytesRef[1];
+    private int count;
+
+    public IpScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}.
+     */
+    public final void runForDoc(int docId) {
+        count = 0;
+        setDocument(docId);
+        execute();
+    }
+
+    /**
+     * Values from the last time {@link #runForDoc(int)} was called. This array
+     * is mutable and will change with the next call of {@link #runForDoc(int)}.
+     * It is also oversized and will contain garbage at all indices at and
+     * above {@link #count()}.
+     * <p>
+     * All values are IPv6 addresses so they are 16 bytes. IPv4 addresses are
+     * encoded by <a href="https://tools.ietf.org/html/rfc4291">rfc4291</a>.
+     */
+    public final BytesRef[] values() {
+        return values;
+    }
+
+    /**
+     * The number of results produced the last time {@link #runForDoc(int)} was called.
+     */
+    public final int count() {
+        return count;
+    }
+
+    protected final void emitValue(String v) {
+        if (values.length < count + 1) {
+            values = ArrayUtil.grow(values, count + 1);
+        }
+        values[count++] = new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)));
+    }
+
+    public static class EmitValue {
+        private final IpScriptFieldScript script;
+
+        public EmitValue(IpScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void emitValue(String v) {
+            script.emitValue(v);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScript.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class LongScriptFieldScript extends AbstractLongScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("long_script_field", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "long_whitelist.txt"));
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        LongScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    public LongScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    public static class EmitValue {
+        private final LongScriptFieldScript script;
+
+        public EmitValue(LongScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void emitValue(long v) {
+            script.emitValue(v);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.xpack.runtimefields.mapper.RuntimeScriptFieldMapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class RuntimeFields extends Plugin implements MapperPlugin, ScriptPlugin {
+
+    @Override
+    public Map<String, Mapper.TypeParser> getMappers() {
+        return Collections.singletonMap(RuntimeScriptFieldMapper.CONTENT_TYPE, RuntimeScriptFieldMapper.PARSER);
+    }
+
+    @Override
+    public List<ScriptContext<?>> getContexts() {
+        return org.elasticsearch.common.collect.List.of(
+            BooleanScriptFieldScript.CONTEXT,
+            DateScriptFieldScript.CONTEXT,
+            DoubleScriptFieldScript.CONTEXT,
+            IpScriptFieldScript.CONTEXT,
+            LongScriptFieldScript.CONTEXT,
+            StringScriptFieldScript.CONTEXT
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFieldsPainlessExtension.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFieldsPainlessExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.painless.spi.PainlessExtension;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.List;
+import java.util.Map;
+
+public class RuntimeFieldsPainlessExtension implements PainlessExtension {
+    @Override
+    public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {
+        return org.elasticsearch.common.collect.Map.of(
+            BooleanScriptFieldScript.CONTEXT,
+            BooleanScriptFieldScript.whitelist(),
+            DateScriptFieldScript.CONTEXT,
+            DateScriptFieldScript.whitelist(),
+            DoubleScriptFieldScript.CONTEXT,
+            DoubleScriptFieldScript.whitelist(),
+            IpScriptFieldScript.CONTEXT,
+            IpScriptFieldScript.whitelist(),
+            LongScriptFieldScript.CONTEXT,
+            LongScriptFieldScript.whitelist(),
+            StringScriptFieldScript.CONTEXT,
+            StringScriptFieldScript.whitelist()
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScript.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptFactory;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class StringScriptFieldScript extends AbstractScriptFieldScript {
+    public static final ScriptContext<Factory> CONTEXT = newContext("string_script_field", Factory.class);
+
+    static List<Whitelist> whitelist() {
+        return Collections.singletonList(
+            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "string_whitelist.txt")
+        );
+    }
+
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        LeafFactory newFactory(Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        StringScriptFieldScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    private final List<String> results = new ArrayList<>();
+
+    public StringScriptFieldScript(Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(params, searchLookup, ctx);
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}.
+     * <p>
+     * @return a mutable {@link List} that contains the results of the script
+     * and will be modified the next time you call {@linkplain #resultsForDoc}.
+     */
+    public final List<String> resultsForDoc(int docId) {
+        results.clear();
+        setDocument(docId);
+        execute();
+        return results;
+    }
+
+    protected final void emitValue(String v) {
+        results.add(v);
+    }
+
+    public static class EmitValue {
+        private final StringScriptFieldScript script;
+
+        public EmitValue(StringScriptFieldScript script) {
+            this.script = script;
+        }
+
+        public void emitValue(String v) {
+            script.emitValue(v);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBinaryFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBinaryFieldData.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.LeafFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+public abstract class ScriptBinaryFieldData implements IndexFieldData<ScriptBinaryFieldData.ScriptBinaryLeafFieldData> {
+    private final String fieldName;
+
+    protected ScriptBinaryFieldData(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ScriptBinaryLeafFieldData load(LeafReaderContext context) {
+        try {
+            return loadDirect(context);
+        } catch (Exception e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public SortField sortField(Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested, boolean reverse) {
+        final XFieldComparatorSource source = new BytesRefFieldComparatorSource(this, missingValue, sortMode, nested);
+        return new SortField(getFieldName(), source, reverse);
+    }
+
+    @Override
+    public BucketedSort newBucketedSort(
+        BigArrays bigArrays,
+        Object missingValue,
+        MultiValueMode sortMode,
+        XFieldComparatorSource.Nested nested,
+        SortOrder sortOrder,
+        DocValueFormat format,
+        int bucketSize,
+        BucketedSort.ExtraData extra
+    ) {
+        throw new IllegalArgumentException("only supported on numeric fields");
+    }
+
+    public abstract class ScriptBinaryLeafFieldData implements LeafFieldData {
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBooleanDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBooleanDocValues.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.elasticsearch.index.fielddata.AbstractSortedNumericDocValues;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+
+import java.io.IOException;
+
+public final class ScriptBooleanDocValues extends AbstractSortedNumericDocValues {
+    private final BooleanScriptFieldScript script;
+    private int cursor;
+
+    ScriptBooleanDocValues(BooleanScriptFieldScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public boolean advanceExact(int docId) {
+        script.runForDoc(docId);
+        cursor = 0;
+        return script.trues() > 0 || script.falses() > 0;
+    }
+
+    @Override
+    public long nextValue() throws IOException {
+        // Emit all false values before all true values
+        return cursor++ < script.falses() ? 0 : 1;
+    }
+
+    @Override
+    public int docValueCount() {
+        return script.trues() + script.falses();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBooleanFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptBooleanFieldData.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.plain.LeafLongFieldData;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+
+import java.io.IOException;
+
+public final class ScriptBooleanFieldData extends IndexNumericFieldData {
+
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final BooleanScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, BooleanScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptBooleanFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptBooleanFieldData(name, leafFactory);
+        }
+    }
+
+    private final String fieldName;
+    private final BooleanScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptBooleanFieldData(String fieldName, BooleanScriptFieldScript.LeafFactory leafFactory) {
+        this.fieldName = fieldName;
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.BOOLEAN;
+    }
+
+    @Override
+    public ScriptBooleanLeafFieldData load(LeafReaderContext context) {
+        try {
+            return loadDirect(context);
+        } catch (Exception e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public ScriptBooleanLeafFieldData loadDirect(LeafReaderContext context) throws IOException {
+        return new ScriptBooleanLeafFieldData(new ScriptBooleanDocValues(leafFactory.newInstance(context)));
+    }
+
+    @Override
+    public NumericType getNumericType() {
+        return NumericType.BOOLEAN;
+    }
+
+    @Override
+    protected boolean sortRequiresCustomComparator() {
+        return true;
+    }
+
+    public static class ScriptBooleanLeafFieldData extends LeafLongFieldData {
+        private final ScriptBooleanDocValues scriptBooleanDocValues;
+
+        ScriptBooleanLeafFieldData(ScriptBooleanDocValues scriptBooleanDocValues) {
+            super(0, NumericType.BOOLEAN);
+            this.scriptBooleanDocValues = scriptBooleanDocValues;
+        }
+
+        @Override
+        public SortedNumericDocValues getLongValues() {
+            return scriptBooleanDocValues;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDateFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDateFieldData.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.plain.LeafLongFieldData;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+
+import java.io.IOException;
+
+public final class ScriptDateFieldData extends IndexNumericFieldData {
+
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final DateScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, DateScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptDateFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptDateFieldData(name, leafFactory);
+        }
+    }
+
+    private final String fieldName;
+    private final DateScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptDateFieldData(String fieldName, DateScriptFieldScript.LeafFactory leafFactory) {
+        this.fieldName = fieldName;
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.DATE;
+    }
+
+    @Override
+    public ScriptDateLeafFieldData load(LeafReaderContext context) {
+        try {
+            return loadDirect(context);
+        } catch (Exception e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public ScriptDateLeafFieldData loadDirect(LeafReaderContext context) throws IOException {
+        return new ScriptDateLeafFieldData(new ScriptLongDocValues(leafFactory.newInstance(context)));
+    }
+
+    @Override
+    public NumericType getNumericType() {
+        return NumericType.DATE;
+    }
+
+    @Override
+    protected boolean sortRequiresCustomComparator() {
+        return true;
+    }
+
+    public static class ScriptDateLeafFieldData extends LeafLongFieldData {
+        private final ScriptLongDocValues scriptLongDocValues;
+
+        ScriptDateLeafFieldData(ScriptLongDocValues scriptLongDocValues) {
+            super(0, NumericType.DATE);
+            this.scriptLongDocValues = scriptLongDocValues;
+        }
+
+        @Override
+        public SortedNumericDocValues getLongValues() {
+            return scriptLongDocValues;
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleDocValues.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class ScriptDoubleDocValues extends SortedNumericDoubleValues {
+    private final DoubleScriptFieldScript script;
+    private int cursor;
+
+    ScriptDoubleDocValues(DoubleScriptFieldScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public boolean advanceExact(int docId) {
+        script.runForDoc(docId);
+        if (script.count() == 0) {
+            return false;
+        }
+        Arrays.sort(script.values(), 0, script.count());
+        cursor = 0;
+        return true;
+    }
+
+    @Override
+    public double nextValue() throws IOException {
+        return script.values()[cursor++];
+    }
+
+    @Override
+    public int docValueCount() {
+        return script.count();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptDoubleFieldData.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.fielddata.plain.LeafDoubleFieldData;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.io.IOException;
+
+public final class ScriptDoubleFieldData extends IndexNumericFieldData {
+
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final DoubleScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, DoubleScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptDoubleFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptDoubleFieldData(name, leafFactory);
+        }
+    }
+
+    private final String fieldName;
+    DoubleScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptDoubleFieldData(String fieldName, DoubleScriptFieldScript.LeafFactory leafFactory) {
+        this.fieldName = fieldName;
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.NUMERIC;
+    }
+
+    @Override
+    public ScriptDoubleLeafFieldData load(LeafReaderContext context) {
+        try {
+            return loadDirect(context);
+        } catch (Exception e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public ScriptDoubleLeafFieldData loadDirect(LeafReaderContext context) throws IOException {
+        return new ScriptDoubleLeafFieldData(new ScriptDoubleDocValues(leafFactory.newInstance(context)));
+    }
+
+    @Override
+    public NumericType getNumericType() {
+        return NumericType.DOUBLE;
+    }
+
+    @Override
+    protected boolean sortRequiresCustomComparator() {
+        return true;
+    }
+
+    public static class ScriptDoubleLeafFieldData extends LeafDoubleFieldData {
+        private final ScriptDoubleDocValues scriptDoubleDocValues;
+
+        ScriptDoubleLeafFieldData(ScriptDoubleDocValues scriptDoubleDocValues) {
+            super(0);
+            this.scriptDoubleDocValues = scriptDoubleDocValues;
+        }
+
+        @Override
+        public SortedNumericDoubleValues getDoubleValues() {
+            return scriptDoubleDocValues;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptIpDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptIpDocValues.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class ScriptIpDocValues extends SortedBinaryDocValues {
+    private final IpScriptFieldScript script;
+    private int cursor;
+
+    ScriptIpDocValues(IpScriptFieldScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public boolean advanceExact(int docId) {
+        script.runForDoc(docId);
+        if (script.count() == 0) {
+            return false;
+        }
+        Arrays.sort(script.values(), 0, script.count());
+        cursor = 0;
+        return true;
+    }
+
+    @Override
+    public BytesRef nextValue() throws IOException {
+        return script.values()[cursor++];
+    }
+
+    @Override
+    public int docValueCount() {
+        return script.count();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptIpFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptIpFieldData.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.net.InetAddress;
+
+public class ScriptIpFieldData extends ScriptBinaryFieldData {
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final IpScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, IpScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptIpFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptIpFieldData(name, leafFactory);
+        }
+    }
+
+    private final IpScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptIpFieldData(String fieldName, IpScriptFieldScript.LeafFactory leafFactory) {
+        super(fieldName);
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public ScriptBinaryLeafFieldData loadDirect(LeafReaderContext context) throws Exception {
+        IpScriptFieldScript script = leafFactory.newInstance(context);
+        return new ScriptBinaryLeafFieldData() {
+            @Override
+            public ScriptDocValues<String> getScriptValues() {
+                return new IpScriptDocValues(getBytesValues());
+            }
+
+            @Override
+            public SortedBinaryDocValues getBytesValues() {
+                return new ScriptIpDocValues(script);
+            }
+        };
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.IP;
+    }
+
+    /**
+     * Doc values implementation for ips. We can't share
+     * {@link IpFieldMapper.IpFieldType.IpScriptDocValues} because it is based
+     * on global ordinals and we don't have those.
+     */
+    public static class IpScriptDocValues extends ScriptDocValues.Strings {
+        public IpScriptDocValues(SortedBinaryDocValues in) {
+            super(in);
+        }
+
+        @Override
+        protected String bytesToString(BytesRef bytes) {
+            InetAddress addr = InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(bytes)));
+            return InetAddresses.toAddrString(addr);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongDocValues.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.elasticsearch.index.fielddata.AbstractSortedNumericDocValues;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class ScriptLongDocValues extends AbstractSortedNumericDocValues {
+    private final AbstractLongScriptFieldScript script;
+    private int cursor;
+
+    ScriptLongDocValues(AbstractLongScriptFieldScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public boolean advanceExact(int docId) {
+        script.runForDoc(docId);
+        if (script.count() == 0) {
+            return false;
+        }
+        Arrays.sort(script.values(), 0, script.count());
+        cursor = 0;
+        return true;
+    }
+
+    @Override
+    public long nextValue() throws IOException {
+        return script.values()[cursor++];
+    }
+
+    @Override
+    public int docValueCount() {
+        return script.count();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptLongFieldData.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.plain.LeafLongFieldData;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+
+import java.io.IOException;
+
+public final class ScriptLongFieldData extends IndexNumericFieldData {
+
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final LongScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, LongScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptLongFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptLongFieldData(name, leafFactory);
+        }
+    }
+
+    private final String fieldName;
+    private final LongScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptLongFieldData(String fieldName, LongScriptFieldScript.LeafFactory leafFactory) {
+        this.fieldName = fieldName;
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.NUMERIC;
+    }
+
+    @Override
+    public ScriptLongLeafFieldData load(LeafReaderContext context) {
+        try {
+            return loadDirect(context);
+        } catch (Exception e) {
+            throw ExceptionsHelper.convertToElastic(e);
+        }
+    }
+
+    @Override
+    public ScriptLongLeafFieldData loadDirect(LeafReaderContext context) throws IOException {
+        return new ScriptLongLeafFieldData(new ScriptLongDocValues(leafFactory.newInstance(context)));
+    }
+
+    @Override
+    public NumericType getNumericType() {
+        return NumericType.LONG;
+    }
+
+    @Override
+    protected boolean sortRequiresCustomComparator() {
+        return true;
+    }
+
+    public static class ScriptLongLeafFieldData extends LeafLongFieldData {
+        private final ScriptLongDocValues scriptLongDocValues;
+
+        ScriptLongLeafFieldData(ScriptLongDocValues scriptLongDocValues) {
+            super(0, NumericType.LONG);
+            this.scriptLongDocValues = scriptLongDocValues;
+        }
+
+        @Override
+        public SortedNumericDocValues getLongValues() {
+            return scriptLongDocValues;
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptStringDocValues.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptStringDocValues.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.elasticsearch.index.fielddata.SortingBinaryDocValues;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+
+public final class ScriptStringDocValues extends SortingBinaryDocValues {
+    private final StringScriptFieldScript script;
+
+    ScriptStringDocValues(StringScriptFieldScript script) {
+        this.script = script;
+    }
+
+    @Override
+    public boolean advanceExact(int docId) {
+        List<String> results = script.resultsForDoc(docId);
+        count = results.size();
+        if (count == 0) {
+            return false;
+        }
+
+        grow();
+        int i = 0;
+        for (String value : results) {
+            values[i++].copyChars(value);
+        }
+        sort();
+        return true;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptStringFieldData.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/fielddata/ScriptStringFieldData.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+public class ScriptStringFieldData extends ScriptBinaryFieldData {
+    public static class Builder implements IndexFieldData.Builder {
+        private final String name;
+        private final StringScriptFieldScript.LeafFactory leafFactory;
+
+        public Builder(String name, StringScriptFieldScript.LeafFactory leafFactory) {
+            this.name = name;
+            this.leafFactory = leafFactory;
+        }
+
+        @Override
+        public ScriptStringFieldData build(IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+            return new ScriptStringFieldData(name, leafFactory);
+        }
+    }
+
+    private final StringScriptFieldScript.LeafFactory leafFactory;
+
+    private ScriptStringFieldData(String fieldName, StringScriptFieldScript.LeafFactory leafFactory) {
+        super(fieldName);
+        this.leafFactory = leafFactory;
+    }
+
+    @Override
+    public ScriptBinaryLeafFieldData loadDirect(LeafReaderContext context) throws Exception {
+        StringScriptFieldScript script = leafFactory.newInstance(context);
+        return new ScriptBinaryLeafFieldData() {
+            @Override
+            public ScriptDocValues<?> getScriptValues() {
+                return new ScriptDocValues.Strings(getBytesValues());
+            }
+
+            @Override
+            public SortedBinaryDocValues getBytesValues() {
+                return new ScriptStringDocValues(script);
+            }
+        };
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return CoreValuesSourceType.BYTES;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
+
+/**
+ * Abstract base {@linkplain MappedFieldType} for scripted fields.
+ */
+abstract class AbstractScriptMappedFieldType extends MappedFieldType {
+    protected final Script script;
+
+    AbstractScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, false, false, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
+        this.script = script;
+    }
+
+    protected abstract String runtimeType();
+
+    @Override
+    public final String typeName() {
+        return RuntimeScriptFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public final String familyTypeName() {
+        return runtimeType();
+    }
+
+    @Override
+    public final boolean isSearchable() {
+        return true;
+    }
+
+    @Override
+    public final boolean isAggregatable() {
+        return true;
+    }
+
+    public abstract Query termsQuery(List<?> values, QueryShardContext context);
+
+    @Override
+    public final Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ShapeRelation relation,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        if (relation == ShapeRelation.DISJOINT) {
+            String message = "Field [%s] of type [%s] with runtime type [%s] does not support DISJOINT ranges";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName(), runtimeType()));
+        }
+        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
+    }
+
+    protected abstract Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    );
+
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        QueryShardContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
+    }
+
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
+    }
+
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
+    }
+
+    public Query regexpQuery(
+        String value,
+        int flags,
+        int maxDeterminizedStates,
+        MultiTermQuery.RewriteMethod method,
+        QueryShardContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
+    }
+
+    public abstract Query existsQuery(QueryShardContext context);
+
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) throws IOException {
+        throw new IllegalArgumentException(unsupported("phrase prefix", "text"));
+    }
+
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        throw new IllegalArgumentException(unsupported("span prefix", "text"));
+    }
+
+    private String unsupported(String query, String supported) {
+        String thisField = "[" + name() + "] which is of type [script] with runtime_type [" + runtimeType() + "]";
+        return "Can only use " + query + " queries on " + supported + " fields - not on " + thisField;
+    }
+
+    protected final void checkAllowExpensiveQueries(QueryShardContext context) {
+        if (context.allowExpensiveQueries() == false) {
+            throw new ElasticsearchException(
+                "queries cannot be executed against ["
+                    + RuntimeScriptFieldMapper.CONTENT_TYPE
+                    + "] fields while ["
+                    + ALLOW_EXPENSIVE_QUERIES.getKey()
+                    + "] is set to [false]."
+            );
+        }
+    }
+
+    /**
+     * The format that this field should use. The default implementation is
+     * {@code null} because most fields don't support formats.
+     */
+    protected String format() {
+        return null;
+    }
+
+    /**
+     * The locale that this field's format should use. The default
+     * implementation is {@code null} because most fields don't
+     * support formats.
+     */
+    protected Locale formatLocale() {
+        return null;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapper.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public final class RuntimeScriptFieldMapper extends ParametrizedFieldMapper {
+
+    public static final String CONTENT_TYPE = "runtime_script";
+
+    public static final TypeParser PARSER = new TypeParser((name, parserContext) -> new Builder(name, new ScriptCompiler() {
+        @Override
+        public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+            return parserContext.scriptService().compile(script, context);
+        }
+    }));
+
+    private final String runtimeType;
+    private final Script script;
+    private final ScriptCompiler scriptCompiler;
+
+    protected RuntimeScriptFieldMapper(
+        String simpleName,
+        AbstractScriptMappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        String runtimeType,
+        Script script,
+        ScriptCompiler scriptCompiler
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.runtimeType = runtimeType;
+        this.script = script;
+        this.scriptCompiler = scriptCompiler;
+    }
+
+    @Override
+    public ParametrizedFieldMapper.Builder getMergeBuilder() {
+        return new RuntimeScriptFieldMapper.Builder(simpleName(), scriptCompiler).init(this);
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) {
+        // there is no lucene field
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(MapperService mapperService, String format) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    public static class Builder extends ParametrizedFieldMapper.Builder {
+
+        static final Map<String, BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType>> FIELD_TYPE_RESOLVER =
+            org.elasticsearch.common.collect.Map.of(BooleanFieldMapper.CONTENT_TYPE, (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
+                BooleanScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    BooleanScriptFieldScript.CONTEXT
+                );
+                return new ScriptBooleanMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    builder.meta.getValue()
+                );
+            }, DateFieldMapper.CONTENT_TYPE, (builder, context) -> {
+                DateScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    DateScriptFieldScript.CONTEXT
+                );
+                String format = builder.format.getValue();
+                if (format == null) {
+                    format = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern();
+                }
+                Locale locale = builder.locale.getValue();
+                if (locale == null) {
+                    locale = Locale.ROOT;
+                }
+                DateFormatter dateTimeFormatter = DateFormatter.forPattern(format).withLocale(locale);
+                return new ScriptDateMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    dateTimeFormatter,
+                    builder.meta.getValue()
+                );
+            }, NumberType.DOUBLE.typeName(), (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
+                DoubleScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    DoubleScriptFieldScript.CONTEXT
+                );
+                return new ScriptDoubleMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    builder.meta.getValue()
+                );
+            }, IpFieldMapper.CONTENT_TYPE, (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
+                IpScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    IpScriptFieldScript.CONTEXT
+                );
+                return new ScriptIpMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    builder.meta.getValue()
+                );
+            }, KeywordFieldMapper.CONTENT_TYPE, (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
+                StringScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    StringScriptFieldScript.CONTEXT
+                );
+                return new ScriptKeywordMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    builder.meta.getValue()
+                );
+            }, NumberType.LONG.typeName(), (builder, context) -> {
+                builder.formatAndLocaleNotSupported();
+                LongScriptFieldScript.Factory factory = builder.scriptCompiler.compile(
+                    builder.script.getValue(),
+                    LongScriptFieldScript.CONTEXT
+                );
+                return new ScriptLongMappedFieldType(
+                    builder.buildFullName(context),
+                    builder.script.getValue(),
+                    factory,
+                    builder.meta.getValue()
+                );
+            });
+
+        private static RuntimeScriptFieldMapper toType(FieldMapper in) {
+            return (RuntimeScriptFieldMapper) in;
+        }
+
+        private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+        private final Parameter<String> runtimeType = Parameter.stringParam(
+            "runtime_type",
+            true,
+            mapper -> toType(mapper).runtimeType,
+            null
+        ).setValidator(runtimeType -> {
+            if (runtimeType == null) {
+                throw new IllegalArgumentException("runtime_type must be specified for " + CONTENT_TYPE + " field [" + name + "]");
+            }
+        });
+        private final Parameter<Script> script = new Parameter<>(
+            "script",
+            true,
+            () -> null,
+            Builder::parseScript,
+            mapper -> toType(mapper).script
+        ).setValidator(script -> {
+            if (script == null) {
+                throw new IllegalArgumentException("script must be specified for " + CONTENT_TYPE + " field [" + name + "]");
+            }
+        });
+        private final Parameter<String> format = Parameter.stringParam(
+            "format",
+            true,
+            mapper -> ((AbstractScriptMappedFieldType) mapper.fieldType()).format(),
+            null
+        ).setSerializer((b, n, v) -> {
+            if (v != null && false == v.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern())) {
+                b.field(n, v);
+            }
+        }, Object::toString).acceptsNull();
+        private final Parameter<Locale> locale = new Parameter<>(
+            "locale",
+            true,
+            () -> null,
+            (n, c, o) -> o == null ? null : LocaleUtils.parse(o.toString()),
+            mapper -> ((AbstractScriptMappedFieldType) mapper.fieldType()).formatLocale()
+        ).setSerializer((b, n, v) -> {
+            if (v != null && false == v.equals(Locale.ROOT)) {
+                b.field(n, v.toString());
+            }
+        }, Object::toString).acceptsNull();
+
+        private final ScriptCompiler scriptCompiler;
+
+        protected Builder(String name, ScriptCompiler scriptCompiler) {
+            super(name);
+            this.scriptCompiler = scriptCompiler;
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return org.elasticsearch.common.collect.List.of(meta, runtimeType, script, format, locale);
+        }
+
+        @Override
+        public RuntimeScriptFieldMapper build(BuilderContext context) {
+            BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType> fieldTypeResolver = Builder.FIELD_TYPE_RESOLVER.get(
+                runtimeType.getValue()
+            );
+            if (fieldTypeResolver == null) {
+                throw new IllegalArgumentException(
+                    "runtime_type [" + runtimeType.getValue() + "] not supported for " + CONTENT_TYPE + " field [" + name + "]"
+                );
+            }
+            MultiFields multiFields = multiFieldsBuilder.build(this, context);
+            if (multiFields.iterator().hasNext()) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field does not support [fields]");
+            }
+            CopyTo copyTo = this.copyTo.build();
+            if (copyTo.copyToFields().isEmpty() == false) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field does not support [copy_to]");
+            }
+            return new RuntimeScriptFieldMapper(
+                name,
+                fieldTypeResolver.apply(this, context),
+                MultiFields.empty(),
+                CopyTo.empty(),
+                runtimeType.getValue(),
+                script.getValue(),
+                scriptCompiler
+            );
+        }
+
+        static Script parseScript(String name, Mapper.TypeParser.ParserContext parserContext, Object scriptObject) {
+            Script script = Script.parse(scriptObject);
+            if (script.getType() == ScriptType.STORED) {
+                throw new IllegalArgumentException(
+                    "stored scripts specified but not supported for " + CONTENT_TYPE + " field [" + name + "]"
+                );
+            }
+            return script;
+        }
+
+        private void formatAndLocaleNotSupported() {
+            if (format.getValue() != null) {
+                throw new IllegalArgumentException("format can not be specified for runtime_type [" + runtimeType.getValue() + "]");
+            }
+            if (locale.getValue() != null) {
+                throw new IllegalArgumentException("locale can not be specified for runtime_type [" + runtimeType.getValue() + "]");
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface ScriptCompiler {
+        <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldType.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptBooleanFieldData;
+import org.elasticsearch.xpack.runtimefields.query.BooleanScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.BooleanScriptFieldTermQuery;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ScriptBooleanMappedFieldType extends AbstractScriptMappedFieldType {
+    private final BooleanScriptFieldScript.Factory scriptFactory;
+
+    ScriptBooleanMappedFieldType(String name, Script script, BooleanScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+        super(name, script, meta);
+        this.scriptFactory = scriptFactory;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return BooleanFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        if (value == null) {
+            return null;
+        }
+        switch (value.toString()) {
+            case "F":
+                return false;
+            case "T":
+                return true;
+            default:
+                throw new IllegalArgumentException("Expected [T] or [F] but got [" + value + "]");
+        }
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+        if (format != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom formats");
+        }
+        if (timeZone != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom time zones");
+        }
+        return DocValueFormat.BOOLEAN;
+    }
+
+    @Override
+    public ScriptBooleanFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new ScriptBooleanFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    }
+
+    private BooleanScriptFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+        return scriptFactory.newFactory(script.getParams(), searchLookup);
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new BooleanScriptFieldExistsQuery(script, leafFactory(context.lookup()), name());
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        boolean trueAllowed;
+        boolean falseAllowed;
+
+        /*
+         * gte: true --- true matches
+         * gt: true ---- none match
+         * gte: false -- both match
+         * gt: false --- true matches
+         */
+        if (toBoolean(lowerTerm)) {
+            if (includeLower) {
+                trueAllowed = true;
+                falseAllowed = false;
+            } else {
+                trueAllowed = false;
+                falseAllowed = false;
+            }
+        } else {
+            if (includeLower) {
+                trueAllowed = true;
+                falseAllowed = true;
+            } else {
+                trueAllowed = true;
+                falseAllowed = false;
+            }
+        }
+
+        /*
+         * This is how the indexed version works:
+         * lte: true --- both match
+         * lt: true ---- false matches
+         * lte: false -- false matches
+         * lt: false --- none match
+         */
+        if (toBoolean(upperTerm)) {
+            if (includeUpper) {
+                trueAllowed &= true;
+                falseAllowed &= true;
+            } else {
+                trueAllowed &= false;
+                falseAllowed &= true;
+            }
+        } else {
+            if (includeUpper) {
+                trueAllowed &= false;
+                falseAllowed &= true;
+            } else {
+                trueAllowed &= false;
+                falseAllowed &= false;
+            }
+        }
+
+        return termsQuery(trueAllowed, falseAllowed, context);
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new BooleanScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), toBoolean(value));
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        if (values.isEmpty()) {
+            return Queries.newMatchNoDocsQuery("Empty terms query");
+        }
+        boolean trueAllowed = false;
+        boolean falseAllowed = false;
+        for (Object value : values) {
+            if (toBoolean(value)) {
+                trueAllowed = true;
+            } else {
+                falseAllowed = true;
+            }
+        }
+        return termsQuery(trueAllowed, falseAllowed, context);
+    }
+
+    private Query termsQuery(boolean trueAllowed, boolean falseAllowed, QueryShardContext context) {
+        if (trueAllowed) {
+            if (falseAllowed) {
+                // Either true or false
+                return existsQuery(context);
+            }
+            checkAllowExpensiveQueries(context);
+            return new BooleanScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), true);
+        }
+        if (falseAllowed) {
+            checkAllowExpensiveQueries(context);
+            return new BooleanScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), false);
+        }
+        return new MatchNoDocsQuery("neither true nor false allowed");
+    }
+
+    /**
+     * Convert the term into a boolean. Inspired by {@link BooleanFieldMapper.BooleanFieldType#indexedValueForSearch(Object)}.
+     */
+    private static boolean toBoolean(Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String sValue;
+        if (value instanceof BytesRef) {
+            sValue = ((BytesRef) value).utf8ToString();
+        } else {
+            sValue = value.toString();
+        }
+        return Booleans.parseBoolean(sValue);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldType.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
+import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptDateFieldData;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldDistanceFeatureQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ScriptDateMappedFieldType extends AbstractScriptMappedFieldType {
+    private final DateScriptFieldScript.Factory scriptFactory;
+    private final DateFormatter dateTimeFormatter;
+
+    ScriptDateMappedFieldType(
+        String name,
+        Script script,
+        DateScriptFieldScript.Factory scriptFactory,
+        DateFormatter dateTimeFormatter,
+        Map<String, String> meta
+    ) {
+        super(name, script, meta);
+        this.scriptFactory = scriptFactory;
+        this.dateTimeFormatter = dateTimeFormatter;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return DateFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        Long val = (Long) value;
+        if (val == null) {
+            return null;
+        }
+        return dateTimeFormatter.format(Resolution.MILLISECONDS.toInstant(val).atZone(ZoneOffset.UTC));
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(@Nullable String format, ZoneId timeZone) {
+        DateFormatter dateTimeFormatter = this.dateTimeFormatter;
+        if (format != null) {
+            dateTimeFormatter = DateFormatter.forPattern(format).withLocale(dateTimeFormatter.locale());
+        }
+        if (timeZone == null) {
+            timeZone = ZoneOffset.UTC;
+        }
+        return new DocValueFormat.DateTime(dateTimeFormatter, timeZone, Resolution.MILLISECONDS);
+    }
+
+    @Override
+    public ScriptDateFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> lookup) {
+        return new ScriptDateFieldData.Builder(name(), leafFactory(lookup.get()));
+    }
+
+    private DateScriptFieldScript.LeafFactory leafFactory(SearchLookup lookup) {
+        return scriptFactory.newFactory(script.getParams(), lookup, dateTimeFormatter);
+    }
+
+    @Override
+    public Query distanceFeatureQuery(Object origin, String pivot, float boost, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return DateFieldType.handleNow(context, now -> {
+            long originLong = DateFieldType.parseToLong(
+                origin,
+                true,
+                null,
+                dateTimeFormatter.toDateMathParser(),
+                now,
+                DateFieldMapper.Resolution.MILLISECONDS
+            );
+            TimeValue pivotTime = TimeValue.parseTimeValue(pivot, "distance_feature.pivot");
+            return new LongScriptFieldDistanceFeatureQuery(
+                script,
+                leafFactory(context.lookup())::newInstance,
+                name(),
+                originLong,
+                pivotTime.getMillis(),
+                boost
+            );
+        });
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new LongScriptFieldExistsQuery(script, leafFactory(context.lookup())::newInstance, name());
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        @Nullable DateMathParser parser,
+        QueryShardContext context
+    ) {
+        parser = parser == null ? dateTimeFormatter.toDateMathParser() : parser;
+        checkAllowExpensiveQueries(context);
+        return DateFieldType.dateRangeQuery(
+            lowerTerm,
+            upperTerm,
+            includeLower,
+            includeUpper,
+            timeZone,
+            parser,
+            context,
+            DateFieldMapper.Resolution.MILLISECONDS,
+            (l, u) -> new LongScriptFieldRangeQuery(script, leafFactory(context.lookup())::newInstance, name(), l, u)
+        );
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        return DateFieldType.handleNow(context, now -> {
+            long l = DateFieldType.parseToLong(
+                value,
+                false,
+                null,
+                dateTimeFormatter.toDateMathParser(),
+                now,
+                DateFieldMapper.Resolution.MILLISECONDS
+            );
+            checkAllowExpensiveQueries(context);
+            return new LongScriptFieldTermQuery(script, leafFactory(context.lookup())::newInstance, name(), l);
+        });
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        if (values.isEmpty()) {
+            return Queries.newMatchAllQuery();
+        }
+        return DateFieldType.handleNow(context, now -> {
+            LongSet terms = new LongHashSet(values.size());
+            for (Object value : values) {
+                terms.add(
+                    DateFieldType.parseToLong(
+                        value,
+                        false,
+                        null,
+                        dateTimeFormatter.toDateMathParser(),
+                        now,
+                        DateFieldMapper.Resolution.MILLISECONDS
+                    )
+                );
+            }
+            checkAllowExpensiveQueries(context);
+            return new LongScriptFieldTermsQuery(script, leafFactory(context.lookup())::newInstance, name(), terms);
+        });
+    }
+
+    @Override
+    protected String format() {
+        return dateTimeFormatter.pattern();
+    }
+
+    @Override
+    protected Locale formatLocale() {
+        return dateTimeFormatter.locale();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldType.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptDoubleFieldData;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermsQuery;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ScriptDoubleMappedFieldType extends AbstractScriptMappedFieldType {
+    private final DoubleScriptFieldScript.Factory scriptFactory;
+
+    ScriptDoubleMappedFieldType(String name, Script script, DoubleScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+        super(name, script, meta);
+        this.scriptFactory = scriptFactory;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return NumberType.DOUBLE.typeName();
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        return value; // These should come back as a Double
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+        if (timeZone != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom time zones");
+        }
+        if (format == null) {
+            return DocValueFormat.RAW;
+        }
+        return new DocValueFormat.Decimal(format);
+    }
+
+    @Override
+    public ScriptDoubleFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new ScriptDoubleFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    }
+
+    private DoubleScriptFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+        return scriptFactory.newFactory(script.getParams(), searchLookup);
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new DoubleScriptFieldExistsQuery(script, leafFactory(context.lookup()), name());
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        checkAllowExpensiveQueries(context);
+        return NumberType.doubleRangeQuery(
+            lowerTerm,
+            upperTerm,
+            includeLower,
+            includeUpper,
+            (l, u) -> new DoubleScriptFieldRangeQuery(script, leafFactory(context.lookup()), name(), l, u)
+        );
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new DoubleScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), NumberType.objectToDouble(value));
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        if (values.isEmpty()) {
+            return Queries.newMatchAllQuery();
+        }
+        LongSet terms = new LongHashSet(values.size());
+        for (Object value : values) {
+            terms.add(Double.doubleToLongBits(NumberType.objectToDouble(value)));
+        }
+        checkAllowExpensiveQueries(context);
+        return new DoubleScriptFieldTermsQuery(script, leafFactory(context.lookup()), name(), terms);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldType.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptIpFieldData;
+import org.elasticsearch.xpack.runtimefields.query.IpScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.IpScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.IpScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.IpScriptFieldTermsQuery;
+
+import java.net.InetAddress;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public final class ScriptIpMappedFieldType extends AbstractScriptMappedFieldType {
+
+    private final Script script;
+    private final IpScriptFieldScript.Factory scriptFactory;
+
+    ScriptIpMappedFieldType(String name, Script script, IpScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+        super(name, script, meta);
+        this.script = script;
+        this.scriptFactory = scriptFactory;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return IpFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return DocValueFormat.IP.format((BytesRef) value);
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+        if (format != null) {
+            String message = "Field [%s] of type [%s] with runtime type [%s] does not support custom formats";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName(), runtimeType()));
+        }
+        if (timeZone != null) {
+            String message = "Field [%s] of type [%s] with runtime type [%s] does not support custom time zones";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName(), runtimeType()));
+        }
+        return DocValueFormat.IP;
+    }
+
+    @Override
+    public ScriptIpFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new ScriptIpFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    }
+
+    private IpScriptFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+        return scriptFactory.newFactory(script.getParams(), searchLookup);
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new IpScriptFieldExistsQuery(script, leafFactory(context.lookup()), name());
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        checkAllowExpensiveQueries(context);
+        return IpFieldMapper.IpFieldType.rangeQuery(
+            lowerTerm,
+            upperTerm,
+            includeLower,
+            includeUpper,
+            (lower, upper) -> new IpScriptFieldRangeQuery(
+                script,
+                leafFactory(context.lookup()),
+                name(),
+                new BytesRef(InetAddressPoint.encode(lower)),
+                new BytesRef(InetAddressPoint.encode(upper))
+            )
+        );
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        if (value instanceof InetAddress) {
+            return InetAddressPoint.newExactQuery(name(), (InetAddress) value);
+        }
+        String term = BytesRefs.toString(value);
+        if (term.contains("/")) {
+            return cidrQuery(term, context);
+        }
+        InetAddress address = InetAddresses.forString(term);
+        return new IpScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), new BytesRef(InetAddressPoint.encode(address)));
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        BytesRefHash terms = new BytesRefHash(values.size(), BigArrays.NON_RECYCLING_INSTANCE);
+        List<Query> cidrQueries = null;
+        for (Object value : values) {
+            if (value instanceof InetAddress) {
+                terms.add(new BytesRef(InetAddressPoint.encode((InetAddress) value)));
+                continue;
+            }
+            String term = BytesRefs.toString(value);
+            if (false == term.contains("/")) {
+                terms.add(new BytesRef(InetAddressPoint.encode(InetAddresses.forString(term))));
+                continue;
+            }
+            if (cidrQueries == null) {
+                cidrQueries = new ArrayList<>();
+            }
+            cidrQueries.add(cidrQuery(term, context));
+        }
+        Query termsQuery = new IpScriptFieldTermsQuery(script, leafFactory(context.lookup()), name(), terms);
+        if (cidrQueries == null) {
+            return termsQuery;
+        }
+        BooleanQuery.Builder bool = new BooleanQuery.Builder();
+        bool.add(termsQuery, Occur.SHOULD);
+        for (Query cidrQuery : cidrQueries) {
+            bool.add(cidrQuery, Occur.SHOULD);
+        }
+        return bool.build();
+    }
+
+    private Query cidrQuery(String term, QueryShardContext context) {
+        Tuple<InetAddress, Integer> cidr = InetAddresses.parseCidr(term);
+        InetAddress addr = cidr.v1();
+        int prefixLength = cidr.v2();
+        // create the lower value by zeroing out the host portion, upper value by filling it with all ones.
+        byte lower[] = addr.getAddress();
+        byte upper[] = addr.getAddress();
+        for (int i = prefixLength; i < 8 * lower.length; i++) {
+            int m = 1 << (7 - (i & 7));
+            lower[i >> 3] &= ~m;
+            upper[i >> 3] |= m;
+        }
+        // Force the terms into IPv6
+        BytesRef lowerBytes = new BytesRef(InetAddressPoint.encode(InetAddressPoint.decode(lower)));
+        BytesRef upperBytes = new BytesRef(InetAddressPoint.encode(InetAddressPoint.decode(upper)));
+        return new IpScriptFieldRangeQuery(script, leafFactory(context.lookup()), name(), lowerBytes, upperBytes);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldType.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptStringFieldData;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldFuzzyQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldPrefixQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldRegexpQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldTermsQuery;
+import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldWildcardQuery;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toSet;
+
+public final class ScriptKeywordMappedFieldType extends AbstractScriptMappedFieldType {
+
+    private final Script script;
+    private final StringScriptFieldScript.Factory scriptFactory;
+
+    ScriptKeywordMappedFieldType(String name, Script script, StringScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+        super(name, script, meta);
+        this.script = script;
+        this.scriptFactory = scriptFactory;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return KeywordFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        if (value == null) {
+            return null;
+        }
+        // keywords are internally stored as utf8 bytes
+        BytesRef binaryValue = (BytesRef) value;
+        return binaryValue.utf8ToString();
+    }
+
+    @Override
+    public ScriptStringFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new ScriptStringFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    }
+
+    private StringScriptFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+        return scriptFactory.newFactory(script.getParams(), searchLookup);
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldExistsQuery(script, leafFactory(context.lookup()), name());
+    }
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        QueryShardContext context
+    ) {
+        checkAllowExpensiveQueries(context);
+        return StringScriptFieldFuzzyQuery.build(
+            script,
+            leafFactory(context.lookup()),
+            name(),
+            BytesRefs.toString(Objects.requireNonNull(value)),
+            fuzziness.asDistance(BytesRefs.toString(value)),
+            prefixLength,
+            transpositions
+        );
+    }
+
+    @Override
+    public Query prefixQuery(String value, RewriteMethod method, org.elasticsearch.index.query.QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldPrefixQuery(script, leafFactory(context.lookup()), name(), value);
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldRangeQuery(
+            script,
+            leafFactory(context.lookup()),
+            name(),
+            BytesRefs.toString(Objects.requireNonNull(lowerTerm)),
+            BytesRefs.toString(Objects.requireNonNull(upperTerm)),
+            includeLower,
+            includeUpper
+        );
+    }
+
+    @Override
+    public Query regexpQuery(String value, int flags, int maxDeterminizedStates, RewriteMethod method, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldRegexpQuery(script, leafFactory(context.lookup()), name(), value, flags, maxDeterminizedStates);
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldTermQuery(
+            script,
+            leafFactory(context.lookup()),
+            name(),
+            BytesRefs.toString(Objects.requireNonNull(value))
+        );
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        Set<String> terms = values.stream().map(v -> BytesRefs.toString(Objects.requireNonNull(v))).collect(toSet());
+        return new StringScriptFieldTermsQuery(script, leafFactory(context.lookup()), name(), terms);
+    }
+
+    @Override
+    public Query wildcardQuery(String value, RewriteMethod method, QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldWildcardQuery(script, leafFactory(context.lookup()), name(), value);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldType.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptLongFieldData;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ScriptLongMappedFieldType extends AbstractScriptMappedFieldType {
+    private final LongScriptFieldScript.Factory scriptFactory;
+
+    ScriptLongMappedFieldType(String name, Script script, LongScriptFieldScript.Factory scriptFactory, Map<String, String> meta) {
+        super(name, script, meta);
+        this.scriptFactory = scriptFactory;
+    }
+
+    @Override
+    protected String runtimeType() {
+        return NumberType.LONG.typeName();
+    }
+
+    @Override
+    public Object valueForDisplay(Object value) {
+        return value; // These should come back as a Long
+    }
+
+    @Override
+    public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+        if (timeZone != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom time zones");
+        }
+        if (format == null) {
+            return DocValueFormat.RAW;
+        }
+        return new DocValueFormat.Decimal(format);
+    }
+
+    @Override
+    public ScriptLongFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new ScriptLongFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    }
+
+    private LongScriptFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+        return scriptFactory.newFactory(script.getParams(), searchLookup);
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        checkAllowExpensiveQueries(context);
+        return new LongScriptFieldExistsQuery(script, leafFactory(context.lookup())::newInstance, name());
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        checkAllowExpensiveQueries(context);
+        return NumberType.longRangeQuery(
+            lowerTerm,
+            upperTerm,
+            includeLower,
+            includeUpper,
+            (l, u) -> new LongScriptFieldRangeQuery(script, leafFactory(context.lookup())::newInstance, name(), l, u)
+        );
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        if (NumberType.hasDecimalPart(value)) {
+            return Queries.newMatchNoDocsQuery("Value [" + value + "] has a decimal part");
+        }
+        checkAllowExpensiveQueries(context);
+        return new LongScriptFieldTermQuery(
+            script,
+            leafFactory(context.lookup())::newInstance,
+            name(),
+            NumberType.objectToLong(value, true)
+        );
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, QueryShardContext context) {
+        if (values.isEmpty()) {
+            return Queries.newMatchAllQuery();
+        }
+        LongSet terms = new LongHashSet(values.size());
+        for (Object value : values) {
+            if (NumberType.hasDecimalPart(value)) {
+                continue;
+            }
+            terms.add(NumberType.objectToLong(value, true));
+        }
+        if (terms.isEmpty()) {
+            return Queries.newMatchNoDocsQuery("All values have a decimal part");
+        }
+        checkAllowExpensiveQueries(context);
+        return new LongScriptFieldTermsQuery(script, leafFactory(context.lookup())::newInstance, name(), terms);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQuery.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on {@link DoubleScriptFieldScript}.
+ */
+abstract class AbstractBooleanScriptFieldQuery extends AbstractScriptFieldQuery {
+    private final BooleanScriptFieldScript.LeafFactory leafFactory;
+
+    AbstractBooleanScriptFieldQuery(Script script, BooleanScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, fieldName);
+        this.leafFactory = Objects.requireNonNull(leafFactory);
+    }
+
+    /**
+     * Does the value match this query?
+     * @param trues the number of true values returned by the script
+     * @param falses the number of false values returned by the script
+     */
+    protected abstract boolean matches(int trues, int falses);
+
+    @Override
+    public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false; // scripts aren't really cacheable at this point
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext ctx) throws IOException {
+                BooleanScriptFieldScript script = leafFactory.newInstance(ctx);
+                DocIdSetIterator approximation = DocIdSetIterator.all(ctx.reader().maxDoc());
+                TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
+                    @Override
+                    public boolean matches() throws IOException {
+                        script.runForDoc(approximation().docID());
+                        return AbstractBooleanScriptFieldQuery.this.matches(script.trues(), script.falses());
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return MATCH_COST;
+                    }
+                };
+                return new ConstantScoreScorer(this, score(), scoreMode, twoPhase);
+            }
+        };
+    }
+
+    @Override
+    public final void visit(QueryVisitor visitor) {
+        // No subclasses contain any Terms because those have to be strings.
+        if (visitor.acceptField(fieldName())) {
+            visitor.visitLeaf(this);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQuery.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on {@link DoubleScriptFieldScript}.
+ */
+abstract class AbstractDoubleScriptFieldQuery extends AbstractScriptFieldQuery {
+    private final DoubleScriptFieldScript.LeafFactory leafFactory;
+
+    AbstractDoubleScriptFieldQuery(Script script, DoubleScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, fieldName);
+        this.leafFactory = Objects.requireNonNull(leafFactory);
+    }
+
+    /**
+     * Does the value match this query?
+     */
+    protected abstract boolean matches(double[] values, int count);
+
+    @Override
+    public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false; // scripts aren't really cacheable at this point
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext ctx) throws IOException {
+                DoubleScriptFieldScript script = leafFactory.newInstance(ctx);
+                DocIdSetIterator approximation = DocIdSetIterator.all(ctx.reader().maxDoc());
+                TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
+                    @Override
+                    public boolean matches() throws IOException {
+                        script.runForDoc(approximation().docID());
+                        return AbstractDoubleScriptFieldQuery.this.matches(script.values(), script.count());
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return MATCH_COST;
+                    }
+                };
+                return new ConstantScoreScorer(this, score(), scoreMode, twoPhase);
+            }
+        };
+    }
+
+    @Override
+    public final void visit(QueryVisitor visitor) {
+        // No subclasses contain any Terms because those have to be strings.
+        if (visitor.acceptField(fieldName())) {
+            visitor.visitLeaf(this);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractIpScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractIpScriptFieldQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on {@link StringScriptFieldScript}.
+ */
+abstract class AbstractIpScriptFieldQuery extends AbstractScriptFieldQuery {
+    private final IpScriptFieldScript.LeafFactory leafFactory;
+
+    AbstractIpScriptFieldQuery(Script script, IpScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, fieldName);
+        this.leafFactory = Objects.requireNonNull(leafFactory);
+    }
+
+    /**
+     * Does the value match this query?
+     */
+    protected abstract boolean matches(BytesRef[] values, int conut);
+
+    @Override
+    public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false; // scripts aren't really cacheable at this point
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext ctx) throws IOException {
+                IpScriptFieldScript script = leafFactory.newInstance(ctx);
+                DocIdSetIterator approximation = DocIdSetIterator.all(ctx.reader().maxDoc());
+                TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
+                    @Override
+                    public boolean matches() throws IOException {
+                        script.runForDoc(approximation().docID());
+                        return AbstractIpScriptFieldQuery.this.matches(script.values(), script.count());
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return MATCH_COST;
+                    }
+                };
+                return new ConstantScoreScorer(this, score(), scoreMode, twoPhase);
+            }
+        };
+    }
+
+    protected static InetAddress decode(BytesRef ref) {
+        return InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(ref)));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQuery.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on {@link AbstractLongScriptFieldScript}.
+ */
+abstract class AbstractLongScriptFieldQuery extends AbstractScriptFieldQuery {
+    private final CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory;
+
+    AbstractLongScriptFieldQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName
+    ) {
+        super(script, fieldName);
+        this.leafFactory = Objects.requireNonNull(leafFactory);
+    }
+
+    /**
+     * Does the value match this query?
+     */
+    protected abstract boolean matches(long[] values, int count);
+
+    @Override
+    public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false; // scripts aren't really cacheable at this point
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext ctx) throws IOException {
+                AbstractLongScriptFieldScript script = leafFactory.apply(ctx);
+                DocIdSetIterator approximation = DocIdSetIterator.all(ctx.reader().maxDoc());
+                TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
+                    @Override
+                    public boolean matches() throws IOException {
+                        script.runForDoc(approximation().docID());
+                        return AbstractLongScriptFieldQuery.this.matches(script.values(), script.count());
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return MATCH_COST;
+                    }
+                };
+                return new ConstantScoreScorer(this, score(), scoreMode, twoPhase);
+            }
+        };
+    }
+
+    @Override
+    public final void visit(QueryVisitor visitor) {
+        // No subclasses contain any Terms because those have to be strings.
+        if (visitor.acceptField(fieldName())) {
+            visitor.visitLeaf(this);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.script.Script;
+
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on script fields.
+ */
+abstract class AbstractScriptFieldQuery extends Query {
+    /**
+     * We don't have the infrastructure to estimate the match cost of a script
+     * so we just use a big number.
+     */
+    protected static final float MATCH_COST = 9000f;
+
+    private final Script script;
+    private final String fieldName;
+
+    AbstractScriptFieldQuery(Script script, String fieldName) {
+        this.script = Objects.requireNonNull(script);
+        this.fieldName = Objects.requireNonNull(fieldName);
+    }
+
+    final Script script() {
+        return script;
+    }
+
+    final String fieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass(), script, fieldName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        AbstractScriptFieldQuery other = (AbstractScriptFieldQuery) obj;
+        return script.equals(other.script) && fieldName.equals(other.fieldName);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldAutomatonQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldAutomatonQuery.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+
+public abstract class AbstractStringScriptFieldAutomatonQuery extends AbstractStringScriptFieldQuery {
+    private final BytesRefBuilder scratch = new BytesRefBuilder();
+    private final ByteRunAutomaton automaton;
+
+    public AbstractStringScriptFieldAutomatonQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        ByteRunAutomaton automaton
+    ) {
+        super(script, leafFactory, fieldName);
+        this.automaton = automaton;
+    }
+
+    @Override
+    protected final boolean matches(List<String> values) {
+        for (String value : values) {
+            scratch.copyChars(value);
+            if (automaton.run(scratch.bytes(), 0, scratch.length())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.consumeTermsMatching(this, fieldName(), () -> automaton);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Abstract base class for building queries based on {@link StringScriptFieldScript}.
+ */
+abstract class AbstractStringScriptFieldQuery extends AbstractScriptFieldQuery {
+    private final StringScriptFieldScript.LeafFactory leafFactory;
+
+    AbstractStringScriptFieldQuery(Script script, StringScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, fieldName);
+        this.leafFactory = Objects.requireNonNull(leafFactory);
+    }
+
+    /**
+     * Does the value match this query?
+     */
+    protected abstract boolean matches(List<String> values);
+
+    @Override
+    public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false; // scripts aren't really cacheable at this point
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext ctx) throws IOException {
+                StringScriptFieldScript script = leafFactory.newInstance(ctx);
+                DocIdSetIterator approximation = DocIdSetIterator.all(ctx.reader().maxDoc());
+                TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
+                    @Override
+                    public boolean matches() throws IOException {
+                        return AbstractStringScriptFieldQuery.this.matches(script.resultsForDoc(approximation().docID()));
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return MATCH_COST;
+                    }
+                };
+                return new ConstantScoreScorer(this, score(), scoreMode, twoPhase);
+            }
+        };
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQuery.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+
+public class BooleanScriptFieldExistsQuery extends AbstractBooleanScriptFieldQuery {
+    public BooleanScriptFieldExistsQuery(Script script, BooleanScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, leafFactory, fieldName);
+    }
+
+    @Override
+    protected boolean matches(int trues, int falses) {
+        return (trues | falses) != 0;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return getClass().getSimpleName();
+        }
+        return fieldName() + ":" + getClass().getSimpleName();
+    }
+
+    // Superclass's equals and hashCode are great for this class
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+
+import java.util.Objects;
+
+public class BooleanScriptFieldTermQuery extends AbstractBooleanScriptFieldQuery {
+    private final boolean term;
+
+    public BooleanScriptFieldTermQuery(Script script, BooleanScriptFieldScript.LeafFactory leafFactory, String fieldName, boolean term) {
+        super(script, leafFactory, fieldName);
+        this.term = term;
+    }
+
+    @Override
+    protected boolean matches(int trues, int falses) {
+        if (term) {
+            return trues > 0;
+        }
+        return falses > 0;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return Boolean.toString(term);
+        }
+        return fieldName() + ":" + term;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), term);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        BooleanScriptFieldTermQuery other = (BooleanScriptFieldTermQuery) obj;
+        return term == other.term;
+    }
+
+    boolean term() {
+        return term;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQuery.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+public class DoubleScriptFieldExistsQuery extends AbstractDoubleScriptFieldQuery {
+    public DoubleScriptFieldExistsQuery(Script script, DoubleScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, leafFactory, fieldName);
+    }
+
+    @Override
+    protected boolean matches(double[] values, int count) {
+        return count > 0;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return getClass().getSimpleName();
+        }
+        return fieldName() + ":" + getClass().getSimpleName();
+    }
+
+    // Superclass's equals and hashCode are great for this class
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.util.Objects;
+
+public class DoubleScriptFieldRangeQuery extends AbstractDoubleScriptFieldQuery {
+    private final double lowerValue;
+    private final double upperValue;
+
+    public DoubleScriptFieldRangeQuery(
+        Script script,
+        DoubleScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        double lowerValue,
+        double upperValue
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lowerValue = lowerValue;
+        this.upperValue = upperValue;
+        assert lowerValue <= upperValue;
+    }
+
+    @Override
+    protected boolean matches(double[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (lowerValue <= values[i] && values[i] <= upperValue) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append('[').append(lowerValue).append(" TO ").append(upperValue).append(']');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lowerValue, upperValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        DoubleScriptFieldRangeQuery other = (DoubleScriptFieldRangeQuery) obj;
+        return lowerValue == other.lowerValue && upperValue == other.upperValue;
+    }
+
+    double lowerValue() {
+        return lowerValue;
+    }
+
+    double upperValue() {
+        return upperValue;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.util.Objects;
+
+public class DoubleScriptFieldTermQuery extends AbstractDoubleScriptFieldQuery {
+    private final double term;
+
+    public DoubleScriptFieldTermQuery(Script script, DoubleScriptFieldScript.LeafFactory leafFactory, String fieldName, double term) {
+        super(script, leafFactory, fieldName);
+        this.term = term;
+    }
+
+    @Override
+    protected boolean matches(double[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (term == values[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return Double.toString(term);
+        }
+        return fieldName() + ":" + term;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), term);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        DoubleScriptFieldTermQuery other = (DoubleScriptFieldTermQuery) obj;
+        return term == other.term;
+    }
+
+    double term() {
+        return term;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQuery.java
@@ -1,0 +1,73 @@
+/*
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongSet;
+import com.carrotsearch.hppc.cursors.LongCursor;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class DoubleScriptFieldTermsQuery extends AbstractDoubleScriptFieldQuery {
+    private final LongSet terms;
+
+    /**
+     * Build the query.
+     * @param terms The terms converted to a long with {@link Double#doubleToLongBits(double)}.
+     */
+    public DoubleScriptFieldTermsQuery(Script script, DoubleScriptFieldScript.LeafFactory leafFactory, String fieldName, LongSet terms) {
+        super(script, leafFactory, fieldName);
+        this.terms = terms;
+    }
+
+    @Override
+    protected boolean matches(double[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (terms.contains(Double.doubleToLongBits(values[i]))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        double[] termsArray = terms();
+        Arrays.sort(termsArray);
+        if (fieldName().equals(field)) {
+            return Arrays.toString(termsArray);
+        }
+        return fieldName() + ":" + Arrays.toString(termsArray);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), terms);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        DoubleScriptFieldTermsQuery other = (DoubleScriptFieldTermsQuery) obj;
+        return terms.equals(other.terms);
+    }
+
+    double[] terms() {
+        double[] result = new double[terms.size()];
+        int i = 0;
+        for (LongCursor lc : terms) {
+            result[i++] = Double.longBitsToDouble(lc.value);
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldExistsQuery.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+public class IpScriptFieldExistsQuery extends AbstractIpScriptFieldQuery {
+    public IpScriptFieldExistsQuery(Script script, IpScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, leafFactory, fieldName);
+    }
+
+    @Override
+    protected boolean matches(BytesRef[] values, int count) {
+        return count > 0;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return getClass().getSimpleName();
+        }
+        return fieldName() + ":" + getClass().getSimpleName();
+    }
+
+    // Superclass's equals and hashCode are great for this class
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldRangeQuery.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.net.InetAddress;
+import java.util.Objects;
+
+public class IpScriptFieldRangeQuery extends AbstractIpScriptFieldQuery {
+    private final BytesRef lower;
+    private final BytesRef upper;
+
+    public IpScriptFieldRangeQuery(
+        Script script,
+        IpScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        BytesRef lower,
+        BytesRef upper
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lower = lower;
+        this.upper = upper;
+        assert this.lower.compareTo(this.upper) <= 0;
+    }
+
+    @Override
+    protected boolean matches(BytesRef[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (lower.compareTo(values[i]) <= 0 && upper.compareTo(values[i]) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append('[')
+            .append(InetAddresses.toAddrString(lowerAddress()))
+            .append(" TO ")
+            .append(InetAddresses.toAddrString(upperAddress()))
+            .append(']');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lower, upper);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        IpScriptFieldRangeQuery other = (IpScriptFieldRangeQuery) obj;
+        return lower.bytesEquals(other.lower) && upper.bytesEquals(other.upper);
+    }
+
+    InetAddress lowerAddress() {
+        return decode(lower);
+    }
+
+    InetAddress upperAddress() {
+        return decode(upper);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermQuery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.net.InetAddress;
+import java.util.Objects;
+
+public class IpScriptFieldTermQuery extends AbstractIpScriptFieldQuery {
+    private final BytesRef term;
+
+    public IpScriptFieldTermQuery(Script script, IpScriptFieldScript.LeafFactory leafFactory, String fieldName, BytesRef term) {
+        super(script, leafFactory, fieldName);
+        this.term = term;
+    }
+
+    @Override
+    protected boolean matches(BytesRef[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (term.bytesEquals(values[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return InetAddresses.toAddrString(address());
+        }
+        return fieldName() + ":" + InetAddresses.toAddrString(address());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), term);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        IpScriptFieldTermQuery other = (IpScriptFieldTermQuery) obj;
+        return term.bytesEquals(other.term);
+    }
+
+    InetAddress address() {
+        return decode(term);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermsQuery.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.util.Objects;
+
+public class IpScriptFieldTermsQuery extends AbstractIpScriptFieldQuery {
+    private final BytesRefHash terms;
+
+    public IpScriptFieldTermsQuery(Script script, IpScriptFieldScript.LeafFactory leafFactory, String fieldName, BytesRefHash terms) {
+        super(script, leafFactory, fieldName);
+        this.terms = terms;
+    }
+
+    @Override
+    protected boolean matches(BytesRef[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (terms.find(values[i]) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(":");
+        }
+        b.append("[");
+        BytesRef spare = new BytesRef();
+        long i = 0;
+        while (i < terms.size() && b.length() < 5000) {
+            if (i != 0) {
+                b.append(", ");
+            }
+            b.append(InetAddresses.toAddrString(decode(terms.get(i++, spare))));
+        }
+        if (i < terms.size()) {
+            b.append("...");
+        }
+        return b.append("]").toString();
+    }
+
+    @Override
+    public int hashCode() {
+        long hash = 0;
+        BytesRef spare = new BytesRef();
+        for (long i = 0; i < terms.size(); i++) {
+            hash = 31 * hash + terms.get(i, spare).hashCode();
+        }
+        return Objects.hash(super.hashCode(), hash);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        IpScriptFieldTermsQuery other = (IpScriptFieldTermsQuery) obj;
+        if (terms.size() != other.terms.size()) {
+            return false;
+        }
+        BytesRef mySpare = new BytesRef();
+        BytesRef otherSpare = new BytesRef();
+        for (long i = 0; i < terms.size(); i++) {
+            terms.get(i, mySpare);
+            other.terms.get(i, otherSpare);
+            if (false == mySpare.bytesEquals(otherSpare)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    BytesRefHash terms() {
+        return terms;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQuery.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+
+public final class LongScriptFieldDistanceFeatureQuery extends AbstractScriptFieldQuery {
+    private final CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory;
+    private final long origin;
+    private final long pivot;
+    private final float boost;
+
+    public LongScriptFieldDistanceFeatureQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName,
+        long origin,
+        long pivot,
+        float boost
+    ) {
+        super(script, fieldName);
+        this.leafFactory = leafFactory;
+        this.origin = origin;
+        this.pivot = pivot;
+        this.boost = boost;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new Weight(this) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+
+            @Override
+            public void extractTerms(Set<Term> terms) {}
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                return new DistanceScorer(this, leafFactory.apply(context), context.reader().maxDoc(), boost);
+            }
+
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                AbstractLongScriptFieldScript script = leafFactory.apply(context);
+                script.runForDoc(doc);
+                long value = valueWithMinAbsoluteDistance(script);
+                float weight = LongScriptFieldDistanceFeatureQuery.this.boost * boost;
+                float score = score(weight, distanceFor(value));
+                return Explanation.match(
+                    score,
+                    "Distance score, computed as weight * pivot / (pivot + abs(value - origin)) from:",
+                    Explanation.match(weight, "weight"),
+                    Explanation.match(pivot, "pivot"),
+                    Explanation.match(origin, "origin"),
+                    Explanation.match(value, "current value")
+                );
+            }
+        };
+    }
+
+    private class DistanceScorer extends Scorer {
+        private final AbstractLongScriptFieldScript script;
+        private final TwoPhaseIterator twoPhase;
+        private final DocIdSetIterator disi;
+        private final float weight;
+
+        protected DistanceScorer(Weight weight, AbstractLongScriptFieldScript script, int maxDoc, float boost) {
+            super(weight);
+            this.script = script;
+            twoPhase = new TwoPhaseIterator(DocIdSetIterator.all(maxDoc)) {
+                @Override
+                public boolean matches() throws IOException {
+                    script.runForDoc(approximation().docID());
+                    return script.count() > 0;
+                }
+
+                @Override
+                public float matchCost() {
+                    return MATCH_COST;
+                }
+            };
+            disi = TwoPhaseIterator.asDocIdSetIterator(twoPhase);
+            this.weight = LongScriptFieldDistanceFeatureQuery.this.boost * boost;
+        }
+
+        @Override
+        public int docID() {
+            return disi.docID();
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return disi;
+        }
+
+        @Override
+        public TwoPhaseIterator twoPhaseIterator() {
+            return twoPhase;
+        }
+
+        @Override
+        public float getMaxScore(int upTo) throws IOException {
+            return weight;
+        }
+
+        @Override
+        public float score() throws IOException {
+            if (script.count() == 0) {
+                return 0;
+            }
+            return LongScriptFieldDistanceFeatureQuery.this.score(weight, (double) minAbsoluteDistance(script));
+        }
+    }
+
+    long minAbsoluteDistance(AbstractLongScriptFieldScript script) {
+        long minDistance = Long.MAX_VALUE;
+        for (int i = 0; i < script.count(); i++) {
+            minDistance = Math.min(minDistance, distanceFor(script.values()[i]));
+        }
+        return minDistance;
+    }
+
+    long valueWithMinAbsoluteDistance(AbstractLongScriptFieldScript script) {
+        long minDistance = Long.MAX_VALUE;
+        long minDistanceValue = Long.MAX_VALUE;
+        for (int i = 0; i < script.count(); i++) {
+            long distance = distanceFor(script.values()[i]);
+            if (distance < minDistance) {
+                minDistance = distance;
+                minDistanceValue = script.values()[i];
+            }
+        }
+        return minDistanceValue;
+    }
+
+    long distanceFor(long value) {
+        long distance = Math.max(value, origin) - Math.min(value, origin);
+        if (distance < 0) {
+            // The distance doesn't fit into signed long so clamp it to MAX_VALUE
+            return Long.MAX_VALUE;
+        }
+        return distance;
+    }
+
+    float score(float weight, double distance) {
+        return (float) (weight * (pivot / (pivot + distance)));
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().equals(field)) {
+            b.append(fieldName()).append(":");
+        }
+        b.append(getClass().getSimpleName());
+        b.append("(origin=").append(origin);
+        b.append(",pivot=").append(pivot);
+        b.append(",boost=").append(boost).append(")");
+        return b.toString();
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), origin, pivot, boost);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldDistanceFeatureQuery other = (LongScriptFieldDistanceFeatureQuery) obj;
+        return origin == other.origin && pivot == other.pivot && boost == other.boost;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        // No subclasses contain any Terms because those have to be strings.
+        if (visitor.acceptField(fieldName())) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    long origin() {
+        return origin;
+    }
+
+    long pivot() {
+        return pivot;
+    }
+
+    float boost() {
+        return boost;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQuery.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+
+public class LongScriptFieldExistsQuery extends AbstractLongScriptFieldQuery {
+    public LongScriptFieldExistsQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName
+    ) {
+        super(script, leafFactory, fieldName);
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        return count > 0;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return getClass().getSimpleName();
+        }
+        return fieldName() + ":" + getClass().getSimpleName();
+    }
+
+    // Superclass's equals and hashCode are great for this class
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class LongScriptFieldRangeQuery extends AbstractLongScriptFieldQuery {
+    private final long lowerValue;
+    private final long upperValue;
+
+    public LongScriptFieldRangeQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName,
+        long lowerValue,
+        long upperValue
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lowerValue = lowerValue;
+        this.upperValue = upperValue;
+        assert lowerValue <= upperValue;
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (lowerValue <= values[i] && values[i] <= upperValue) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append('[').append(lowerValue).append(" TO ").append(upperValue).append(']');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lowerValue, upperValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldRangeQuery other = (LongScriptFieldRangeQuery) obj;
+        return lowerValue == other.lowerValue && upperValue == other.upperValue;
+    }
+
+    long lowerValue() {
+        return lowerValue;
+    }
+
+    long upperValue() {
+        return upperValue;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQuery.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class LongScriptFieldTermQuery extends AbstractLongScriptFieldQuery {
+    private final long term;
+
+    public LongScriptFieldTermQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName,
+        long term
+    ) {
+        super(script, leafFactory, fieldName);
+        this.term = term;
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (term == values[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return Long.toString(term);
+        }
+        return fieldName() + ":" + term;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), term);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldTermQuery other = (LongScriptFieldTermQuery) obj;
+        return term == other.term;
+    }
+
+    long term() {
+        return term;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongSet;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class LongScriptFieldTermsQuery extends AbstractLongScriptFieldQuery {
+    private final LongSet terms;
+
+    public LongScriptFieldTermsQuery(
+        Script script,
+        CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory,
+        String fieldName,
+        LongSet terms
+    ) {
+        super(script, leafFactory, fieldName);
+        this.terms = terms;
+    }
+
+    @Override
+    protected boolean matches(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            if (terms.contains(values[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return terms.toString();
+        }
+        return fieldName() + ":" + terms;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), terms);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        LongScriptFieldTermsQuery other = (LongScriptFieldTermsQuery) obj;
+        return terms.equals(other.terms);
+    }
+
+    LongSet terms() {
+        return terms;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQuery.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+
+public class StringScriptFieldExistsQuery extends AbstractStringScriptFieldQuery {
+    public StringScriptFieldExistsQuery(Script script, StringScriptFieldScript.LeafFactory leafFactory, String fieldName) {
+        super(script, leafFactory, fieldName);
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        return false == values.isEmpty();
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return getClass().getSimpleName();
+        }
+        return fieldName() + ":" + getClass().getSimpleName();
+    }
+
+    // Superclass's equals and hashCode are great for this class
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldFuzzyQuery extends AbstractStringScriptFieldAutomatonQuery {
+    public static StringScriptFieldFuzzyQuery build(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String term,
+        int maxEdits,
+        int prefixLength,
+        boolean transpositions
+    ) {
+        int maxExpansions = 1; // We don't actually expand anything so the value here doesn't matter
+        FuzzyQuery delegate = new FuzzyQuery(new Term(fieldName, term), maxEdits, prefixLength, maxExpansions, transpositions);
+        ByteRunAutomaton automaton = delegate.getAutomata().runAutomaton;
+        return new StringScriptFieldFuzzyQuery(script, leafFactory, fieldName, automaton, delegate);
+    }
+
+    private final FuzzyQuery delegate;
+
+    private StringScriptFieldFuzzyQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        ByteRunAutomaton automaton,
+        FuzzyQuery delegate
+    ) {
+        super(script, leafFactory, fieldName, automaton);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public final String toString(String field) {
+        return delegate.toString(field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), delegate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldFuzzyQuery other = (StringScriptFieldFuzzyQuery) obj;
+        return delegate.equals(other.delegate);
+    }
+
+    FuzzyQuery delegate() {
+        return delegate;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Objects;
+
+public class StringScriptFieldPrefixQuery extends AbstractStringScriptFieldQuery {
+    private final String prefix;
+
+    public StringScriptFieldPrefixQuery(Script script, StringScriptFieldScript.LeafFactory leafFactory, String fieldName, String prefix) {
+        super(script, leafFactory, fieldName);
+        this.prefix = Objects.requireNonNull(prefix);
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        for (String value : values) {
+            if (value != null && value.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.consumeTermsMatching(this, fieldName(), () -> new ByteRunAutomaton(PrefixQuery.toAutomaton(new BytesRef(prefix))));
+        }
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return prefix + "*";
+        }
+        return fieldName() + ":" + prefix + "*";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), prefix);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldPrefixQuery other = (StringScriptFieldPrefixQuery) obj;
+        return prefix.equals(other.prefix);
+    }
+
+    String prefix() {
+        return prefix;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQuery.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Objects;
+
+public class StringScriptFieldRangeQuery extends AbstractStringScriptFieldQuery {
+    private final String lowerValue;
+    private final String upperValue;
+    private final boolean includeLower;
+    private final boolean includeUpper;
+
+    public StringScriptFieldRangeQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String lowerValue,
+        String upperValue,
+        boolean includeLower,
+        boolean includeUpper
+    ) {
+        super(script, leafFactory, fieldName);
+        this.lowerValue = Objects.requireNonNull(lowerValue);
+        this.upperValue = Objects.requireNonNull(upperValue);
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
+        assert lowerValue.compareTo(upperValue) <= 0;
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        for (String value : values) {
+            int lct = lowerValue.compareTo(value);
+            boolean lowerOk = includeLower ? lct <= 0 : lct < 0;
+            if (lowerOk) {
+                int uct = upperValue.compareTo(value);
+                boolean upperOk = includeUpper ? uct >= 0 : uct > 0;
+                if (upperOk) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.consumeTermsMatching(
+                this,
+                fieldName(),
+                () -> new ByteRunAutomaton(
+                    Automata.makeBinaryInterval(new BytesRef(lowerValue), includeLower, new BytesRef(upperValue), includeUpper)
+                )
+            );
+        }
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        b.append(includeLower ? '[' : '{');
+        b.append(lowerValue).append(" TO ").append(upperValue);
+        b.append(includeUpper ? ']' : '}');
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lowerValue, upperValue, includeLower, includeUpper);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldRangeQuery other = (StringScriptFieldRangeQuery) obj;
+        return lowerValue.equals(other.lowerValue)
+            && upperValue.equals(other.upperValue)
+            && includeLower == other.includeLower
+            && includeUpper == other.includeUpper;
+    }
+
+    String lowerValue() {
+        return lowerValue;
+    }
+
+    String upperValue() {
+        return upperValue;
+    }
+
+    boolean includeLower() {
+        return includeLower;
+    }
+
+    boolean includeUpper() {
+        return includeUpper;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutomatonQuery {
+    private final String pattern;
+    private final int flags;
+
+    public StringScriptFieldRegexpQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String pattern,
+        int flags,
+        int maxDeterminizedStates
+    ) {
+        super(
+            script,
+            leafFactory,
+            fieldName,
+            new ByteRunAutomaton(new RegExp(Objects.requireNonNull(pattern), flags).toAutomaton(maxDeterminizedStates))
+        );
+        this.pattern = pattern;
+        this.flags = flags;
+    }
+
+    @Override
+    public final String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().contentEquals(field)) {
+            b.append(fieldName()).append(':');
+        }
+        return b.append('/').append(pattern).append('/').toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pattern, flags);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldRegexpQuery other = (StringScriptFieldRegexpQuery) obj;
+        return pattern.equals(other.pattern) && flags == other.flags;
+    }
+
+    String pattern() {
+        return pattern;
+    }
+
+    int flags() {
+        return flags;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQuery.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.QueryVisitor;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Objects;
+
+public class StringScriptFieldTermQuery extends AbstractStringScriptFieldQuery {
+    private final String term;
+
+    public StringScriptFieldTermQuery(Script script, StringScriptFieldScript.LeafFactory leafFactory, String fieldName, String term) {
+        super(script, leafFactory, fieldName);
+        this.term = Objects.requireNonNull(term);
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        for (String value : values) {
+            if (term.equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        visitor.consumeTerms(this, new Term(fieldName(), term));
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return term;
+        }
+        return fieldName() + ":" + term;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), term);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldTermQuery other = (StringScriptFieldTermQuery) obj;
+        return term.equals(other.term);
+    }
+
+    String term() {
+        return term;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.QueryVisitor;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class StringScriptFieldTermsQuery extends AbstractStringScriptFieldQuery {
+    private final Set<String> terms;
+
+    public StringScriptFieldTermsQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        Set<String> terms
+    ) {
+        super(script, leafFactory, fieldName);
+        this.terms = terms;
+    }
+
+    @Override
+    protected boolean matches(List<String> values) {
+        for (String value : values) {
+            if (terms.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            for (String term : terms) {
+                visitor.consumeTerms(this, new Term(fieldName(), term));
+            }
+        }
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().contentEquals(field)) {
+            return terms.toString();
+        }
+        return fieldName() + ":" + terms;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), terms);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldTermsQuery other = (StringScriptFieldTermsQuery) obj;
+        return terms.equals(other.terms);
+    }
+
+    Set<String> terms() {
+        return terms;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQuery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.Objects;
+
+public class StringScriptFieldWildcardQuery extends AbstractStringScriptFieldAutomatonQuery {
+    private final String pattern;
+
+    public StringScriptFieldWildcardQuery(
+        Script script,
+        StringScriptFieldScript.LeafFactory leafFactory,
+        String fieldName,
+        String pattern
+    ) {
+        super(
+            script,
+            leafFactory,
+            fieldName,
+            new ByteRunAutomaton(WildcardQuery.toAutomaton(new Term(fieldName, Objects.requireNonNull(pattern))))
+        );
+        this.pattern = pattern;
+    }
+
+    @Override
+    public final String toString(String field) {
+        if (fieldName().equals(field)) {
+            return pattern;
+        }
+        return fieldName() + ":" + pattern;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pattern);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        StringScriptFieldWildcardQuery other = (StringScriptFieldWildcardQuery) obj;
+        return pattern.equals(other.pattern);
+    }
+
+    String pattern() {
+        return pattern;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
+++ b/x-pack/plugin/runtime-fields/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
@@ -1,0 +1,1 @@
+org.elasticsearch.xpack.runtimefields.RuntimeFieldsPainlessExtension

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/boolean_whitelist.txt
@@ -1,0 +1,21 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for boolean-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript, boolean) bound_to org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript$EmitValue
+    # Parse a value from the source to a boolean
+    boolean parse(def) from_class org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript
+}
+

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/date_whitelist.txt
@@ -1,0 +1,25 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for date-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$EmitValue
+    # Parse a value from the source to millis since epoch
+    long parse(org.elasticsearch.xpack.runtimefields.DateScriptFieldScript, def) bound_to org.elasticsearch.xpack.runtimefields.DateScriptFieldScript$Parse
+    # Add an easy method to convert temporalAccessors to millis since epoch.
+    long toEpochMilli(java.time.temporal.TemporalAccessor) from_class org.elasticsearch.xpack.runtimefields.DateScriptFieldScript
+}
+
+
+

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/double_whitelist.txt
@@ -1,0 +1,19 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for double-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript, double) bound_to org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript$EmitValue
+}
+

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/ip_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/ip_whitelist.txt
@@ -1,0 +1,18 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for ip-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.IpScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.IpScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.IpScriptFieldScript$EmitValue
+}

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/long_whitelist.txt
@@ -1,0 +1,18 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for long-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.LongScriptFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.LongScriptFieldScript$EmitValue
+}

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/string_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/string_whitelist.txt
@@ -1,0 +1,18 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# The whitelist for string-valued runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.xpack.runtimefields.StringScriptFieldScript @no_import {
+}
+class org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emitValue` callback to collect values for the field
+    void emitValue(org.elasticsearch.xpack.runtimefields.StringScriptFieldScript, String) bound_to org.elasticsearch.xpack.runtimefields.StringScriptFieldScript$EmitValue
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/BooleanScriptFieldScriptTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class BooleanScriptFieldScriptTests extends ScriptFieldScriptTestCase<BooleanScriptFieldScript.Factory> {
+    public static final BooleanScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new BooleanScriptFieldScript(
+        params,
+        lookup,
+        ctx
+    ) {
+        @Override
+        public void execute() {
+            emitValue(false);
+        }
+    };
+
+    @Override
+    protected ScriptContext<BooleanScriptFieldScript.Factory> context() {
+        return BooleanScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected BooleanScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DateScriptFieldScriptTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class DateScriptFieldScriptTests extends ScriptFieldScriptTestCase<DateScriptFieldScript.Factory> {
+    public static final DateScriptFieldScript.Factory DUMMY = (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(
+        params,
+        lookup,
+        formatter,
+        ctx
+    ) {
+        @Override
+        public void execute() {
+            emitValue(1595431354874L);
+        }
+    };
+
+    @Override
+    protected ScriptContext<DateScriptFieldScript.Factory> context() {
+        return DateScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected DateScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/DoubleScriptFieldScriptTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class DoubleScriptFieldScriptTests extends ScriptFieldScriptTestCase<DoubleScriptFieldScript.Factory> {
+    public static final DoubleScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new DoubleScriptFieldScript(
+        params,
+        lookup,
+        ctx
+    ) {
+        @Override
+        public void execute() {
+            emitValue(1.0);
+        }
+    };
+
+    @Override
+    protected ScriptContext<DoubleScriptFieldScript.Factory> context() {
+        return DoubleScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected DoubleScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/IpScriptFieldScriptTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class IpScriptFieldScriptTests extends ScriptFieldScriptTestCase<IpScriptFieldScript.Factory> {
+    public static final IpScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new IpScriptFieldScript(params, lookup, ctx) {
+        @Override
+        public void execute() {
+            emitValue("192.168.0.1");
+        }
+    };
+
+    @Override
+    protected ScriptContext<IpScriptFieldScript.Factory> context() {
+        return IpScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected IpScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/LongScriptFieldScriptTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class LongScriptFieldScriptTests extends ScriptFieldScriptTestCase<LongScriptFieldScript.Factory> {
+    public static final LongScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new LongScriptFieldScript(params, lookup, ctx) {
+        @Override
+        public void execute() {
+            emitValue(1);
+        }
+    };
+
+    @Override
+    protected ScriptContext<LongScriptFieldScript.Factory> context() {
+        return LongScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected LongScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/ScriptFieldScriptTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/ScriptFieldScriptTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public abstract class ScriptFieldScriptTestCase<T> extends ESTestCase {
+    protected abstract ScriptContext<T> context();
+
+    protected abstract T dummyScript();
+
+    public final void testRateLimitingDisabled() throws IOException {
+        try (ScriptService scriptService = TestScriptEngine.scriptService(context(), dummyScript())) {
+            for (int i = 0; i < 1000; i++) {
+                scriptService.compile(new Script(ScriptType.INLINE, "test", "test_" + i, Collections.emptyMap()), context());
+            }
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/StringScriptFieldScriptTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.script.ScriptContext;
+
+public class StringScriptFieldScriptTests extends ScriptFieldScriptTestCase<StringScriptFieldScript.Factory> {
+    public static final StringScriptFieldScript.Factory DUMMY = (params, lookup) -> ctx -> new StringScriptFieldScript(
+        params,
+        lookup,
+        ctx
+    ) {
+        @Override
+        public void execute() {
+            emitValue("foo");
+        }
+    };
+
+    @Override
+    protected ScriptContext<StringScriptFieldScript.Factory> context() {
+        return StringScriptFieldScript.CONTEXT;
+    }
+
+    @Override
+    protected StringScriptFieldScript.Factory dummyScript() {
+        return DUMMY;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/TestScriptEngine.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/TestScriptEngine.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class TestScriptEngine implements ScriptEngine {
+    public static <F> ScriptService scriptService(ScriptContext<F> context, F factory) {
+        return new ScriptService(Settings.EMPTY, Collections.singletonMap("test", new TestScriptEngine() {
+            @Override
+            protected Object buildScriptFactory(ScriptContext<?> context) {
+                return factory;
+            }
+
+            @Override
+            public Set<ScriptContext<?>> getSupportedContexts() {
+                return Collections.singleton(context);
+            }
+        }), Collections.singletonMap(context.name, context));
+    }
+
+    @Override
+    public final String getType() {
+        return "test";
+    }
+
+    @Override
+    public final <FactoryType> FactoryType compile(
+        String name,
+        String code,
+        ScriptContext<FactoryType> context,
+        Map<String, String> params
+    ) {
+        @SuppressWarnings("unchecked")
+        FactoryType castFactory = (FactoryType) buildScriptFactory(context);
+        return castFactory;
+    }
+
+    protected abstract Object buildScriptFactory(ScriptContext<?> context);
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractNonTextScriptMappedFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractNonTextScriptMappedFieldTypeTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.unit.Fuzziness;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+abstract class AbstractNonTextScriptMappedFieldTypeTestCase extends AbstractScriptMappedFieldTypeTestCase {
+    public void testFuzzyQueryIsError() throws IOException {
+        assertQueryOnlyOnTextAndKeyword(
+            "fuzzy",
+            () -> simpleMappedFieldType().fuzzyQuery("cat", Fuzziness.AUTO, 0, 1, true, mockContext())
+        );
+    }
+
+    public void testPrefixQueryIsError() throws IOException {
+        assertQueryOnlyOnTextKeywordAndWildcard("prefix", () -> simpleMappedFieldType().prefixQuery("cat", null, mockContext()));
+    }
+
+    public void testRegexpQueryIsError() throws IOException {
+        assertQueryOnlyOnTextAndKeyword(
+            "regexp",
+            () -> simpleMappedFieldType().regexpQuery("cat", 0, Operations.DEFAULT_MAX_DETERMINIZED_STATES, null, mockContext())
+        );
+    }
+
+    public void testWildcardQueryIsError() throws IOException {
+        assertQueryOnlyOnTextKeywordAndWildcard("wildcard", () -> simpleMappedFieldType().wildcardQuery("cat", null, mockContext()));
+    }
+
+    private void assertQueryOnlyOnTextAndKeyword(String queryName, ThrowingRunnable buildQuery) {
+        Exception e = expectThrows(IllegalArgumentException.class, buildQuery);
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "Can only use "
+                    + queryName
+                    + " queries on keyword and text fields - not on [test] which is of type [script] with runtime_type ["
+                    + runtimeType()
+                    + "]"
+            )
+        );
+    }
+
+    private void assertQueryOnlyOnTextKeywordAndWildcard(String queryName, ThrowingRunnable buildQuery) {
+        Exception e = expectThrows(IllegalArgumentException.class, buildQuery);
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "Can only use "
+                    + queryName
+                    + " queries on keyword, text and wildcard fields - not on [test] which is of type [script] with runtime_type ["
+                    + runtimeType()
+                    + "]"
+            )
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldTypeTestCase.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.index.IndexReader;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+abstract class AbstractScriptMappedFieldTypeTestCase extends ESTestCase {
+    protected abstract AbstractScriptMappedFieldType simpleMappedFieldType() throws IOException;
+
+    protected abstract String runtimeType();
+
+    @SuppressWarnings("unused")
+    public abstract void testDocValues() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testSort() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testUsedInScript() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testExistsQuery() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testExistsQueryIsExpensive() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testRangeQuery() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testRangeQueryIsExpensive() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testTermQuery() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testTermQueryIsExpensive() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testTermsQuery() throws IOException;
+
+    @SuppressWarnings("unused")
+    public abstract void testTermsQueryIsExpensive() throws IOException;
+
+    protected static QueryShardContext mockContext() {
+        return mockContext(true);
+    }
+
+    protected static QueryShardContext mockContext(boolean allowExpensiveQueries) {
+        return mockContext(allowExpensiveQueries, null);
+    }
+
+    protected static QueryShardContext mockContext(boolean allowExpensiveQueries, AbstractScriptMappedFieldType mappedFieldType) {
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType(anyString())).thenReturn(mappedFieldType);
+        QueryShardContext context = mock(QueryShardContext.class);
+        when(context.getMapperService()).thenReturn(mapperService);
+        if (mappedFieldType != null) {
+            when(context.fieldMapper(anyString())).thenReturn(mappedFieldType);
+            when(context.getSearchAnalyzer(any())).thenReturn(mappedFieldType.getTextSearchInfo().getSearchAnalyzer());
+        }
+        when(context.allowExpensiveQueries()).thenReturn(allowExpensiveQueries);
+        SearchLookup lookup = new SearchLookup(
+            mapperService,
+            (mft, lookupSupplier) -> mft.fielddataBuilder("test", lookupSupplier).build(null, null, mapperService),
+            null
+        );
+        when(context.lookup()).thenReturn(lookup);
+        return context;
+    }
+
+    public void testRangeQueryWithShapeRelationIsError() throws IOException {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> simpleMappedFieldType().rangeQuery(1, 2, true, true, ShapeRelation.DISJOINT, null, null, null)
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo("Field [test] of type [runtime_script] with runtime type [" + runtimeType() + "] does not support DISJOINT ranges")
+        );
+    }
+
+    public void testPhraseQueryIsError() {
+        assertQueryOnlyOnText("phrase", () -> simpleMappedFieldType().phraseQuery(null, 1, false));
+    }
+
+    public void testPhrasePrefixQueryIsError() {
+        assertQueryOnlyOnText("phrase prefix", () -> simpleMappedFieldType().phrasePrefixQuery(null, 1, 1));
+    }
+
+    public void testMultiPhraseQueryIsError() {
+        assertQueryOnlyOnText("phrase", () -> simpleMappedFieldType().multiPhraseQuery(null, 1, false));
+    }
+
+    public void testSpanPrefixQueryIsError() {
+        assertQueryOnlyOnText("span prefix", () -> simpleMappedFieldType().spanPrefixQuery(null, null, null));
+    }
+
+    private void assertQueryOnlyOnText(String queryName, ThrowingRunnable buildQuery) {
+        Exception e = expectThrows(IllegalArgumentException.class, buildQuery);
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "Can only use "
+                    + queryName
+                    + " queries on text fields - not on [test] which is of type [script] with runtime_type ["
+                    + runtimeType()
+                    + "]"
+            )
+        );
+    }
+
+    protected String readSource(IndexReader reader, int docId) throws IOException {
+        return reader.document(docId).getBinaryValue("_source").utf8ToString();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeScriptFieldMapperTests.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScriptTests;
+import org.elasticsearch.xpack.runtimefields.TestScriptEngine;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class RuntimeScriptFieldMapperTests extends MapperTestCase {
+
+    private final String[] runtimeTypes;
+
+    public RuntimeScriptFieldMapperTests() {
+        this.runtimeTypes = RuntimeScriptFieldMapper.Builder.FIELD_TYPE_RESOLVER.keySet().toArray(new String[0]);
+        Arrays.sort(runtimeTypes);
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "runtime_script").field("runtime_type", "keyword");
+        b.startObject("script").field("source", "dummy_source").field("lang", "test").endObject();
+    }
+
+    public void testRuntimeTypeIsRequired() throws Exception {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("script", "keyword('test')")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
+        assertEquals(
+            "Failed to parse mapping [_doc]: runtime_type must be specified for runtime_script field [my_field]",
+            exception.getMessage()
+        );
+    }
+
+    public void testScriptIsRequired() throws Exception {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
+        assertEquals(
+            "Failed to parse mapping [_doc]: script must be specified for runtime_script field [my_field]",
+            exception.getMessage()
+        );
+    }
+
+    public void testCopyToIsNotSupported() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .field("script", "keyword('test')")
+            .field("copy_to", "field")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
+        assertEquals("Failed to parse mapping [_doc]: runtime_script field does not support [copy_to]", exception.getMessage());
+    }
+
+    public void testMultiFieldsIsNotSupported() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .field("script", "keyword('test')")
+            .startObject("fields")
+            .startObject("test")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
+        assertEquals("Failed to parse mapping [_doc]: runtime_script field does not support [fields]", exception.getMessage());
+    }
+
+    public void testStoredScriptsAreNotSupported() throws Exception {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my_field")
+            .field("type", "runtime_script")
+            .field("runtime_type", randomFrom(runtimeTypes))
+            .startObject("script")
+            .field("id", "test")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
+        assertEquals(
+            "Failed to parse mapping [_doc]: stored scripts specified but not supported for runtime_script field [my_field]",
+            exception.getMessage()
+        );
+    }
+
+    public void testUnsupportedRuntimeType() {
+        MapperParsingException exc = expectThrows(MapperParsingException.class, () -> createMapperService(mapping("unsupported")));
+        assertEquals(
+            "Failed to parse mapping [_doc]: runtime_type [unsupported] not supported for runtime_script field [field]",
+            exc.getMessage()
+        );
+    }
+
+    public void testBoolean() throws IOException {
+        MapperService mapperService = createMapperService(mapping("boolean"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("boolean")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDouble() throws IOException {
+        MapperService mapperService = createMapperService(mapping("double"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("double")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testIp() throws IOException {
+        MapperService mapperService = createMapperService(mapping("ip"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("ip")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testKeyword() throws IOException {
+        MapperService mapperService = createMapperService(mapping("keyword"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("keyword")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testLong() throws IOException {
+        MapperService mapperService = createMapperService(mapping("long"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("long")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDate() throws IOException {
+        MapperService mapperService = createMapperService(mapping("date"));
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping("date")), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDateWithFormat() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping("date", b -> b.field("format", "yyyy-MM-dd"));
+        MapperService mapperService = createMapperService(mapping.get());
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDateWithLocale() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping("date", b -> b.field("locale", "en_GB"));
+        MapperService mapperService = createMapperService(mapping.get());
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testDateWithLocaleAndFormat() throws IOException {
+        CheckedSupplier<XContentBuilder, IOException> mapping = () -> mapping(
+            "date",
+            b -> b.field("format", "yyyy-MM-dd").field("locale", "en_GB")
+        );
+        MapperService mapperService = createMapperService(mapping.get());
+        FieldMapper mapper = (FieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper, instanceOf(RuntimeScriptFieldMapper.class));
+        assertEquals(Strings.toString(mapping.get()), Strings.toString(mapperService.documentMapper()));
+    }
+
+    public void testNonDateWithFormat() {
+        String runtimeType = randomValueOtherThan("date", () -> randomFrom(runtimeTypes));
+        Exception e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(mapping(runtimeType, b -> b.field("format", "yyyy-MM-dd")))
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo("Failed to parse mapping [_doc]: format can not be specified for runtime_type [" + runtimeType + "]")
+        );
+    }
+
+    public void testNonDateWithLocale() {
+        String runtimeType = randomValueOtherThan("date", () -> randomFrom(runtimeTypes));
+        Exception e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(mapping(runtimeType, b -> b.field("locale", "en_GB")))
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo("Failed to parse mapping [_doc]: locale can not be specified for runtime_type [" + runtimeType + "]")
+        );
+    }
+
+    public void testFieldCaps() throws Exception {
+        for (String runtimeType : runtimeTypes) {
+            MapperService scriptIndexMapping = createMapperService(mapping(runtimeType));
+            MapperService concreteIndexMapping;
+            {
+                XContentBuilder mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("_doc")
+                    .startObject("properties")
+                    .startObject("field")
+                    .field("type", runtimeType)
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                concreteIndexMapping = createMapperService(mapping);
+            }
+            MappedFieldType scriptFieldType = scriptIndexMapping.fieldType("field");
+            MappedFieldType concreteIndexType = concreteIndexMapping.fieldType("field");
+            assertEquals(concreteIndexType.familyTypeName(), scriptFieldType.familyTypeName());
+            assertEquals(concreteIndexType.isSearchable(), scriptFieldType.isSearchable());
+            assertEquals(concreteIndexType.isAggregatable(), scriptFieldType.isAggregatable());
+        }
+    }
+
+    public void testIndexSorting() {
+        Settings build = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put("index.sort.field", "runtime")
+            .build();
+        IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("index").settings(build).build(), Settings.EMPTY);
+        IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
+        NoneCircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
+        final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService, null);
+        IndexSortConfig config = indexSettings.getIndexSortConfig();
+        assertTrue(config.hasIndexSort());
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> config.buildIndexSort(
+                field -> new ScriptKeywordMappedFieldType(field, new Script(""), null, Collections.emptyMap()),
+                (fieldType, searchLookupSupplier) -> indexFieldDataService.getForField(fieldType, "index", searchLookupSupplier)
+            )
+        );
+        assertEquals("docvalues not found for index sort field:[runtime]", iae.getMessage());
+        assertThat(iae.getCause(), instanceOf(UnsupportedOperationException.class));
+        assertEquals("index sorting not supported on runtime field [runtime]", iae.getCause().getMessage());
+    }
+
+    private static XContentBuilder mapping(String type) throws IOException {
+        return mapping(type, builder -> {});
+    }
+
+    private static XContentBuilder mapping(String type, CheckedConsumer<XContentBuilder, IOException> extra) throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject();
+        {
+            mapping.startObject("_doc");
+            {
+                mapping.startObject("properties");
+                {
+                    mapping.startObject("field");
+                    {
+                        mapping.field("type", "runtime_script").field("runtime_type", type);
+                        mapping.startObject("script");
+                        {
+                            mapping.field("source", "dummy_source").field("lang", "test");
+                        }
+                        mapping.endObject();
+                        extra.accept(mapping);
+                    }
+                    mapping.endObject();
+                }
+                mapping.endObject();
+            }
+            mapping.endObject();
+        }
+        return mapping.endObject();
+    }
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return org.elasticsearch.common.collect.List.of(new RuntimeFields(), new TestScriptPlugin());
+    }
+
+    private static class TestScriptPlugin extends Plugin implements ScriptPlugin {
+        @Override
+        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+            return new TestScriptEngine() {
+                @Override
+                protected Object buildScriptFactory(ScriptContext<?> context) {
+                    if (context == BooleanScriptFieldScript.CONTEXT) {
+                        return BooleanScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == DateScriptFieldScript.CONTEXT) {
+                        return DateScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == DoubleScriptFieldScript.CONTEXT) {
+                        return DoubleScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == IpScriptFieldScript.CONTEXT) {
+                        return IpScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == LongScriptFieldScript.CONTEXT) {
+                        return LongScriptFieldScriptTests.DUMMY;
+                    }
+                    if (context == StringScriptFieldScript.CONTEXT) {
+                        return StringScriptFieldScriptTests.DUMMY;
+                    }
+                    throw new IllegalArgumentException("Unsupported context: " + context);
+                };
+
+                public Set<ScriptContext<?>> getSupportedContexts() {
+                    return org.elasticsearch.common.collect.Set.of(
+                        BooleanScriptFieldScript.CONTEXT,
+                        DateScriptFieldScript.CONTEXT,
+                        DoubleScriptFieldScript.CONTEXT,
+                        IpScriptFieldScript.CONTEXT,
+                        StringScriptFieldScript.CONTEXT,
+                        LongScriptFieldScript.CONTEXT
+                    );
+                }
+            };
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptBooleanMappedFieldTypeTests.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper.BuilderContext;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptBooleanFieldData;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ScriptBooleanMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"true\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true, false]}"))));
+            List<Long> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptBooleanMappedFieldType ft = simpleMappedFieldType();
+                ScriptBooleanFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
+                        SortedNumericDocValues dv = ifd.load(context).getLongValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(dv.nextValue());
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of(1L, 0L, 1L)));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptBooleanFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup)
+                    .build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [false]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [true]}"));
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) {
+                        return new ScoreScript(org.elasticsearch.common.collect.Map.of(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptDocValues.Booleans booleans = (ScriptDocValues.Booleans) getDoc().get("test");
+                                return booleans.get(0) ? 3 : 0;
+                            }
+                        };
+                    }
+                }, 2.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true, false]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(3));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptBooleanMappedFieldType::existsQuery);
+    }
+
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery(true, true, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, true, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, true, false, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, false, true, true, null, null, null, mockContext())), equalTo(0));
+            }
+        }
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery(false, false, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, true, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, true, true, false, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(true, true, true, true, null, null, null, mockContext())), equalTo(0));
+            }
+        }
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery(false, false, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(true, true, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(false, true, true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(false, false, false, false, null, null, null, mockContext())), equalTo(0));
+                assertThat(searcher.count(ft.rangeQuery(true, true, false, false, null, null, null, mockContext())), equalTo(0));
+            }
+        }
+    }
+
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.rangeQuery(true, true, true, true, null, null, null, ctx));
+        checkExpensiveQuery((ft, ctx) -> ft.rangeQuery(false, true, true, true, null, null, null, ctx));
+        checkExpensiveQuery((ft, ctx) -> ft.rangeQuery(false, true, false, true, null, null, null, ctx));
+        // These are not expensive queries
+        assertThat(
+            simpleMappedFieldType().rangeQuery(true, true, false, false, null, null, null, mockContext()),
+            instanceOf(MatchNoDocsQuery.class)
+        );
+        assertThat(
+            simpleMappedFieldType().rangeQuery(false, false, false, false, null, null, null, mockContext()),
+            instanceOf(MatchNoDocsQuery.class)
+        );
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(true, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("true", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(false, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(
+                        build("xor_param", org.elasticsearch.common.collect.Map.of("param", false)).termQuery(true, mockContext())
+                    ),
+                    equalTo(1)
+                );
+            }
+        }
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(false, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("false", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(null, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(true, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(
+                        build("xor_param", org.elasticsearch.common.collect.Map.of("param", false)).termQuery(false, mockContext())
+                    ),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(randomBoolean(), ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(true, true), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of("true", "true"), mockContext())
+                    ),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(false, false), mockContext())
+                    ),
+                    equalTo(0)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(true, false), mockContext())
+                    ),
+                    equalTo(1)
+                );
+            }
+        }
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(false, false), mockContext())
+                    ),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of("false", "false"), mockContext())
+                    ),
+                    equalTo(1)
+                );
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(singletonList(null), mockContext())), equalTo(1));
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(true, true), mockContext())),
+                    equalTo(0)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(true, false), mockContext())
+                    ),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(true), ctx));
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(false), ctx));
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(false, true), ctx));
+        // This is not an expensive query
+        assertThat(
+            simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(), mockContext()),
+            instanceOf(MatchNoDocsQuery.class)
+        );
+    }
+
+    public void testDualingQueries() throws IOException {
+        BooleanFieldMapper ootb = new BooleanFieldMapper.Builder("foo").build(new BuilderContext(Settings.EMPTY, new ContentPath()));
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            List<Boolean> values = randomList(0, 2, ESTestCase::randomBoolean);
+            String source = "{\"foo\": " + values + "}";
+            ParseContext ctx = mock(ParseContext.class);
+            when(ctx.parser()).thenReturn(createParser(JsonXContent.jsonXContent, source));
+            ParseContext.Document doc = new ParseContext.Document();
+            when(ctx.doc()).thenReturn(doc);
+            when(ctx.sourceToParse()).thenReturn(new SourceToParse("test", "test", "test", new BytesArray(source), XContentType.JSON));
+            doc.add(new StoredField("_source", new BytesRef(source)));
+            ctx.parser().nextToken();
+            ctx.parser().nextToken();
+            ctx.parser().nextToken();
+            while (ctx.parser().nextToken() != Token.END_ARRAY) {
+                ootb.parse(ctx);
+            }
+            iw.addDocument(doc);
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertSameCount(
+                    searcher,
+                    source,
+                    "*",
+                    simpleMappedFieldType().existsQuery(mockContext()),
+                    ootb.fieldType().existsQuery(mockContext())
+                );
+                boolean term = randomBoolean();
+                assertSameCount(
+                    searcher,
+                    source,
+                    term,
+                    simpleMappedFieldType().termQuery(term, mockContext()),
+                    ootb.fieldType().termQuery(term, mockContext())
+                );
+                List<Boolean> terms = randomList(0, 3, ESTestCase::randomBoolean);
+                assertSameCount(
+                    searcher,
+                    source,
+                    terms,
+                    simpleMappedFieldType().termsQuery(terms, mockContext()),
+                    ootb.fieldType().termsQuery(terms, mockContext())
+                );
+                boolean low;
+                boolean high;
+                if (randomBoolean()) {
+                    low = high = randomBoolean();
+                } else {
+                    low = false;
+                    high = true;
+                }
+                boolean includeLow = randomBoolean();
+                boolean includeHigh = randomBoolean();
+                assertSameCount(
+                    searcher,
+                    source,
+                    (includeLow ? "[" : "(") + low + "," + high + (includeHigh ? "]" : ")"),
+                    simpleMappedFieldType().rangeQuery(low, high, includeLow, includeHigh, null, null, null, mockContext()),
+                    ootb.fieldType().rangeQuery(low, high, includeLow, includeHigh, null, null, null, mockContext())
+                );
+            }
+        }
+    }
+
+    private void assertSameCount(IndexSearcher searcher, String source, Object queryDescription, Query scriptedQuery, Query ootbQuery)
+        throws IOException {
+        assertThat(
+            "source=" + source + ",query=" + queryDescription + ",scripted=" + scriptedQuery + ",ootb=" + ootbQuery,
+            searcher.count(scriptedQuery),
+            equalTo(searcher.count(ootbQuery))
+        );
+    }
+
+    @Override
+    protected ScriptBooleanMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_foo", org.elasticsearch.common.collect.Map.of());
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "boolean";
+    }
+
+    private static ScriptBooleanMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params));
+    }
+
+    private static ScriptBooleanMappedFieldType build(Script script) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(DoubleScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private BooleanScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_foo":
+                                return (params, lookup) -> (ctx) -> new BooleanScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(parse(foo));
+                                        }
+                                    }
+                                };
+                            case "xor_param":
+                                return (params, lookup) -> (ctx) -> new BooleanScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue((Boolean) foo ^ ((Boolean) getParams().get("param")));
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            BooleanScriptFieldScript.Factory factory = scriptService.compile(script, BooleanScriptFieldScript.CONTEXT);
+            return new ScriptBooleanMappedFieldType("test", script, factory, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptBooleanMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptBooleanMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDateMappedFieldTypeTests.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptDateFieldData;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ScriptDateMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+    public void testFormat() throws IOException {
+        assertThat(simpleMappedFieldType().docValueFormat("date", null).format(1595432181354L), equalTo("2020-07-22"));
+        assertThat(
+            simpleMappedFieldType().docValueFormat("strict_date_optional_time", null).format(1595432181354L),
+            equalTo("2020-07-22T15:36:21.354Z")
+        );
+        assertThat(
+            simpleMappedFieldType().docValueFormat("strict_date_optional_time", ZoneId.of("America/New_York")).format(1595432181354L),
+            equalTo("2020-07-22T11:36:21.354-04:00")
+        );
+        assertThat(
+            simpleMappedFieldType().docValueFormat(null, ZoneId.of("America/New_York")).format(1595432181354L),
+            equalTo("2020-07-22T11:36:21.354-04:00")
+        );
+        assertThat(coolFormattedFieldType().docValueFormat(null, null).format(1595432181354L), equalTo("2020-07-22(-■_■)15:36:21.354Z"));
+    }
+
+    public void testFormatDuel() throws IOException {
+        DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(randomLocale(random()));
+        ScriptDateMappedFieldType scripted = build(
+            new Script(ScriptType.INLINE, "test", "read_timestamp", org.elasticsearch.common.collect.Map.of()),
+            formatter
+        );
+        DateFieldMapper.DateFieldType indexed = new DateFieldMapper.DateFieldType("test", formatter);
+        for (int i = 0; i < 100; i++) {
+            long date = randomLongBetween(0, 3000000000000L); // Maxes out in the year 2065
+            assertThat(indexed.docValueFormat(null, null).format(date), equalTo(scripted.docValueFormat(null, null).format(date)));
+            String format = randomDateFormatterPattern();
+            assertThat(indexed.docValueFormat(format, null).format(date), equalTo(scripted.docValueFormat(format, null).format(date)));
+            ZoneId zone = randomZone();
+            assertThat(indexed.docValueFormat(null, zone).format(date), equalTo(scripted.docValueFormat(null, zone).format(date)));
+            assertThat(indexed.docValueFormat(format, zone).format(date), equalTo(scripted.docValueFormat(format, zone).format(date)));
+        }
+    }
+
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(
+                    new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356, 1595432181351]}"))
+                )
+            );
+            List<Long> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptDateMappedFieldType ft = build("add_days", org.elasticsearch.common.collect.Map.of("days", 1));
+                ScriptDateFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+                        SortedNumericDocValues dv = ifd.load(context).getLongValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) throws IOException {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(dv.nextValue());
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of(1595518581354L, 1595518581351L, 1595518581356L)));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptDateFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(readSource(reader, docs.scoreDocs[0].doc), equalTo("{\"timestamp\": [1595432181351]}"));
+                assertThat(readSource(reader, docs.scoreDocs[1].doc), equalTo("{\"timestamp\": [1595432181354]}"));
+                assertThat(readSource(reader, docs.scoreDocs[2].doc), equalTo("{\"timestamp\": [1595432181356]}"));
+                assertThat((Long) (((FieldDoc) docs.scoreDocs[0]).fields[0]), equalTo(1595432181351L));
+                assertThat((Long) (((FieldDoc) docs.scoreDocs[1]).fields[0]), equalTo(1595432181354L));
+                assertThat((Long) (((FieldDoc) docs.scoreDocs[2]).fields[0]), equalTo(1595432181356L));
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
+                        return new ScoreScript(org.elasticsearch.common.collect.Map.of(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptDocValues.Dates dates = (ScriptDocValues.Dates) getDoc().get("test");
+                                return dates.get(0).toInstant().toEpochMilli() % 1000;
+                            }
+                        };
+                    }
+                }, 354.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    public void testDistanceFeatureQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocuments(
+                org.elasticsearch.common.collect.List.of(
+                    org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}"))),
+                    org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}"))),
+                    org.elasticsearch.common.collect.List.of(
+                        new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356, 1]}"))
+                    ),
+                    org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": []}")))
+                )
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                Query query = simpleMappedFieldType().distanceFeatureQuery(1595432181354L, "1ms", 1, mockContext());
+                TopDocs docs = searcher.search(query, 4);
+                assertThat(docs.scoreDocs, arrayWithSize(3));
+                assertThat(readSource(reader, docs.scoreDocs[0].doc), equalTo("{\"timestamp\": [1595432181354]}"));
+                assertThat(docs.scoreDocs[0].score, equalTo(1.0F));
+                assertThat(readSource(reader, docs.scoreDocs[1].doc), equalTo("{\"timestamp\": [1595432181356, 1]}"));
+                assertThat((double) docs.scoreDocs[1].score, closeTo(.333, .001));
+                assertThat(readSource(reader, docs.scoreDocs[2].doc), equalTo("{\"timestamp\": [1595432181351]}"));
+                assertThat((double) docs.scoreDocs[2].score, closeTo(.250, .001));
+                Explanation explanation = query.createWeight(searcher, ScoreMode.TOP_SCORES, 1.0F)
+                    .explain(reader.leaves().get(0), docs.scoreDocs[0].doc);
+                assertThat(explanation.toString(), containsString("1.0 = Distance score, computed as weight * pivot / (pivot"));
+                assertThat(explanation.toString(), containsString("1.0 = weight"));
+                assertThat(explanation.toString(), containsString("1 = pivot"));
+                assertThat(explanation.toString(), containsString("1595432181354 = origin"));
+                assertThat(explanation.toString(), containsString("1595432181354 = current value"));
+            }
+        }
+    }
+
+    public void testDistanceFeatureQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.distanceFeatureQuery(randomLong(), randomAlphaOfLength(5), randomFloat(), ctx));
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}")))
+            );
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptDateMappedFieldType::existsQuery);
+    }
+
+    @Override
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(
+                    searcher.count(
+                        ft.rangeQuery("2020-07-22T15:36:21.356Z", "2020-07-23T00:00:00.000Z", true, true, null, null, null, mockContext())
+                    ),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(
+                        ft.rangeQuery("2020-07-22T00:00:00.00Z", "2020-07-22T15:36:21.354Z", true, true, null, null, null, mockContext())
+                    ),
+                    equalTo(2)
+                );
+                assertThat(
+                    searcher.count(ft.rangeQuery(1595432181351L, 1595432181356L, true, true, null, null, null, mockContext())),
+                    equalTo(3)
+                );
+                assertThat(
+                    searcher.count(
+                        ft.rangeQuery("2020-07-22T15:36:21.356Z", "2020-07-23T00:00:00.000Z", true, false, null, null, null, mockContext())
+                    ),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(
+                        ft.rangeQuery("2020-07-22T15:36:21.356Z", "2020-07-23T00:00:00.000Z", false, false, null, null, null, mockContext())
+                    ),
+                    equalTo(0)
+                );
+                checkBadDate(
+                    () -> searcher.count(
+                        ft.rangeQuery(
+                            "2020-07-22(-■_■)00:00:00.000Z",
+                            "2020-07-23(-■_■)00:00:00.000Z",
+                            false,
+                            false,
+                            null,
+                            null,
+                            null,
+                            mockContext()
+                        )
+                    )
+                );
+                assertThat(
+                    searcher.count(
+                        coolFormattedFieldType().rangeQuery(
+                            "2020-07-22(-■_■)00:00:00.000Z",
+                            "2020-07-23(-■_■)00:00:00.000Z",
+                            false,
+                            false,
+                            null,
+                            null,
+                            null,
+                            mockContext()
+                        )
+                    ),
+                    equalTo(3)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(
+            (ft, ctx) -> ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx)
+        );
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181355]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("2020-07-22T15:36:21.354Z", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("1595432181355", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1595432181354L, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(2595432181354L, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(
+                        build("add_days", org.elasticsearch.common.collect.Map.of("days", 1)).termQuery(
+                            "2020-07-23T15:36:21.354Z",
+                            mockContext()
+                        )
+                    ),
+                    equalTo(1)
+                );
+                checkBadDate(() -> searcher.count(simpleMappedFieldType().termQuery("2020-07-22(-■_■)15:36:21.354Z", mockContext())));
+                assertThat(searcher.count(coolFormattedFieldType().termQuery("2020-07-22(-■_■)15:36:21.354Z", mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(0, ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181355]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                MappedFieldType ft = simpleMappedFieldType();
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of("2020-07-22T15:36:21.354Z"), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of("1595432181354"), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of(1595432181354L), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of(2595432181354L), mockContext())),
+                    equalTo(0)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of(1595432181354L, 2595432181354L), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of(2595432181354L, 1595432181354L), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(ft.termsQuery(org.elasticsearch.common.collect.List.of(1595432181355L, 1595432181354L), mockContext())),
+                    equalTo(2)
+                );
+                checkBadDate(
+                    () -> searcher.count(
+                        simpleMappedFieldType().termsQuery(
+                            org.elasticsearch.common.collect.List.of("2020-07-22T15:36:21.354Z", "2020-07-22(-■_■)15:36:21.354Z"),
+                            mockContext()
+                        )
+                    )
+                );
+                assertThat(
+                    searcher.count(
+                        coolFormattedFieldType().termsQuery(
+                            org.elasticsearch.common.collect.List.of("2020-07-22(-■_■)15:36:21.354Z", "2020-07-22(-■_■)15:36:21.355Z"),
+                            mockContext()
+                        )
+                    ),
+                    equalTo(2)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(0), ctx));
+    }
+
+    @Override
+    protected ScriptDateMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_timestamp");
+    }
+
+    private ScriptDateMappedFieldType coolFormattedFieldType() throws IOException {
+        return build(simpleMappedFieldType().script, DateFormatter.forPattern("yyyy-MM-dd(-■_■)HH:mm:ss.SSSz||epoch_millis"));
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "date";
+    }
+
+    private static ScriptDateMappedFieldType build(String code) throws IOException {
+        return build(code, org.elasticsearch.common.collect.Map.of());
+    }
+
+    private static ScriptDateMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params), DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER);
+    }
+
+    private static ScriptDateMappedFieldType build(Script script, DateFormatter dateTimeFormatter) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(DateScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private DateScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_timestamp":
+                                return (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(params, lookup, formatter, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                            DateScriptFieldScript.Parse parse = new DateScriptFieldScript.Parse(this);
+                                            emitValue(parse.parse(timestamp));
+                                        }
+                                    }
+                                };
+                            case "add_days":
+                                return (params, lookup, formatter) -> ctx -> new DateScriptFieldScript(params, lookup, formatter, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                            long epoch = (Long) timestamp;
+                                            ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
+                                            dt = dt.plus(((Number) params.get("days")).longValue(), ChronoUnit.DAYS);
+                                            emitValue(toEpochMilli(dt));
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            DateScriptFieldScript.Factory factory = scriptService.compile(script, DateScriptFieldScript.CONTEXT);
+            return new ScriptDateMappedFieldType("test", script, factory, dateTimeFormatter, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptDateMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptDateMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+
+    private void checkBadDate(ThrowingRunnable queryBuilder) {
+        Exception e = expectThrows(ElasticsearchParseException.class, queryBuilder);
+        assertThat(e.getMessage(), containsString("failed to parse date field"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptDoubleMappedFieldTypeTests.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptDoubleFieldData;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ScriptDoubleMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+    public void testFormat() throws IOException {
+        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1), equalTo("1.0"));
+        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1.2), equalTo("1.2"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(11), equalTo("11"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(1123), equalTo("1,123"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123), equalTo("1,123.00"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123.1), equalTo("1,123.10"));
+    }
+
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.0]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [3.14, 1.4]}"))));
+            List<Double> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptDoubleMappedFieldType ft = build("add_param", org.elasticsearch.common.collect.Map.of("param", 1));
+                ScriptDoubleFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
+                        SortedNumericDoubleValues dv = ifd.load(context).getDoubleValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(dv.nextValue());
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of(2.0, 2.4, 4.140000000000001)));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptDoubleFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1.1]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2.1]}"));
+                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4.2]}"));
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) {
+                        return new ScoreScript(org.elasticsearch.common.collect.Map.of(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptDocValues.Doubles doubles = (ScriptDocValues.Doubles) getDoc().get("test");
+                                return doubles.get(0);
+                            }
+                        };
+                    }
+                }, 2.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptDoubleMappedFieldType::existsQuery);
+    }
+
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.5]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2.5, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2.5, 3, false, true, null, null, null, mockContext())), equalTo(0));
+            }
+        }
+    }
+
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(
+            (ft, ctx) -> ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx)
+        );
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("1", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1.1, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(build("add_param", org.elasticsearch.common.collect.Map.of("param", 1)).termQuery(2, mockContext())),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(randomLong(), ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of("1"), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1.1), mockContext())),
+                    equalTo(0)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1.1, 2.1), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(2.1, 1), mockContext())),
+                    equalTo(2)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(randomLong()), ctx));
+    }
+
+    @Override
+    protected ScriptDoubleMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_foo", org.elasticsearch.common.collect.Map.of());
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "double";
+    }
+
+    private static ScriptDoubleMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params));
+    }
+
+    private static ScriptDoubleMappedFieldType build(Script script) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(DoubleScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private DoubleScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_foo":
+                                return (params, lookup) -> (ctx) -> new DoubleScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(((Number) foo).doubleValue());
+                                        }
+                                    }
+                                };
+                            case "add_param":
+                                return (params, lookup) -> (ctx) -> new DoubleScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            DoubleScriptFieldScript.Factory factory = scriptService.compile(script, DoubleScriptFieldScript.CONTEXT);
+            return new ScriptDoubleMappedFieldType("test", script, factory, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptDoubleMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptDoubleMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptIpMappedFieldTypeTests.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptBinaryFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptIpFieldData;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class ScriptIpMappedFieldTypeTests extends AbstractScriptMappedFieldTypeTestCase {
+    public void testFormat() throws IOException {
+        assertThat(simpleMappedFieldType().docValueFormat(null, null), sameInstance(DocValueFormat.IP));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat("ASDFA", null));
+        assertThat(e.getMessage(), equalTo("Field [test] of type [runtime_script] with runtime type [ip] does not support custom formats"));
+        e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat(null, ZoneId.of("America/New_York")));
+        assertThat(
+            e.getMessage(),
+            equalTo("Field [test] of type [runtime_script] with runtime type [ip] does not support custom time zones")
+        );
+    }
+
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(
+                    new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.2\", \"192.168.1\"]}"))
+                )
+            );
+            List<Object> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptIpMappedFieldType ft = build("append_param", org.elasticsearch.common.collect.Map.of("param", ".1"));
+                ScriptBinaryFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                DocValueFormat format = ft.docValueFormat(null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
+                        SortedBinaryDocValues dv = ifd.load(context).getBytesValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(format.format(dv.nextValue()));
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of("192.168.0.1", "192.168.1.1", "192.168.2.1")));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptBinaryFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(
+                    reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.1\"]}")
+                );
+                assertThat(
+                    reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.2\"]}")
+                );
+                assertThat(
+                    reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.4\"]}")
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) {
+                        return new ScoreScript(org.elasticsearch.common.collect.Map.of(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptIpFieldData.IpScriptDocValues bytes = (ScriptIpFieldData.IpScriptDocValues) getDoc().get("test");
+                                return Integer.parseInt(bytes.getValue().substring(bytes.getValue().lastIndexOf(".") + 1));
+                            }
+                        };
+                    }
+                }, 2.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}")))
+            );
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptIpMappedFieldType::existsQuery);
+    }
+
+    @Override
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}")))
+            );
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().rangeQuery("192.0.0.0", "200.0.0.0", false, false, null, null, null, mockContext())
+                    ),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.rangeQuery("192.0.0.0", "200.0.0.0", randomBoolean(), randomBoolean(), null, null, null, ctx));
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1\"]}")))
+            );
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptIpMappedFieldType fieldType = build("append_param", org.elasticsearch.common.collect.Map.of("param", ".1"));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.1", mockContext())), equalTo(1));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.7", mockContext())), equalTo(0));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.0/16", mockContext())), equalTo(2));
+                assertThat(searcher.count(fieldType.termQuery("10.168.0.0/16", mockContext())), equalTo(0));
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(randomIp(randomBoolean()), ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1.1\"]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}")))
+            );
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(
+                            org.elasticsearch.common.collect.List.of("192.168.0.1", "1.1.1.1"),
+                            mockContext()
+                        )
+                    ),
+                    equalTo(2)
+                );
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().termsQuery(
+                            org.elasticsearch.common.collect.List.of("192.168.0.0/16", "1.1.1.1"),
+                            mockContext()
+                        )
+                    ),
+                    equalTo(3)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(randomList(100, () -> randomAlphaOfLengthBetween(1, 1000)), ctx));
+    }
+
+    @Override
+    protected ScriptIpMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_foo", org.elasticsearch.common.collect.Map.of());
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "ip";
+    }
+
+    private static ScriptIpMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params));
+    }
+
+    private static ScriptIpMappedFieldType build(Script script) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(StringScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private IpScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_foo":
+                                return (params, lookup) -> (ctx) -> new IpScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(foo.toString());
+                                        }
+                                    }
+                                };
+                            case "append_param":
+                                return (params, lookup) -> (ctx) -> new IpScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(foo.toString() + getParams().get("param"));
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            IpScriptFieldScript.Factory factory = scriptService.compile(script, IpScriptFieldScript.CONTEXT);
+            return new ScriptIpMappedFieldType("test", script, factory, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptIpMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptIpMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptKeywordMappedFieldTypeTests.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptBinaryFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptStringFieldData;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ScriptKeywordMappedFieldTypeTests extends AbstractScriptMappedFieldTypeTestCase {
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2, 1]}"))));
+            List<String> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptKeywordMappedFieldType ft = build("append_param", org.elasticsearch.common.collect.Map.of("param", "-suffix"));
+                ScriptStringFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
+                        SortedBinaryDocValues dv = ifd.load(context).getBytesValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(dv.nextValue().utf8ToString());
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of("1-suffix", "1-suffix", "2-suffix")));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"a\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"d\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"b\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptBinaryFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [\"a\"]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [\"b\"]}"));
+                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [\"d\"]}"));
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"a\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aaa\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aa\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) {
+                        return new ScoreScript(org.elasticsearch.common.collect.Map.of(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptDocValues.Strings bytes = (ScriptDocValues.Strings) getDoc().get("test");
+                                return bytes.get(0).length();
+                            }
+                        };
+                    }
+                }, 2.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptKeywordMappedFieldType::existsQuery);
+    }
+
+    public void testFuzzyQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            // No edits, matches
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cat\"]}"))));
+            // Single insertion, matches
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"caat\"]}"))));
+            // Single transposition, matches
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cta\"]}"))));
+            // Two insertions, no match
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"caaat\"]}"))));
+            // Totally wrong, no match
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"dog\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().fuzzyQuery("cat", Fuzziness.AUTO, 0, 1, true, mockContext())),
+                    equalTo(3)
+                );
+            }
+        }
+    }
+
+    public void testFuzzyQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(
+            (ft, ctx) -> ft.fuzzyQuery(
+                randomAlphaOfLengthBetween(1, 1000),
+                randomFrom(Fuzziness.AUTO, Fuzziness.ZERO, Fuzziness.ONE, Fuzziness.TWO),
+                randomInt(),
+                randomInt(),
+                randomBoolean(),
+                ctx
+            )
+        );
+    }
+
+    public void testPrefixQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cat\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cata\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"dog\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().prefixQuery("cat", null, mockContext())), equalTo(2));
+            }
+        }
+    }
+
+    public void testPrefixQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.prefixQuery(randomAlphaOfLengthBetween(1, 1000), null, ctx));
+    }
+
+    @Override
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cat\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cata\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"dog\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().rangeQuery("cat", "d", false, false, null, null, null, mockContext())),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(
+            (ft, ctx) -> ft.rangeQuery(
+                "a" + randomAlphaOfLengthBetween(0, 1000),
+                "b" + randomAlphaOfLengthBetween(0, 1000),
+                randomBoolean(),
+                randomBoolean(),
+                null,
+                null,
+                null,
+                ctx
+            )
+        );
+    }
+
+    public void testRegexpQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cat\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"cata\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"dog\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().regexpQuery("ca.+", 0, Operations.DEFAULT_MAX_DETERMINIZED_STATES, null, mockContext())
+                    ),
+                    equalTo(2)
+                );
+            }
+        }
+    }
+
+    public void testRegexpQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.regexpQuery(randomAlphaOfLengthBetween(1, 1000), randomInt(0xFFFF), randomInt(), null, ctx));
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptKeywordMappedFieldType fieldType = build("append_param", org.elasticsearch.common.collect.Map.of("param", "-suffix"));
+                assertThat(searcher.count(fieldType.termQuery("1-suffix", mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(randomAlphaOfLengthBetween(1, 1000), ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [3]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of("1", "2"), mockContext())),
+                    equalTo(2)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(randomList(100, () -> randomAlphaOfLengthBetween(1, 1000)), ctx));
+    }
+
+    public void testWildcardQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aab\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"b\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().wildcardQuery("a*b", null, mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    public void testWildcardQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.wildcardQuery(randomAlphaOfLengthBetween(1, 1000), null, ctx));
+    }
+
+    public void testMatchQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptKeywordMappedFieldType fieldType = build("append_param", org.elasticsearch.common.collect.Map.of("param", "-Suffix"));
+                QueryShardContext queryShardContext = mockContext(true, fieldType);
+                Query query = new MatchQueryBuilder("test", "1-Suffix").toQuery(queryShardContext);
+                assertThat(searcher.count(query), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    protected ScriptKeywordMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_foo", org.elasticsearch.common.collect.Map.of());
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "keyword";
+    }
+
+    private static ScriptKeywordMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params));
+    }
+
+    private static ScriptKeywordMappedFieldType build(Script script) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(StringScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private StringScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_foo":
+                                return (params, lookup) -> (ctx) -> new StringScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(foo.toString());
+                                        }
+                                    }
+                                };
+                            case "append_param":
+                                return (params, lookup) -> (ctx) -> new StringScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(foo.toString() + getParams().get("param").toString());
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            StringScriptFieldScript.Factory factory = scriptService.compile(script, StringScriptFieldScript.CONTEXT);
+            return new ScriptKeywordMappedFieldType("test", script, factory, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptKeywordMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptKeywordMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/ScriptLongMappedFieldTypeTests.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.xpack.runtimefields.LongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.xpack.runtimefields.fielddata.ScriptLongFieldData;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class ScriptLongMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+    public void testFormat() throws IOException {
+        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1), equalTo("1.0"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(11), equalTo("11"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(1123), equalTo("1,123"));
+    }
+
+    @Override
+    public void testDocValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2, 1]}"))));
+            List<Long> results = new ArrayList<>();
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptLongMappedFieldType ft = build("add_param", org.elasticsearch.common.collect.Map.of("param", 1));
+                ScriptLongFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                searcher.search(new MatchAllDocsQuery(), new Collector() {
+                    @Override
+                    public ScoreMode scoreMode() {
+                        return ScoreMode.COMPLETE_NO_SCORES;
+                    }
+
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) {
+                        SortedNumericDocValues dv = ifd.load(context).getLongValues();
+                        return new LeafCollector() {
+                            @Override
+                            public void setScorer(Scorable scorer) {}
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                if (dv.advanceExact(doc)) {
+                                    for (int i = 0; i < dv.docValueCount(); i++) {
+                                        results.add(dv.nextValue());
+                                    }
+                                }
+                            }
+                        };
+                    }
+                });
+                assertThat(results, equalTo(org.elasticsearch.common.collect.List.of(2L, 2L, 3L)));
+            }
+        }
+    }
+
+    @Override
+    public void testSort() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptLongFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2]}"));
+                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4]}"));
+            }
+        }
+    }
+
+    public void testNow() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                ScriptLongFieldData ifd = build("millis_ago", Collections.emptyMap()).fielddataBuilder("test", mockContext()::lookup)
+                    .build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(readSource(reader, docs.scoreDocs[0].doc), equalTo("{\"timestamp\": [1595432181356]}"));
+                assertThat(readSource(reader, docs.scoreDocs[1].doc), equalTo("{\"timestamp\": [1595432181354]}"));
+                assertThat(readSource(reader, docs.scoreDocs[2].doc), equalTo("{\"timestamp\": [1595432181351]}"));
+                long t1 = (Long) (((FieldDoc) docs.scoreDocs[0]).fields[0]);
+                assertThat(t1, greaterThan(3638011399L));
+                long t2 = (Long) (((FieldDoc) docs.scoreDocs[1]).fields[0]);
+                long t3 = (Long) (((FieldDoc) docs.scoreDocs[2]).fields[0]);
+                assertThat(t2, equalTo(t1 + 2));
+                assertThat(t3, equalTo(t1 + 5));
+            }
+        }
+    }
+
+    @Override
+    public void testUsedInScript() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
+                    @Override
+                    public boolean needs_score() {
+                        return false;
+                    }
+
+                    @Override
+                    public ScoreScript newInstance(LeafReaderContext ctx) {
+                        return new ScoreScript(Collections.emptyMap(), qsc.lookup(), ctx) {
+                            @Override
+                            public double execute(ExplanationHolder explanation) {
+                                ScriptDocValues.Longs longs = (ScriptDocValues.Longs) getDoc().get("test");
+                                return longs.get(0);
+                            }
+                        };
+                    }
+                }, 2.5f, "test", 0, Version.CURRENT)), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().existsQuery(mockContext())), equalTo(1));
+            }
+        }
+    }
+
+    @Override
+    public void testExistsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(ScriptLongMappedFieldType::existsQuery);
+    }
+
+    @Override
+    public void testRangeQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(0));
+            }
+        }
+    }
+
+    @Override
+    public void testRangeQueryIsExpensive() throws IOException {
+        checkExpensiveQuery(
+            (ft, ctx) -> ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx)
+        );
+    }
+
+    @Override
+    public void testTermQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("1", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1.1, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(build("add_param", org.elasticsearch.common.collect.Map.of("param", 1)).termQuery(2, mockContext())),
+                    equalTo(1)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termQuery(randomLong(), ctx));
+    }
+
+    @Override
+    public void testTermsQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of("1"), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1.1), mockContext())),
+                    equalTo(0)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(1.1, 2), mockContext())),
+                    equalTo(1)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(org.elasticsearch.common.collect.List.of(2, 1), mockContext())),
+                    equalTo(2)
+                );
+            }
+        }
+    }
+
+    @Override
+    public void testTermsQueryIsExpensive() throws IOException {
+        checkExpensiveQuery((ft, ctx) -> ft.termsQuery(org.elasticsearch.common.collect.List.of(randomLong()), ctx));
+    }
+
+    @Override
+    protected ScriptLongMappedFieldType simpleMappedFieldType() throws IOException {
+        return build("read_foo", Collections.emptyMap());
+    }
+
+    @Override
+    protected String runtimeType() {
+        return "long";
+    }
+
+    private static ScriptLongMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+        return build(new Script(ScriptType.INLINE, "test", code, params));
+    }
+
+    private static ScriptLongMappedFieldType build(Script script) throws IOException {
+        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ScriptEngine() {
+                    @Override
+                    public String getType() {
+                        return "test";
+                    }
+
+                    @Override
+                    public Set<ScriptContext<?>> getSupportedContexts() {
+                        return org.elasticsearch.common.collect.Set.of(LongScriptFieldScript.CONTEXT);
+                    }
+
+                    @Override
+                    public <FactoryType> FactoryType compile(
+                        String name,
+                        String code,
+                        ScriptContext<FactoryType> context,
+                        Map<String, String> params
+                    ) {
+                        @SuppressWarnings("unchecked")
+                        FactoryType factory = (FactoryType) factory(code);
+                        return factory;
+                    }
+
+                    private LongScriptFieldScript.Factory factory(String code) {
+                        switch (code) {
+                            case "read_foo":
+                                return (params, lookup) -> (ctx) -> new LongScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(((Number) foo).longValue());
+                                        }
+                                    }
+                                };
+                            case "add_param":
+                                return (params, lookup) -> (ctx) -> new LongScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                            emitValue(((Number) foo).longValue() + ((Number) getParams().get("param")).longValue());
+                                        }
+                                    }
+                                };
+                            case "millis_ago":
+                                // Painless actually call System.currentTimeMillis. We could mock the time but this works fine too.
+                                long now = System.currentTimeMillis();
+                                return (params, lookup) -> (ctx) -> new LongScriptFieldScript(params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                            emitValue(now - ((Number) timestamp).longValue());
+                                        }
+                                    }
+                                };
+                            default:
+                                throw new IllegalArgumentException("unsupported script [" + code + "]");
+                        }
+                    }
+                };
+            }
+        };
+        ScriptModule scriptModule = new ScriptModule(
+            Settings.EMPTY,
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+        );
+        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
+            LongScriptFieldScript.Factory factory = scriptService.compile(script, LongScriptFieldScript.CONTEXT);
+            return new ScriptLongMappedFieldType("test", script, factory, emptyMap());
+        }
+    }
+
+    private void checkExpensiveQuery(BiConsumer<ScriptLongMappedFieldType, QueryShardContext> queryBuilder) throws IOException {
+        ScriptLongMappedFieldType ft = simpleMappedFieldType();
+        Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(ft, mockContext(false)));
+        assertThat(
+            e.getMessage(),
+            equalTo("queries cannot be executed against [runtime_script] fields while [search.allow_expensive_queries] is set to [false].")
+        );
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractBooleanScriptFieldQueryTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.xpack.runtimefields.BooleanScriptFieldScript;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractBooleanScriptFieldQueryTestCase<T extends AbstractBooleanScriptFieldQuery> extends
+    AbstractScriptFieldQueryTestCase<T> {
+
+    protected final BooleanScriptFieldScript.LeafFactory leafFactory = mock(BooleanScriptFieldScript.LeafFactory.class);
+
+    @Override
+    public final void testVisit() {
+        T query = createTestInstance();
+        List<Query> leavesVisited = new ArrayList<>();
+        query.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                fail();
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                fail();
+            }
+
+            @Override
+            public void visitLeaf(Query query) {
+                leavesVisited.add(query);
+            }
+        });
+        assertThat(leavesVisited, equalTo(org.elasticsearch.common.collect.List.of(query)));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractDoubleScriptFieldQueryTestCase.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.xpack.runtimefields.DoubleScriptFieldScript;
+
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractDoubleScriptFieldQueryTestCase<T extends AbstractDoubleScriptFieldQuery> extends
+    AbstractScriptFieldQueryTestCase<T> {
+
+    protected final DoubleScriptFieldScript.LeafFactory leafFactory = mock(DoubleScriptFieldScript.LeafFactory.class);
+
+    @Override
+    public final void testVisit() {
+        assertEmptyVisit();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractIpScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractIpScriptFieldQueryTestCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.runtimefields.IpScriptFieldScript;
+
+import java.net.InetAddress;
+
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractIpScriptFieldQueryTestCase<T extends AbstractIpScriptFieldQuery> extends AbstractScriptFieldQueryTestCase<T> {
+
+    protected final IpScriptFieldScript.LeafFactory leafFactory = mock(IpScriptFieldScript.LeafFactory.class);
+
+    @Override
+    public final void testVisit() {
+        assertEmptyVisit();
+    }
+
+    protected static BytesRef encode(InetAddress addr) {
+        return new BytesRef(InetAddressPoint.encode(addr));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractLongScriptFieldQueryTestCase.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+
+import java.io.IOException;
+
+public abstract class AbstractLongScriptFieldQueryTestCase<T extends AbstractLongScriptFieldQuery> extends AbstractScriptFieldQueryTestCase<
+    T> {
+    protected final CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory = ctx -> null;
+
+    @Override
+    public final void testVisit() {
+        assertEmptyVisit();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class AbstractScriptFieldQueryTestCase<T extends AbstractScriptFieldQuery> extends ESTestCase {
+    protected abstract T createTestInstance();
+
+    protected abstract T copy(T orig);
+
+    protected abstract T mutate(T orig);
+
+    protected final Script randomScript() {
+        return new Script(randomAlphaOfLength(10));
+    }
+
+    public final void testEqualsAndHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::mutate);
+    }
+
+    public abstract void testMatches() throws IOException;
+
+    public final void testToString() {
+        T query = createTestInstance();
+        assertThat(query.toString(), equalTo(query.fieldName() + ":" + query.toString(query.fieldName())));
+        assertToString(query);
+    }
+
+    protected abstract void assertToString(T query);
+
+    public abstract void testVisit();
+
+    protected final void assertEmptyVisit() {
+        T query = createTestInstance();
+        List<Query> leavesVisited = new ArrayList<>();
+        query.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                fail();
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                fail();
+            }
+
+            @Override
+            public void visitLeaf(Query query) {
+                leavesVisited.add(query);
+            }
+        });
+        assertThat(leavesVisited, equalTo(org.elasticsearch.common.collect.List.of(query)));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractStringScriptFieldQueryTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.xpack.runtimefields.StringScriptFieldScript;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractStringScriptFieldQueryTestCase<T extends AbstractStringScriptFieldQuery> extends
+    AbstractScriptFieldQueryTestCase<T> {
+    protected final StringScriptFieldScript.LeafFactory leafFactory = mock(StringScriptFieldScript.LeafFactory.class);
+
+    /**
+     * {@link Query#visit Visit} a query, collecting {@link ByteRunAutomaton automata},
+     * failing if there are any terms or if there are more than one automaton.
+     */
+    protected final ByteRunAutomaton visitForSingleAutomata(T testQuery) {
+        List<ByteRunAutomaton> automata = new ArrayList<>();
+        testQuery.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                fail();
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                assertThat(query, sameInstance(testQuery));
+                assertThat(field, equalTo(testQuery.fieldName()));
+                automata.add(automaton.get());
+            }
+        });
+        assertThat(automata, hasSize(1));
+        return automata.get(0);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldExistsQueryTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class BooleanScriptFieldExistsQueryTests extends AbstractBooleanScriptFieldQueryTestCase<BooleanScriptFieldExistsQuery> {
+    @Override
+    protected BooleanScriptFieldExistsQuery createTestInstance() {
+        return new BooleanScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
+    }
+
+    @Override
+    protected BooleanScriptFieldExistsQuery copy(BooleanScriptFieldExistsQuery orig) {
+        return new BooleanScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
+    }
+
+    @Override
+    protected BooleanScriptFieldExistsQuery mutate(BooleanScriptFieldExistsQuery orig) {
+        if (randomBoolean()) {
+            new BooleanScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new BooleanScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(between(1, Integer.MAX_VALUE), 0));
+        assertTrue(createTestInstance().matches(0, between(1, Integer.MAX_VALUE)));
+        assertTrue(createTestInstance().matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
+        assertFalse(createTestInstance().matches(0, 0));
+    }
+
+    @Override
+    protected void assertToString(BooleanScriptFieldExistsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("BooleanScriptFieldExistsQuery"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/BooleanScriptFieldTermQueryTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class BooleanScriptFieldTermQueryTests extends AbstractBooleanScriptFieldQueryTestCase<BooleanScriptFieldTermQuery> {
+    @Override
+    protected BooleanScriptFieldTermQuery createTestInstance() {
+        return createTestInstance(randomBoolean());
+    }
+
+    private BooleanScriptFieldTermQuery createTestInstance(boolean term) {
+        return new BooleanScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), term);
+    }
+
+    @Override
+    protected BooleanScriptFieldTermQuery copy(BooleanScriptFieldTermQuery orig) {
+        return new BooleanScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term());
+    }
+
+    @Override
+    protected BooleanScriptFieldTermQuery mutate(BooleanScriptFieldTermQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        boolean term = orig.term();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term = !term;
+                break;
+            default:
+                fail();
+        }
+        return new BooleanScriptFieldTermQuery(script, leafFactory, fieldName, term);
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance(true).matches(between(1, Integer.MAX_VALUE), 0));
+        assertFalse(createTestInstance(true).matches(0, between(1, Integer.MAX_VALUE)));
+        assertTrue(createTestInstance(true).matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
+
+        assertFalse(createTestInstance(false).matches(between(1, Integer.MAX_VALUE), 0));
+        assertTrue(createTestInstance(false).matches(0, between(1, Integer.MAX_VALUE)));
+        assertTrue(createTestInstance(false).matches(between(1, Integer.MAX_VALUE), between(1, Integer.MAX_VALUE)));
+
+        assertFalse(createTestInstance().matches(0, 0));
+    }
+
+    @Override
+    protected void assertToString(BooleanScriptFieldTermQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(Boolean.toString(query.term())));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldExistsQueryTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DoubleScriptFieldExistsQueryTests extends AbstractDoubleScriptFieldQueryTestCase<DoubleScriptFieldExistsQuery> {
+    @Override
+    protected DoubleScriptFieldExistsQuery createTestInstance() {
+        return new DoubleScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
+    }
+
+    @Override
+    protected DoubleScriptFieldExistsQuery copy(DoubleScriptFieldExistsQuery orig) {
+        return new DoubleScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
+    }
+
+    @Override
+    protected DoubleScriptFieldExistsQuery mutate(DoubleScriptFieldExistsQuery orig) {
+        if (randomBoolean()) {
+            new DoubleScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new DoubleScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(new double[0], randomIntBetween(1, Integer.MAX_VALUE)));
+        assertFalse(createTestInstance().matches(new double[0], 0));
+        assertFalse(createTestInstance().matches(new double[] { 1, 2, 3 }, 0));
+    }
+
+    @Override
+    protected void assertToString(DoubleScriptFieldExistsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("DoubleScriptFieldExistsQuery"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldRangeQueryTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DoubleScriptFieldRangeQueryTests extends AbstractDoubleScriptFieldQueryTestCase<DoubleScriptFieldRangeQuery> {
+    @Override
+    protected DoubleScriptFieldRangeQuery createTestInstance() {
+        double lower = randomDouble();
+        double upper = randomValueOtherThan(lower, ESTestCase::randomDouble);
+        if (lower > upper) {
+            double tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new DoubleScriptFieldRangeQuery(randomScript(), leafFactory, randomAlphaOfLength(5), lower, upper);
+    }
+
+    @Override
+    protected DoubleScriptFieldRangeQuery copy(DoubleScriptFieldRangeQuery orig) {
+        return new DoubleScriptFieldRangeQuery(orig.script(), leafFactory, orig.fieldName(), orig.lowerValue(), orig.upperValue());
+    }
+
+    @Override
+    protected DoubleScriptFieldRangeQuery mutate(DoubleScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        double lower = orig.lowerValue();
+        double upper = orig.upperValue();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                lower -= 1;
+                break;
+            case 3:
+                upper += 1;
+                break;
+            default:
+                fail();
+        }
+        return new DoubleScriptFieldRangeQuery(script, leafFactory, fieldName, lower, upper);
+    }
+
+    @Override
+    public void testMatches() {
+        DoubleScriptFieldRangeQuery query = new DoubleScriptFieldRangeQuery(randomScript(), leafFactory, "test", 1.2, 3.14);
+        assertTrue(query.matches(new double[] { 1.2 }, 1));
+        assertTrue(query.matches(new double[] { 3.14 }, 1));
+        assertTrue(query.matches(new double[] { 2 }, 1));
+        assertFalse(query.matches(new double[] { 0 }, 0));
+        assertFalse(query.matches(new double[] { 5 }, 1));
+        assertTrue(query.matches(new double[] { 2, 5 }, 2));
+        assertTrue(query.matches(new double[] { 5, 2 }, 2));
+        assertFalse(query.matches(new double[] { 5, 2 }, 1));
+    }
+
+    @Override
+    protected void assertToString(DoubleScriptFieldRangeQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("[" + query.lowerValue() + " TO " + query.upperValue() + "]"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermQueryTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DoubleScriptFieldTermQueryTests extends AbstractDoubleScriptFieldQueryTestCase<DoubleScriptFieldTermQuery> {
+    @Override
+    protected DoubleScriptFieldTermQuery createTestInstance() {
+        return new DoubleScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomDouble());
+    }
+
+    @Override
+    protected DoubleScriptFieldTermQuery copy(DoubleScriptFieldTermQuery orig) {
+        return new DoubleScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term());
+    }
+
+    @Override
+    protected DoubleScriptFieldTermQuery mutate(DoubleScriptFieldTermQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        double term = orig.term();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term = randomValueOtherThan(term, ESTestCase::randomDouble);
+                break;
+            default:
+                fail();
+        }
+        return new DoubleScriptFieldTermQuery(script, leafFactory, fieldName, term);
+    }
+
+    @Override
+    public void testMatches() {
+        DoubleScriptFieldTermQuery query = new DoubleScriptFieldTermQuery(randomScript(), leafFactory, "test", 3.14);
+        assertTrue(query.matches(new double[] { 3.14 }, 1));     // Match because value matches
+        assertFalse(query.matches(new double[] { 2 }, 1));       // No match because wrong value
+        assertFalse(query.matches(new double[] { 2, 3.14 }, 1)); // No match because value after count of values
+        assertTrue(query.matches(new double[] { 2, 3.14 }, 2));  // Match because one value matches
+    }
+
+    @Override
+    protected void assertToString(DoubleScriptFieldTermQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(Double.toString(query.term())));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/DoubleScriptFieldTermsQueryTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.elasticsearch.script.Script;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
+
+public class DoubleScriptFieldTermsQueryTests extends AbstractDoubleScriptFieldQueryTestCase<DoubleScriptFieldTermsQuery> {
+    @Override
+    protected DoubleScriptFieldTermsQuery createTestInstance() {
+        LongSet terms = new LongHashSet();
+        int count = between(1, 100);
+        while (terms.size() < count) {
+            terms.add(Double.doubleToLongBits(randomDouble()));
+        }
+        return new DoubleScriptFieldTermsQuery(randomScript(), leafFactory, randomAlphaOfLength(5), terms);
+    }
+
+    @Override
+    protected DoubleScriptFieldTermsQuery copy(DoubleScriptFieldTermsQuery orig) {
+        LongSet terms = new LongHashSet();
+        for (double term : orig.terms()) {
+            terms.add(Double.doubleToLongBits(term));
+        }
+        return new DoubleScriptFieldTermsQuery(orig.script(), leafFactory, orig.fieldName(), terms);
+    }
+
+    @Override
+    protected DoubleScriptFieldTermsQuery mutate(DoubleScriptFieldTermsQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        LongSet terms = new LongHashSet();
+        for (double term : orig.terms()) {
+            terms.add(Double.doubleToLongBits(term));
+        }
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                terms = new LongHashSet(terms);
+                while (false == terms.add(Double.doubleToLongBits(randomDouble()))) {
+                    // Random double was already in the set
+                }
+                break;
+            default:
+                fail();
+        }
+        return new DoubleScriptFieldTermsQuery(script, leafFactory, fieldName, terms);
+    }
+
+    @Override
+    public void testMatches() {
+        DoubleScriptFieldTermsQuery query = new DoubleScriptFieldTermsQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            LongHashSet.from(Double.doubleToLongBits(0.1), Double.doubleToLongBits(0.2), Double.doubleToLongBits(7.5))
+        );
+        assertTrue(query.matches(new double[] { 0.1 }, 1));
+        assertTrue(query.matches(new double[] { 0.2 }, 1));
+        assertTrue(query.matches(new double[] { 7.5 }, 1));
+        assertTrue(query.matches(new double[] { 0.1, 0 }, 2));
+        assertTrue(query.matches(new double[] { 0, 0.1 }, 2));
+        assertFalse(query.matches(new double[] { 0 }, 1));
+        assertFalse(query.matches(new double[] { 0, 0.1 }, 1));
+    }
+
+    @Override
+    protected void assertToString(DoubleScriptFieldTermsQuery query) {
+        String toString = query.toString(query.fieldName());
+        assertThat(toString, startsWith("["));
+        assertThat(toString, endsWith("]"));
+        List<Double> list = Arrays.asList(toString.substring(1, toString.length() - 1).split(","))
+            .stream()
+            .map(Double::parseDouble)
+            .collect(toList());
+
+        // Assert that the list is sorted
+        for (int i = 1; i < list.size(); i++) {
+            assertThat(list.get(i), greaterThan(list.get(i - 1)));
+        }
+
+        // Assert that all terms are in the list
+        for (double term : query.terms()) {
+            assertThat(list, hasItem(term));
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldExistsQueryTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IpScriptFieldExistsQueryTests extends AbstractIpScriptFieldQueryTestCase<IpScriptFieldExistsQuery> {
+    @Override
+    protected IpScriptFieldExistsQuery createTestInstance() {
+        return new IpScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
+    }
+
+    @Override
+    protected IpScriptFieldExistsQuery copy(IpScriptFieldExistsQuery orig) {
+        return new IpScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
+    }
+
+    @Override
+    protected IpScriptFieldExistsQuery mutate(IpScriptFieldExistsQuery orig) {
+        if (randomBoolean()) {
+            new IpScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new IpScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(new BytesRef[0], randomIntBetween(1, Integer.MAX_VALUE)));
+        assertFalse(createTestInstance().matches(new BytesRef[0], 0));
+        assertFalse(createTestInstance().matches(new BytesRef[] { new BytesRef("not even an IP") }, 0));
+    }
+
+    @Override
+    protected void assertToString(IpScriptFieldExistsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("IpScriptFieldExistsQuery"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldRangeQueryTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.script.Script;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IpScriptFieldRangeQueryTests extends AbstractIpScriptFieldQueryTestCase<IpScriptFieldRangeQuery> {
+    @Override
+    protected IpScriptFieldRangeQuery createTestInstance() {
+        InetAddress lower = randomIp(randomBoolean());
+        InetAddress upper = randomIp(randomBoolean());
+        if (mustFlip(lower, upper)) {
+            InetAddress tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new IpScriptFieldRangeQuery(randomScript(), leafFactory, randomAlphaOfLength(5), encode(lower), encode(upper));
+    }
+
+    @Override
+    protected IpScriptFieldRangeQuery copy(IpScriptFieldRangeQuery orig) {
+        return new IpScriptFieldRangeQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            encode(orig.lowerAddress()),
+            encode(orig.upperAddress())
+        );
+    }
+
+    @Override
+    protected IpScriptFieldRangeQuery mutate(IpScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        InetAddress lower = orig.lowerAddress();
+        InetAddress upper = orig.upperAddress();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                lower = randomIp(randomBoolean());
+                break;
+            case 3:
+                upper = randomIp(randomBoolean());
+                break;
+            default:
+                fail();
+        }
+        if (mustFlip(lower, upper)) {
+            InetAddress tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new IpScriptFieldRangeQuery(script, leafFactory, fieldName, encode(lower), encode(upper));
+    }
+
+    @Override
+    public void testMatches() {
+        // Try with ipv4
+        BytesRef min = encode(InetAddresses.forString("192.168.0.1"));
+        BytesRef max = encode(InetAddresses.forString("200.255.255.255"));
+        IpScriptFieldRangeQuery query = new IpScriptFieldRangeQuery(randomScript(), leafFactory, "test", min, max);
+        assertTrue(query.matches(new BytesRef[] { min }, 1));
+        assertTrue(query.matches(new BytesRef[] { max }, 1));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("200.255.255.0")) }, 1));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("127.0.0.1")) }, 0));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("127.0.0.1")) }, 1));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("241.0.0.0")) }, 1));
+        assertTrue(query.matches(new BytesRef[] { min, encode(InetAddresses.forString("241.0.0.0")) }, 2));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("241.0.0.0")), min }, 2));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("241.0.0.0")), min }, 1));
+
+        // Now ipv6
+        min = encode(InetAddresses.forString("ff00::"));
+        max = encode(InetAddresses.forString("fff0:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+        query = new IpScriptFieldRangeQuery(randomScript(), leafFactory, "test", min, max);
+        assertTrue(query.matches(new BytesRef[] { min }, 1));
+        assertTrue(query.matches(new BytesRef[] { max }, 1));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("ff00::1")) }, 1));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("fa00::")) }, 1));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("127.0.0.1")) }, 1));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("127.0.0.1")) }, 0));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("241.0.0.0")) }, 1));
+        assertTrue(query.matches(new BytesRef[] { min, encode(InetAddresses.forString("fa00::")) }, 2));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("fa00::")), min }, 2));
+        assertFalse(query.matches(new BytesRef[] { encode(InetAddresses.forString("fa00::")), min }, 1));
+
+        // Finally, try with an ipv6 range that contains ipv4
+        min = encode(InetAddresses.forString("::fff:0:0"));
+        max = encode(InetAddresses.forString("::ffff:ffff:ffff"));
+        query = new IpScriptFieldRangeQuery(randomScript(), leafFactory, "test", min, max);
+        assertTrue(query.matches(new BytesRef[] { min }, 1));
+        assertTrue(query.matches(new BytesRef[] { max }, 1));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("127.0.0.1")) }, 1));
+        assertTrue(query.matches(new BytesRef[] { encode(InetAddresses.forString("241.0.0.0")) }, 1));
+    }
+
+    @Override
+    protected void assertToString(IpScriptFieldRangeQuery query) {
+        assertThat(
+            query.toString(query.fieldName()),
+            equalTo(
+                "[" + InetAddresses.toAddrString(query.lowerAddress()) + " TO " + InetAddresses.toAddrString(query.upperAddress()) + "]"
+            )
+        );
+    }
+
+    private boolean mustFlip(InetAddress minCandidate, InetAddress maxCandidate) {
+        return encode(minCandidate).compareTo(encode(maxCandidate)) > 0;
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermQueryTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.script.Script;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IpScriptFieldTermQueryTests extends AbstractIpScriptFieldQueryTestCase<IpScriptFieldTermQuery> {
+    @Override
+    protected IpScriptFieldTermQuery createTestInstance() {
+        return new IpScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), encode(randomIp(randomBoolean())));
+    }
+
+    @Override
+    protected IpScriptFieldTermQuery copy(IpScriptFieldTermQuery orig) {
+        return new IpScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), encode(orig.address()));
+    }
+
+    @Override
+    protected IpScriptFieldTermQuery mutate(IpScriptFieldTermQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        InetAddress term = orig.address();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term = randomValueOtherThan(term, () -> randomIp(randomBoolean()));
+                break;
+            default:
+                fail();
+        }
+        return new IpScriptFieldTermQuery(script, leafFactory, fieldName, encode(term));
+    }
+
+    @Override
+    public void testMatches() {
+        BytesRef ip = encode(randomIp(randomBoolean()));
+        BytesRef notIpRef = randomValueOtherThan(ip, () -> encode(randomIp(randomBoolean())));
+        IpScriptFieldTermQuery query = new IpScriptFieldTermQuery(randomScript(), leafFactory, "test", ip);
+        assertTrue(query.matches(new BytesRef[] { ip }, 1));            // Match because value matches
+        assertFalse(query.matches(new BytesRef[] { notIpRef }, 1));     // No match because wrong value
+        assertFalse(query.matches(new BytesRef[] { notIpRef, ip }, 1)); // No match because value after count of values
+        assertTrue(query.matches(new BytesRef[] { notIpRef, ip }, 2));  // Match because one value matches
+    }
+
+    @Override
+    protected void assertToString(IpScriptFieldTermQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(InetAddresses.toAddrString(query.address())));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/IpScriptFieldTermsQueryTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+public class IpScriptFieldTermsQueryTests extends AbstractIpScriptFieldQueryTestCase<IpScriptFieldTermsQuery> {
+    @Override
+    protected IpScriptFieldTermsQuery createTestInstance() {
+        return createTestInstance(between(1, 100));
+    }
+
+    private IpScriptFieldTermsQuery createTestInstance(int size) {
+        BytesRefHash terms = new BytesRefHash(size, BigArrays.NON_RECYCLING_INSTANCE);
+        while (terms.size() < size) {
+            terms.add(new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean()))));
+        }
+        return new IpScriptFieldTermsQuery(randomScript(), leafFactory, randomAlphaOfLength(5), terms);
+    }
+
+    @Override
+    protected IpScriptFieldTermsQuery copy(IpScriptFieldTermsQuery orig) {
+        return new IpScriptFieldTermsQuery(orig.script(), leafFactory, orig.fieldName(), copyTerms(orig.terms()));
+    }
+
+    private BytesRefHash copyTerms(BytesRefHash terms) {
+        BytesRefHash copy = new BytesRefHash(terms.size(), BigArrays.NON_RECYCLING_INSTANCE);
+        BytesRef spare = new BytesRef();
+        for (long i = 0; i < terms.size(); i++) {
+            terms.get(i, spare);
+            assertEquals(i, copy.add(spare));
+        }
+        return copy;
+    }
+
+    @Override
+    protected IpScriptFieldTermsQuery mutate(IpScriptFieldTermsQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        BytesRefHash terms = copyTerms(orig.terms());
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                long size = terms.size() + 1;
+                while (terms.size() < size) {
+                    terms.add(new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean()))));
+                }
+                break;
+            default:
+                fail();
+        }
+        return new IpScriptFieldTermsQuery(script, leafFactory, fieldName, terms);
+    }
+
+    @Override
+    public void testMatches() {
+        BytesRef ip1 = encode(InetAddresses.forString("192.168.0.1"));
+        BytesRef ip2 = encode(InetAddresses.forString("192.168.0.2"));
+        BytesRef notIp = encode(InetAddresses.forString("192.168.0.3"));
+
+        BytesRefHash terms = new BytesRefHash(2, BigArrays.NON_RECYCLING_INSTANCE);
+        terms.add(ip1);
+        terms.add(ip2);
+        IpScriptFieldTermsQuery query = new IpScriptFieldTermsQuery(randomScript(), leafFactory, "test", terms);
+        assertTrue(query.matches(new BytesRef[] { ip1 }, 1));
+        assertTrue(query.matches(new BytesRef[] { ip2 }, 1));
+        assertTrue(query.matches(new BytesRef[] { ip1, notIp }, 2));
+        assertTrue(query.matches(new BytesRef[] { notIp, ip1 }, 2));
+        assertFalse(query.matches(new BytesRef[] { notIp }, 1));
+        assertFalse(query.matches(new BytesRef[] { notIp, ip1 }, 1));
+    }
+
+    @Override
+    protected void assertToString(IpScriptFieldTermsQuery query) {
+        if (query.toString(query.fieldName()).contains("...")) {
+            assertBigToString(query);
+        } else {
+            assertLittleToString(query);
+        }
+    }
+
+    private void assertBigToString(IpScriptFieldTermsQuery query) {
+        String toString = query.toString(query.fieldName());
+        BytesRef spare = new BytesRef();
+        assertThat(toString, startsWith("["));
+        query.terms().get(0, spare);
+        assertThat(
+            toString,
+            containsString(InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(spare)))))
+        );
+        query.terms().get(query.terms().size() - 1, spare);
+        assertThat(
+            toString,
+            not(containsString(InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(spare))))))
+        );
+        assertThat(toString, endsWith("...]"));
+    }
+
+    private void assertLittleToString(IpScriptFieldTermsQuery query) {
+        String toString = query.toString(query.fieldName());
+        BytesRef spare = new BytesRef();
+        assertThat(toString, startsWith("["));
+        for (long i = 0; i < query.terms().size(); i++) {
+            query.terms().get(i, spare);
+            assertThat(
+                toString,
+                containsString(InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(spare)))))
+            );
+        }
+        assertThat(toString, endsWith("]"));
+    }
+
+    public void testBigToString() {
+        assertBigToString(createTestInstance(1000));
+    }
+
+    public void testLittleToString() {
+        assertLittleToString(createTestInstance(5));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.runtimefields.AbstractLongScriptFieldScript;
+import org.elasticsearch.xpack.runtimefields.DateScriptFieldScript;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldDistanceFeatureQueryTests extends AbstractScriptFieldQueryTestCase<LongScriptFieldDistanceFeatureQuery> {
+    private final CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory = ctx -> null;
+
+    @Override
+    protected LongScriptFieldDistanceFeatureQuery createTestInstance() {
+        long origin = randomLong();
+        long pivot = randomValueOtherThan(origin, ESTestCase::randomLong);
+        return new LongScriptFieldDistanceFeatureQuery(randomScript(), leafFactory, randomAlphaOfLength(5), origin, pivot, randomFloat());
+    }
+
+    @Override
+    protected LongScriptFieldDistanceFeatureQuery copy(LongScriptFieldDistanceFeatureQuery orig) {
+        return new LongScriptFieldDistanceFeatureQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.origin(),
+            orig.pivot(),
+            orig.boost()
+        );
+    }
+
+    @Override
+    protected LongScriptFieldDistanceFeatureQuery mutate(LongScriptFieldDistanceFeatureQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        long origin = orig.origin();
+        long pivot = orig.pivot();
+        float boost = orig.boost();
+        switch (randomInt(4)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                origin = randomValueOtherThan(origin, () -> randomValueOtherThan(orig.pivot(), ESTestCase::randomLong));
+                break;
+            case 3:
+                pivot = randomValueOtherThan(origin, () -> randomValueOtherThan(orig.pivot(), ESTestCase::randomLong));
+                break;
+            case 4:
+                boost = randomValueOtherThan(boost, ESTestCase::randomFloat);
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldDistanceFeatureQuery(script, leafFactory, fieldName, origin, pivot, boost);
+    }
+
+    @Override
+    public void testMatches() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}")))
+            );
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}")))
+            );
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                CheckedFunction<LeafReaderContext, AbstractLongScriptFieldScript, IOException> leafFactory =
+                    ctx -> new DateScriptFieldScript(Collections.emptyMap(), new SearchLookup(null, null, null), null, ctx) {
+                        @Override
+                        public void execute() {
+                            for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                emitValue(((Number) timestamp).longValue());
+                            }
+                        }
+                    };
+                LongScriptFieldDistanceFeatureQuery query = new LongScriptFieldDistanceFeatureQuery(
+                    randomScript(),
+                    leafFactory,
+                    "test",
+                    1595432181351L,
+                    6L,
+                    between(1, 100)
+                );
+                TopDocs td = searcher.search(query, 1);
+                assertThat(td.scoreDocs[0].score, equalTo(query.boost()));
+                assertThat(td.scoreDocs[0].doc, equalTo(1));
+            }
+        }
+    }
+
+    public void testMaxScore() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(Collections.emptyList());
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                LongScriptFieldDistanceFeatureQuery query = createTestInstance();
+                float boost = randomFloat();
+                assertThat(
+                    query.createWeight(searcher, ScoreMode.COMPLETE, boost).scorer(reader.leaves().get(0)).getMaxScore(randomInt()),
+                    equalTo(query.boost() * boost)
+                );
+            }
+        }
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldDistanceFeatureQuery query) {
+        assertThat(
+            query.toString(query.fieldName()),
+            equalTo(
+                "LongScriptFieldDistanceFeatureQuery(origin=" + query.origin() + ",pivot=" + query.pivot() + ",boost=" + query.boost() + ")"
+            )
+        );
+    }
+
+    @Override
+    public final void testVisit() {
+        assertEmptyVisit();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldExistsQueryTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldExistsQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldExistsQuery> {
+    @Override
+    protected LongScriptFieldExistsQuery createTestInstance() {
+        return new LongScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
+    }
+
+    @Override
+    protected LongScriptFieldExistsQuery copy(LongScriptFieldExistsQuery orig) {
+        return new LongScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
+    }
+
+    @Override
+    protected LongScriptFieldExistsQuery mutate(LongScriptFieldExistsQuery orig) {
+        if (randomBoolean()) {
+            new LongScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new LongScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(new long[0], randomIntBetween(1, Integer.MAX_VALUE)));
+        assertFalse(createTestInstance().matches(new long[0], 0));
+        assertFalse(createTestInstance().matches(new long[] { 1, 2, 3 }, 0));
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldExistsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("LongScriptFieldExistsQuery"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldRangeQueryTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldRangeQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldRangeQuery> {
+    @Override
+    protected LongScriptFieldRangeQuery createTestInstance() {
+        long lower = randomLong();
+        long upper = randomValueOtherThan(lower, ESTestCase::randomLong);
+        if (lower > upper) {
+            long tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new LongScriptFieldRangeQuery(randomScript(), leafFactory, randomAlphaOfLength(5), lower, upper);
+    }
+
+    @Override
+    protected LongScriptFieldRangeQuery copy(LongScriptFieldRangeQuery orig) {
+        return new LongScriptFieldRangeQuery(orig.script(), leafFactory, orig.fieldName(), orig.lowerValue(), orig.upperValue());
+    }
+
+    @Override
+    protected LongScriptFieldRangeQuery mutate(LongScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        long lower = orig.lowerValue();
+        long upper = orig.upperValue();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                if (lower == Long.MIN_VALUE) {
+                    fieldName += "modified_instead_of_lower";
+                } else {
+                    lower -= 1;
+                }
+                break;
+            case 3:
+                if (upper == Long.MAX_VALUE) {
+                    fieldName += "modified_instead_of_upper";
+                } else {
+                    upper += 1;
+                }
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldRangeQuery(script, leafFactory, fieldName, lower, upper);
+    }
+
+    @Override
+    public void testMatches() {
+        LongScriptFieldRangeQuery query = new LongScriptFieldRangeQuery(randomScript(), leafFactory, "test", 1, 3);
+        assertTrue(query.matches(new long[] { 1 }, 1));
+        assertTrue(query.matches(new long[] { 2 }, 1));
+        assertTrue(query.matches(new long[] { 3 }, 1));
+        assertFalse(query.matches(new long[] { 1 }, 0));
+        assertFalse(query.matches(new long[] { 5 }, 1));
+        assertTrue(query.matches(new long[] { 1, 5 }, 2));
+        assertTrue(query.matches(new long[] { 5, 1 }, 2));
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldRangeQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("[" + query.lowerValue() + " TO " + query.upperValue() + "]"));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermQueryTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldTermQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldTermQuery> {
+    @Override
+    protected LongScriptFieldTermQuery createTestInstance() {
+        return new LongScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomLong());
+    }
+
+    @Override
+    protected LongScriptFieldTermQuery copy(LongScriptFieldTermQuery orig) {
+        return new LongScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term());
+    }
+
+    @Override
+    protected LongScriptFieldTermQuery mutate(LongScriptFieldTermQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        long term = orig.term();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term = randomValueOtherThan(term, ESTestCase::randomLong);
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldTermQuery(script, leafFactory, fieldName, term);
+    }
+
+    @Override
+    public void testMatches() {
+        LongScriptFieldTermQuery query = new LongScriptFieldTermQuery(randomScript(), leafFactory, "test", 1);
+        assertTrue(query.matches(new long[] { 1 }, 1));     // Match because value matches
+        assertFalse(query.matches(new long[] { 2 }, 1));    // No match because wrong value
+        assertFalse(query.matches(new long[] { 2, 1 }, 1)); // No match because value after count of values
+        assertTrue(query.matches(new long[] { 2, 1 }, 2));  // Match because one value matches
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldTermQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(Long.toString(query.term())));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldTermsQueryTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongSet;
+
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LongScriptFieldTermsQueryTests extends AbstractLongScriptFieldQueryTestCase<LongScriptFieldTermsQuery> {
+    @Override
+    protected LongScriptFieldTermsQuery createTestInstance() {
+        LongSet terms = new LongHashSet();
+        int count = between(1, 100);
+        while (terms.size() < count) {
+            terms.add(randomLong());
+        }
+        return new LongScriptFieldTermsQuery(randomScript(), leafFactory, randomAlphaOfLength(5), terms);
+    }
+
+    @Override
+    protected LongScriptFieldTermsQuery copy(LongScriptFieldTermsQuery orig) {
+        return new LongScriptFieldTermsQuery(orig.script(), leafFactory, orig.fieldName(), orig.terms());
+    }
+
+    @Override
+    protected LongScriptFieldTermsQuery mutate(LongScriptFieldTermsQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        LongSet terms = orig.terms();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                terms = new LongHashSet(terms);
+                while (false == terms.add(randomLong())) {
+                    // Random long was already in the set
+                }
+                break;
+            default:
+                fail();
+        }
+        return new LongScriptFieldTermsQuery(script, leafFactory, fieldName, terms);
+    }
+
+    @Override
+    public void testMatches() {
+        LongScriptFieldTermsQuery query = new LongScriptFieldTermsQuery(randomScript(), leafFactory, "test", LongHashSet.from(1, 2, 3));
+        assertTrue(query.matches(new long[] { 1 }, 1));
+        assertTrue(query.matches(new long[] { 2 }, 1));
+        assertTrue(query.matches(new long[] { 3 }, 1));
+        assertTrue(query.matches(new long[] { 1, 0 }, 2));
+        assertTrue(query.matches(new long[] { 0, 1 }, 2));
+        assertFalse(query.matches(new long[] { 0 }, 1));
+        assertFalse(query.matches(new long[] { 0, 1 }, 1));
+    }
+
+    @Override
+    protected void assertToString(LongScriptFieldTermsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.terms().toString()));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldExistsQueryTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringScriptFieldExistsQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldExistsQuery> {
+    @Override
+    protected StringScriptFieldExistsQuery createTestInstance() {
+        return new StringScriptFieldExistsQuery(randomScript(), leafFactory, randomAlphaOfLength(5));
+    }
+
+    @Override
+    protected StringScriptFieldExistsQuery copy(StringScriptFieldExistsQuery orig) {
+        return new StringScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName());
+    }
+
+    @Override
+    protected StringScriptFieldExistsQuery mutate(StringScriptFieldExistsQuery orig) {
+        if (randomBoolean()) {
+            new StringScriptFieldExistsQuery(randomValueOtherThan(orig.script(), this::randomScript), leafFactory, orig.fieldName());
+        }
+        return new StringScriptFieldExistsQuery(orig.script(), leafFactory, orig.fieldName() + "modified");
+    }
+
+    @Override
+    public void testMatches() {
+        assertTrue(createTestInstance().matches(org.elasticsearch.common.collect.List.of("test")));
+        assertFalse(createTestInstance().matches(org.elasticsearch.common.collect.List.of()));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldExistsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("StringScriptFieldExistsQuery"));
+    }
+
+    @Override
+    public void testVisit() {
+        createTestInstance().visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                fail();
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                fail();
+            }
+        });
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldFuzzyQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldFuzzyQuery> {
+    @Override
+    protected StringScriptFieldFuzzyQuery createTestInstance() {
+        String term = randomAlphaOfLength(6);
+        return StringScriptFieldFuzzyQuery.build(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            term,
+            randomIntBetween(0, 2),
+            randomIntBetween(0, term.length()),
+            randomBoolean()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldFuzzyQuery copy(StringScriptFieldFuzzyQuery orig) {
+        return StringScriptFieldFuzzyQuery.build(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.delegate().getTerm().bytes().utf8ToString(),
+            orig.delegate().getMaxEdits(),
+            orig.delegate().getPrefixLength(),
+            orig.delegate().getTranspositions()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldFuzzyQuery mutate(StringScriptFieldFuzzyQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String term = orig.delegate().getTerm().bytes().utf8ToString();
+        int maxEdits = orig.delegate().getMaxEdits();
+        int prefixLength = orig.delegate().getPrefixLength();
+        boolean transpositions = orig.delegate().getTranspositions();
+        switch (randomInt(5)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term += "modified";
+                break;
+            case 3:
+                maxEdits = randomValueOtherThan(maxEdits, () -> randomIntBetween(0, 2));
+                break;
+            case 4:
+                prefixLength += 1;
+                break;
+            case 5:
+                transpositions = !transpositions;
+                break;
+            default:
+                fail();
+        }
+        return StringScriptFieldFuzzyQuery.build(script, leafFactory, fieldName, term, maxEdits, prefixLength, transpositions);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldFuzzyQuery query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 1, 0, false);
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foa")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo", "bar")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("bar")));
+        query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 0, 0, false);
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("foa")));
+        query = StringScriptFieldFuzzyQuery.build(randomScript(), leafFactory, "test", "foo", 2, 0, false);
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foa")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("faa")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("faaa")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldFuzzyQuery query) {
+        assertThat(
+            query.toString(query.fieldName()),
+            equalTo(query.delegate().getTerm().bytes().utf8ToString() + "~" + query.delegate().getMaxEdits())
+        );
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldFuzzyQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = query.delegate().getTerm().bytes();
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.delegate().getTerm().bytes().utf8ToString() + "a");
+        assertThat(
+            automaton.run(term.bytes, term.offset, term.length),
+            is(query.delegate().getMaxEdits() > 0 && query.delegate().getPrefixLength() < term.length)
+        );
+        term = new BytesRef(query.delegate().getTerm().bytes().utf8ToString() + "abba");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldPrefixQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldPrefixQuery> {
+    @Override
+    protected StringScriptFieldPrefixQuery createTestInstance() {
+        return new StringScriptFieldPrefixQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected StringScriptFieldPrefixQuery copy(StringScriptFieldPrefixQuery orig) {
+        return new StringScriptFieldPrefixQuery(orig.script(), leafFactory, orig.fieldName(), orig.prefix());
+    }
+
+    @Override
+    protected StringScriptFieldPrefixQuery mutate(StringScriptFieldPrefixQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String prefix = orig.prefix();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                prefix += "modified";
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldPrefixQuery(script, leafFactory, fieldName, prefix);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldPrefixQuery query = new StringScriptFieldPrefixQuery(randomScript(), leafFactory, "test", "foo");
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foooo")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("fo")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("fo", "foo")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldPrefixQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.prefix() + "*"));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldPrefixQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef(query.prefix());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.prefix() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef("a" + query.prefix());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldRangeQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldRangeQuery> {
+    @Override
+    protected StringScriptFieldRangeQuery createTestInstance() {
+        String lower = randomAlphaOfLength(3);
+        String upper = randomValueOtherThan(lower, () -> randomAlphaOfLength(3));
+        if (lower.compareTo(upper) > 0) {
+            String tmp = lower;
+            lower = upper;
+            upper = tmp;
+        }
+        return new StringScriptFieldRangeQuery(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            lower,
+            upper,
+            randomBoolean(),
+            randomBoolean()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRangeQuery copy(StringScriptFieldRangeQuery orig) {
+        return new StringScriptFieldRangeQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.lowerValue(),
+            orig.upperValue(),
+            orig.includeLower(),
+            orig.includeUpper()
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRangeQuery mutate(StringScriptFieldRangeQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String lower = orig.lowerValue();
+        String upper = orig.upperValue();
+        boolean includeLower = orig.includeLower();
+        boolean includeUpper = orig.includeUpper();
+        switch (randomInt(5)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                lower += "modified";
+                break;
+            case 3:
+                upper += "modified";
+                break;
+            case 4:
+                includeLower = !includeLower;
+                break;
+            case 5:
+                includeUpper = !includeUpper;
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldRangeQuery(script, leafFactory, fieldName, lower, upper, includeLower, includeUpper);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldRangeQuery query = new StringScriptFieldRangeQuery(randomScript(), leafFactory, "test", "a", "b", true, true);
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("a")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("ab")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("b")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("ba")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("a", "c")));
+        query = new StringScriptFieldRangeQuery(randomScript(), leafFactory, "test", "a", "b", false, false);
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("a")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("ab")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("b")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("ba")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldRangeQuery query) {
+        assertThat(query.toString(query.fieldName()), containsString(query.includeLower() ? "[" : "{"));
+        assertThat(query.toString(query.fieldName()), containsString(query.includeUpper() ? "]" : "}"));
+        assertThat(query.toString(query.fieldName()), containsString(query.lowerValue() + " TO " + query.upperValue()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldRangeQuery query = createTestInstance();
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef(query.lowerValue() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+        term = new BytesRef(query.lowerValue());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(query.includeLower()));
+        term = new BytesRef(query.upperValue() + "a");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(false));
+        term = new BytesRef(query.upperValue());
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(query.includeUpper()));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.runtimefields.query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.script.Script;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -22,7 +23,7 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             leafFactory,
             randomAlphaOfLength(5),
             randomAlphaOfLength(6),
-            randomInt(0xFFFF),
+            randomInt(RegExp.ALL),
             Operations.DEFAULT_MAX_DETERMINIZED_STATES
         );
     }
@@ -56,7 +57,7 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
                 pattern += "modified";
                 break;
             case 3:
-                flags = randomValueOtherThan(flags, () -> randomInt(0xFFFF));
+                flags = randomValueOtherThan(flags, () -> randomInt(RegExp.ALL));
                 break;
             default:
                 fail();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRegexpQueryTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldRegexpQuery> {
+    @Override
+    protected StringScriptFieldRegexpQuery createTestInstance() {
+        return new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(6),
+            randomInt(0xFFFF),
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRegexpQuery copy(StringScriptFieldRegexpQuery orig) {
+        return new StringScriptFieldRegexpQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.pattern(),
+            orig.flags(),
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+    }
+
+    @Override
+    protected StringScriptFieldRegexpQuery mutate(StringScriptFieldRegexpQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String pattern = orig.pattern();
+        int flags = orig.flags();
+        switch (randomInt(3)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                pattern += "modified";
+                break;
+            case 3:
+                flags = randomValueOtherThan(flags, () -> randomInt(0xFFFF));
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldRegexpQuery(script, leafFactory, fieldName, pattern, flags, Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldRegexpQuery query = new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            "a.+b",
+            0,
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("astuffb")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("fffff")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("ab")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("aasdf")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("dsfb")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("astuffb", "fffff")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldRegexpQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo("/" + query.pattern() + "/"));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldRegexpQuery query = new StringScriptFieldRegexpQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            "a.+b",
+            0,
+            Operations.DEFAULT_MAX_DETERMINIZED_STATES
+        );
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef("astuffb");
+        assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringScriptFieldTermQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldTermQuery> {
+    @Override
+    protected StringScriptFieldTermQuery createTestInstance() {
+        return new StringScriptFieldTermQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected StringScriptFieldTermQuery copy(StringScriptFieldTermQuery orig) {
+        return new StringScriptFieldTermQuery(orig.script(), leafFactory, orig.fieldName(), orig.term());
+    }
+
+    @Override
+    protected StringScriptFieldTermQuery mutate(StringScriptFieldTermQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String term = orig.term();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                term += "modified";
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldTermQuery(script, leafFactory, fieldName, term);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldTermQuery query = new StringScriptFieldTermQuery(randomScript(), leafFactory, "test", "foo");
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("bar")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo", "bar")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldTermQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.term()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldTermQuery query = createTestInstance();
+        Set<Term> allTerms = new TreeSet<>();
+        query.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                allTerms.addAll(Arrays.asList(terms));
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                fail();
+            }
+        });
+        assertThat(allTerms, equalTo(org.elasticsearch.common.collect.Set.of(new Term(query.fieldName(), query.term()))));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermsQueryTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toCollection;
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringScriptFieldTermsQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldTermsQuery> {
+    @Override
+    protected StringScriptFieldTermsQuery createTestInstance() {
+        Set<String> terms = new TreeSet<>(Arrays.asList(generateRandomStringArray(4, 6, false, false)));
+        return new StringScriptFieldTermsQuery(randomScript(), leafFactory, randomAlphaOfLength(5), terms);
+    }
+
+    @Override
+    protected StringScriptFieldTermsQuery copy(StringScriptFieldTermsQuery orig) {
+        return new StringScriptFieldTermsQuery(orig.script(), leafFactory, orig.fieldName(), orig.terms());
+    }
+
+    @Override
+    protected StringScriptFieldTermsQuery mutate(StringScriptFieldTermsQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        Set<String> terms = orig.terms();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                terms = new TreeSet<>(orig.terms());
+                terms.add(randomAlphaOfLength(7));
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldTermsQuery(script, leafFactory, fieldName, terms);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldTermsQuery query = new StringScriptFieldTermsQuery(
+            randomScript(),
+            leafFactory,
+            "test",
+            org.elasticsearch.common.collect.Set.of("foo", "bar")
+        );
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("bar")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("baz")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("foo", "baz")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("bar", "baz")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("baz", "bort")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldTermsQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.terms().toString()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldTermsQuery query = createTestInstance();
+        Set<Term> allTerms = new TreeSet<>();
+        query.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query query, Term... terms) {
+                allTerms.addAll(Arrays.asList(terms));
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, Supplier<ByteRunAutomaton> automaton) {
+                fail();
+            }
+        });
+        assertThat(allTerms, equalTo(query.terms().stream().map(t -> new Term(query.fieldName(), t)).collect(toCollection(TreeSet::new))));
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.script.Script;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldWildcardQuery> {
+    @Override
+    protected StringScriptFieldWildcardQuery createTestInstance() {
+        return new StringScriptFieldWildcardQuery(randomScript(), leafFactory, randomAlphaOfLength(5), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected StringScriptFieldWildcardQuery copy(StringScriptFieldWildcardQuery orig) {
+        return new StringScriptFieldWildcardQuery(orig.script(), leafFactory, orig.fieldName(), orig.pattern());
+    }
+
+    @Override
+    protected StringScriptFieldWildcardQuery mutate(StringScriptFieldWildcardQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        String pattern = orig.pattern();
+        switch (randomInt(2)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                pattern += "modified";
+                break;
+            default:
+                fail();
+        }
+        return new StringScriptFieldWildcardQuery(script, leafFactory, fieldName, pattern);
+    }
+
+    @Override
+    public void testMatches() {
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("astuffb")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("fffff")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("a")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("b")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("aasdf")));
+        assertFalse(query.matches(org.elasticsearch.common.collect.List.of("dsfb")));
+        assertTrue(query.matches(org.elasticsearch.common.collect.List.of("astuffb", "fffff")));
+    }
+
+    @Override
+    protected void assertToString(StringScriptFieldWildcardQuery query) {
+        assertThat(query.toString(query.fieldName()), equalTo(query.pattern()));
+    }
+
+    @Override
+    public void testVisit() {
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(randomScript(), leafFactory, "test", "a*b");
+        ByteRunAutomaton automaton = visitForSingleAutomata(query);
+        BytesRef term = new BytesRef("astuffb");
+        assertTrue(automaton.run(term.bytes, term.offset, term.length));
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -1,0 +1,278 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+                store: true
+              day_of_week:
+                type: runtime_script
+                runtime_type: keyword
+                script: |
+                  emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+              # Test fetching from _source
+              day_of_week_from_source:
+                type: runtime_script
+                runtime_type: keyword
+                script: |
+                  Instant instant = Instant.ofEpochMilli(params._source.timestamp);
+                  ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
+                  emitValue(dt.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ROOT));
+              # Test fetching many values
+              day_of_week_letters:
+                type: runtime_script
+                runtime_type: keyword
+                script: |
+                  for (String dow: doc['day_of_week']) {
+                    for (int i = 0; i < dow.length(); i++) {
+                      emitValue(dow.charAt(i).toString());
+                    }
+                  }
+              prefixed_node:
+                type: runtime_script
+                runtime_type: keyword
+                script:
+                  source: |
+                    for (String node : params._fields.node.values) {
+                      emitValue(params.prefix + node);
+                    }
+                  params:
+                    prefix: node_
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.day_of_week.type: runtime_script }
+  - match: {sensor.mappings.properties.day_of_week.runtime_type: keyword }
+  - match:
+      sensor.mappings.properties.day_of_week.script.source: |
+        emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+  - match: {sensor.mappings.properties.day_of_week.script.lang: painless }
+
+---
+"get field mapping":
+  - do:
+      indices.get_field_mapping:
+        index: sensor
+        fields: day_of_week
+        include_defaults: true
+  - match:
+      sensor.mappings.day_of_week.mapping.day_of_week:
+        type: runtime_script
+        runtime_type: keyword
+        script:
+          source: |
+            emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+          lang: painless
+        meta: {}
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [day_of_week, day_of_week_from_source, day_of_week_letters, prefixed_node]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.day_of_week: [Thursday] }
+  - match: {hits.hits.0.fields.day_of_week_from_source: [Thursday] }
+  - match: {hits.hits.0.fields.day_of_week_letters: [T, a, d, h, r, s, u, y] }
+  - match: {hits.hits.0.fields.prefixed_node: [node_c] }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            dow:
+              terms:
+                field: day_of_week
+  - match: {hits.total.value: 6}
+  - match: {aggregations.dow.buckets.0.key: Friday}
+  - match: {aggregations.dow.buckets.0.doc_count: 1}
+  - match: {aggregations.dow.buckets.1.key: Monday}
+  - match: {aggregations.dow.buckets.1.doc_count: 1}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              day_of_week: Monday
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"match query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              day_of_week: Monday
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              day_of_week:
+                query: Monday
+                analyzer: standard
+  - match: {hits.total.value: 0}
+
+---
+"dynamic mapping update":
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"animal": "cow"}
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              animal: cow
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.animal: cow}
+
+---
+"nested":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              users:
+                type: nested
+                properties:
+                  first:
+                    type: keyword
+                  last:
+                    type: keyword
+                  first_script:
+                    type: runtime_script
+                    runtime_type: keyword
+                    script: emitValue(doc['users.first'].value)
+                  last_script:
+                    type: runtime_script
+                    runtime_type: keyword
+                    script: emitValue(doc['users.last'].value)
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body: |
+          {"index":{"_id": 1}}
+          {"group" : "fans", "users" : [{"first" : "John", "last" : "Smith"}, {"first": "Alice", "last": "White"}]}
+          {"index":{"_id": 2}}
+          {"group" : "fans", "users" : [{"first" : "Mark", "last" : "Doe"}]}
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            nested:
+              path: users
+              query:
+                bool:
+                  must:
+                    - match:
+                        users.first_script: John
+                    - match:
+                        users.last_script: Smith
+  - match: {hits.total.value: 1}
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            nested:
+              path: users
+              query:
+                bool:
+                  must:
+                    - match:
+                        users.first_script: John
+                    - match:
+                        users.last_script: White
+  - match: {hits.total.value: 0}
+
+  - do:
+      search:
+        body:
+          aggs:
+            to-users:
+              nested:
+                path: users
+              aggs:
+                users:
+                  top_hits:
+                    sort: users.last_script
+  - match: { hits.total.value: 2 }
+  - length: { aggregations.to-users.users.hits.hits: 3 }
+  - match: { aggregations.to-users.users.hits.hits.0._id: "2" }
+  - match: { aggregations.to-users.users.hits.hits.0._index: test }
+  - match: { aggregations.to-users.users.hits.hits.0._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.0._nested.offset: 0 }
+  - match: { aggregations.to-users.users.hits.hits.1._id: "1" }
+  - match: { aggregations.to-users.users.hits.hits.1._index: test }
+  - match: { aggregations.to-users.users.hits.hits.1._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.1._nested.offset: 0 }
+  - match: { aggregations.to-users.users.hits.hits.2._id: "1" }
+  - match: { aggregations.to-users.users.hits.hits.2._index: test }
+  - match: { aggregations.to-users.users.hits.hits.2._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.2._nested.offset: 1 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -1,0 +1,242 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              voltage_times_ten:
+                type: runtime_script
+                runtime_type: long
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emitValue((long)(v * params.multiplier));
+                    }
+                  params:
+                    multiplier: 10
+              # Test fetching from _source
+              voltage_times_ten_from_source:
+                type: runtime_script
+                runtime_type: long
+                script:
+                  source: |
+                    emitValue((long)(params._source.voltage * params.multiplier));
+                  params:
+                    multiplier: 10
+              # Test fetching many values
+              temperature_digits:
+                type: runtime_script
+                runtime_type: long
+                script:
+                  source: |
+                    for (long temperature : doc['temperature']) {
+                      long t = temperature;
+                      while (t != 0) {
+                        emitValue(t % 10);
+                        t /= 10;
+                      }
+                    }
+              # Test now
+              millis_ago:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    for (def dt : doc['timestamp']) {
+                      emitValue(System.currentTimeMillis() - dt.toInstant().toEpochMilli());
+                    }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.voltage_times_ten.type: runtime_script }
+  - match: {sensor.mappings.properties.voltage_times_ten.runtime_type: long }
+  - match:
+      sensor.mappings.properties.voltage_times_ten.script.source: |
+        for (double v : doc['voltage']) {
+          emitValue((long)(v * params.multiplier));
+        }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.params: {multiplier: 10} }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.lang: painless }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields:
+            - voltage_times_ten
+            - voltage_times_ten_from_source
+            - temperature_digits
+            - field: millis_ago
+              format: epoch_millis
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.0.fields.voltage_times_ten_from_source: [40] }
+  - match: {hits.hits.0.fields.temperature_digits: [0, 2, 2] }
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.1.fields.voltage_times_ten: [42] }
+  - match: {hits.hits.2.fields.voltage_times_ten: [56] }
+  - match: {hits.hits.3.fields.voltage_times_ten: [51] }
+  - match: {hits.hits.4.fields.voltage_times_ten: [58] }
+  - match: {hits.hits.5.fields.voltage_times_ten: [52] }
+  # We can't check the value because it is constantly increasing. If `gt` worked on strings we could do it, but it doens't.
+  - is_true: hits.hits.0.fields.millis_ago.0
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_times_ten
+  - match: {hits.total.value: 6}
+  - match: {aggregations.v10.buckets.0.key: 40.0}
+  - match: {aggregations.v10.buckets.0.doc_count: 1}
+  - match: {aggregations.v10.buckets.1.key: 42.0}
+  - match: {aggregations.v10.buckets.1.doc_count: 1}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              voltage_times_ten: 58
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+---
+"nested":
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              users:
+                type: nested
+                properties:
+                  first:
+                    type: keyword
+                  last:
+                    type: keyword
+                  first_script:
+                    type: runtime_script
+                    runtime_type: long
+                    script: emitValue(doc['users.first'].value.length())
+                  last_script:
+                    type: runtime_script
+                    runtime_type: long
+                    script: emitValue(doc['users.last'].value.length())
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body: |
+          {"index":{"_id": 1}}
+          {"group" : "fans", "users" : [{"first" : "John", "last" : "Smith"}, {"first": "Alice", "last": "Whighte"}]}
+          {"index":{"_id": 2}}
+          {"group" : "fans", "users" : [{"first" : "Mark", "last" : "Doe"}]}
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            nested:
+              path: users
+              query:
+                bool:
+                  must:
+                    - match:
+                        users.first_script: 4
+                    - match:
+                        users.last_script: 5
+  - match: {hits.total.value: 1}
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            nested:
+              path: users
+              query:
+                bool:
+                  must:
+                    - match:
+                        users.first_script: 4
+                    - match:
+                        users.last_script: 7
+  - match: {hits.total.value: 0}
+
+  - do:
+      search:
+        body:
+          aggs:
+            to-users:
+              nested:
+                path: users
+              aggs:
+                users:
+                  top_hits:
+                    sort: users.last_script
+  - match: { hits.total.value: 2 }
+  - length: { aggregations.to-users.users.hits.hits: 3 }
+  - match: { aggregations.to-users.users.hits.hits.0._id: "2" }
+  - match: { aggregations.to-users.users.hits.hits.0._index: test }
+  - match: { aggregations.to-users.users.hits.hits.0._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.0._nested.offset: 0 }
+  - match: { aggregations.to-users.users.hits.hits.1._id: "1" }
+  - match: { aggregations.to-users.users.hits.hits.1._index: test }
+  - match: { aggregations.to-users.users.hits.hits.1._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.1._nested.offset: 0 }
+  - match: { aggregations.to-users.users.hits.hits.2._id: "1" }
+  - match: { aggregations.to-users.users.hits.hits.2._index: test }
+  - match: { aggregations.to-users.users.hits.hits.2._nested.field: users }
+  - match: { aggregations.to-users.users.hits.hits.2._nested.offset: 1 }
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/30_double.yml
@@ -1,0 +1,177 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              voltage_percent:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emitValue(v / params.max);
+                    }
+                  params:
+                    max: 5.8
+              # Test fetching from _source
+              voltage_percent_from_source:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                    emitValue(params._source.voltage / params.max);
+                  params:
+                    max: 5.8
+              # Test fetching many values
+              voltage_sqrts:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                    for (double voltage : doc['voltage']) {
+                      double v = voltage;
+                      while (v > 1.2) {
+                        emitValue(v);
+                        v = Math.sqrt(v);
+                      }
+                    }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.voltage_percent.type: runtime_script }
+  - match: {sensor.mappings.properties.voltage_percent.runtime_type: double }
+  - match:
+      sensor.mappings.properties.voltage_percent.script.source: |
+        for (double v : doc['voltage']) {
+          emitValue(v / params.max);
+        }
+  - match: {sensor.mappings.properties.voltage_percent.script.params: {max: 5.8} }
+  - match: {sensor.mappings.properties.voltage_percent.script.lang: painless }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [voltage_percent, voltage_percent_from_source, voltage_sqrts]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
+  - match: {hits.hits.0.fields.voltage_percent_from_source: [0.6896551724137931] }
+  # Scripts that scripts that emit multiple values are supported and their results are sorted
+  - match: {hits.hits.0.fields.voltage_sqrts: [1.4142135623730951, 2.0, 4.0] }
+  - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }
+  - match: {hits.hits.2.fields.voltage_percent: [0.9655172413793103] }
+  - match: {hits.hits.3.fields.voltage_percent: [0.8793103448275862] }
+  - match: {hits.hits.4.fields.voltage_percent: [1.0] }
+  - match: {hits.hits.5.fields.voltage_percent: [0.896551724137931] }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_percent
+  - match: {hits.total.value: 6}
+  - match: {aggregations.v10.buckets.0.key: 0.6896551724137931}
+  - match: {aggregations.v10.buckets.0.doc_count: 1}
+  - match: {aggregations.v10.buckets.1.key: 0.7241379310344828}
+  - match: {aggregations.v10.buckets.1.doc_count: 1}
+
+---
+"range query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                lt: .7
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 4.0}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gt: 1
+  - match: {hits.total.value: 0}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gte: 1
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gte: .7
+                lte: .8
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 4.2}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              voltage_percent: 1.0
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -1,0 +1,162 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              tomorrow:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    for (def dt : doc['timestamp']) {
+                      emitValue(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+                    }
+                  params:
+                    days: 1
+              # Test fetching from _source and parsing
+              tomorrow_from_source:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    Instant instant = Instant.ofEpochMilli(parse(params._source.timestamp));
+                    ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
+                    emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+              # Test returning millis
+              the_past:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    for (def dt : doc['timestamp']) {
+                      emitValue(dt.toInstant().toEpochMilli() - 1000);
+                    }
+              # Test fetching many values
+              all_week:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    for (def dt : doc['timestamp']) {
+                      for (int i = 0; i < 7; i++) {
+                        emitValue(toEpochMilli(dt.plus(i, ChronoUnit.DAYS)));
+                      }
+                    }
+              # Test format parameter
+              formatted_tomorrow:
+                type: runtime_script
+                runtime_type: date
+                format: yyyy-MM-dd
+                script: |
+                  for (def dt : doc['timestamp']) {
+                    emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+                  }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": "2018-01-18T17:41:34.000Z", "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.tomorrow.type: runtime_script }
+  - match: {sensor.mappings.properties.tomorrow.runtime_type: date }
+  - match:
+      sensor.mappings.properties.tomorrow.script.source: |
+        for (def dt : doc['timestamp']) {
+          emitValue(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+        }
+  - match: {sensor.mappings.properties.tomorrow.script.params: {days: 1} }
+  - match: {sensor.mappings.properties.tomorrow.script.lang: painless }
+
+  - match: {sensor.mappings.properties.formatted_tomorrow.type: runtime_script }
+  - match: {sensor.mappings.properties.formatted_tomorrow.runtime_type: date }
+  - match:
+      sensor.mappings.properties.formatted_tomorrow.script.source: |
+        for (def dt : doc['timestamp']) {
+          emitValue(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+        }
+  - match: {sensor.mappings.properties.formatted_tomorrow.script.lang: painless }
+  - match: {sensor.mappings.properties.formatted_tomorrow.format: yyyy-MM-dd }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [tomorrow, tomorrow_from_source, the_past, all_week, formatted_tomorrow]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.tomorrow: [2018-01-19T17:41:34.000Z] }
+  - match: {hits.hits.0.fields.tomorrow_from_source: [2018-01-19T17:41:34.000Z] }
+  - match: {hits.hits.0.fields.the_past: [2018-01-18T17:41:33.000Z] }
+  - match:
+      hits.hits.0.fields.all_week:
+        - 2018-01-18T17:41:34.000Z
+        - 2018-01-19T17:41:34.000Z
+        - 2018-01-20T17:41:34.000Z
+        - 2018-01-21T17:41:34.000Z
+        - 2018-01-22T17:41:34.000Z
+        - 2018-01-23T17:41:34.000Z
+        - 2018-01-24T17:41:34.000Z
+  - match: {hits.hits.0.fields.formatted_tomorrow: [2018-01-19] }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            v10:
+              terms:
+                field: tomorrow
+                format: strict_date_optional_time
+  - match: {hits.total.value: 6}
+  - match: {aggregations.v10.buckets.0.key_as_string: 2018-01-19T17:41:34.000Z}
+  - match: {aggregations.v10.buckets.0.doc_count: 1}
+  - match: {aggregations.v10.buckets.1.key_as_string: 2018-01-20T17:41:34.000Z}
+  - match: {aggregations.v10.buckets.1.doc_count: 1}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              tomorrow: 2018-01-19T17:41:34Z
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 4.0}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -1,0 +1,144 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: http_logs
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              message:
+                type: keyword
+              ip:
+                type: runtime_script
+                runtime_type: ip
+                script:
+                  source: |
+                    String m = doc["message"].value;
+                    int end = m.indexOf(" ");
+                    emitValue(m.substring(0, end));
+              # Test fetching from _source
+              ip_from_source:
+                type: runtime_script
+                runtime_type: ip
+                script:
+                  source: |
+                    String m = params._source.message;
+                    int end = m.indexOf(" ");
+                    emitValue(m.substring(0, end));
+              # Test emitting many values
+              ip_many:
+                type: runtime_script
+                runtime_type: ip
+                script:
+                  source: |
+                    String m = doc["message"].value;
+                    int end = m.indexOf(" ");
+                    end = m.lastIndexOf(".", end);
+                    String stem = m.substring(0, end + 1);
+                    for (int i = 0; i < 5; i++) {
+                      emitValue(stem + i);
+                    }
+  - do:
+      bulk:
+        index: http_logs
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:17-05:00", "message" : "40.135.0.0 - - [1998-04-30T14:30:17-05:00] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "message" : "232.0.0.0 - - [1998-04-30T14:30:53-05:00] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "message" : "26.1.0.0 - - [1998-04-30T14:31:12-05:00] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "message" : "247.37.0.0 - - [1998-04-30T14:31:19-05:00] \"GET /french/splash_inet.html HTTP/1.0\" 200 3781"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:22-05:00", "message" : "247.37.0.0 - - [1998-04-30T14:31:22-05:00] \"GET /images/hm_nbg.jpg HTTP/1.0\" 304 0"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:27-05:00", "message" : "252.0.0.0 - - [1998-04-30T14:31:27-05:00] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: http_logs
+  - match: {http_logs.mappings.properties.ip.type: runtime_script }
+  - match: {http_logs.mappings.properties.ip.runtime_type: ip }
+  - match:
+      http_logs.mappings.properties.ip.script.source: |
+        String m = doc["message"].value;
+        int end = m.indexOf(" ");
+        emitValue(m.substring(0, end));
+  - match: {http_logs.mappings.properties.ip.script.lang: painless }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: http_logs
+        body:
+          sort: timestamp
+          docvalue_fields: [ip, ip_from_source, ip_many]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.ip: ["40.135.0.0"] }
+  - match: {hits.hits.0.fields.ip_from_source: ["40.135.0.0"] }
+  - match:
+      hits.hits.0.fields.ip_many:
+        - 40.135.0.0
+        - 40.135.0.1
+        - 40.135.0.2
+        - 40.135.0.3
+        - 40.135.0.4
+
+---
+"terms agg":
+  - do:
+      search:
+        index: http_logs
+        body:
+          aggs:
+            ip:
+              terms:
+                field: ip
+  - match: {hits.total.value: 6}
+  - match: {aggregations.ip.buckets.0.key: 247.37.0.0}
+  - match: {aggregations.ip.buckets.0.doc_count: 2}
+  - match: {aggregations.ip.buckets.1.key: 26.1.0.0}
+  - match: {aggregations.ip.buckets.1.doc_count: 1}
+
+---
+"use in scripts":
+  - do:
+      search:
+        index: http_logs
+        body:
+          aggs:
+            ip:
+              terms:
+                script:
+                  String v = doc['ip'].value;
+                  return v.substring(0, v.indexOf('.'));
+  - match: {hits.total.value: 6}
+  - match: {aggregations.ip.buckets.0.key: '247'}
+  - match: {aggregations.ip.buckets.0.doc_count: 2}
+  - match: {aggregations.ip.buckets.1.key: '232'}
+  - match: {aggregations.ip.buckets.1.doc_count: 1}
+
+---
+"term query":
+  - do:
+      search:
+        index: http_logs
+        body:
+          query:
+            term:
+              ip: 252.0.0.0
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.timestamp: 1998-04-30T14:31:27-05:00}
+
+# TODO tests for using the ip in a script. there is almost certainly whitelist "fun" here.

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
@@ -1,0 +1,124 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              over_v:
+                type: runtime_script
+                runtime_type: boolean
+                script:
+                  source: |
+                    for (def v : doc['voltage']) {
+                      emitValue(v >= params.min_v);
+                    }
+                  params:
+                    min_v: 5.0
+              # Test fetching from _source
+              over_v_from_source:
+                type: runtime_script
+                runtime_type: boolean
+                script:
+                  source: |
+                    emitValue(params._source.voltage >= 5.0);
+              # Test many booleans
+              big_vals:
+                type: runtime_script
+                runtime_type: boolean
+                script:
+                  source: |
+                    for (def v : doc['temperature']) {
+                      emitValue(v >= 200);
+                    }
+                    for (def v : doc['voltage']) {
+                      emitValue(v >= 5.0);
+                    }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.over_v.type: runtime_script }
+  - match: {sensor.mappings.properties.over_v.runtime_type: boolean }
+  - match:
+      sensor.mappings.properties.over_v.script.source: |
+        for (def v : doc['voltage']) {
+          emitValue(v >= params.min_v);
+        }
+  - match: {sensor.mappings.properties.over_v.script.params: {min_v: 5.0} }
+  - match: {sensor.mappings.properties.over_v.script.lang: painless }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [over_v, over_v_from_source, big_vals]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.over_v: [false] }
+  - match: {hits.hits.0.fields.over_v_from_source: [false] }
+  - match: {hits.hits.0.fields.big_vals: [false, true] } # doc values are sorted with falses before trues
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            over_v:
+              terms:
+                field: over_v
+  - match: {hits.total.value: 6}
+  - match: {aggregations.over_v.buckets.0.key_as_string: "true"}
+  - match: {aggregations.over_v.buckets.0.doc_count: 4}
+  - match: {aggregations.over_v.buckets.1.key_as_string: "false"}
+  - match: {aggregations.over_v.buckets.1.doc_count: 2}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              over_v: true
+          sort:
+            timestamp: asc
+  - match: {hits.total.value: 4}
+  - match: {hits.hits.0._source.voltage: 5.6}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
@@ -1,0 +1,240 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor1
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              message:
+                type: keyword
+              day_of_week:
+                type: runtime_script
+                runtime_type: keyword
+                script: |
+                  emitValue(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT));
+              tomorrow:
+                type: runtime_script
+                runtime_type: date
+                script:
+                  source: |
+                    for (def dt : doc['timestamp']) {
+                      emitValue(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+                    }
+                  params:
+                    days: 1
+              voltage:
+                type: double
+              voltage_times_ten:
+                type: runtime_script
+                runtime_type: long
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emitValue((long)(v * params.multiplier));
+                    }
+                  params:
+                    multiplier: 10
+              voltage_percent:
+                type: runtime_script
+                runtime_type: double
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emitValue(v / params.max);
+                    }
+                  params:
+                    max: 5.8
+              ip:
+                type: runtime_script
+                runtime_type: ip
+                script:
+                  source: |
+                    String m = doc["message"].value;
+                    int end = m.indexOf(" ");
+                    emitValue(m.substring(0, end));
+              over_v:
+                type: runtime_script
+                runtime_type: boolean
+                script:
+                  source: |
+                    for (def v : doc['voltage']) {
+                      emitValue(v >= params.min_v);
+                    }
+                  params:
+                    min_v: 5.0
+
+  - do:
+      bulk:
+        index: sensor1
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "voltage": 5.2}
+          {"index":{}}
+          {"timestamp": 1516642894000, "voltage": 5.1}
+          {"index":{}}
+          {"timestamp": 1516556494000, "voltage": 5.8}
+          {"index":{}}
+          {"timestamp": 1516470094000, "voltage": 5.7}
+          {"index":{}}
+          {"timestamp": 1516383694000, "voltage": 5.6}
+          {"index":{}}
+          {"timestamp": 1516297294000, "voltage": 5.5}
+
+  - do:
+      indices.create:
+        index: sensor2
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              message:
+                type: keyword
+              timestamp:
+                type: date
+              day_of_week:
+                type: keyword
+              tomorrow:
+                type: date
+              voltage:
+                type: double
+              voltage_times_ten:
+                type: long
+              voltage_percent:
+                type: double
+              ip:
+                type: ip
+              over_v:
+                type: boolean
+
+  - do:
+      bulk:
+        index: sensor2
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "day_of_week": "Monday", "voltage": 5.5, "voltage_times_ten": 55, "voltage_percent": 0.6}
+          {"index":{}}
+          {"timestamp": 1516642894000, "day_of_week": "Tuesday","voltage": 5.3, "voltage_times_ten": 53, "voltage_percent": 0.5}
+          {"index":{}}
+          {"timestamp": 1516556494000, "day_of_week": "Wednesday","voltage": 5.2, "voltage_times_ten": 52, "voltage_percent": 0.4}
+          {"index":{}}
+          {"timestamp": 1516470094000, "day_of_week": "Thursday","voltage": 5.1, "voltage_times_ten": 51, "voltage_percent": 0.3}
+          {"index":{}}
+          {"timestamp": 1516383694000, "day_of_week": "Friday","voltage": 5.6, "voltage_times_ten": 56, "voltage_percent": 0.7}
+          {"index":{}}
+          {"timestamp": 1516297294000, "day_of_week": "Saturday","voltage": 5.8, "voltage_times_ten": 58, "voltage_percent": 1}
+
+---
+"field capabilities":
+  - do:
+      field_caps:
+        index: sensor*
+        fields: [day_of_week, voltage_*, tomorrow, ip, over_v]
+
+  - match: {indices: [sensor1, sensor2]}
+  - match: {fields.day_of_week.keyword.searchable: true}
+  - match: {fields.day_of_week.keyword.aggregatable: true}
+  - is_false: fields.day_of_week.keyword.indices
+  - match: {fields.voltage_times_ten.long.searchable: true}
+  - match: {fields.voltage_times_ten.long.aggregatable: true}
+  - is_false: fields.voltage_times_ten.long.indices
+  - match: {fields.voltage_percent.double.searchable: true}
+  - match: {fields.voltage_percent.double.aggregatable: true}
+  - is_false: fields.voltage_percent.double.indices
+  - match: {fields.tomorrow.date.searchable: true}
+  - match: {fields.tomorrow.date.aggregatable: true}
+  - is_false: fields.tomorrow.date.indices
+  - match: {fields.ip.ip.searchable: true}
+  - match: {fields.ip.ip.aggregatable: true}
+  - is_false: fields.ip.ip.indices
+  - match: {fields.over_v.boolean.searchable: true}
+  - match: {fields.over_v.boolean.aggregatable: true}
+  - is_false: fields.over_v.boolean.indices
+
+---
+"terms agg - keyword":
+  - do:
+      search:
+        index: sensor*
+        body:
+          aggs:
+            dow:
+              terms:
+                field: day_of_week
+  - match: {hits.total.value: 12}
+  - match: {aggregations.dow.buckets.0.key: Friday}
+  - match: {aggregations.dow.buckets.0.doc_count: 2}
+  - match: {aggregations.dow.buckets.1.key: Monday}
+  - match: {aggregations.dow.buckets.1.doc_count: 2}
+
+---
+"match query - keyword":
+  - do:
+      search:
+        index: sensor*
+        body:
+          query:
+            match:
+              day_of_week: Monday
+  - match: {hits.total.value: 2}
+
+---
+"terms agg - long":
+  - do:
+      search:
+        index: sensor*
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_times_ten
+  - match: {hits.total.value: 12}
+  - match: {aggregations.v10.buckets.0.key: 51}
+  - match: {aggregations.v10.buckets.0.doc_count: 2}
+
+---
+"range query - long":
+  - do:
+      search:
+        index: sensor*
+        body:
+          query:
+            range:
+              voltage_times_ten:
+                lt: 55
+  - match: {hits.total.value: 5}
+
+---
+"terms agg - double":
+  - do:
+      search:
+        index: sensor*
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_percent
+  - match: {hits.total.value: 12}
+  - match: {aggregations.v10.buckets.0.key: 1.0}
+  - match: {aggregations.v10.buckets.0.doc_count: 2}
+
+---
+"range query - double":
+  - do:
+      search:
+        index: sensor*
+        body:
+          query:
+            range:
+              voltage_percent:
+                lt: .7
+  - match: {hits.total.value: 4}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/90_loops.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/90_loops.yml
@@ -1,0 +1,202 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              tight_loop:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['tight_loop'].value)
+              loose_loop:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['lla'].value)
+              lla:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['llb'].value)
+              llb:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['llc'].value)
+              llc:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['loose_loop'].value)
+              refs:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_2'].value + doc['over_max_depth_3'].value + doc['over_max_depth_4'].value + doc['over_max_depth_5'].value + doc['node'].value)
+              over_max_depth:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_1'].value)
+              over_max_depth_1:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_2'].value)
+              over_max_depth_2:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_3'].value)
+              over_max_depth_3:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_4'].value)
+              over_max_depth_4:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue(doc['over_max_depth_5'].value)
+              over_max_depth_5:
+                type: runtime_script
+                runtime_type: keyword
+                script: emitValue('test')
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+---
+"tight loop - docvalue_fields":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: tight_loop -> tight_loop/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [tight_loop]
+---
+"tight loop - aggs":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: tight_loop -> tight_loop/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          aggs:
+            loop:
+             terms:
+               field: tight_loop
+---
+"tight loop - sort":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: tight_loop -> tight_loop/'
+      search:
+        index: sensor
+        body:
+          sort: tight_loop
+
+---
+"loose loop - aggs":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: loose_loop -> lla -> llb -> llc -> loose_loop/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          aggs:
+            loop:
+             terms:
+               field: loose_loop
+
+---
+"loose loop - sort":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: loose_loop -> lla -> llb -> llc -> loose_loop/'
+      search:
+        index: sensor
+        body:
+          sort: loose_loop
+---
+"loose loop - docvalue_fields":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: loose_loop -> lla -> llb -> llc -> loose_loop/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [loose_loop]
+
+---
+"loose loop - begins within":
+  - do:
+      catch: '/Cyclic dependency detected while resolving runtime fields: lla -> llb -> llc -> loose_loop -> lla/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          aggs:
+            loop:
+             terms:
+               field: lla
+
+---
+"Max chain depth - 5 is allowed":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [over_max_depth_1]
+
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0.fields.over_max_depth_1.0: test}
+
+---
+"Max chain depth - direct references are not counted":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [refs]
+
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0.fields.refs.0: testtesttesttesta}
+
+---
+"Max chain depth - aggs":
+  - do:
+      catch: '/Field requires resolving too many dependent fields: over_max_depth -> over_max_depth_1 -> over_max_depth_2 -> over_max_depth_3 -> over_max_depth_4 -> over_max_depth_5/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          aggs:
+            loop:
+             terms:
+               field: over_max_depth
+---
+"Max chain depth - sort":
+  - do:
+      catch: '/Field requires resolving too many dependent fields: over_max_depth -> over_max_depth_1 -> over_max_depth_2 -> over_max_depth_3 -> over_max_depth_4 -> over_max_depth_5/'
+      search:
+        index: sensor
+        body:
+          sort: over_max_depth
+---
+"Max chain depth - docvalue_fields":
+  - do:
+      catch: '/Field requires resolving too many dependent fields: over_max_depth -> over_max_depth_1 -> over_max_depth_2 -> over_max_depth_3 -> over_max_depth_4 -> over_max_depth_5/'
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [over_max_depth]


### PR DESCRIPTION
This is the backport for #61776 .

This commit includes the work that has been done on the runtime fields feature branch until now. The high level tasks are listed in #59332. The tasks that have not yet been completed can be worked on after merging the feature branch.

We are adding a new x-pack plugin called runtime-fields that plugs in a custom mapper which allows to define runtime fields based on a script.
The changes included in this commit that were made outside of the x-pack/plugin/runtime-fields directory are minimal and revolve around 1) making the ScriptService available while parsing index mappings so that the scripts associated to runtime fields can be compiled 2) sharing code to manipulate ranges etc. as it can be reused in runtime fields.

Co-authored-by: Nik Everett <nik9000@gmail.com>