### PR TITLE
Wildcard field bug fix for term queries. Wildcard syntax should not be supported in plain term queries.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -250,7 +250,7 @@ setup:
           query:
             prefix:
               my_wildcard:
-                value: "hell*"
+                value: "hell"
 
 
   - match: {hits.total.value: 1}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -33,7 +33,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.apache.lucene.util.automaton.RegExp.Kind;

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -181,9 +181,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
     }
     
     
-    public void testTermQueryIgnoresWildcardSyntax() throws IOException {
-        // Test for bug https://github.com/elastic/elasticsearch/issues/62081
-        // where term queries honoured wildcard quwery syntax
+    public void testTermAndPrefixQueryIgnoreWildcardSyntax() throws IOException {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
         iwc.setMergePolicy(newTieredMergePolicy(random()));

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -179,6 +179,41 @@ public class WildcardFieldMapperTests extends ESTestCase {
         reader.close();
         dir.close();
     }
+    
+    
+    public void testTermQueryIgnoresWildcardSyntax() throws IOException {
+        // Test for bug https://github.com/elastic/elasticsearch/issues/62081
+        // where term queries honoured wildcard quwery syntax
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        iwc.setMergePolicy(newTieredMergePolicy(random()));
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+
+        Document doc = new Document();
+        ParseContext.Document parseDoc = new ParseContext.Document();
+        addFields(parseDoc, doc, "foo?");
+        indexDoc(parseDoc, doc, iw);
+
+        iw.forceMerge(1);
+        DirectoryReader reader = iw.getReader();
+        IndexSearcher searcher = newSearcher(reader);
+        iw.close();
+
+        
+        expectMatch(searcher, "foo*", 0);
+        expectMatch(searcher, "foo?", 1);
+        expectMatch(searcher, "?oo?", 0);
+        
+        reader.close();
+        dir.close();
+    }
+    
+    private void expectMatch(IndexSearcher searcher, String term,long count) throws IOException {
+        Query q = wildcardFieldType.fieldType().termQuery(term, MOCK_QSC);
+        TopDocs td = searcher.search(q, 10, Sort.RELEVANCE);
+        assertThat(td.totalHits.value, equalTo(count));        
+    }
+    
 
 
     public void testSearchResultsVersusKeywordField() throws IOException {


### PR DESCRIPTION
Replaced the simple logic that delegated to wildcardQuery() method with dedicated exact-match query logic for term queries.
Added test.

Closes #62081