### PR TITLE
Wraps timestamp values in quotes in runtime fields YAML tests.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -118,9 +118,9 @@ setup:
           sort: timestamp
           docvalue_fields: [tomorrow, tomorrow_from_source, the_past, all_week, formatted_tomorrow]
   - match: {hits.total.value: 6}
-  - match: {hits.hits.0.fields.tomorrow: [2018-01-19T17:41:34.000Z] }
-  - match: {hits.hits.0.fields.tomorrow_from_source: [2018-01-19T17:41:34.000Z] }
-  - match: {hits.hits.0.fields.the_past: [2018-01-18T17:41:33.000Z] }
+  - match: {hits.hits.0.fields.tomorrow: ["2018-01-19T17:41:34.000Z"] }
+  - match: {hits.hits.0.fields.tomorrow_from_source: ["2018-01-19T17:41:34.000Z"] }
+  - match: {hits.hits.0.fields.the_past: ["2018-01-18T17:41:33.000Z"] }
   - match:
       hits.hits.0.fields.all_week:
         - 2018-01-18T17:41:34.000Z
@@ -144,9 +144,9 @@ setup:
                 field: tomorrow
                 format: strict_date_optional_time
   - match: {hits.total.value: 6}
-  - match: {aggregations.v10.buckets.0.key_as_string: 2018-01-19T17:41:34.000Z}
+  - match: {aggregations.v10.buckets.0.key_as_string: "2018-01-19T17:41:34.000Z"}
   - match: {aggregations.v10.buckets.0.doc_count: 1}
-  - match: {aggregations.v10.buckets.1.key_as_string: 2018-01-20T17:41:34.000Z}
+  - match: {aggregations.v10.buckets.1.key_as_string: "2018-01-20T17:41:34.000Z"}
   - match: {aggregations.v10.buckets.1.doc_count: 1}
 
 ---

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -139,6 +139,6 @@ setup:
             term:
               ip: 252.0.0.0
   - match: {hits.total.value: 1}
-  - match: {hits.hits.0._source.timestamp: 1998-04-30T14:31:27-05:00}
+  - match: {hits.hits.0._source.timestamp: "1998-04-30T14:31:27-05:00"}
 
 # TODO tests for using the ip in a script. there is almost certainly whitelist "fun" here.


### PR DESCRIPTION
Backport of #62153 