### PR TITLE
[Transform] Improve robustness when saving state

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -245,7 +245,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
     /**
      * Checks if the state should be persisted, if true doSaveState is called before continuing. Inherited classes
-     * can overwrite this, to provide a better logic, when state should be saved.
+     * can override this, to provide a better logic, when state should be saved.
      *
      * @return true if state should be saved, false if not.
      */
@@ -270,9 +270,10 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     /**
      * Re-schedules the current search request to run immediately, iff one is scheduled.
      *
-     * Call this if you need the indexer to fast forward a scheduled(throttled) search once in order to complete a full cycle.
+     * Call this if you need the indexer to fast forward a scheduled(in case it's throttled) search once in order to
+     * complete a full cycle.
      */
-    protected void runSearchImmediatly() {
+    protected void runSearchImmediately() {
         reQueueThrottledSearch(true);
     }
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -220,7 +220,7 @@ public class TransformIT extends TransformIntegTestCase {
 
     public void testStopWaitForCheckpoint() throws Exception {
         String indexName = "wait-for-checkpoint-reviews";
-        String transformId = "data-frame-transform-wait-for-checkpoint";
+        String transformId = "transform-wait-for-checkpoint";
         createReviewsIndex(indexName, 1000);
 
         Map<String, SingleGroupSource> groups = new HashMap<>();
@@ -243,10 +243,11 @@ public class TransformIT extends TransformIntegTestCase {
         ).setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1))).build();
 
         assertTrue(putTransform(config, RequestOptions.DEFAULT).isAcknowledged());
+
         assertTrue(startTransform(config.getId(), RequestOptions.DEFAULT).isAcknowledged());
 
         // waitForCheckpoint: true should make the transform continue until we hit the first checkpoint, then it will stop
-        stopTransform(transformId, false, null, true);
+        assertTrue(stopTransform(transformId, false, null, true).isAcknowledged());
 
         // Wait until the first checkpoint
         waitUntilCheckpoint(config.getId(), 1L);
@@ -258,7 +259,31 @@ public class TransformIT extends TransformIntegTestCase {
             assertThat(stateAndStats.getIndexerStats().getDocumentsIndexed(), equalTo(1000L));
         });
 
-        stopTransform(config.getId());
+        int additionalRuns = randomIntBetween(1, 10);
+
+        for (int i = 0; i < additionalRuns; ++i) {
+            // index some more docs using a new user
+            long timeStamp = Instant.now().toEpochMilli() - 1_000;
+            long user = 42 + i;
+            indexMoreDocs(timeStamp, user, indexName);
+            assertTrue(startTransformWithRetryOnConflict(config.getId(), RequestOptions.DEFAULT).isAcknowledged());
+
+            boolean waitForCompletion = randomBoolean();
+            assertTrue(stopTransform(transformId, waitForCompletion, null, true).isAcknowledged());
+
+            assertBusy(() -> {
+                TransformStats stateAndStats = getTransformStats(config.getId()).getTransformsStats().get(0);
+                assertThat(stateAndStats.getState(), equalTo(TransformStats.State.STOPPED));
+            });
+            TransformStats stateAndStats = getTransformStats(config.getId()).getTransformsStats().get(0);
+            assertThat(stateAndStats.getState(), equalTo(TransformStats.State.STOPPED));
+        }
+
+        TransformStats stateAndStats = getTransformStats(config.getId()).getTransformsStats().get(0);
+        assertThat(stateAndStats.getState(), equalTo(TransformStats.State.STOPPED));
+        assertThat(stateAndStats.getIndexerStats().getDocumentsIndexed(), greaterThan(1000L));
+
+        assertTrue(stopTransform(transformId).isAcknowledged());
         deleteTransform(config.getId());
     }
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -154,7 +154,6 @@ abstract class TransformIntegTestCase extends ESRestTestCase {
                 }
 
                 lastConflict = e;
