### PR TITLE
Fix testMasterFailOverWithQueuedDeletes (#62062)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -476,6 +476,11 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
                 // rarely the master node fails over twice when shutting down the initial master and fails the transport listener
                 assertThat(rex.repository(), is("_all"));
                 assertThat(rex.getMessage(), endsWith("Failed to update cluster state during repository operation"));
+            } catch (SnapshotMissingException sme) {
+                // very rarely a master node fail-over happens at such a time that the client on the data-node sees a disconnect exception
+                // after the master has already started the delete, leading to the delete retry to run into a situation where the
+                // snapshot has already been deleted potentially
+                assertThat(sme.getSnapshotName(), is(firstSnapshot));
             }
         }
         expectThrows(SnapshotException.class, snapshotThreeFuture::actionGet);


### PR DESCRIPTION
Fixing very rare corner case where the delete retry is slow.

Closes #62031

backport of #62062 