### PR TITLE
[7.9] [DOCS] Fix field caps API docs (#62110)

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -1,5 +1,9 @@
 [[search-field-caps]]
-=== Field Capabilities API
+=== Field capabilities API
+++++
+<titleabbrev>Field capabilities</titleabbrev>
+++++
+
 
 Allows you to retrieve the capabilities of fields among multiple indices.
 For data streams, the API returns field capabilities among the stream's backing
@@ -14,13 +18,13 @@ GET /_field_caps?fields=rating
 [[search-field-caps-api-request]]
 ==== {api-request-title}
 
-`GET /_field_caps`
+`GET /_field_caps?fields=<fields>`
 
-`POST /_field_caps`
+`POST /_field_caps?fields=<fields>`
 
-`GET /<target>/_field_caps`
+`GET /<target>/_field_caps?fields=<fields>`
 
-`POST /<target>/_field_caps`
+`POST /<target>/_field_caps?fields=<fields>`
 
 
 [[search-field-caps-api-desc]]
@@ -46,6 +50,11 @@ To target all data streams and indices in a cluster, omit this parameter or use
 [[search-field-caps-api-query-params]]
 ==== {api-query-parms-title}
 
+`fields`::
+(Required, string)
+Comma-separated list of fields to retrieve capabilities for. Wildcard (`*`)
+expressions are supported.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
@@ -55,8 +64,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 --
 Defaults to `open`.
 --
-
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fix field caps API docs (#62110)