### PR TITLE
Adding a note about Component templates being a newly introduced functionality in 7.8

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -67,6 +67,8 @@ For more information, see <<indices-templates, Index Templates>>.
 * <<indices-simulate-index>>
 * <<indices-simulate-template>>
 
+(Component templates have been introduced in 7.8.)
+
 [discrete]
 [[monitoring]]
 === Monitoring:

--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -67,7 +67,6 @@ For more information, see <<indices-templates, Index Templates>>.
 * <<indices-simulate-index>>
 * <<indices-simulate-template>>
 
-(Component templates have been introduced in 7.8.)
 
 [discrete]
 [[monitoring]]

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Put component template</titleabbrev>
 ++++
 
+(Component templates have been introduced in 7.8.)
+
 Creates or updates a component template. 
 Component templates are building blocks for constructing <<indices-templates,index templates>>.  
 that specify index <<mapping,mappings>>, <<index-modules-settings,settings>>, 

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Put component template</titleabbrev>
 ++++
 
-(Component templates have been introduced in 7.8.)
+added::[7.8.0]
 
 Creates or updates a component template. 
 Component templates are building blocks for constructing <<indices-templates,index templates>>.  


### PR DESCRIPTION
I couldn't find a mention about Component templates not being available prior to 7.8. I myself learned about it [the annoying way](https://stackoverflow.com/questions/63748434/put-component-template-yields-incorrect-http-method). :)