### PR TITLE
[7.x] [ML] setting require_alias to previous value on bulk index retry (#62103)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
@@ -227,6 +227,7 @@ public class MlConfigMigratorIT extends MlSingleNodeTestCase {
         IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).id("ml-config")
                 .source(Collections.singletonMap("a_field", "a_value"))
                 .opType(DocWriteRequest.OpType.CREATE)
+                .setRequireAlias(true)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         client().index(indexRequest).actionGet();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -288,6 +288,7 @@ public class ResultsPersisterService {
     private BulkRequest buildNewRequestFromFailures(BulkRequest bulkRequest, BulkResponse bulkResponse) {
         // If we failed, lets set the bulkRequest to be a collection of the failed requests
         BulkRequest bulkRequestOfFailures = new BulkRequest();
+        bulkRequestOfFailures.requireAlias(bulkRequest.requireAlias());
         Set<String> failedDocIds = Arrays.stream(bulkResponse.getItems())
             .filter(BulkItemResponse::isFailed)
             .map(BulkItemResponse::getId)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] setting require_alias to previous value on bulk index retry (#62103)