### PR TITLE
Introduce bulk routing optimization.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -154,7 +154,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final String SETTING_ROUTING_PARTITION_SIZE = "index.routing_partition_size";
     public static final Setting<Integer> INDEX_ROUTING_PARTITION_SIZE_SETTING =
-            Setting.intSetting(SETTING_ROUTING_PARTITION_SIZE, 1, 1, Property.IndexScope);
+        Setting.intSetting(SETTING_ROUTING_PARTITION_SIZE, 1, 1, Property.IndexScope);
 
     public static final Setting<Integer> INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING = Setting.intSetting(
         "index.number_of_routing_shards",
@@ -266,7 +266,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_VERSION_CREATED = "index.version.created";
 
     public static final Setting<Version> SETTING_INDEX_VERSION_CREATED =
-            Setting.versionSetting(SETTING_VERSION_CREATED, Version.V_EMPTY, Property.IndexScope, Property.PrivateIndex);
+        Setting.versionSetting(SETTING_VERSION_CREATED, Version.V_EMPTY, Property.IndexScope, Property.PrivateIndex);
 
     public static final String SETTING_VERSION_CREATED_STRING = "index.version.created_string";
     public static final String SETTING_VERSION_UPGRADED = "index.version.upgraded";
@@ -302,16 +302,18 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope));
     public static final Setting.AffixSetting<String> INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING =
         Setting.prefixKeySetting("index.routing.allocation.initial_recovery.", key -> Setting.simpleString(key));
