### PR TITLE
Mute MlMappingsUpgradeIT testMappingsUpgrade (#61909)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -42,6 +42,7 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
      * The purpose of this test is to ensure that when a job is open through a rolling upgrade we upgrade the results
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/61908")
     public void testMappingsUpgrade() throws Exception {
 
         switch (CLUSTER_TYPE) {


### PR DESCRIPTION
Backport to 7.x since it fails on 7.x as well and can be reproduced locally.
For #61908