### PR TITLE
[7.x] [DOCS] Fix typo in Java API docs (#62095)

### DIFF
--- a/docs/java-api/docs/get.asciidoc
+++ b/docs/java-api/docs/get.asciidoc
@@ -3,7 +3,7 @@
 
 The get API allows to get a typed JSON document from the index based on
 its id. The following example gets a JSON document from an index called
-twitter, under a type called `_doc``, with id valued 1:
+twitter, under a type called `_doc`, with id valued 1:
 
 [source,java]
 --------------------------------------------------

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -113,7 +113,7 @@ String json = Strings.toString(builder);
 ==== Index document
 
 The following example indexes a JSON document into an index called
-twitter, under a type called `_doc``, with id valued 1:
+twitter, under a type called `_doc`, with id valued 1:
 
 [source,java]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo in Java API docs (#62095)