### PR TITLE
[DOCS] Removes inference from the names of trained model APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
 [[delete-inference]]
-= Delete {infer} trained model API
+= Delete trained model API
 [subs="attributes"]
 ++++
-<titleabbrev>Delete {infer} trained model</titleabbrev>
+<titleabbrev>Delete trained model</titleabbrev>
 ++++
 
 Deletes an existing trained {infer} model that is currently not referenced by an 
@@ -42,8 +42,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 == {api-response-codes-title}
 
 `409`::
-  The code indicates that the trained {infer} model is referenced by an ingest 
-  pipeline and cannot be deleted.
+  The code indicates that the trained model is referenced by an ingest pipeline 
+  and cannot be deleted.
 
 
 [[ml-delete-inference-example]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -1,13 +1,13 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-inference-stats]]
-= Get {infer} trained model statistics API
+= Get trained model statistics API
 [subs="attributes"]
 ++++
-<titleabbrev>Get {infer} trained model stats</titleabbrev>
+<titleabbrev>Get trained model stats</titleabbrev>
 ++++
 
-Retrieves usage information for trained {infer} models.
+Retrieves usage information for trained models.
 
 experimental[]
 
@@ -72,14 +72,14 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 `count`::
 (integer)
-The total number of trained model statistics that matched the requested ID patterns.
-Could be higher than the number of items in the `trained_model_stats` array as the
-size of the array is restricted by the supplied `size` parameter.
+The total number of trained model statistics that matched the requested ID 
+patterns. Could be higher than the number of items in the `trained_model_stats` 
+array as the size of the array is restricted by the supplied `size` parameter.
 
 `trained_model_stats`::
 (array)
-An array of trained model statistics, which are sorted by the `model_id` value in
-ascending order.
+An array of trained model statistics, which are sorted by the `model_id` value 
+in ascending order.
 +
 .Properties of trained model stats
 [%collapsible%open]
@@ -112,11 +112,11 @@ This is across all inference contexts, including all pipelines.
 
 `cache_miss_count`:::
 (integer)
-The number of times the model was loaded for inference and was not retrieved from the
-cache. If this number is close to the `inference_count`, then the cache
-is not being appropriately used. This can be remedied by increasing the cache's size
-or its time-to-live (TTL). See <<general-ml-settings>> for the
-appropriate settings.
+The number of times the model was loaded for inference and was not retrieved 
+from the cache. If this number is close to the `inference_count`, then the cache 
+is not being appropriately used. This can be solved by increasing the cache size 
+or its time-to-live (TTL). See <<general-ml-settings>> for the appropriate 
+settings.
 
 `failure_count`:::
 (integer)

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -1,13 +1,13 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-inference]]
-= Get {infer} trained model API
+= Get trained model API
 [subs="attributes"]
 ++++
-<titleabbrev>Get {infer} trained model</titleabbrev>
+<titleabbrev>Get trained model</titleabbrev>
 ++++
 
-Retrieves configuration information for a trained {infer} model.
+Retrieves configuration information for a trained model.
 
 experimental[]
 
@@ -34,7 +34,8 @@ privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+For more information, see <<security-privileges>> and 
+{ml-docs-setup-privileges}.
 
 
 [[ml-get-inference-desc]]
@@ -70,9 +71,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `include_model_definition`::
 (Optional, boolean)
-Specifies whether the model definition is returned in the response. Defaults 
-to `false`. When `true`, only a single model must match the ID patterns 
-provided. Otherwise, a bad request is returned.
+Specifies whether the model definition is returned in the response. Defaults to 
+`false`. When `true`, only a single model must match the ID patterns provided. 
+Otherwise, a bad request is returned.
 
 `size`::
 (Optional, integer) 
@@ -141,7 +142,7 @@ Identifier for the trained model.
 
 `tags`:::
 (string)
-A comma delimited string of tags. A {infer} model can have many tags, or none.
+A comma delimited string of tags. A trained model can have many tags, or none.
 
 `version`:::
 (string)

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -1,13 +1,13 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-inference]]
-= Create {infer} trained model API
+= Create trained model API
 [subs="attributes"]
 ++++
-<titleabbrev>Create {infer} trained model</titleabbrev>
+<titleabbrev>Create trained model</titleabbrev>
 ++++
 
-Creates an {infer} trained model.
+Creates an trained model.
 
 WARNING: Models created in version 7.8.0 are not backwards compatible
          with older node versions. If in a mixed cluster environment,
@@ -38,8 +38,8 @@ For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 [[ml-put-inference-desc]]
 == {api-description-title}
 
-The create {infer} trained model API enables you to supply a trained model that
-is not created by {dfanalytics}.
+The create trained model API enables you to supply a trained model that is not 
+created by {dfanalytics}.
 
 
 [[ml-put-inference-path-params]]
@@ -61,7 +61,7 @@ If `compressed_definition` is specified, then `definition` cannot be specified.
 //Begin definition
 `definition`::
 (Required, object)
-The {infer} definition for the model. If `definition` is specified, then
+The {infer} definition for the model. If `definition` is specified, then 
 `compressed_definition` cannot be specified.
 +
 .Properties of `definition`
@@ -172,7 +172,7 @@ The definition for a binary decision tree.
 [%collapsible%open]
 ======
 `classification_labels`:::
-(Optional, string) An array of classification labels (used for
+(Optional, string) An array of classification labels (used for 
 `classification`).
 
 `feature_names`:::


### PR DESCRIPTION
## Overview

This PR removes the phrase `inference` from the names of the trained model APIs. It also fine-tunes the API description text certain points.

This PR does not change any of the page links or anchors.

### Preview

[Delete trained model](https://elasticsearch_62036.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-inference.html)
[Get trained model stats](https://elasticsearch_62036.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference-stats.html)
[Get trained model](https://elasticsearch_62036.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference.html)
[Put trained model](https://elasticsearch_62036.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-inference.html)