### PR TITLE
[TEST] adjust TransportSearchActionTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -836,6 +836,9 @@ public class TransportSearchActionTests extends ESTestCase {
                 if (collapse != null) {
                     collapse.setInnerHits(Collections.emptyList());
                 }
+                if (source.pointInTimeBuilder() != null) {
+                    source.pointInTimeBuilder(null);
+                }
             }
             searchRequest.setCcsMinimizeRoundtrips(true);
             assertTrue(TransportSearchAction.shouldMinimizeRoundtrips(searchRequest));


### PR DESCRIPTION
testShouldMinimizeRoundtrips creates a random search request, though some parts of the request can't be randomized or they will affect what shouldMinimizeRoundtrips returns. We just introduced randomizing the point in time builder (#62080) which is causing failures as roundtrips cannot be minimized when pit is used.