### PR TITLE
Release search context when scroll keep_alive is too large

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -610,19 +610,16 @@ public class SearchScrollIT extends ESIntegTestCase {
             .setScroll(TimeValue.timeValueMinutes(5))
             .get();
         assertNotNull(searchResponse.getScrollId());
-        try {
-            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(searchResponse.getHits().getHits().length, equalTo(1));
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
+        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
 
-            exc = expectThrows(Exception.class,
-                () -> client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueHours(3)).get());
-            illegalArgumentException =
-                (IllegalArgumentException) ExceptionsHelper.unwrap(exc, IllegalArgumentException.class);
-            assertNotNull(illegalArgumentException);
-            assertThat(illegalArgumentException.getMessage(), containsString("Keep alive for request (3h) is too large"));
-        } finally {
-            client().prepareClearScroll().addScrollId(searchResponse.getScrollId()).get();
-        }
+        exc = expectThrows(Exception.class,
+            () -> client().prepareSearchScroll(searchResponse.getScrollId())
+                    .setScroll(TimeValue.timeValueHours(3)).get());
+        illegalArgumentException =
+            (IllegalArgumentException) ExceptionsHelper.unwrap(exc, IllegalArgumentException.class);
+        assertNotNull(illegalArgumentException);
+        assertThat(illegalArgumentException.getMessage(), containsString("Keep alive for request (3h) is too large"));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -610,16 +610,19 @@ public class SearchScrollIT extends ESIntegTestCase {
             .setScroll(TimeValue.timeValueMinutes(5))
             .get();
         assertNotNull(searchResponse.getScrollId());
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
+        try {
+            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
+            assertThat(searchResponse.getHits().getHits().length, equalTo(1));
 
-        exc = expectThrows(Exception.class,
-            () -> client().prepareSearchScroll(searchResponse.getScrollId())
-                    .setScroll(TimeValue.timeValueHours(3)).get());
-        illegalArgumentException =
-            (IllegalArgumentException) ExceptionsHelper.unwrap(exc, IllegalArgumentException.class);
-        assertNotNull(illegalArgumentException);
-        assertThat(illegalArgumentException.getMessage(), containsString("Keep alive for request (3h) is too large"));
+            exc = expectThrows(Exception.class,
+                () -> client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueHours(3)).get());
+            illegalArgumentException =
+                (IllegalArgumentException) ExceptionsHelper.unwrap(exc, IllegalArgumentException.class);
+            assertNotNull(illegalArgumentException);
+            assertThat(illegalArgumentException.getMessage(), containsString("Keep alive for request (3h) is too large"));
+        } finally {
+            client().prepareClearScroll().addScrollId(searchResponse.getScrollId()).get();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -476,7 +476,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
         } catch (Exception e) {
             // We need to release the reader context of the scroll when we hit any exception (here the keep_alive can be too large)
-            processFailure(readerContext, e);
+            freeReaderContext(readerContext.id());
             throw e;
         }
         runAsync(getExecutor(readerContext.indexShard()), () -> {
@@ -548,7 +548,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
         } catch (Exception e) {
             // We need to release the reader context of the scroll when we hit any exception (here the keep_alive can be too large)
-            processFailure(readerContext, e);
+            freeReaderContext(readerContext.id());
             throw e;
         }
         runAsync(getExecutor(readerContext.indexShard()), () -> {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -471,7 +471,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                                   SearchShardTask task,
                                   ActionListener<ScrollQuerySearchResult> listener) {
         final LegacyReaderContext readerContext = (LegacyReaderContext) findReaderContext(request.contextId(), request);
-        final Releasable markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
+        final Releasable markAsUsed;
+        try {
+            markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
+        } catch (Exception e) {
+            // We need to release the reader context of the scroll when we hit any exception (here the keep_alive can be too large)
+            processFailure(readerContext, e);
+            throw e;
+        }
         runAsync(getExecutor(readerContext.indexShard()), () -> {
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, false);
@@ -536,7 +543,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     public void executeFetchPhase(InternalScrollSearchRequest request, SearchShardTask task,
                                   ActionListener<ScrollQueryFetchSearchResult> listener) {
         final LegacyReaderContext readerContext = (LegacyReaderContext) findReaderContext(request.contextId(), request);
-        final Releasable markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
+        final Releasable markAsUsed;
+        try {
+            markAsUsed = readerContext.markAsUsed(getScrollKeepAlive(request.scroll()));
+        } catch (Exception e) {
+            // We need to release the reader context of the scroll when we hit any exception (here the keep_alive can be too large)
+            processFailure(readerContext, e);
+            throw e;
+        }
         runAsync(getExecutor(readerContext.indexShard()), () -> {
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, false);


### PR DESCRIPTION
Previously, we close related search contexts if the keep_alive of a scroll is too large.  But we accidentally change this behavior in #62061.

CI: https://gradle-enterprise.elastic.co/s/f2aczys5rxvik/console-log/raw