-                --retries;
                 Thread.sleep(5);
             }
         }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.transform.integration;
 
 import org.apache.logging.log4j.Level;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -55,6 +56,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -138,6 +140,26 @@ abstract class TransformIntegTestCase extends ESRestTestCase {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             return restClient.transform().startTransform(new StartTransformRequest(id), options);
         }
+    }
+
+    // workaround for https://github.com/elastic/elasticsearch/issues/62204
+    protected StartTransformResponse startTransformWithRetryOnConflict(String id, RequestOptions options) throws Exception {
+        int retries = 10;
+        ElasticsearchStatusException lastConflict = null;
+        while (retries > 0) {
+            try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
+                return restClient.transform().startTransform(new StartTransformRequest(id), options);
+            } catch (ElasticsearchStatusException e) {
+                if (e.status().equals(RestStatus.CONFLICT) == false) {
+                    throw e;
+                }
+
+                lastConflict = e;
+                --retries;
+                Thread.sleep(5);
+            }
+        }
+        throw lastConflict;
     }
 
     protected AcknowledgedResponse deleteTransform(String id) throws IOException {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -144,13 +144,12 @@ abstract class TransformIntegTestCase extends ESRestTestCase {
 
     // workaround for https://github.com/elastic/elasticsearch/issues/62204
     protected StartTransformResponse startTransformWithRetryOnConflict(String id, RequestOptions options) throws Exception {
-        int retries = 10;
         ElasticsearchStatusException lastConflict = null;
-        while (retries > 0) {
+        for (int retries = 10; retries > 0; --retries) {
             try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
                 return restClient.transform().startTransform(new StartTransformRequest(id), options);
             } catch (ElasticsearchStatusException e) {
-                if (e.status().equals(RestStatus.CONFLICT) == false) {
+                if (RestStatus.CONFLICT.equals(e.status()) == false) {
                     throw e;
                 }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.transform.integration.continuous;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -38,7 +37,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60781")
 public class DateHistogramGroupByIT extends ContinuousTestCase {
     private static final String NAME = "continuous-date-histogram-pivot-test";
     private static final String MISSING_BUCKET_KEY = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.transform.integration.continuous;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -34,7 +33,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60781")
 public class TermsGroupByIT extends ContinuousTestCase {
 
     private static final String NAME = "continuous-terms-pivot-test";

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -243,6 +243,9 @@ class ClientTransformIndexer extends TransformIndexer {
         // If the state is `STOPPED` this means that TransformTask#stop was called while we were checking for changes.
         // Allow the stop call path to continue
         if (hasSourceChanged == false && indexerState.equals(IndexerState.STOPPED) == false) {
+            if (saveStateListenersAtTheMomentOfCalling != null) {
+                ActionListener.onResponse(saveStateListenersAtTheMomentOfCalling, null);
+            }
             next.run();
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -589,14 +589,16 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                     return null;
                 }
 
-                currentListeners = new ArrayList<>();
+                return Collections.singletonList(shouldStopAtCheckpointListener);
             }
-            currentListeners.add(shouldStopAtCheckpointListener);
-            context.setShouldStopAtCheckpoint(shouldStopAtCheckpoint);
-            return currentListeners;
+
+            List<ActionListener<Void>> newListeners = new ArrayList<>(currentListeners);
+            newListeners.add(shouldStopAtCheckpointListener);
+            return newListeners;
         }) == null) {
             shouldStopAtCheckpointListener.onResponse(null);
         } else {
+            context.setShouldStopAtCheckpoint(shouldStopAtCheckpoint);
             // in case of throttling the indexer might wait for the next search, fast forward, so stop listeners do not wait to long
             runSearchImmediately();
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -547,7 +547,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         });
 
         // in case of throttling the indexer might wait for the next search, fast forward, so stop listeners do not wait to long
-        runSearchImmediatly();
+        runSearchImmediately();
     }
 
     void stopAndSaveState() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -557,11 +557,12 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 // the transport wraps this with a REST status code
                 shouldStopAtCheckpointListener.onFailure(
                     new RuntimeException(
-                        "Timed out (" + PERSIST_STOP_AT_CHECKPOINT_TIMEOUT_SEC + "s) waiting for transform state to be stored.\"",
+                        "Timed out (" + PERSIST_STOP_AT_CHECKPOINT_TIMEOUT_SEC + "s) waiting for transform state to be stored.",
                         e
                     )
                 );
             } catch (Exception e) {
+                logger.error(new ParameterizedMessage("[{}] failed to persist transform state.", getJobId()), e);
                 shouldStopAtCheckpointListener.onFailure(e);
             }
             return;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -518,18 +518,10 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         context.shutdown();
     }
 
-    protected void callAndResetSaveStateListeners() {
-        Collection<ActionListener<Void>> listeners = saveStateListeners.getAndSet(null);
-        if (listeners != null) {
-            for (ActionListener<Void> l : listeners) {
-                l.onResponse(null);
-            }
-        }
-    }
-
     void stopAtCheckpoint(boolean shouldStopAtCheckpoint, ActionListener<Void> shouldStopAtCheckpointListener) {
         IndexerState indexerState = getState();
 
+        // in case shouldStopAtCheckpoint has already the desired value or the indexer isn't running, respond immediately
         if (context.shouldStopAtCheckpoint() == shouldStopAtCheckpoint
             || indexerState == IndexerState.STOPPED
             || indexerState == IndexerState.STOPPING) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -289,16 +289,10 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
     /**
      * This sets the flag for the task to stop at the next checkpoint.
      *
-     * If first persists the flag and then mutates the local variable.
-     *
-     * It only persists if the value is different than what is currently held in memory.
      * @param shouldStopAtCheckpoint whether or not we should stop at the next checkpoint or not
      * @param shouldStopAtCheckpointListener the listener to return to when we have persisted the updated value to the state index.
      */
-    public void setShouldStopAtCheckpoint(
-        boolean shouldStopAtCheckpoint,
-        ActionListener<Void> shouldStopAtCheckpointListener
-    ) {
+    public void setShouldStopAtCheckpoint(boolean shouldStopAtCheckpoint, ActionListener<Void> shouldStopAtCheckpointListener) {
         logger.debug(
             "[{}] attempted to set task to stop at checkpoint [{}] with state [{}]",
             getTransformId(),
@@ -309,7 +303,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             shouldStopAtCheckpointListener.onResponse(null);
             return;
         }
-        getIndexer().stopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener);
+        getIndexer().setStopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener);
     }
 
     public synchronized void stop(boolean force, boolean shouldStopAtCheckpoint) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -286,10 +286,6 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         }));
     }
 
