### PR TITLE
[7.x] [DOCS] Split delete index template API docs (#62074)

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -114,6 +114,8 @@ include::indices/delete-component-template.asciidoc[]
 
 include::indices/delete-index-template.asciidoc[]
 
+include::indices/delete-index-template-v1.asciidoc[]
+
 include::indices/flush.asciidoc[]
 
 include::indices/forcemerge.asciidoc[]

--- a/docs/reference/indices/delete-index-template-v1.asciidoc
+++ b/docs/reference/indices/delete-index-template-v1.asciidoc
@@ -1,0 +1,52 @@
+[[indices-delete-template-v1]]
+=== Delete index template API
+++++
+<titleabbrev>Delete index template (legacy)</titleabbrev>
+++++
+
+IMPORTANT: This documentation is about <<indices-templates-v1,legacy index
+templates>>, which are deprecated and will be replaced by the composable
+templates introduced in {es} 7.8. For information about composable templates,
+<<indices-templates>>.
+
+Deletes a legacy index template.
+
+////
+[source,console]
+--------------------------------------------------
+PUT _template/my-legacy-index-template
+{
+ "index_patterns" : ["te*"],
+  "settings": {
+    "number_of_shards": 1
+  }
+}
+--------------------------------------------------
+// TESTSETUP
+////
+
+[source,console]
+--------------------------------------------------
+DELETE /_template/my-legacy-index-template
+--------------------------------------------------
+
+
+[[delete-template-api-v1-request]]
+==== {api-request-title}
+
+`DELETE /_template/<legacy-index-template>`
+
+
+[[delete-template-api-v1-path-params]]
+==== {api-path-parms-title}
+
+`<legacy-index-template>`::
+(Required, string)
+Comma-separated list of legacy index templates to delete. Wildcard (`*`)
+expressions are supported.
+
+
+[[delete-template-api-v1-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/delete-index-template.asciidoc
+++ b/docs/reference/indices/delete-index-template.asciidoc
@@ -4,32 +4,34 @@
 <titleabbrev>Delete index template</titleabbrev>
 ++++
 
-Deletes an index template.
+Deletes an <<index-templates,index template>>.
 
 ////
 [source,console]
---------------------------------------------------
-PUT _template/template_1
+----
+PUT /_index_template/my-index-template
 {
  "index_patterns" : ["te*"],
-  "settings": {
+ "template": {
+     "settings": {
     "number_of_shards": 1
   }
+ }
 }
---------------------------------------------------
+----
 // TESTSETUP
 ////
 
 [source,console]
---------------------------------------------------
-DELETE /_template/template_1
---------------------------------------------------
+----
+DELETE /_index_template/my-index-template
+----
 
 
 [[delete-template-api-request]]
 ==== {api-request-title}
 
-`DELETE /_template/<index-template>`
+`DELETE /_index_template/<index-template>`
 
 
 [[delete-template-api-desc]]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -531,8 +531,8 @@ end::index-metric[]
 tag::index-template[]
 `<index-template>`::
 (Required, string)
-Comma-separated list or wildcard expression of index template names
-used to limit the request.
+Comma-separated list of index template names used to limit the request. Wildcard
+(`*`) expressions are supported.
 end::index-template[]
 
 tag::component-template[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Split delete index template API docs (#62074)