### PR TITLE
Wildcard field bug fix for prefix + term queries. Wildcard syntax should not be supported (#62085)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -250,7 +250,7 @@ setup:
           query:
             prefix:
               my_wildcard:
-                value: "hell*"
+                value: "hell"
 
 
   - match: {hits.total.value: 1}

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -178,6 +178,47 @@ public class WildcardFieldMapperTests extends ESTestCase {
         reader.close();
         dir.close();
     }
+    
+    
+    public void testTermAndPrefixQueryIgnoreWildcardSyntax() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        iwc.setMergePolicy(newTieredMergePolicy(random()));
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+
+        Document doc = new Document();
+        ParseContext.Document parseDoc = new ParseContext.Document();
+        addFields(parseDoc, doc, "f*oo?");
+        indexDoc(parseDoc, doc, iw);
+
+        iw.forceMerge(1);
+        DirectoryReader reader = iw.getReader();
+        IndexSearcher searcher = newSearcher(reader);
+        iw.close();
+        
+        expectTermMatch(searcher, "f*oo*", 0);
+        expectTermMatch(searcher, "f*oo?", 1);
+        expectTermMatch(searcher, "*oo?", 0);
+
+        expectPrefixMatch(searcher, "f*o", 1);
+        expectPrefixMatch(searcher, "f*oo?", 1);
+        expectPrefixMatch(searcher, "f??o", 0);
+        
+        reader.close();
+        dir.close();
+    }
+    
+    private void expectTermMatch(IndexSearcher searcher, String term,long count) throws IOException {
+        Query q = wildcardFieldType.fieldType().termQuery(term, MOCK_QSC);
+        TopDocs td = searcher.search(q, 10, Sort.RELEVANCE);
+        assertThat(td.totalHits.value, equalTo(count));        
+    }
+    
+    private void expectPrefixMatch(IndexSearcher searcher, String term,long count) throws IOException {
+        Query q = wildcardFieldType.fieldType().prefixQuery(term, null, MOCK_QSC);
+        TopDocs td = searcher.search(q, 10, Sort.RELEVANCE);
+        assertThat(td.totalHits.value, equalTo(count));        
+    }    
 
 
     public void testSearchResultsVersusKeywordField() throws IOException {


### PR DESCRIPTION
Wildcard field bug fix for term and prefix queries.
We now escape any * or ? characters in the search string before delegating to the main wildcardQuery() method.

Closes #62081