-    void setShouldStopAtCheckpoint(boolean shouldStopAtCheckpoint) {
-        this.context.setShouldStopAtCheckpoint(shouldStopAtCheckpoint);
-    }
-
     /**
      * This sets the flag for the task to stop at the next checkpoint.
      *
@@ -299,7 +295,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
      * @param shouldStopAtCheckpoint whether or not we should stop at the next checkpoint or not
      * @param shouldStopAtCheckpointListener the listener to return to when we have persisted the updated value to the state index.
      */
-    public synchronized void setShouldStopAtCheckpoint(
+    public void setShouldStopAtCheckpoint(
         boolean shouldStopAtCheckpoint,
         ActionListener<Void> shouldStopAtCheckpointListener
     ) {
@@ -313,7 +309,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             shouldStopAtCheckpointListener.onResponse(null);
             return;
         }
-        getIndexer().persistShouldStopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener);
+        getIndexer().stopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener);
     }
 
     public synchronized void stop(boolean force, boolean shouldStopAtCheckpoint) {
@@ -346,12 +342,13 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
 
         // If state was in a failed state, we should stop immediately
         if (wasFailed) {
-            getIndexer().onStop();
-            getIndexer().doSaveState(IndexerState.STOPPED, getIndexer().getPosition(), () -> {});
+            getIndexer().stopAndSaveState();
             return;
         }
 
-        if (getIndexer().getState() == IndexerState.STOPPED || getIndexer().getState() == IndexerState.STOPPING) {
+        IndexerState indexerState = getIndexer().getState();
+
+        if (indexerState == IndexerState.STOPPED || indexerState == IndexerState.STOPPING) {
             return;
         }
 
@@ -361,11 +358,10 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         // If the indexerState is STARTED and it is on an initialRun, that means that the indexer has previously finished a checkpoint,
         // or has yet to even start one.
         // Either way, this means that we won't get to have onFinish called down stream (or at least won't for some time).
-            (getIndexer().getState() == IndexerState.STARTED && getIndexer().initialRun())) {
+            (indexerState == IndexerState.STARTED && getIndexer().initialRun())) {
             IndexerState state = getIndexer().stop();
             if (state == IndexerState.STOPPED) {
-                getIndexer().onStop();
-                getIndexer().doSaveState(state, getIndexer().getPosition(), () -> {});
+                getIndexer().stopAndSaveState();
             }
         }
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -303,7 +303,10 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             shouldStopAtCheckpointListener.onResponse(null);
             return;
         }
