### PR TITLE
Prevent cardinality aggregation reserving a fixed amount of memory per bucket

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongArray;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -47,6 +48,8 @@ import java.util.Set;
  *
  * This implementation is different from the original implementation in that it uses a hash table instead of a sorted list for linear
  * counting. Although this requires more space and makes hyperloglog (which is less accurate) used sooner, this is also considerably faster.
+ * In order to limit the space requirements for low cardinality data at high precision, The Linear counting algorithm is first initialize
+ * in a small unordered list that uses linear search.
  *
  * Trying to understand what this class does without having read the paper is considered adventurous.
  *
@@ -62,10 +65,22 @@ public final class HyperLogLogPlusPlus implements Releasable {
     private static final boolean LINEAR_COUNTING = false;
     private static final boolean HYPERLOGLOG = true;
     public static final int DEFAULT_PRECISION = 14;
-
+    // Algorithm used by a bucketOrd.
     private final BitArray algorithm;
-    private final HyperLogLog hll;
+    // First structure created to handle low cardinality sketches.
+    // Order is given by the bucketOrd
+    private final LowCardinalityLinearCounting low;
+    // Structure created when cardinality reaches capacity of LowCardinalityLinearCounting.
+    // Order is given by the ordMapping
     private final LinearCounting lc;
+    // Structure created when cardinality reaches capacity of LinearCounting.
+    // Order is given by the ordMapping
+    private final HyperLogLog hll;
+    // Mapping between bucketOrd and ord in HLL and LinearCounting
+    private LongArray ordMapping;
+    private long maxOrd;
+    private final BigArrays bigArrays;
+
 
     /**
      * Compute the required precision so that <code>count</code> distinct entries would be counted with linear counting.
@@ -85,11 +100,19 @@ public final class HyperLogLogPlusPlus implements Releasable {
         return 1L << precision;
     }
 
-
     public HyperLogLogPlusPlus(int precision, BigArrays bigArrays, long initialBucketCount) {
         hll = new HyperLogLog(bigArrays, initialBucketCount, precision);
         lc = new LinearCounting(bigArrays, initialBucketCount, precision, hll);
+        low = new LowCardinalityLinearCounting(bigArrays, computeLowCardinalityForPrecision(precision), precision);
         algorithm = new BitArray(1, bigArrays);
+        ordMapping = bigArrays.newLongArray(1, false);
+        ordMapping.set(0, -1);
+        this.bigArrays = bigArrays;
+    }
+
+    private static int computeLowCardinalityForPrecision(int precision) {
+        // TODO: better heuristics here?
+        return Math.max(1, precision - AbstractCardinalityAlgorithm.MIN_PRECISION);
     }
 
     public int precision() {
@@ -97,67 +120,128 @@ public final class HyperLogLogPlusPlus implements Releasable {
     }
 
     public long maxBucket() {
-        return hll.runLens.size() >>> hll.precision();
+        // This is an approximation, the value is always >= to the actual max bucket
+        return low.hashes.size() / low.capacity;
     }
 
     public void merge(long thisBucket, HyperLogLogPlusPlus other, long otherBucket) {
-        if (precision() != other.precision()) {
-            throw new IllegalArgumentException();
-        }
-        hll.bucket = thisBucket;
-        lc.bucket = thisBucket;
-        hll.ensureCapacity(thisBucket + 1);
         if (other.algorithm.get(otherBucket) == LINEAR_COUNTING) {
-            other.lc.bucket = otherBucket;
-            final AbstractLinearCounting.HashesIterator values = other.lc.values();
-            while (values.next()) {
-                final int encoded = values.value();
-                if (algorithm.get(thisBucket) == LINEAR_COUNTING) {
-                    final int newSize = lc.addEncoded(encoded);
-                    if (newSize > lc.threshold) {
-                        upgradeToHll(thisBucket);
-                    }
-                } else {
-                    hll.collectEncoded(encoded);
-                }
+            other.low.bucket = otherBucket;
+            if (other.low.exhausted()) {
+                other.lc.ord = other.bucketToOrd(otherBucket);
+                merge(thisBucket, other.lc);
+            } else {
+                merge(thisBucket, other.low);
             }
         } else {
-            if (algorithm.get(thisBucket) != HYPERLOGLOG) {
-                upgradeToHll(thisBucket);
-            }
-            other.hll.bucket = otherBucket;
-            hll.merge(other.hll);
+            other.hll.ord = other.bucketToOrd(otherBucket);
+            merge(thisBucket, other.hll);
         }
     }
 
-    public void collect(long bucket, long hash) {
-        hll.ensureCapacity(bucket + 1);
+    public void merge(long bucket, AbstractLinearCounting other) {
+        if (precision() != other.precision()) {
+            throw new IllegalArgumentException();
+        }
+        final long ord = bucketToOrd(bucket);
+        final AbstractLinearCounting.HashesIterator values = other.values();
         if (algorithm.get(bucket) == LINEAR_COUNTING) {
-            lc.bucket = bucket;
-            final int newSize = lc.collect(hash);
-            if (newSize > lc.threshold) {
-                upgradeToHll(bucket);
+            low.bucket = bucket;
+            if (low.exhausted()) {
+                mergeIntoLc(bucket, ord, values);
+            } else {
+                mergeIntoLow(bucket, ord, values);
             }
         } else {
-            hll.bucket = bucket;
+            mergeIntoHLL(ord, values);
+        }
+    }
+
+    private void mergeIntoLow(long bucket, long ord, AbstractLinearCounting.HashesIterator values) {
+        while (values.next()) {
+            low.addEncoded(values.value());
+            if (low.exhausted()) {
+                upgradeToLinearCounting(bucket, ord);
+                mergeIntoLc(bucket, ord, values);
+                return;
+            }
+        }
+    }
+
+    private void mergeIntoLc(long bucket, long ord, AbstractLinearCounting.HashesIterator values) {
+        lc.ord = ord;
+        while (values.next()) {
+            if (lc.addEncoded(values.value()) > lc.threshold) {
+                upgradeToHll(bucket, ord);
+                mergeIntoHLL(ord, values);
+                return;
+            }
+        }
+    }
+
+    private void mergeIntoHLL(long ord, AbstractLinearCounting.HashesIterator values) {
+        hll.ord = ord;
+        while (values.next()) {
+            hll.collectEncoded(values.value());
+        }
+    }
+
+    public void merge(long bucket, AbstractHyperLogLog other) {
+        if (precision() != other.precision()) {
+            throw new IllegalArgumentException();
+        }
+        final long ord = bucketToOrd(bucket);
+        if (algorithm.get(bucket) != HYPERLOGLOG) {
+            low.bucket = bucket;
+            if (low.exhausted() == false) {
+                upgradeToLinearCounting(bucket, ord);
+            }
+            upgradeToHll(bucket, ord);
+        } else {
+            hll.ord = ord;
+        }
+        hll.merge(other);
+    }
+
+    public void collect(long bucket, long hash) {
+        if (algorithm.get(bucket) == LINEAR_COUNTING) {
+            low.bucket = bucket;
+            if (low.exhausted()) {
+                lc.ord = bucketToOrd(bucket);
+                if (lc.collect(hash) > lc.threshold) {
+                    upgradeToHll(bucket, lc.ord);
+                }
+            } else {
+                low.collect(hash);
+                if (low.exhausted()) {
+                    upgradeToLinearCounting(bucket, bucketToOrd(bucket));
+                }
+            }
+        } else {
+            hll.ord = bucketToOrd(bucket);
             hll.collect(hash);
         }
     }
 
     public long cardinality(long bucket) {
         if (algorithm.get(bucket) == LINEAR_COUNTING) {
-            lc.bucket = bucket;
-            return lc.cardinality();
+            low.bucket = bucket;
+            if (low.exhausted()) {
+                lc.ord = bucketToOrd(bucket);
+                return lc.cardinality();
+            } else {
+                return low.cardinality();
+            }
         } else {
-            hll.bucket = bucket;
+            hll.ord = bucketToOrd(bucket);
             return hll.cardinality();
         }
     }
 
-    void upgradeToHll(long bucket) {
-        hll.ensureCapacity(bucket + 1);
-        lc.bucket = bucket;
-        hll.bucket = bucket;
+    // protected for testing
+    void upgradeToHll(long bucket, long ord) {
+        lc.ord = ord;
+        hll.ord = ord;
         final AbstractLinearCounting.HashesIterator hashes = lc.values();
         // We need to copy values into an arrays as we will override
         // the values on the buffer
@@ -179,17 +263,68 @@ public final class HyperLogLogPlusPlus implements Releasable {
         }
     }
 
+    // protected for testing
+    void upgradeToLinearCounting(long bucket, long ord) {
+        low.bucket = bucket;
+        lc.ord = ord;
+        hll.ensureCapacity(ord + 1);
+        final AbstractLinearCounting.HashesIterator hashes = low.values();
+        while (hashes.next()) {
+            lc.addEncoded(hashes.value());
+        }
+    }
+
+    // used for deserializing sketches
+    private void collectEncoded(long bucket, int encoded) {
+        if (algorithm.get(bucket) == LINEAR_COUNTING) {
+            low.bucket = bucket;
+            if (low.exhausted()) {
+                lc.ord = bucketToOrd(bucket);
+                if (lc.addEncoded(encoded) > lc.threshold) {
+                    upgradeToHll(bucket, lc.ord);
+                }
+            } else {
+                low.addEncoded(encoded);
+                if (low.exhausted()) {
+                    upgradeToLinearCounting(bucket, bucketToOrd(bucket));
+                }
+            }
+        } else {
+            hll.ord = bucketToOrd(bucket);
+            hll.collectEncoded(encoded);
+        }
+    }
+
+    private long bucketToOrd(long bucket) {
+        long size = ordMapping.size();
+        if (size <= bucket) {
+            ordMapping = bigArrays.grow(ordMapping, bucket + 1);
+            ordMapping.fill(size, ordMapping.size(), -1);
+        }
+        long ord = ordMapping.get(bucket);
+        if (ord == -1) {
+            ord = maxOrd;
+            ordMapping.set(bucket, maxOrd++);
+        }
+        return ord;
+    }
+
     @Override
     public void close() {
-        Releasables.close(algorithm, hll, lc);
+        Releasables.close(algorithm, hll, lc, low, ordMapping);
     }
 
     private Object getComparableData(long bucket) {
         if (algorithm.get(bucket) == LINEAR_COUNTING) {
-            lc.bucket = bucket;
-            return lc.getComparableData();
+            low.bucket = bucket;
+            if (low.exhausted()) {
+                lc.ord =  bucketToOrd(bucket);
+                return lc.getComparableData();
+            } else {
+                return low.getComparableData();
+            }
         } else {
-            hll.bucket = bucket;
+            hll.ord = bucketToOrd(bucket);
             return hll.getComparableData();
         }
     }
@@ -208,15 +343,21 @@ public final class HyperLogLogPlusPlus implements Releasable {
         out.writeVInt(precision());
         if (algorithm.get(bucket) == LINEAR_COUNTING) {
             out.writeBoolean(LINEAR_COUNTING);
-            lc.bucket = bucket;
-            AbstractLinearCounting.HashesIterator hashes = lc.values();
+            low.bucket = bucket;
+            AbstractLinearCounting.HashesIterator hashes;
+            if (low.exhausted()) {
+                lc.ord = bucketToOrd(bucket);
+                hashes = lc.values();
+            } else {
+                hashes = low.values();
+            }
             out.writeVLong(hashes.size());
             while (hashes.next()) {
                 out.writeInt(hashes.value());
             }
         } else {
             out.writeBoolean(HYPERLOGLOG);
-            hll.bucket = bucket;
+            hll.ord = bucketToOrd(bucket);
             AbstractHyperLogLog.RunLenIterator iterator = hll.getRunLens();
             while (iterator.next()){
                 out.writeByte(iterator.value());
@@ -231,14 +372,13 @@ public final class HyperLogLogPlusPlus implements Releasable {
         if (algorithm == LINEAR_COUNTING) {
             counts.algorithm.clear(0);
             final long size = in.readVLong();
-            counts.lc.bucket = 0;
             for (long i = 0; i < size; ++i) {
                 final int encoded = in.readInt();
-                counts.lc.addEncoded(encoded);
+                counts.collectEncoded(0, encoded);
             }
         } else {
             counts.algorithm.set(0);
-            counts.hll.bucket = 0;
+            counts.hll.ord = counts.bucketToOrd(0);
             for (int i = 0; i < counts.hll.m; ++i) {
                 counts.hll.addRunLen(i, in.readByte());
             }
@@ -253,7 +393,7 @@ public final class HyperLogLogPlusPlus implements Releasable {
         private ByteArray runLens;
         // Defines the position of the data structure. Callers of this object should set this value
         // before calling any of the methods.
-        protected long bucket;
+        protected long ord;
 
         HyperLogLog(BigArrays bigArrays, long initialBucketCount, int precision) {
             super(precision);
@@ -264,24 +404,24 @@ public final class HyperLogLogPlusPlus implements Releasable {
 
         @Override
         protected void addRunLen(int register, int encoded) {
-            final long bucketIndex = (bucket << p) + register;
+            final long bucketIndex = (ord << p) + register;
             runLens.set(bucketIndex, (byte) Math.max(encoded, runLens.get(bucketIndex)));
         }
 
         @Override
         protected RunLenIterator getRunLens() {
-            iterator.reset(bucket);
+            iterator.reset(ord);
             return iterator;
         }
 
         protected void reset() {
-            runLens.fill(bucket << p, (bucket << p) + m, (byte) 0);
+            runLens.fill(ord << p, (ord << p) + m, (byte) 0);
         }
 
         protected Object getComparableData() {
             Map<Byte, Integer> values = new HashMap<>();
             for (long i = 0; i < runLens.size(); i++) {
-                byte runLength = runLens.get((bucket << p) + i);
+                byte runLength = runLens.get((ord << p) + i);
                 Integer numOccurances = values.get(runLength);
                 if (numOccurances == null) {
                     values.put(runLength, 1);
@@ -353,7 +493,7 @@ public final class HyperLogLogPlusPlus implements Releasable {
         private IntArray sizes;
         // Defines the position of the data structure. Callers of this object should set this value
         // before calling any of the methods.
-        protected long bucket;
+        protected long ord;
 
         LinearCounting(BigArrays bigArrays, long initialBucketCount, int p, HyperLogLog hll) {
             super(p);
@@ -371,14 +511,14 @@ public final class HyperLogLogPlusPlus implements Releasable {
 
         @Override
         protected int addEncoded(int encoded) {
-            sizes = bigArrays.grow(sizes, bucket + 1);
+            sizes = bigArrays.grow(sizes, ord + 1);
             assert encoded != 0;
             for (int i = (encoded & mask);; i = (i + 1) & mask) {
                 final int v = get(i);
                 if (v == 0) {
                     // means unused, take it!
                     set(i, encoded);
-                    return sizes.increment(bucket, 1);
+                    return sizes.increment(ord, 1);
                 } else if (v == encoded) {
                     // k is already in the set
                     return -1;
@@ -388,10 +528,10 @@ public final class HyperLogLogPlusPlus implements Releasable {
 
         @Override
         protected int size() {
-            if (bucket >= sizes.size()) {
+            if (ord >= sizes.size()) {
                 return 0;
             }
-            final int size = sizes.get(bucket);
+            final int size = sizes.get(ord);
             assert size == recomputedSize();
             return size;
         }
@@ -412,7 +552,7 @@ public final class HyperLogLogPlusPlus implements Releasable {
         }
 
         private long index(int index) {
-            return (bucket << p) + (index << 2);
+            return (ord << p) + (index << 2);
         }
 
         private int get(int index) {
@@ -476,6 +616,148 @@ public final class HyperLogLogPlusPlus implements Releasable {
                         return true;
                     }
                 }
+            }
+            return false;
+        }
+
+        @Override
+        public int value() {
+            return value;
+        }
+    }
+
+    private static class LowCardinalityLinearCounting extends AbstractLinearCounting implements Releasable {
+        private final BigArrays bigArrays;
+        private final LowCardinalityLinearCountingIterator iterator;
+        // max number of encoded hashes
+        private final int capacity;
+        // Number of elements stored.
+        private IntArray sizes;
+        // Actual encoded hashes stored.
+        private IntArray hashes;
+        // Defines the position of the data structure. Callers of this object should set this value
+        // before calling any of the methods.
+        protected long bucket;
+
+        LowCardinalityLinearCounting(BigArrays bigArrays, int capacity, int p) {
+            super(p);
+            if (capacity < 1) {
+                throw new IllegalArgumentException("Capacity must be bigger > 0, got " + capacity);
+            }
+            this.bigArrays = bigArrays;
+            this.capacity = capacity;
+            sizes = bigArrays.newIntArray(capacity);
+            hashes = bigArrays.newIntArray(capacity);
+            iterator = new LowCardinalityLinearCountingIterator(this);
+        }
+
+        @Override
+        protected int addEncoded(int encoded) {
+            assert encoded != 0;
+            ensureCapacity(bucket);
+            final int size = size();
+            // we just iterate over all existing values
+            for (int i = 0; i < size; i++) {
+                if (get(i) == encoded) {
+                    // encoded value is already in the set
+                    return -1;
+                }
+            }
+            assert get(size) == 0;
+            set(size, encoded);
+            return sizes.increment(bucket, 1);
+        }
+
+        @Override
+        protected int size() {
+            if (bucket >= sizes.size()) {
+                return 0;
+            }
+            final int size = sizes.get(bucket);
+            assert size == recomputedSize();
+            return size;
+        }
+
+        protected boolean exhausted() {
+            return capacity == size();
+        }
+
+        @Override
+        protected HashesIterator values() {
+            iterator.reset(size());
+            return iterator;
+        }
+
+        protected Object getComparableData() {
+            Set<Integer> values = new HashSet<>();
+            HashesIterator iteratorValues = values();
+            while (iteratorValues.next()) {
+                values.add(iteratorValues.value());
+            }
+            return values;
+        }
+
+        private long index(int index) {
+            return (bucket * capacity) + index;
+        }
+
+        private int get(int index) {
+            return hashes.get(index(index));
+        }
+
+        private void set(int index, int value) {
+            hashes.set(index(index), value);
+        }
+
+        private int recomputedSize() {
+            if ((bucket + 1) * capacity > hashes.size()) {
+                return 0;
+            }
+            for (int i = 0; i < capacity; ++i) {
+                if (get(i) == 0) {
+                    return i;
+                }
+            }
+            return capacity;
+        }
+
+        private void ensureCapacity(long numBuckets) {
+            sizes = bigArrays.grow(sizes, numBuckets + 1);
+            hashes = bigArrays.grow(hashes, capacity * (numBuckets + 1));
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(sizes, hashes);
+        }
+    }
+
+    private static class LowCardinalityLinearCountingIterator implements AbstractLinearCounting.HashesIterator {
+
+        private final LowCardinalityLinearCounting lc;
+        private int pos;
+        private long size;
+        private int value;
+
+        LowCardinalityLinearCountingIterator(LowCardinalityLinearCounting lc) {
+            this.lc = lc;
+        }
+
+        void reset(long size) {
+            this.pos = 0;
+            this.size = size;
+        }
+
+        @Override
+        public long size() {
+            return size;
+        }
+
+        @Override
+        public boolean next() {
+            if (pos < size) {
+                value = lc.get(pos++);
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
The cardinality aggregation currently allocates a fixed amount of memory per aggregation which can be controlled by precision_threshold. Depending on that value, this amount of memory can be from 16 bytes to 250KB. This is ok if the cardinality aggregation is at the top level but it can be very wasteful if it is inside a bucket aggregation that is generating thousands of buckets.More over if each bucket is just collecting few unique values.

This PR improves the situation when most of this buckets contain only few unique values. We add first approximation for low cardinality that allocates just a small array. HLL++ arrays are only allocated when they are needed, so we need a mapping between the bucket ord and the current position on that structure.

closes #15892
