### PR TITLE
[Test] Fix data-stream rest test failure for release builds

### DIFF
--- a/x-pack/plugin/data-streams/qa/rest/build.gradle
+++ b/x-pack/plugin/data-streams/qa/rest/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 restResources {
@@ -12,6 +14,9 @@ restResources {
 
 testClusters.all {
   testDistribution = 'DEFAULT'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
+  }
   // Data streams is basic, but a few tests test data streams in combination with paid features
   setting 'xpack.license.self_generated.type', 'trial'
   // disable ILM history, since it disturbs tests using _all


### PR DESCRIPTION
By enabling searchable snapshots for release builds.

The failure can be reproduced locally and the reason being searchable snapshot not enabled in release build. Thanks to @tvernum 

Resovles: #62090