### PR TITLE
[7.x] Mute Docs rollover index test snippet (#62045)

### DIFF
--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -395,7 +395,7 @@ POST /logs_write/_rollover <2>
   }
 }
 --------------------------------------------------
-// TEST[s/now/2016.10.31%7C%7C/]
+// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/62043"]
 
 <1> Creates an index named with today's date (e.g.) `logs-2016.10.31-1`
 <2> Rolls over to a new index with today's date, e.g. `logs-2016.10.31-000002` if run immediately, or `logs-2016.11.01-000002` if run after 24 hours


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mute Docs rollover index test snippet (#62045)