### PR TITLE
EQL: create the search request with a list of indices (#62005)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
@@ -34,12 +34,12 @@ public class BasicQueryClient implements QueryClient {
 
     private final EqlConfiguration cfg;
     private final Client client;
-    private final String indices;
+    private final String[] indices;
 
     public BasicQueryClient(EqlSession eqlSession) {
         this.cfg = eqlSession.configuration();
         this.client = eqlSession.client();
-        this.indices = cfg.indexAsWildcard();
+        this.indices = cfg.indices();
     }
 
     @Override


### PR DESCRIPTION
* The query client uses an array of indices instead of the comma separated
version of the indices names

(cherry picked from commit 8ec4a768f4892a4a2faed25836cb333a9deb2ace)