### PR TITLE
[7.x] [DOCS] Fix ILM read only link (#62113)

### DIFF
--- a/docs/reference/ilm/actions/ilm-readonly.asciidoc
+++ b/docs/reference/ilm/actions/ilm-readonly.asciidoc
@@ -4,7 +4,7 @@
 
 Phases allowed: warm.
 
-Makes the index <<dynamic-index-settings,read-only>>.
+Makes the index <<index-blocks-read-only,read-only>>.
 
 [[ilm-read-only-options]]
 ==== Options

--- a/docs/reference/index-modules/blocks.asciidoc
+++ b/docs/reference/index-modules/blocks.asciidoc
@@ -17,6 +17,7 @@ block.
 The following _dynamic_ index settings determine the blocks present on an
 index:
 
+[[index-blocks-read-only]]
 `index.blocks.read_only`::
 
     Set to `true` to make the index and index metadata read only, `false` to


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix ILM read only link (#62113)