### PR TITLE
[DOCS] Fix from and size descriptions for model APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -60,11 +60,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-models]
 
 `from`::
 (Optional, integer) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from-models]
 
 `size`::
 (Optional, integer) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size-models]
 
 [role="child_attributes"]
 [[ml-get-inference-stats-results]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -65,9 +65,15 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-models]
 Specifies whether the included model definition should be returned as a JSON map 
 (`true`) or in a custom compressed format (`false`). Defaults to `true`.
 
+`for_export`::
+(Optional, boolean)
+Indicates if certain fields should be removed from the model configuration on
+retrieval. This allows the model to be in an acceptable format to be retrieved
+and then added to another cluster. Default is false.
+
 `from`::
 (Optional, integer) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from-models]
 
 `include_model_definition`::
 (Optional, boolean)
@@ -77,17 +83,11 @@ Otherwise, a bad request is returned.
 
 `size`::
 (Optional, integer) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size-models]
 
 `tags`::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=tags]
-
-`for_export`::
-(Optional, boolean)
-Indicates if certain fields should be removed from the model configuration on
-retrieval. This allows the model to be in an acceptable format to be retrieved
-and then added to another cluster. Default is false.
 
 [role="child_attributes"]
 [[ml-get-inference-results]]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -696,6 +696,10 @@ tag::from[]
 Skips the specified number of {dfanalytics-jobs}. The default value is `0`.
 end::from[]
 
+tag::from-models[]
+Skips the specified number of models. The default value is `0`.
+end::from-models[]
+
 tag::function[]
 The analysis function that is used. For example, `count`, `rare`, `mean`, `min`,
 `max`, and `sum`. For more information, see
@@ -1279,6 +1283,11 @@ tag::size[]
 Specifies the maximum number of {dfanalytics-jobs} to obtain. The default value
 is `100`.
 end::size[]
+
+tag::size-models[]
+Specifies the maximum number of models to obtain. The default value
+is `100`.
+end::size-models[]
 
 tag::snapshot-id[]
 Identifier for the model snapshot.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/62008

The get inference trained model stats API and the get inference trained model API have from and size options. The API documentation incorrectly refers to data frame analytics jobs instead of models. This PR creates the appropriate shared description.

### Previews

* https://elasticsearch_62128.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference.html
* https://elasticsearch_62128.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference-stats.html