-
+    public static final String INDEX_BULK_ROUTING_ENABLED = "index.bulk_routing.enabled";
+    public static final Setting<Boolean> INDEX_BULK_ROUTING_ENABLED_SETTING =
+        Setting.boolSetting(INDEX_BULK_ROUTING_ENABLED, false, Property.Dynamic, Property.IndexScope);
     /**
      * The number of active shard copies to check for before proceeding with a write operation.
      */
     public static final Setting<ActiveShardCount> SETTING_WAIT_FOR_ACTIVE_SHARDS =
         new Setting<>("index.write.wait_for_active_shards",
-                      "1",
-                      ActiveShardCount::parseString,
-                      Setting.Property.Dynamic,
-                      Setting.Property.IndexScope);
+            "1",
+            ActiveShardCount::parseString,
+            Setting.Property.Dynamic,
+            Setting.Property.IndexScope);
 
     public static final String SETTING_INDEX_HIDDEN = "index.hidden";
     /**
@@ -326,7 +328,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     private static final String INDEX_FORMAT = "index.format";
     public static final Setting<Integer> INDEX_FORMAT_SETTING =
-            Setting.intSetting(INDEX_FORMAT, 0, Setting.Property.IndexScope, Setting.Property.Final);
+        Setting.intSetting(INDEX_FORMAT, 0, Setting.Property.IndexScope, Setting.Property.Final);
 
     public static final String KEY_IN_SYNC_ALLOCATIONS = "in_sync_allocations";
     static final String KEY_VERSION = "version";
@@ -390,32 +392,35 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final ImmutableOpenMap<String, RolloverInfo> rolloverInfos;
     private final boolean isSystem;
 
+    private final boolean bulkRoutingEnabled;
+
     private IndexMetadata(
-            final Index index,
-            final long version,
-            final long mappingVersion,
-            final long settingsVersion,
-            final long aliasesVersion,
-            final long[] primaryTerms,
-            final State state,
-            final int numberOfShards,
-            final int numberOfReplicas,
-            final Settings settings,
-            final ImmutableOpenMap<String, MappingMetadata> mappings,
-            final ImmutableOpenMap<String, AliasMetadata> aliases,
-            final ImmutableOpenMap<String, DiffableStringMap> customData,
-            final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
-            final DiscoveryNodeFilters requireFilters,
-            final DiscoveryNodeFilters initialRecoveryFilters,
-            final DiscoveryNodeFilters includeFilters,
-            final DiscoveryNodeFilters excludeFilters,
-            final Version indexCreatedVersion,
-            final Version indexUpgradedVersion,
-            final int routingNumShards,
-            final int routingPartitionSize,
-            final ActiveShardCount waitForActiveShards,
-            final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
-            final boolean isSystem) {
+        final Index index,
+        final long version,
+        final long mappingVersion,
+        final long settingsVersion,
+        final long aliasesVersion,
+        final long[] primaryTerms,
+        final State state,
+        final int numberOfShards,
+        final int numberOfReplicas,
+        final Settings settings,
+        final ImmutableOpenMap<String, MappingMetadata> mappings,
+        final ImmutableOpenMap<String, AliasMetadata> aliases,
+        final ImmutableOpenMap<String, DiffableStringMap> customData,
+        final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
+        final DiscoveryNodeFilters requireFilters,
+        final DiscoveryNodeFilters initialRecoveryFilters,
+        final DiscoveryNodeFilters includeFilters,
+        final DiscoveryNodeFilters excludeFilters,
+        final Version indexCreatedVersion,
+        final Version indexUpgradedVersion,
+        final int routingNumShards,
+        final int routingPartitionSize,
+        final ActiveShardCount waitForActiveShards,
+        final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
+        final boolean isSystem,
+        final boolean bulkRoutingEnabled) {
 
         this.index = index;
         this.version = version;
@@ -448,6 +453,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.waitForActiveShards = waitForActiveShards;
         this.rolloverInfos = rolloverInfos;
         this.isSystem = isSystem;
+        this.bulkRoutingEnabled = bulkRoutingEnabled;
         assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
@@ -548,6 +554,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     public ActiveShardCount getWaitForActiveShards() {
         return waitForActiveShards;
+    }
+
+    public boolean isBulkRoutingEnabled() {
+        return bulkRoutingEnabled;
     }
 
     public Settings getSettings() {
@@ -1197,7 +1207,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {
                 throw new IllegalArgumentException("routing partition size [" + routingPartitionSize + "] should be a positive number"
-                        + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
+                    + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
             }
 
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
@@ -1250,38 +1260,40 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final ActiveShardCount waitForActiveShards = SETTING_WAIT_FOR_ACTIVE_SHARDS.get(settings);
             if (waitForActiveShards.validate(numberOfReplicas) == false) {
                 throw new IllegalArgumentException("invalid " + SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey() +
-                                                   "[" + waitForActiveShards + "]: cannot be greater than " +
-                                                   "number of shard copies [" + (numberOfReplicas + 1) + "]");
+                    "[" + waitForActiveShards + "]: cannot be greater than " +
+                    "number of shard copies [" + (numberOfReplicas + 1) + "]");
             }
 
             final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
+            final boolean bulkRoutingEnabled = settings.getAsBoolean(INDEX_BULK_ROUTING_ENABLED, false);
 
             return new IndexMetadata(
-                    new Index(index, uuid),
-                    version,
-                    mappingVersion,
-                    settingsVersion,
-                    aliasesVersion,
-                    primaryTerms,
-                    state,
-                    numberOfShards,
-                    numberOfReplicas,
-                    tmpSettings,
-                    mappings.build(),
-                    tmpAliases.build(),
-                    customMetadata.build(),
-                    filledInSyncAllocationIds.build(),
-                    requireFilters,
-                    initialRecoveryFilters,
-                    includeFilters,
-                    excludeFilters,
-                    indexCreatedVersion,
-                    indexUpgradedVersion,
-                    getRoutingNumShards(),
-                    routingPartitionSize,
-                    waitForActiveShards,
-                    rolloverInfos.build(),
-                    isSystem);
+                new Index(index, uuid),
+                version,
+                mappingVersion,
+                settingsVersion,
+                aliasesVersion,
+                primaryTerms,
+                state,
+                numberOfShards,
+                numberOfReplicas,
+                tmpSettings,
+                mappings.build(),
+                tmpAliases.build(),
+                customMetadata.build(),
+                filledInSyncAllocationIds.build(),
+                requireFilters,
+                initialRecoveryFilters,
+                includeFilters,
+                excludeFilters,
+                indexCreatedVersion,
+                indexUpgradedVersion,
+                getRoutingNumShards(),
+                routingPartitionSize,
+                waitForActiveShards,
+                rolloverInfos.build(),
+                isSystem,
+                bulkRoutingEnabled);
         }
 
         public static void toXContent(IndexMetadata indexMetadata, XContentBuilder builder, ToXContent.Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -310,10 +310,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     public static final Setting<ActiveShardCount> SETTING_WAIT_FOR_ACTIVE_SHARDS =
         new Setting<>("index.write.wait_for_active_shards",
-              "1",
-                           ActiveShardCount::parseString,
-                           Setting.Property.Dynamic,
-                           Setting.Property.IndexScope);
+                      "1",
+                      ActiveShardCount::parseString,
+                      Setting.Property.Dynamic,
+                      Setting.Property.IndexScope);
 
     public static final String SETTING_INDEX_HIDDEN = "index.hidden";
     /**
@@ -328,7 +328,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     private static final String INDEX_FORMAT = "index.format";
     public static final Setting<Integer> INDEX_FORMAT_SETTING =
-        Setting.intSetting(INDEX_FORMAT, 0, Setting.Property.IndexScope, Setting.Property.Final);
+            Setting.intSetting(INDEX_FORMAT, 0, Setting.Property.IndexScope, Setting.Property.Final);
 
     public static final String KEY_IN_SYNC_ALLOCATIONS = "in_sync_allocations";
     static final String KEY_VERSION = "version";
@@ -419,42 +419,40 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final int routingPartitionSize,
             final ActiveShardCount waitForActiveShards,
             final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
-            final boolean isSystem,
-            final boolean bulkRoutingEnabled) {
+            final boolean isSystem) {
 
-            this.index = index;
-            this.version = version;
-            assert mappingVersion >= 0 : mappingVersion;
-            this.mappingVersion = mappingVersion;
-            assert settingsVersion >= 0 : settingsVersion;
-            this.settingsVersion = settingsVersion;
-            assert aliasesVersion >= 0 : aliasesVersion;
-            this.aliasesVersion = aliasesVersion;
-            this.primaryTerms = primaryTerms;
-            assert primaryTerms.length == numberOfShards;
-            this.state = state;
-            this.numberOfShards = numberOfShards;
-            this.numberOfReplicas = numberOfReplicas;
-            this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
-            this.settings = settings;
-            this.mappings = mappings;
-            this.customData = customData;
-            this.aliases = aliases;
-            this.inSyncAllocationIds = inSyncAllocationIds;
-            this.requireFilters = requireFilters;
-            this.includeFilters = includeFilters;
-            this.excludeFilters = excludeFilters;
-            this.initialRecoveryFilters = initialRecoveryFilters;
-            this.indexCreatedVersion = indexCreatedVersion;
-            this.indexUpgradedVersion = indexUpgradedVersion;
-            this.routingNumShards = routingNumShards;
-            this.routingFactor = routingNumShards / numberOfShards;
-            this.routingPartitionSize = routingPartitionSize;
-            this.waitForActiveShards = waitForActiveShards;
-            this.rolloverInfos = rolloverInfos;
-            this.isSystem = isSystem;
-            this.bulkRoutingEnabled = bulkRoutingEnabled;
-            assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
+        this.index = index;
+        this.version = version;
+        assert mappingVersion >= 0 : mappingVersion;
+        this.mappingVersion = mappingVersion;
+        assert settingsVersion >= 0 : settingsVersion;
+        this.settingsVersion = settingsVersion;
+        assert aliasesVersion >= 0 : aliasesVersion;
+        this.aliasesVersion = aliasesVersion;
+        this.primaryTerms = primaryTerms;
+        assert primaryTerms.length == numberOfShards;
+        this.state = state;
+        this.numberOfShards = numberOfShards;
+        this.numberOfReplicas = numberOfReplicas;
+        this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
+        this.settings = settings;
+        this.mappings = mappings;
+        this.customData = customData;
+        this.aliases = aliases;
+        this.inSyncAllocationIds = inSyncAllocationIds;
+        this.requireFilters = requireFilters;
+        this.includeFilters = includeFilters;
+        this.excludeFilters = excludeFilters;
+        this.initialRecoveryFilters = initialRecoveryFilters;
+        this.indexCreatedVersion = indexCreatedVersion;
+        this.indexUpgradedVersion = indexUpgradedVersion;
+        this.routingNumShards = routingNumShards;
+        this.routingFactor = routingNumShards / numberOfShards;
+        this.routingPartitionSize = routingPartitionSize;
+        this.waitForActiveShards = waitForActiveShards;
+        this.rolloverInfos = rolloverInfos;
+        this.isSystem = isSystem;
+        assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
     public Index getIndex() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -154,7 +154,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final String SETTING_ROUTING_PARTITION_SIZE = "index.routing_partition_size";
     public static final Setting<Integer> INDEX_ROUTING_PARTITION_SIZE_SETTING =
-        Setting.intSetting(SETTING_ROUTING_PARTITION_SIZE, 1, 1, Property.IndexScope);
+            Setting.intSetting(SETTING_ROUTING_PARTITION_SIZE, 1, 1, Property.IndexScope);
 
     public static final Setting<Integer> INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING = Setting.intSetting(
         "index.number_of_routing_shards",
@@ -266,7 +266,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_VERSION_CREATED = "index.version.created";
 
     public static final Setting<Version> SETTING_INDEX_VERSION_CREATED =
-        Setting.versionSetting(SETTING_VERSION_CREATED, Version.V_EMPTY, Property.IndexScope, Property.PrivateIndex);
+            Setting.versionSetting(SETTING_VERSION_CREATED, Version.V_EMPTY, Property.IndexScope, Property.PrivateIndex);
 
     public static final String SETTING_VERSION_CREATED_STRING = "index.version.created_string";
     public static final String SETTING_VERSION_UPGRADED = "index.version.upgraded";
@@ -310,10 +310,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     public static final Setting<ActiveShardCount> SETTING_WAIT_FOR_ACTIVE_SHARDS =
         new Setting<>("index.write.wait_for_active_shards",
-            "1",
-            ActiveShardCount::parseString,
-            Setting.Property.Dynamic,
-            Setting.Property.IndexScope);
+              "1",
+                           ActiveShardCount::parseString,
+                           Setting.Property.Dynamic,
+                           Setting.Property.IndexScope);
 
     public static final String SETTING_INDEX_HIDDEN = "index.hidden";
     /**
@@ -395,66 +395,66 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final boolean bulkRoutingEnabled;
 
     private IndexMetadata(
-        final Index index,
-        final long version,
-        final long mappingVersion,
-        final long settingsVersion,
-        final long aliasesVersion,
-        final long[] primaryTerms,
-        final State state,
-        final int numberOfShards,
-        final int numberOfReplicas,
-        final Settings settings,
-        final ImmutableOpenMap<String, MappingMetadata> mappings,
-        final ImmutableOpenMap<String, AliasMetadata> aliases,
-        final ImmutableOpenMap<String, DiffableStringMap> customData,
-        final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
-        final DiscoveryNodeFilters requireFilters,
-        final DiscoveryNodeFilters initialRecoveryFilters,
-        final DiscoveryNodeFilters includeFilters,
-        final DiscoveryNodeFilters excludeFilters,
-        final Version indexCreatedVersion,
-        final Version indexUpgradedVersion,
-        final int routingNumShards,
-        final int routingPartitionSize,
-        final ActiveShardCount waitForActiveShards,
-        final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
-        final boolean isSystem,
-        final boolean bulkRoutingEnabled) {
+            final Index index,
+            final long version,
+            final long mappingVersion,
+            final long settingsVersion,
+            final long aliasesVersion,
+            final long[] primaryTerms,
+            final State state,
+            final int numberOfShards,
+            final int numberOfReplicas,
+            final Settings settings,
+            final ImmutableOpenMap<String, MappingMetadata> mappings,
+            final ImmutableOpenMap<String, AliasMetadata> aliases,
+            final ImmutableOpenMap<String, DiffableStringMap> customData,
+            final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
+            final DiscoveryNodeFilters requireFilters,
+            final DiscoveryNodeFilters initialRecoveryFilters,
+            final DiscoveryNodeFilters includeFilters,
+            final DiscoveryNodeFilters excludeFilters,
+            final Version indexCreatedVersion,
+            final Version indexUpgradedVersion,
+            final int routingNumShards,
+            final int routingPartitionSize,
+            final ActiveShardCount waitForActiveShards,
+            final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
+            final boolean isSystem,
+            final boolean bulkRoutingEnabled) {
 
-        this.index = index;
-        this.version = version;
-        assert mappingVersion >= 0 : mappingVersion;
-        this.mappingVersion = mappingVersion;
-        assert settingsVersion >= 0 : settingsVersion;
-        this.settingsVersion = settingsVersion;
-        assert aliasesVersion >= 0 : aliasesVersion;
-        this.aliasesVersion = aliasesVersion;
-        this.primaryTerms = primaryTerms;
-        assert primaryTerms.length == numberOfShards;
-        this.state = state;
-        this.numberOfShards = numberOfShards;
-        this.numberOfReplicas = numberOfReplicas;
-        this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
-        this.settings = settings;
-        this.mappings = mappings;
-        this.customData = customData;
-        this.aliases = aliases;
-        this.inSyncAllocationIds = inSyncAllocationIds;
-        this.requireFilters = requireFilters;
-        this.includeFilters = includeFilters;
-        this.excludeFilters = excludeFilters;
-        this.initialRecoveryFilters = initialRecoveryFilters;
-        this.indexCreatedVersion = indexCreatedVersion;
-        this.indexUpgradedVersion = indexUpgradedVersion;
-        this.routingNumShards = routingNumShards;
-        this.routingFactor = routingNumShards / numberOfShards;
-        this.routingPartitionSize = routingPartitionSize;
-        this.waitForActiveShards = waitForActiveShards;
-        this.rolloverInfos = rolloverInfos;
-        this.isSystem = isSystem;
-        this.bulkRoutingEnabled = bulkRoutingEnabled;
-        assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
+            this.index = index;
+            this.version = version;
+            assert mappingVersion >= 0 : mappingVersion;
+            this.mappingVersion = mappingVersion;
+            assert settingsVersion >= 0 : settingsVersion;
+            this.settingsVersion = settingsVersion;
+            assert aliasesVersion >= 0 : aliasesVersion;
+            this.aliasesVersion = aliasesVersion;
+            this.primaryTerms = primaryTerms;
+            assert primaryTerms.length == numberOfShards;
+            this.state = state;
+            this.numberOfShards = numberOfShards;
+            this.numberOfReplicas = numberOfReplicas;
+            this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
+            this.settings = settings;
+            this.mappings = mappings;
+            this.customData = customData;
+            this.aliases = aliases;
+            this.inSyncAllocationIds = inSyncAllocationIds;
+            this.requireFilters = requireFilters;
+            this.includeFilters = includeFilters;
+            this.excludeFilters = excludeFilters;
+            this.initialRecoveryFilters = initialRecoveryFilters;
+            this.indexCreatedVersion = indexCreatedVersion;
+            this.indexUpgradedVersion = indexUpgradedVersion;
+            this.routingNumShards = routingNumShards;
+            this.routingFactor = routingNumShards / numberOfShards;
+            this.routingPartitionSize = routingPartitionSize;
+            this.waitForActiveShards = waitForActiveShards;
+            this.rolloverInfos = rolloverInfos;
+            this.isSystem = isSystem;
+            this.bulkRoutingEnabled = bulkRoutingEnabled;
+            assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
     public Index getIndex() {
@@ -1207,7 +1207,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {
                 throw new IllegalArgumentException("routing partition size [" + routingPartitionSize + "] should be a positive number"
-                    + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
+                        + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
             }
 
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
@@ -1260,40 +1260,40 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final ActiveShardCount waitForActiveShards = SETTING_WAIT_FOR_ACTIVE_SHARDS.get(settings);
             if (waitForActiveShards.validate(numberOfReplicas) == false) {
                 throw new IllegalArgumentException("invalid " + SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey() +
-                    "[" + waitForActiveShards + "]: cannot be greater than " +
-                    "number of shard copies [" + (numberOfReplicas + 1) + "]");
+                                                   "[" + waitForActiveShards + "]: cannot be greater than " +
+                                                   "number of shard copies [" + (numberOfReplicas + 1) + "]");
             }
 
             final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
             final boolean bulkRoutingEnabled = settings.getAsBoolean(INDEX_BULK_ROUTING_ENABLED, false);
 
             return new IndexMetadata(
-                new Index(index, uuid),
-                version,
-                mappingVersion,
-                settingsVersion,
-                aliasesVersion,
-                primaryTerms,
-                state,
-                numberOfShards,
-                numberOfReplicas,
-                tmpSettings,
-                mappings.build(),
-                tmpAliases.build(),
-                customMetadata.build(),
-                filledInSyncAllocationIds.build(),
-                requireFilters,
-                initialRecoveryFilters,
-                includeFilters,
-                excludeFilters,
-                indexCreatedVersion,
-                indexUpgradedVersion,
-                getRoutingNumShards(),
-                routingPartitionSize,
-                waitForActiveShards,
-                rolloverInfos.build(),
-                isSystem,
-                bulkRoutingEnabled);
+                    new Index(index, uuid),
+                    version,
+                    mappingVersion,
+                    settingsVersion,
+                    aliasesVersion,
+                    primaryTerms,
+                    state,
+                    numberOfShards,
+                    numberOfReplicas,
+                    tmpSettings,
+                    mappings.build(),
+                    tmpAliases.build(),
+                    customMetadata.build(),
+                    filledInSyncAllocationIds.build(),
+                    requireFilters,
+                    initialRecoveryFilters,
+                    includeFilters,
+                    excludeFilters,
+                    indexCreatedVersion,
+                    indexUpgradedVersion,
+                    getRoutingNumShards(),
+                    routingPartitionSize,
+                    waitForActiveShards,
+                    rolloverInfos.build(),
+                    isSystem,
+                    bulkRoutingEnabled);
         }
 
         public static void toXContent(IndexMetadata indexMetadata, XContentBuilder builder, ToXContent.Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -80,6 +80,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             IndexMetadata.INDEX_DATA_PATH_SETTING,
             IndexMetadata.INDEX_HIDDEN_SETTING,
             IndexMetadata.INDEX_FORMAT_SETTING,
+            IndexMetadata.INDEX_BULK_ROUTING_ENABLED_SETTING,
             SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
             SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,
             SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING,


### PR DESCRIPTION
# Issue
In large scale cluster, to avoid single shard size too big, user needs to set too many shards in a single index. 
For example, one of our user's production cluster has 100 data nodes, and each of `downlink` index has around 150 shards to control single shard size around 30-50GB:
```
health status index              uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   downlink-20200904.3  gT_4J_-dQHuOq_G8cE00kg 153   0 8098910441            0      4.4tb          4.4tb
green  open   downlink-20200904    _ruilUSwQMq7aEYfXwBykQ 150   0 7078752021            0      3.8tb          3.8tb
green  open   downlink-20200904.9  EzVpJ4PTS1ae5E3SBYAXiA 159   0 8201595897            0      4.5tb          4.5tb
green  open   downlink-20200903.4  mRGqgjXXRN2rQQ6uj8Womw 154   0 1892298596            0        1tb            1tb
green  open   downlink-20200905.6  Z4TsjPjvQhO-APWo5aoPWw 156   0 6674856189            0      3.6tb          3.6tb
green  open   downlink-20200904.8  TGn8-xCcRzikNb2ZejkfxQ 158   0 7345715637            0        4tb            4tb
green  open   downlink-20200903.3  lmB-kjw9Rt6g2sdEEzjnuA 153   0 7452545046            0      4.1tb          4.1tb
green  open   downlink-20200905.8  GmECfHqESi6n3VxADWP8eg 158   0 4064526603            0      2.5tb          2.5tb
```

This cluster has total 1 million+ docs TPS, we found cluster has 0.1%+ bulk reject rate per minute.
The main reason is that each bulk request (bulk size around 2MB) would be separated to 100 sub write requests to each data node. In this case, if one or several data nodes got Old GC, unstable network or hardware failures, we call these shards as long-tail sick shards (they are randomly and temporarily), they would cause the bulk request to be delayed and finally cause the bulk reject exception. In scenarios with a large number of shards in a single index, this bulk reject issue can be significant.

# Solution
User could use routing to control a bulk request only goes to a single shard, to avoid long-tail sick shards affection. However, this needs user's extra developments for each business index, sometimes specially in logging platform scenario, they don't care about routings, high performance of bulk throughput is very important.

This PR introduces a bulk routing optimization to speed up bulk performance. There is an index level setting called `index.bulk_routing.enabled` to control this optimization, it's false by default. If no user defined `_id` field and no user defined `_routing`, with the setting enabled, all the sub requests of the same index in a bulk request will be added the same routing automatically. Then same index's writing requests only go to one of the shards. Here is the setting:
```
// set it on index creation
PUT /my-index
{
    "settings" : {
        "index" : {
            "bulk_routing.enabled" : true
        }
    }
}

// update it dynamically
PUT /my-index/_settings
{
  "index.bulk_routing.enabled": true
}

// use template to control some of the indices
PUT /_template/bulk_routing_template
{
  "index_patterns": ["indices-prefix*"],
  "settings": {
    "bulk_routing.enabled": true
  }
}

```
Then if user has large cluster with lots of shards in an index, user could simple enable this optimization on this index without extra developments.

# Performance improvement
In the above customer production cluster, after enabling this bulk routing optimization, The original rejection rate drops to 0, the CPU drops 25%, and the write speed increases 10%:

![image](https://user-images.githubusercontent.com/15325213/92320167-147de180-f052-11ea-894d-2ed0a26ddad6.png)


