### PR TITLE
[DOCS] [7.x] Clarify HTTPS usage for create key API (#60858)

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -123,6 +123,8 @@ The API key returned by this API can then be used by sending a request with a
 `Authorization` header with a value having the prefix `ApiKey` followed
 by the _credentials_, where _credentials_ is the base64 encoding of `id` and `api_key` joined by a colon.
 
+NOTE: If your node has `xpack.security.http.ssl.enabled` set to `true`, then you must specify `https` when creating your API key.
+
 [source,shell]
 --------------------------------------------------
 curl -H "Authorization: ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==" http://localhost:9200/_cluster/health

--- a/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
@@ -5,10 +5,29 @@
 When {security-features} are enabled, you can optionally use TLS to ensure that
 communication between HTTP clients and the cluster is encrypted.
 
-NOTE: Enabling TLS on the HTTP layer is strongly recommended but is not required.
-If you enable TLS on the HTTP layer in {es}, then you might need to make
-configuration changes in other parts of the {stack} and in any {es} clients that
-you use.
+Enabling TLS on the HTTP layer is strongly recommended, but is not required.
+
+IMPORTANT: In a <<dev-vs-prod-mode,production environment>>, some {es} features
+such as tokens and API keys will be disabled unless you enable TLS on the HTTP
+layer.
+
+If you enable TLS on the HTTP layer in {es}, you might need to make
+configuration changes in other parts of the Elastic Stack and in any {es}
+clients that you use. For example, the following changes are typically
+necessary:
+
+* Update all clients, tools, and applications that connect to {es} to use the
+`https` protocol in their configuration URL. For example, {kib}, {beats}, {ls},
+language clients, and custom applications.
+* Set trusted certificate authorities. This change is typically required only
+if the {es} server certificate is issued by a certificate authority that is not
+automatically trusted by the clients, tools, and applications that connect to
+{es}.
+
+If you enable advanced TLS features on {es} (such as
+`ssl.client_authentication`), additional
+configuration could be necessary, but is not typically required in most {es}
+deployments.
 
 . If you have not done so already, <<node-certificates,generate node certificates>>.
 +


### PR DESCRIPTION
7.x backport for #60858