### PR TITLE
Add host validation in CCS cluster settings.

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -406,4 +406,20 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         }
     }
 
+    public void testCCSSettingsUpdate() {
+        final Settings settings1 = Settings.builder().put("cluster.remote.test_cluster.seeds", "127.0.0.12345:9300").build();
+        final IllegalArgumentException e =
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> client().admin().cluster().prepareUpdateSettings()
+                    .setPersistentSettings(settings1).setTransientSettings(settings1).execute().actionGet());
+        assertEquals("unknown host [127.0.0.12345]", e.getMessage());
+
+        final Settings settings2 = Settings.builder().put("cluster.remote.test_cluster.seeds", "127.0.0.1:9300").build();
+        client().admin().cluster().prepareUpdateSettings()
+            .setPersistentSettings(settings2).setTransientSettings(settings2).execute().actionGet();
+        ClusterStateResponse state = client().admin().cluster().prepareState().execute().actionGet();
+        assertEquals("127.0.0.1:9300",
+            state.getState().getMetadata().persistentSettings().get("cluster.remote.test_cluster.seeds"));
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -74,7 +74,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
             Collections.emptyList(),
             s -> {
                 // validate seed address
-                parsePort(s);
+                parseConfiguredAddress(s);
                 return s;
             },
             new StrategyValidator<>(ns, key, ConnectionStrategy.SNIFF),


### PR DESCRIPTION
# Issue
If we set a wrong IP address in CCS `seeds` settings, it could be updated successfully:
```
PUT /_cluster/settings?pretty
{
  "persistent": {
    "cluster": {
      "remote": {
        "cluster_one": {
          "seeds": [
            "127.0.0.12345:9300"
          ]
        }
      }
    }
  }
}

Response:
{
  "acknowledged" : true,
  "persistent" : {
    "cluster" : {
      "remote" : {
        "cluster_one" : {
          "skip_unavailable" : "true",
          "seeds" : [
            "127.0.0.12345:9300",
           ]
        }
      }
    }
  },
  "transient" : { }
}
```

However, we got nothing in `_remove/info` :
```
GET /_remote/info?pretty
{
  "cluster_one" : {
    "seeds" : [
    ],
    "http_addresses" : [],
    "connected" : false,
    "num_nodes_connected" : 0,
    "max_connections_per_cluster" : 3,
    "initial_connect_timeout" : "30s",
    "skip_unavailable" : true
  }
}
```

From the node log, we found host parse exception:
```
[2020-09-03T16:52:23,991][WARN ][o.e.t.RemoteClusterService] [1590399813264357132] failed to update seed list for cluster: cluster_one
java.lang.IllegalArgumentException: unknown host [127.0.0.12345:9300]
        at org.elasticsearch.transport.RemoteClusterAware.parseSeedAddress(RemoteClusterAware.java:329) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterAware.buildSeedNode(RemoteClusterAware.java:229) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterService.lambda$updateRemoteCluster$12(RemoteClusterService.java:455) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterConnection$ConnectHandler.lambda$collectRemoteNodes$2(RemoteClusterConnection.java:498) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.common.util.CancellableThreads.executeIO(CancellableThreads.java:108) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterConnection$ConnectHandler.collectRemoteNodes(RemoteClusterConnection.java:497) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterConnection$ConnectHandler.access$900(RemoteClusterConnection.java:387) ~[elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.transport.RemoteClusterConnection$ConnectHandler$1.doRun(RemoteClusterConnection.java:485) [elasticsearch-6.8.2.jar:6.8.2]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-6.8.2.jar:6.8.2]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:1.8.0_181]
        at java.util.concurrent.FutureTask.run(Unknown Source) [?:1.8.0_181]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:681) [elasticsearch-6.8.2.jar:6.8.2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:1.8.0_181]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:1.8.0_181]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]
Caused by: java.net.UnknownHostException: 127.0.0.12345:9300: Name or service not known
        at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) ~[?:1.8.0_181]
        at java.net.InetAddress$2.lookupAllHostAddr(Unknown Source) ~[?:1.8.0_181]
        at java.net.InetAddress.getAddressesFromNameService(Unknown Source) ~[?:1.8.0_181]
        at java.net.InetAddress.getAllByName0(Unknown Source) ~[?:1.8.0_181]
        at java.net.InetAddress.getAllByName(Unknown Source) ~[?:1.8.0_181]
        at java.net.InetAddress.getAllByName(Unknown Source) ~[?:1.8.0_181]
        at java.net.InetAddress.getByName(Unknown Source) ~[?:1.8.0_181]
        at org.elasticsearch.transport.RemoteClusterAware.parseSeedAddress(RemoteClusterAware.java:327) ~[elasticsearch-6.8.2.jar:6.8.2]
        ... 14 more
```

This would lead to confusion for users, successfully updated CCS in cluster settings, but actually failed. Also it's hard to find issue before checking the log exceptions.

# Solution
Currently only `port` has been validated in `REMOTE_CLUSTER_SEEDS`, we need to add whole host validation for CCS cluster settings update. 