-        getIndexer().setStopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener);
+
+        // move the call to the generic thread pool, so we do not block the network thread
+        getThreadPool().executor(ThreadPool.Names.GENERIC)
+            .execute(() -> { getIndexer().setStopAtCheckpoint(shouldStopAtCheckpoint, shouldStopAtCheckpointListener); });
     }
 
     public synchronized void stop(boolean force, boolean shouldStopAtCheckpoint) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -292,7 +292,10 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
      * @param shouldStopAtCheckpoint whether or not we should stop at the next checkpoint or not
      * @param shouldStopAtCheckpointListener the listener to return to when we have persisted the updated value to the state index.
      */
-    public void setShouldStopAtCheckpoint(boolean shouldStopAtCheckpoint, ActionListener<Void> shouldStopAtCheckpointListener) {
+    public synchronized void setShouldStopAtCheckpoint(
+        boolean shouldStopAtCheckpoint,
+        ActionListener<Void> shouldStopAtCheckpointListener
+    ) {
         logger.debug(
             "[{}] attempted to set task to stop at checkpoint [{}] with state [{}]",
             getTransformId(),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/MockTimebasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/MockTimebasedCheckpointProvider.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
 package org.elasticsearch.xpack.transform.checkpoint;
 
 import org.elasticsearch.action.ActionListener;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/MockTimebasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/MockTimebasedCheckpointProvider.java
@@ -1,0 +1,104 @@
+package org.elasticsearch.xpack.transform.checkpoint;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo.TransformCheckpointingInfoBuilder;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
+import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
+import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
+
+import java.util.Collections;
+
+/**
+ * mock of a time based checkpoint provider for testing
+ */
+public class MockTimebasedCheckpointProvider implements CheckpointProvider {
+
+    private final TransformConfig transformConfig;
+    private final TimeSyncConfig timeSyncConfig;
+
+    public MockTimebasedCheckpointProvider(final TransformConfig transformConfig) {
+        this.transformConfig = ExceptionsHelper.requireNonNull(transformConfig, "transformConfig");
+        timeSyncConfig = ExceptionsHelper.requireNonNull((TimeSyncConfig) transformConfig.getSyncConfig(), "timeSyncConfig");
+    }
+
+    @Override
+    public void createNextCheckpoint(TransformCheckpoint lastCheckpoint, ActionListener<TransformCheckpoint> listener) {
+
+        final long timestamp = System.currentTimeMillis();
+        long timeUpperBound = timestamp - timeSyncConfig.getDelay().millis();
+
+        if (lastCheckpoint == null) {
+            listener.onResponse(new TransformCheckpoint(transformConfig.getId(), timestamp, 0, Collections.emptyMap(), timeUpperBound));
+        }
+
+        listener.onResponse(
+            new TransformCheckpoint(
+                transformConfig.getId(),
+                timestamp,
+                lastCheckpoint.getCheckpoint() + 1,
+                Collections.emptyMap(),
+                timeUpperBound
+            )
+        );
+    }
+
+    @Override
+    public void sourceHasChanged(TransformCheckpoint lastCheckpoint, ActionListener<Boolean> listener) {
+        // lets pretend there are always changes
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void getCheckpointingInfo(
+        TransformCheckpoint lastCheckpoint,
+        TransformCheckpoint nextCheckpoint,
+        TransformIndexerPosition nextCheckpointPosition,
+        TransformProgress nextCheckpointProgress,
+        ActionListener<TransformCheckpointingInfoBuilder> listener
+    ) {
+        TransformCheckpointingInfoBuilder checkpointingInfoBuilder = new TransformCheckpointingInfoBuilder();
+        checkpointingInfoBuilder.setLastCheckpoint(lastCheckpoint)
+            .setNextCheckpoint(nextCheckpoint)
+            .setNextCheckpointPosition(nextCheckpointPosition)
+            .setNextCheckpointProgress(nextCheckpointProgress);
+
+        long timestamp = System.currentTimeMillis();
+        TransformCheckpoint sourceCheckpoint = new TransformCheckpoint(transformConfig.getId(), timestamp, -1L, Collections.emptyMap(), 0L);
+        checkpointingInfoBuilder.setSourceCheckpoint(sourceCheckpoint);
+        checkpointingInfoBuilder.setOperationsBehind(TransformCheckpoint.getBehind(lastCheckpoint, sourceCheckpoint));
+        listener.onResponse(checkpointingInfoBuilder);
+    }
+
+    @Override
+    public void getCheckpointingInfo(
+        long lastCheckpointNumber,
+        TransformIndexerPosition nextCheckpointPosition,
+        TransformProgress nextCheckpointProgress,
+        ActionListener<TransformCheckpointingInfoBuilder> listener
+    ) {
+        long timestamp = System.currentTimeMillis();
+
+        // emulate the 2 last checkpoints as if last run 1 second ago and next right now
+        TransformCheckpoint lastCheckpoint = new TransformCheckpoint(
+            transformConfig.getId(),
+            timestamp - 1000,
+            lastCheckpointNumber,
+            Collections.emptyMap(),
+            timestamp - 1000 - timeSyncConfig.getDelay().millis()
+        );
+
+        TransformCheckpoint nextCheckpoint = new TransformCheckpoint(
+            transformConfig.getId(),
+            timestamp,
+            lastCheckpointNumber + 1,
+            Collections.emptyMap(),
+            timestamp - timeSyncConfig.getDelay().millis()
+        );
+
+        getCheckpointingInfo(lastCheckpoint, nextCheckpoint, nextCheckpointPosition, nextCheckpointProgress, listener);
+    }
+
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -1,0 +1,423 @@
+package org.elasticsearch.xpack.transform.transforms;
+
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.internal.InternalSearchResponse;
+import org.elasticsearch.search.profile.SearchProfileShardResults;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
+import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
+import org.elasticsearch.xpack.transform.checkpoint.MockTimebasedCheckpointProvider;
+import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.InMemoryTransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
+import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
+import static org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests.randomPivotConfig;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.Mockito.mock;
+
+public class TransformIndexerStateTests extends ESTestCase {
+
+    private static final SearchResponse ONE_HIT_SEARCH_RESPONSE = new SearchResponse(
+        new InternalSearchResponse(
+            new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+            // Simulate completely null aggs
+            null,
+            new Suggest(Collections.emptyList()),
+            new SearchProfileShardResults(Collections.emptyMap()),
+            false,
+            false,
+            1
+        ),
+        "",
+        1,
+        1,
+        0,
+        0,
+        ShardSearchFailure.EMPTY_ARRAY,
+        SearchResponse.Clusters.EMPTY
+    );
+
+    private Client client;
+    private ThreadPool threadPool;
+    private TransformAuditor auditor;
+    private TransformConfigManager transformConfigManager;
+
+    class MockedTransformIndexer extends TransformIndexer {
+
+        private int saveStateListenerCallCount = 0;
+        // used for synchronizing with the test
+        private CountDownLatch searchLatch;
+
+        public MockedTransformIndexer(
+            ThreadPool threadPool,
+            String executorName,
+            TransformConfigManager transformsConfigManager,
+            CheckpointProvider checkpointProvider,
+            TransformAuditor auditor,
+            TransformConfig transformConfig,
+            Map<String, String> fieldMappings,
+            AtomicReference<IndexerState> initialState,
+            TransformIndexerPosition initialPosition,
+            TransformIndexerStats jobStats,
+            TransformContext context
+        ) {
+            super(
+                threadPool,
+                executorName,
+                transformsConfigManager,
+                checkpointProvider,
+                auditor,
+                transformConfig,
+                fieldMappings,
+                initialState,
+                initialPosition,
+                jobStats,
+                /* TransformProgress */ null,
+                TransformCheckpoint.EMPTY,
+                TransformCheckpoint.EMPTY,
+                context
+            );
+        }
+
+        public void initialize() {
+            this.initializeFunction();
+        }
+
+        public CountDownLatch newSearchLatch(int count) {
+            return searchLatch = new CountDownLatch(count);
+        }
+
+        @Override
+        void doGetInitialProgress(SearchRequest request, ActionListener<SearchResponse> responseListener) {
+            responseListener.onResponse(ONE_HIT_SEARCH_RESPONSE);
+        }
+
+        @Override
+        protected void doNextSearch(long waitTimeInNanos, ActionListener<SearchResponse> nextPhase) {
+            if (searchLatch != null) {
+                try {
+                    searchLatch.await();
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+            nextPhase.onResponse(ONE_HIT_SEARCH_RESPONSE);
+        }
+
+        @Override
+        protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+            nextPhase.onResponse(new BulkResponse(new BulkItemResponse[0], 100));
+        }
+
+        @Override
+        protected void doSaveState(IndexerState state, TransformIndexerPosition position, Runnable next) {
+            Collection<ActionListener<Void>> saveStateListenersAtTheMomentOfCalling = saveStateListeners.getAndSet(null);
+            try {
+                if (saveStateListenersAtTheMomentOfCalling != null) {
+                    saveStateListenerCallCount += saveStateListenersAtTheMomentOfCalling.size();
+                    ActionListener.onResponse(saveStateListenersAtTheMomentOfCalling, null);
+                }
+            } catch (Exception onResponseException) {
+                fail("failed to call save state listeners");
+            } finally {
+                next.run();
+            }
+        }
+
+        public int getSaveStateListenerCallCount() {
+            return saveStateListenerCallCount;
+        }
+    }
+
+    @Before
+    public void setUpMocks() {
+        auditor = new MockTransformAuditor();
+        transformConfigManager = new InMemoryTransformConfigManager();
+        client = new NoOpClient(getTestName());
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void tearDownClient() {
+        client.close();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    public void testStopAtCheckpoint() throws Exception {
+        TransformConfig config = new TransformConfig(
+            randomAlphaOfLength(10),
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)),
+            null,
+            randomPivotConfig(),
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null
+        );
+
+        for (IndexerState state : IndexerState.values()) {
+            // skip indexing case, tested below
+            if (IndexerState.INDEXING.equals(state)) {
+                continue;
+            }
+            AtomicReference<IndexerState> stateRef = new AtomicReference<>(state);
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+            final MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                stateRef,
+                null,
+                threadPool,
+                ThreadPool.Names.GENERIC,
+                auditor,
+                new TransformIndexerStats(),
+                context
+            );
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+            assertEquals(0, indexer.getSaveStateListenerCallCount());
+        }
+
+        // lets test a running indexer
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STARTED);
+        {
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+            final MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                state,
+                null,
+                threadPool,
+                ThreadPool.Names.GENERIC,
+                auditor,
+                new TransformIndexerStats(),
+                context
+            );
+            indexer.start();
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+
+            indexer.stop();
+            assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)), 5, TimeUnit.SECONDS);
+
+            // listener must have been called by the indexing thread
+            assertEquals(1, indexer.getSaveStateListenerCallCount());
+
+            // as the state is stopped it should go back to directly
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+            assertEquals(1, indexer.getSaveStateListenerCallCount());
+        }
+
+        // do another round
+        {
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+            final MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                state,
+                null,
+                threadPool,
+                ThreadPool.Names.GENERIC,
+                auditor,
+                new TransformIndexerStats(),
+                context
+            );
+
+            indexer.start();
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+            // this time call it 3 times
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+            assertResponse(listener -> indexer.stopAtCheckpoint(true, listener));
+
+            indexer.stop();
+            assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)), 5, TimeUnit.SECONDS);
+
+            // listener must have been called by the indexing thread between 1 and 3 times
+            assertThat(indexer.getSaveStateListenerCallCount(), greaterThanOrEqualTo(1));
+            assertThat(indexer.getSaveStateListenerCallCount(), lessThanOrEqualTo(3));
+        }
+
+        // 3rd round with some back and forth
+        {
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+            final MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                state,
+                null,
+                threadPool,
+                ThreadPool.Names.GENERIC,
+                auditor,
+                new TransformIndexerStats(),
+                context
+            );
+            indexer.start();
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+            // slow down the indexer
+            CountDownLatch searchLatch = indexer.newSearchLatch(1);
+
+            // this time call 5 times and change stopAtCheckpoint every time
+            List<CountDownLatch> responseLatches = new ArrayList<>();
+            for (int i = 0; i < 5; ++i) {
+                CountDownLatch latch = new CountDownLatch(1);
+                boolean stopAtCheckpoint = i % 2 == 0;
+                countResponse(listener -> indexer.stopAtCheckpoint(stopAtCheckpoint, listener), latch);
+                responseLatches.add(latch);
+            }
+
+            // now let the indexer run again
+            searchLatch.countDown();
+
+            indexer.stop();
+            assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)), 5, TimeUnit.SECONDS);
+
+            // wait for all listeners
+            for (CountDownLatch l : responseLatches) {
+                assertTrue("timed out after 5s", l.await(5, TimeUnit.SECONDS));
+            }
+
+            // listener must have been called 5 times, because the value changed every time and we slowed down the indexer
+            assertThat(indexer.getSaveStateListenerCallCount(), equalTo(5));
+        }
+
+        // 4th round: go wild
+        {
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+            final MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                state,
+                null,
+                threadPool,
+                ThreadPool.Names.GENERIC,
+                auditor,
+                new TransformIndexerStats(),
+                context
+            );
+            indexer.start();
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+            // slow down the indexer
+            CountDownLatch searchLatch = indexer.newSearchLatch(1);
+
+            List<CountDownLatch> responseLatches = new ArrayList<>();
+            for (int i = 0; i < 3; ++i) {
+                CountDownLatch latch = new CountDownLatch(1);
+                boolean stopAtCheckpoint = randomBoolean();
+                countResponse(listener -> indexer.stopAtCheckpoint(stopAtCheckpoint, listener), latch);
+                responseLatches.add(latch);
+            }
+
+            // now let the indexer run again
+            searchLatch.countDown();
+
+            // this time call it 3 times
+            assertResponse(listener -> indexer.stopAtCheckpoint(randomBoolean(), listener));
+            assertResponse(listener -> indexer.stopAtCheckpoint(randomBoolean(), listener));
+            assertResponse(listener -> indexer.stopAtCheckpoint(randomBoolean(), listener));
+
+            indexer.stop();
+            assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)), 5, TimeUnit.SECONDS);
+
+            // wait for all listeners
+            for (CountDownLatch l : responseLatches) {
+                assertTrue("timed out after 5s", l.await(5, TimeUnit.SECONDS));
+            }
+
+            // listener must have been called by the indexing thread between 1 and 6 times
+            assertThat(indexer.getSaveStateListenerCallCount(), greaterThanOrEqualTo(1));
+            assertThat(indexer.getSaveStateListenerCallCount(), lessThanOrEqualTo(6));
+        }
+    }
+
+    private void assertResponse(Consumer<ActionListener<Void>> function) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        countResponse(function, latch);
+        assertTrue("timed out after 5s", latch.await(5, TimeUnit.SECONDS));
+    }
+
+    private void countResponse(Consumer<ActionListener<Void>> function, CountDownLatch latch) throws InterruptedException {
+        LatchedActionListener<Void> listener = new LatchedActionListener<>(
+            ActionListener.wrap(
+                r -> { assertEquals("listener called more than once", 1, latch.getCount()); },
+                e -> { fail("got unexpected exception: " + e.getMessage()); }
+            ),
+            latch
+        );
+
+        function.accept(listener);
+    }
+
+    private MockedTransformIndexer createMockIndexer(
+        TransformConfig config,
+        AtomicReference<IndexerState> state,
+        Consumer<String> failureConsumer,
+        ThreadPool threadPool,
+        String executorName,
+        TransformAuditor auditor,
+        TransformIndexerStats jobStats,
+        TransformContext context
+    ) {
+        CheckpointProvider checkpointProvider = new MockTimebasedCheckpointProvider(config);
+        transformConfigManager.putTransformConfiguration(config, ActionListener.wrap(r -> {}, e -> {}));
+
+        MockedTransformIndexer indexer = new MockedTransformIndexer(
+            threadPool,
+            executorName,
+            transformConfigManager,
+            checkpointProvider,
+            auditor,
+            config,
+            Collections.emptyMap(),
+            state,
+            null,
+            jobStats,
+            context
+        );
+
+        indexer.initialize();
+        return indexer;
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.apache.lucene.search.TotalHits;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -481,10 +481,14 @@ public class TransformIndexerStateTests extends ESTestCase {
 
         // the calls are likely executed _before_ the next search is even scheduled
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
+        assertTrue(indexer.getPersistedState().shouldStopAtNextCheckpoint());
         assertResponse(listener -> setStopAtCheckpoint(indexer, false, listener));
+        assertFalse(indexer.getPersistedState().shouldStopAtNextCheckpoint());
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
+        assertTrue(indexer.getPersistedState().shouldStopAtNextCheckpoint());
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
         assertResponse(listener -> setStopAtCheckpoint(indexer, false, listener));
+        assertFalse(indexer.getPersistedState().shouldStopAtNextCheckpoint());
 
         onResponseLatch.await();
         onResponseLatch = indexer.createCountDownOnResponseLatch(1);
@@ -492,15 +496,19 @@ public class TransformIndexerStateTests extends ESTestCase {
         // wait until a search is scheduled
         assertBusy(() -> assertTrue(indexer.waitingForNextSearch()), 5, TimeUnit.SECONDS);
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
+        assertTrue(indexer.getPersistedState().shouldStopAtNextCheckpoint());
 
         onResponseLatch.await();
         onResponseLatch = indexer.createCountDownOnResponseLatch(1);
 
         assertBusy(() -> assertTrue(indexer.waitingForNextSearch()), 5, TimeUnit.SECONDS);
         assertResponse(listener -> setStopAtCheckpoint(indexer, false, listener));
+        assertFalse(indexer.getPersistedState().shouldStopAtNextCheckpoint());
+
         onResponseLatch.await();
         assertBusy(() -> assertTrue(indexer.waitingForNextSearch()), 5, TimeUnit.SECONDS);
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
+        assertTrue(indexer.getPersistedState().shouldStopAtNextCheckpoint());
         assertResponse(listener -> setStopAtCheckpoint(indexer, true, listener));
 
         indexer.stop();


### PR DESCRIPTION
refactor how state is persisted, call doSaveState only from the indexer thread, except there is none.


fixes #60781
fixes #52931
fixes #51629
fixes #52035