### PR TITLE
[7.x][ML] Update mappings of ml stats index (#61980)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_mappings.json
@@ -10,6 +10,9 @@
       },
       "hyperparameters": {
         "properties": {
+          "alpha": {
+            "type": "double"
+          },
           "class_assignment_objective": {
             "type": "keyword"
           },
@@ -23,6 +26,12 @@
             "type": "double"
           },
           "feature_bag_fraction": {
+            "type": "double"
+          },
+          "gamma": {
+            "type": "double"
+          },
+          "lambda": {
             "type": "double"
           },
           "max_attempts_to_add_tree": {
@@ -40,19 +49,10 @@
           "num_splits_per_feature": {
             "type": "integer"
           },
-          "regularization_depth_penalty_multiplier": {
+          "soft_tree_depth_limit": {
             "type": "double"
           },
-          "regularization_leaf_weight_penalty_multiplier": {
-            "type": "double"
-          },
-          "regularization_soft_tree_depth_limit": {
-            "type": "double"
-          },
-          "regularization_soft_tree_depth_tolerance": {
-            "type": "double"
-          },
-          "regularization_tree_size_penalty_multiplier": {
+          "soft_tree_depth_tolerance": {
             "type": "double"
           }
         }


### PR DESCRIPTION
- Adds missing mappings for `alpha`, `gamma`, and `lambda`.
- Corrects name of `soft_tree_depth_limit` and `soft_tree_depth_tolerance`.
- Removes unused `regularization_depth_penalty_multiplier`,
  `regularization_leaf_weight_penalty_multiplier` and
  `regularization_tree_size_penalty_multiplier`.

Backport of #61980
