### PR TITLE
[DOCS] Removes inference from trained model API text

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -965,7 +965,7 @@ failure.
 end::model-bytes-exceeded[]
 
 tag::model-id[]
-The unique identifier of the trained {infer} model.
+The unique identifier of the trained model.
 end::model-id[]
 
 tag::model-memory-limit[]
@@ -1343,8 +1343,8 @@ function.
 end::summary-count-field-name[]
 
 tag::tags[]
-A comma delimited string of tags. A {infer} model can have many tags, or none.
-When supplied, only {infer} models that contain all the supplied tags are
+A comma delimited string of tags. A trained model can have many tags, or none.
+When supplied, only trained models that contain all the supplied tags are
 returned.
 end::tags[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/62036

This PR changes "inference trained model" to "trained model" in some parameter descriptions for machine learning APIs.

### Previews

* https://elasticsearch_62125.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-inference.html#ml-put-inference-path-params
* https://elasticsearch_62125.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference.html#ml-get-inference-query-params
* https://elasticsearch_62125.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference-stats.html#ml-get-inference-stats-path-params
* https://elasticsearch_62125.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-inference.html#ml-delete-inference-path-params