### PR TITLE
Fix point in time toXContent impl

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1379,7 +1379,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             builder.field(COLLAPSE.getPreferredName(), collapse);
         }
         if (pointInTimeBuilder != null) {
-            builder.field(POINT_IN_TIME.getPreferredName(), pointInTimeBuilder);
+            pointInTimeBuilder.toXContent(builder, params);
         }
         return builder;
     }
@@ -1692,8 +1692,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject(POINT_IN_TIME.getPreferredName());
             builder.field(ID_FIELD.getPreferredName(), id);
             builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive);
+            builder.endObject();
             return builder;
         }
 

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -360,7 +360,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         }
     }
 
-    public void testToXContent() throws  IOException {
+    public void testToXContent() throws IOException {
         //verify that only what is set gets printed out through toXContent
         XContentType xContentType = randomFrom(XContentType.values());
         {
@@ -381,6 +381,22 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             assertEquals(1, sourceAsMap.size());
             assertEquals("query", sourceAsMap.keySet().iterator().next());
         }
+    }
+
+    public void testToXContentWithPointInTime() throws IOException {
+        XContentType xContentType = randomFrom(XContentType.values());
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.pointInTimeBuilder(new SearchSourceBuilder.PointInTimeBuilder("id", TimeValue.timeValueHours(1)));
+        XContentBuilder builder = XContentFactory.contentBuilder(xContentType);
+        searchSourceBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        BytesReference bytes = BytesReference.bytes(builder);
+        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(bytes, false, xContentType).v2();
+        assertEquals(1, sourceAsMap.size());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> pit = (Map<String, Object>) sourceAsMap.get("pit");
+        assertEquals(2, pit.size());
+        assertEquals("id", pit.get("id"));
+        assertEquals("1h", pit.get("keep_alive"));
     }
 
     public void testParseIndicesBoost() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -51,7 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ShardSearchRequestTests extends AbstractSearchTestCase {
-    private IndexMetadata baseMetadata = IndexMetadata.builder("test").settings(Settings.builder()
+    private static final IndexMetadata BASE_METADATA = IndexMetadata.builder("test").settings(Settings.builder()
         .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build())
         .numberOfShards(1).numberOfReplicas(1).build();
 
@@ -92,7 +92,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
     }
 
     public void testFilteringAliases() throws Exception {
-        IndexMetadata indexMetadata = baseMetadata;
+        IndexMetadata indexMetadata = BASE_METADATA;
         indexMetadata = add(indexMetadata, "cats", filter(termQuery("animal", "cat")));
         indexMetadata = add(indexMetadata, "dogs", filter(termQuery("animal", "dog")));
         indexMetadata = add(indexMetadata, "all", null);
@@ -118,7 +118,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
     }
 
     public void testRemovedAliasFilter() throws Exception {
-        IndexMetadata indexMetadata = baseMetadata;
+        IndexMetadata indexMetadata = BASE_METADATA;
         indexMetadata = add(indexMetadata, "cats", filter(termQuery("animal", "cat")));
         indexMetadata = remove(indexMetadata, "cats");
         try {
@@ -130,7 +130,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
     }
 
     public void testUnknownAliasFilter() throws Exception {
-        IndexMetadata indexMetadata = baseMetadata;
+        IndexMetadata indexMetadata = BASE_METADATA;
         indexMetadata = add(indexMetadata, "cats", filter(termQuery("animal", "cat")));
         indexMetadata = add(indexMetadata, "dogs", filter(termQuery("animal", "dog")));
         IndexMetadata finalIndexMetadata = indexMetadata;

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -370,6 +370,10 @@ public class RandomSearchRequestGenerator {
         if (randomBoolean()) {
             builder.collapse(randomCollapseBuilder.get());
         }
+        if (randomBoolean()) {
+            builder.pointInTimeBuilder(new SearchSourceBuilder.PointInTimeBuilder(randomAlphaOfLengthBetween(3, 10),
+                TimeValue.timeValueMinutes(randomIntBetween(1, 60))));
+        }
         return builder;
     }
 }


### PR DESCRIPTION
PointInTimeBuilder is a ToXContentObject yet it does not print out a whole object (it is rather a fragment). Also, when it is printed out as part of SearchSourceBuilder, an error is thrown because pit should be wrapped into its own object.

This commit fixes this and adds tests for it.

Relates to #61062