### PR TITLE
[7.x] [DOCS] Fix range query admon for clarity (#62163)

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -65,11 +65,12 @@ For valid syntax, see <<mapping-date-format,`format`>>.
 [WARNING]
 ====
 If a `format` and `date` value are incomplete, {es} replaces any missing year,
-month, or date component with the start of
-{wikipedia}/Unix_time[Unix time], which is January 1st, 1970.
+month, or day component with the 
+{wikipedia}/Unix_time[Unix epoch], which is January 1st, 1970.
 
-For example, if the `format` value is `dd`, {es} converts a `gte` value of `10`
-to `1970-01-10T00:00:00.000Z`.
+For example, if the `format` value is `dd`, {es} converts a `gte` value of `22`
+to `1970-01-22T00:00:00.000Z`. This date uses `22` as the day of the month but
+uses the Unix epoch's year (`1970`) and month (`01`).
 ====
 
 --


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix range query admon for clarity (#62163)