### PR TITLE
Correct command for docs snippets test

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -50,7 +50,7 @@ You don't have to do that.
 Snippets marked with `[source,console]` are automatically annotated with
 "VIEW IN CONSOLE" and "COPY AS CURL" in the documentation and are automatically
 tested by the command `./gradlew -pdocs check`. To test just the docs from a
-single page, use e.g. `./gradlew -pdocs integTestRunner --tests "\*rollover*"`.
+single page, use e.g. `./gradlew -pdocs integTest --tests "\*rollover*"`.
 
 By default each `[source,console]` snippet runs as its own isolated test. You
 can manipulate the test execution in the following ways:


### PR DESCRIPTION
The command for running individual test seems outdated. Using `integTestRunner`
produces an error while `integTest` seems to work.
