### PR TITLE
Run zulu8 fips CI with BCJSSE instead of SunJSSE (#61857)

### DIFF
--- a/buildSrc/src/main/resources/fips_java_bcjsse_11.policy
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_11.policy
@@ -1,0 +1,18 @@
+// Security Policy for JDK 11 and higher, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
+
+grant {
+     permission java.security.SecurityPermission "putProviderProperty.BCFIPS";
+     permission java.security.SecurityPermission "putProviderProperty.BCJSSE";
+     permission java.lang.RuntimePermission "getProtectionDomain";
+     permission java.util.PropertyPermission "java.runtime.name", "read";
+     permission org.bouncycastle.crypto.CryptoServicesPermission "tlsAlgorithmsEnabled";
+     //io.netty.handler.codec.DecoderException
+     permission java.lang.RuntimePermission "accessClassInPackage.sun.security.internal.spec";
+     //java.security.InvalidAlgorithmParameterException: Cannot process GCMParameterSpec
+     permission java.lang.RuntimePermission "accessDeclaredMembers";
+     permission java.util.PropertyPermission "intellij.debug.agent", "read";
+     permission java.util.PropertyPermission "intellij.debug.agent", "write";
+     permission org.bouncycastle.crypto.CryptoServicesPermission "exportSecretKey";
+     permission org.bouncycastle.crypto.CryptoServicesPermission "exportPrivateKey";
+     permission java.io.FilePermission "${javax.net.ssl.trustStore}", "read";
+};

--- a/buildSrc/src/main/resources/fips_java_bcjsse_11.security
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_11.security
@@ -1,3 +1,5 @@
+# Security Properties for JDK 11 and higher, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
+
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN

--- a/buildSrc/src/main/resources/fips_java_bcjsse_8.policy
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_8.policy
@@ -1,3 +1,10 @@
+// Security Policy for JDK 8, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
+
+grant codeBase "file:${java.home}/lib/ext/localedata.jar" {
+          // Allow resource bundles to be loaded for non root locales. See
+          // https://github.com/elastic/elasticsearch/issues/39981
+          permission java.lang.RuntimePermission "accessClassInPackage.sun.util.*";
+};
 grant {
      permission java.security.SecurityPermission "putProviderProperty.BCFIPS";
      permission java.security.SecurityPermission "putProviderProperty.BCJSSE";

--- a/buildSrc/src/main/resources/fips_java_bcjsse_8.security
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_8.security
@@ -1,0 +1,134 @@
+# Security Properties for JDK 8, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
+
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.3=sun.security.provider.Sun
+security.provider.4=sun.security.jgss.SunProvider
+securerandom.source=file:/dev/urandom
+securerandom.strongAlgorithms=NativePRNGBlocking:SUN
+login.configuration.provider=sun.security.provider.ConfigFile
+policy.provider=sun.security.provider.PolicyFile
+policy.url.1=file:${java.home}/lib/security/java.policy
+policy.url.2=file:${user.home}/.java.policy
+policy.expandProperties=true
+policy.allowSystemProperty=true
+policy.ignoreIdentityScope=false
+keystore.type=bcfks
+keystore.type.compat=true
+package.access=sun.,\
+               org.GNOME.Accessibility.,\
+               com.sun.xml.internal.,\
+               com.sun.imageio.,\
+               com.sun.istack.internal.,\
+               com.sun.jmx.,\
+               com.sun.media.sound.,\
+               com.sun.naming.internal.,\
+               com.sun.proxy.,\
+               com.sun.corba.se.,\
+               com.sun.org.apache.bcel.internal.,\
+               com.sun.org.apache.regexp.internal.,\
+               com.sun.org.apache.xerces.internal.,\
+               com.sun.org.apache.xpath.internal.,\
+               com.sun.org.apache.xalan.internal.extensions.,\
+               com.sun.org.apache.xalan.internal.lib.,\
+               com.sun.org.apache.xalan.internal.res.,\
+               com.sun.org.apache.xalan.internal.templates.,\
+               com.sun.org.apache.xalan.internal.utils.,\
+               com.sun.org.apache.xalan.internal.xslt.,\
+               com.sun.org.apache.xalan.internal.xsltc.cmdline.,\
+               com.sun.org.apache.xalan.internal.xsltc.compiler.,\
+               com.sun.org.apache.xalan.internal.xsltc.trax.,\
+               com.sun.org.apache.xalan.internal.xsltc.util.,\
+               com.sun.org.apache.xml.internal.res.,\
+               com.sun.org.apache.xml.internal.resolver.helpers.,\
+               com.sun.org.apache.xml.internal.resolver.readers.,\
+               com.sun.org.apache.xml.internal.security.,\
+               com.sun.org.apache.xml.internal.serializer.utils.,\
+               com.sun.org.apache.xml.internal.utils.,\
+               com.sun.org.glassfish.,\
+               com.oracle.xmlns.internal.,\
+               com.oracle.webservices.internal.,\
+               oracle.jrockit.jfr.,\
+               org.jcp.xml.dsig.internal.,\
+               jdk.internal.,\
+               jdk.nashorn.internal.,\
+               jdk.nashorn.tools.,\
+               jdk.xml.internal.,\
+               com.sun.activation.registries.
+
+package.definition=sun.,\
+                   com.sun.xml.internal.,\
+                   com.sun.imageio.,\
+                   com.sun.istack.internal.,\
+                   com.sun.jmx.,\
+                   com.sun.media.sound.,\
+                   com.sun.naming.internal.,\
+                   com.sun.proxy.,\
+                   com.sun.corba.se.,\
+                   com.sun.org.apache.bcel.internal.,\
+                   com.sun.org.apache.regexp.internal.,\
+                   com.sun.org.apache.xerces.internal.,\
+                   com.sun.org.apache.xpath.internal.,\
+                   com.sun.org.apache.xalan.internal.extensions.,\
+                   com.sun.org.apache.xalan.internal.lib.,\
+                   com.sun.org.apache.xalan.internal.res.,\
+                   com.sun.org.apache.xalan.internal.templates.,\
+                   com.sun.org.apache.xalan.internal.utils.,\
+                   com.sun.org.apache.xalan.internal.xslt.,\
+                   com.sun.org.apache.xalan.internal.xsltc.cmdline.,\
+                   com.sun.org.apache.xalan.internal.xsltc.compiler.,\
+                   com.sun.org.apache.xalan.internal.xsltc.trax.,\
+                   com.sun.org.apache.xalan.internal.xsltc.util.,\
+                   com.sun.org.apache.xml.internal.res.,\
+                   com.sun.org.apache.xml.internal.resolver.helpers.,\
+                   com.sun.org.apache.xml.internal.resolver.readers.,\
+                   com.sun.org.apache.xml.internal.security.,\
+                   com.sun.org.apache.xml.internal.serializer.utils.,\
+                   com.sun.org.apache.xml.internal.utils.,\
+                   com.sun.org.glassfish.,\
+                   com.oracle.xmlns.internal.,\
+                   com.oracle.webservices.internal.,\
+                   oracle.jrockit.jfr.,\
+                   org.jcp.xml.dsig.internal.,\
+                   jdk.internal.,\
+                   jdk.nashorn.internal.,\
+                   jdk.nashorn.tools.,\
+                   jdk.xml.internal.,\
+                   com.sun.activation.registries.
+
+ssl.KeyManagerFactory.algorithm=PKIX
+ssl.TrustManagerFactory.algorithm=PKIX
+networkaddress.cache.negative.ttl=10
+krb5.kdc.bad.policy = tryLast
+jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224
+
+jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, DSA keySize < 1024
+
+
+jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 1024, \
+    EC keySize < 224, DES40_CBC, RC4_40, 3DES_EDE_CBC
+
+jdk.tls.legacyAlgorithms= \
+        K_NULL, C_NULL, M_NULL, \
+        DH_anon, ECDH_anon, \
+        RC4_128, RC4_40, DES_CBC, DES40_CBC, \
+        3DES_EDE_CBC
+crypto.policy=unlimited
+
+jdk.xml.dsig.secureValidationPolicy=\
+    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
+    maxTransforms 5,\
+    maxReferences 30,\
+    disallowReferenceUriSchemes file http https,\
+    minKeySize RSA 1024,\
+    minKeySize DSA 1024,\
+    minKeySize EC 224,\
+    noDuplicateIds,\
+    noRetrievalMethodLoops
+
+jceks.key.serialFilter = java.lang.Enum;java.security.KeyRep;\
+  java.security.KeyRep$Type;javax.crypto.spec.SecretKeySpec;!*

--- a/buildSrc/src/main/resources/fips_java_sunjsse.policy
+++ b/buildSrc/src/main/resources/fips_java_sunjsse.policy
@@ -1,3 +1,5 @@
+// Security Policy for JDK 8, with BouncyCastle FIPS provider and SunJSSE in FIPS mode
+
 grant codeBase "file:${java.home}/lib/ext/localedata.jar" {
           // Allow resource bundles to be loaded for non root locales. See
           // https://github.com/elastic/elasticsearch/issues/39981

--- a/buildSrc/src/main/resources/fips_java_sunjsse.security
+++ b/buildSrc/src/main/resources/fips_java_sunjsse.security
@@ -1,4 +1,5 @@
-# List of providers and their preference orders (see above):
+# Security Properties for JDK 8, with BouncyCastle FIPS provider and SunJSSE in FIPS mode
+
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.2=com.sun.net.ssl.internal.ssl.Provider BCFIPS
 security.provider.3=sun.security.provider.Sun

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -1,7 +1,6 @@
 import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 
 // Common config when running with a FIPS-140 runtime JVM
 if (BuildParams.inFipsJvm) {
@@ -9,8 +8,22 @@ if (BuildParams.inFipsJvm) {
   allprojects {
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     boolean java8 = BuildParams.runtimeJavaVersion == JavaVersion.VERSION_1_8
-    File fipsSecurity = new File(fipsResourcesDir, "fips_java${java8 ? '8' : ''}.security")
-    File fipsPolicy = new File(fipsResourcesDir, "fips_java${java8 ? '8' : ''}.policy")
+    boolean zulu8 = java8 && BuildParams.runtimeJavaDetails.contains("Zulu")
+    File fipsSecurity;
+    File fipsPolicy;
+    if (java8) {
+      if (zulu8) {
+        //Azul brings many changes from JDK 11 to their Zulu8 so we can only use BCJSSE
+        fipsSecurity = new File(fipsResourcesDir, "fips_java_bcjsse_8.security")
+        fipsPolicy = new File(fipsResourcesDir, "fips_java_bcjsse_8.policy")
+      } else {
+        fipsSecurity = new File(fipsResourcesDir, "fips_java_sunjsse.security")
+        fipsPolicy = new File(fipsResourcesDir, "fips_java_sunjsse.policy")
+      }
+    } else {
+      fipsSecurity = new File(fipsResourcesDir, "fips_java_bcjsse_11.security")
+      fipsPolicy = new File(fipsResourcesDir, "fips_java_bcjsse_11.policy")
+    }
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')
     def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
     def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')


### PR DESCRIPTION
As we figured out in
https://github.com/elastic/elasticsearch/issues/61316#issuecomment-685482708
Azul brings back a lot of changes from JDK 11 to their Zulu8 build
and this means that we can't run this with SunJSSE in FIPS 140 mode.

This change ensures that we configure Zulu8 JDK JVMs in FIPS 140
mode, using the bouncy castle JSSE FIPS provider, instead of the
SunJSSE one ( as we do for the rest of the java 8 JVMs )

Backport of #61857 