### PR TITLE
[Proposal] Date-Type field `doc_value` return numeric format when `dovalue_fields ` format is null or epoch_millis

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -477,6 +477,9 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public DocValueFormat docValueFormat(@Nullable String format, ZoneId timeZone) {
+            if (format == null || "epoch_millis".equals(format)) {
+                return DocValueFormat.RAW;
+            }
             DateFormatter dateTimeFormatter = this.dateTimeFormatter;
             if (format != null) {
                 dateTimeFormatter = DateFormatter.forPattern(format).withLocale(dateTimeFormatter.locale());


### PR DESCRIPTION
## Summary
When `epoch_millis` format assigned for `Date` field type

```
PUT /test
{
   "settings": {
      "number_of_shards": 1,
      "number_of_replicas": 0
   },
   "mappings": {
      "properties": {
         "ctime": {
            "type": "date",
            "format": "epoch_millis"
         }
      }
   }
}
```

execute `dovalue_fields fetch`  search :
```
POST test/_search
{
   "query": {
      "match_all": {}
   },
   "docvalue_fields": [
      "ctime"
   ]
}

or 

POST test/_search
{
   "query": {
      "match_all": {}
   },
   "docvalue_fields": [
      {
            "field": "ctime",
            "format": "epoch_millis" 
       }
   ]
}
```

and get the `string-format timestamp` from search hits `fields`:

```
{
   "took": 4,
   "timed_out": false,
   "_shards": {
      "total": 1,
      "successful": 1,
      "skipped": 0,
      "failed": 0
   },
   "hits": {
      "total": {
         "value": 1,
         "relation": "eq"
      },
      "max_score": null,
      "hits": [
         {
            "_index": "index",
            "_type": "_doc",
            "_score": null,
            "fields": {
               "ctime": [
                  "1599125222000"
               ]
            }
         }
      ]
   }
}
```


I worked on  [Doris](https://github.com/apache/incubator-doris) On Elasticsearch, which is the distributed compute sql Engine.   
In the analysis scenario, we just need a few fields from Elasticsearch, When these field's docvalue is turned on, we would get these field value from docvalue_fields,  `date` type field is such a feild, we hope to get the  long `unix-timestamp` value from Elasticsearch. but we found Elasticsearch return the `unix-timestamp string literal value`.  It is complicated for external service such as `Doris` or `Spark` process the different string format date field.

## Proposal Change

Can we just return just return the  long `unix-timestamp` from the docvalue fields  when format is null or format is `epoch_mills`?   

Cross-system data transmission may be more efficient to pass date format fields with timestamps,  and it can handle the date format better

If we can do this, maybe the performance can be slightly promoted because of avoiding `long -> string` transformation, and the external compute service such as Doris can efficiently process `date` type field (date type field maybe have many in the analysis scenario)

After apply this patch, execute  search

```
POST index/_search
{
   "query": {
      "match_all": {}
   },
   "docvalue_fields": [
      "ctime"
   ]
}

or 
POST test/_search
{
   "query": {
      "match_all": {}
   },
   "docvalue_fields": [
      {
            "field": "ctime",
            "format": "epoch_millis" 
       }
   ]
}

```

 get the real unix-timestamp value from this field, results are:

```
   "hits": {
      "total": {
         "value": 1,
         "relation": "eq"
      },
      "max_score": 1,
      "hits": [
         {
            "_index": "index",
            "_type": "_doc",
            "_score": 1,
            "fields": {
               "ctime": [
                  1599125222000
               ]
            }
         }
      ]
   }
```
