### PR TITLE
Move loading of stored fields into a dedicated FetchSubPhase

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -84,7 +84,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     private static final float DEFAULT_SCORE = Float.NaN;
     private float score = DEFAULT_SCORE;
 
-    private final Text id;
+    private Text id;
 
     private final NestedIdentity nestedIdentity;
 
@@ -95,7 +95,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     private BytesReference source;
 
     private Map<String, DocumentField> documentFields;
-    private final Map<String, DocumentField> metaFields;
+    private Map<String, DocumentField> metaFields;
 
     private Map<String, HighlightField> highlightFields = null;
 
@@ -459,6 +459,15 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         this.documentFields.put(fieldName, field);
     }
 
+    public void setId(String id) {
+        this.id = new Text(id);
+    }
+
+    public void setFields(Map<String, DocumentField> docFields, Map<String, DocumentField> metaFields) {
+        this.documentFields = docFields;
+        this.metaFields = metaFields;
+    }
+
     /**
      * A map of hit fields (from field name to hit fields) if additional fields
      * were required to be loaded.
@@ -569,6 +578,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     public void setInnerHits(Map<String, SearchHits> innerHits) {
         this.innerHits = innerHits;
     }
+
 
     public static class Fields {
         static final String _INDEX = "_index";

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -224,6 +224,7 @@ import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
 import org.elasticsearch.search.fetch.subphase.FetchScorePhase;
 import org.elasticsearch.search.fetch.subphase.FetchSourcePhase;
 import org.elasticsearch.search.fetch.subphase.FetchVersionPhase;
+import org.elasticsearch.search.fetch.subphase.LoadStoredFieldsPhase;
 import org.elasticsearch.search.fetch.subphase.MatchedQueriesPhase;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsPhase;
 import org.elasticsearch.search.fetch.subphase.SeqNoPrimaryTermPhase;
@@ -732,6 +733,7 @@ public class SearchModule {
     }
 
     private void registerFetchSubPhases(List<SearchPlugin> plugins) {
+        registerFetchSubPhase(new LoadStoredFieldsPhase());
         registerFetchSubPhase(new ExplainPhase());
         registerFetchSubPhase(new FetchDocValuesPhase());
         registerFetchSubPhase(new ScriptFieldsPhase());

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -89,9 +89,6 @@ public class FetchPhase {
             LOGGER.trace("{}", new SearchContextSourcePrinter(context));
         }
 
-        Map<String, Set<String>> storedToRequestedFields = new HashMap<>();
-        FieldsVisitor fieldsVisitor = createStoredFieldsVisitor(context, storedToRequestedFields);
-
         try {
             DocIdToIndex[] docs = new DocIdToIndex[context.docIdsToLoadSize()];
             for (int index = 0; index < context.docIdsToLoadSize(); index++) {
@@ -127,8 +124,7 @@ public class FetchPhase {
                 }
                 assert currentReaderContext != null;
 
-                HitContext hit
-                    = prepareHitContext(context, fieldsVisitor, docId, storedToRequestedFields, currentReaderContext, sharedCache);
+                HitContext hit = prepareHitContext(context, docId, currentReaderContext, sharedCache);
                 for (FetchSubPhaseProcessor processor : processors) {
                     processor.process(hit);
                 }
@@ -160,53 +156,7 @@ public class FetchPhase {
         }
     }
 
-    private FieldsVisitor createStoredFieldsVisitor(SearchContext context, Map<String, Set<String>> storedToRequestedFields) {
-        StoredFieldsContext storedFieldsContext = context.storedFieldsContext();
 
-        if (storedFieldsContext == null) {
-            // no fields specified, default to return source if no explicit indication
-            if (!context.hasScriptFields() && !context.hasFetchSourceContext()) {
-                context.fetchSourceContext(new FetchSourceContext(true));
-            }
-            boolean loadSource = context.sourceRequested() || context.fetchFieldsContext() != null;
-            return new FieldsVisitor(loadSource);
-        } else if (storedFieldsContext.fetchFields() == false) {
-            // disable stored fields entirely
-            return null;
-        } else {
-            for (String fieldNameOrPattern : context.storedFieldsContext().fieldNames()) {
-                if (fieldNameOrPattern.equals(SourceFieldMapper.NAME)) {
-                    FetchSourceContext fetchSourceContext = context.hasFetchSourceContext() ? context.fetchSourceContext()
-                        : FetchSourceContext.FETCH_SOURCE;
-                    context.fetchSourceContext(new FetchSourceContext(true, fetchSourceContext.includes(), fetchSourceContext.excludes()));
-                    continue;
-                }
-
-                Collection<String> fieldNames = context.mapperService().simpleMatchToFullName(fieldNameOrPattern);
-                for (String fieldName : fieldNames) {
-                    MappedFieldType fieldType = context.fieldType(fieldName);
-                    if (fieldType == null) {
-                        // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
-                        if (context.getObjectMapper(fieldName) != null) {
-                            throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
-                        }
-                    } else {
-                        String storedField = fieldType.name();
-                        Set<String> requestedFields = storedToRequestedFields.computeIfAbsent(
-                            storedField, key -> new HashSet<>());
-                        requestedFields.add(fieldName);
-                    }
-                }
-            }
-            boolean loadSource = context.sourceRequested() || context.fetchFieldsContext() != null;
-            if (storedToRequestedFields.isEmpty()) {
-                // empty list specified, default to disable _source if no explicit indication
-                return new FieldsVisitor(loadSource);
-            } else {
-                return new CustomFieldsVisitor(storedToRequestedFields.keySet(), loadSource);
-            }
-        }
-    }
 
     private int findRootDocumentIfNested(SearchContext context, LeafReaderContext subReaderContext, int subDocId) throws IOException {
         if (context.mapperService().hasNested()) {
@@ -220,269 +170,12 @@ public class FetchPhase {
         return -1;
     }
 
-    private HitContext prepareHitContext(SearchContext context, FieldsVisitor fieldsVisitor, int docId,
-                                         Map<String, Set<String>> storedToRequestedFields,
+    private HitContext prepareHitContext(SearchContext context, int docId,
                                          LeafReaderContext subReaderContext, Map<String, Object> sharedCache) throws IOException {
         int rootDocId = findRootDocumentIfNested(context, subReaderContext, docId - subReaderContext.docBase);
-        if (rootDocId == -1) {
-            return prepareNonNestedHitContext(context, fieldsVisitor, docId, storedToRequestedFields, subReaderContext, sharedCache);
-        } else {
-            return prepareNestedHitContext(context, docId, rootDocId, storedToRequestedFields, subReaderContext, sharedCache);
-        }
-    }
-
-    /**
-     * Resets the provided {@link HitContext} with information on the current
-     * document. This includes the following:
-     *   - Adding an initial {@link SearchHit} instance.
-     *   - Loading the document source and setting it on {@link SourceLookup}. This allows
-     *     fetch subphases that use the hit context to access the preloaded source.
-     */
-    private HitContext prepareNonNestedHitContext(SearchContext context,
-                                   FieldsVisitor fieldsVisitor,
-                                   int docId,
-                                   Map<String, Set<String>> storedToRequestedFields,
-                                   LeafReaderContext subReaderContext,
-                                   Map<String, Object> sharedCache) {
         int subDocId = docId - subReaderContext.docBase;
-        if (fieldsVisitor == null) {
-            SearchHit hit = new SearchHit(docId, null, null, null);
-            return new HitContext(hit, subReaderContext, subDocId, context.searcher(), sharedCache);
-        } else {
-            SearchHit hit;
-            loadStoredFields(context.shardTarget(), context.mapperService(), subReaderContext, fieldsVisitor, subDocId);
-            if (fieldsVisitor.fields().isEmpty() == false) {
-                Map<String, DocumentField> docFields = new HashMap<>();
-                Map<String, DocumentField> metaFields = new HashMap<>();
-                fillDocAndMetaFields(context, fieldsVisitor, storedToRequestedFields, docFields, metaFields);
-                hit = new SearchHit(docId, fieldsVisitor.id(), docFields, metaFields);
-            } else {
-                hit = new SearchHit(docId, fieldsVisitor.id(), emptyMap(), emptyMap());
-            }
-
-            HitContext hitContext = new HitContext(hit, subReaderContext, subDocId, context.searcher(), sharedCache);
-            if (fieldsVisitor.source() != null) {
-                hitContext.sourceLookup().setSource(fieldsVisitor.source());
-            }
-            return hitContext;
-        }
+        SearchHit hit = new SearchHit(docId, null, new HashMap<>(), new HashMap<>());
+        return new HitContext(hit, subReaderContext, subDocId, rootDocId, context.searcher(), sharedCache);
     }
 
-    /**
-     /**
-     * Resets the provided {@link HitContext} with information on the current
-     * nested document. This includes the following:
-     *   - Adding an initial {@link SearchHit} instance.
-     *   - Loading the document source, filtering it based on the nested document ID, then
-     *     setting it on {@link SourceLookup}. This allows fetch subphases that use the hit
-     *     context to access the preloaded source.
-     */
-    @SuppressWarnings("unchecked")
-    private HitContext prepareNestedHitContext(SearchContext context,
-                                               int nestedTopDocId,
-                                               int rootDocId,
-                                               Map<String, Set<String>> storedToRequestedFields,
-                                               LeafReaderContext subReaderContext,
-                                               Map<String, Object> sharedCache) throws IOException {
-        // Also if highlighting is requested on nested documents we need to fetch the _source from the root document,
-        // otherwise highlighting will attempt to fetch the _source from the nested doc, which will fail,
-        // because the entire _source is only stored with the root document.
-        boolean needSource = context.sourceRequested() || context.highlight() != null;
-
-        String rootId;
-        Map<String, Object> rootSourceAsMap = null;
-        XContentType rootSourceContentType = null;
-
-        int nestedDocId = nestedTopDocId - subReaderContext.docBase;
-
-        if (context instanceof InnerHitsContext.InnerHitSubContext) {
-            InnerHitsContext.InnerHitSubContext innerHitsContext = (InnerHitsContext.InnerHitSubContext) context;
-            rootId = innerHitsContext.getRootId();
-
-            if (needSource) {
-                SourceLookup rootLookup = innerHitsContext.getRootLookup();
-                rootSourceAsMap = rootLookup.loadSourceIfNeeded();
-                rootSourceContentType = rootLookup.sourceContentType();
-            }
-        } else {
-            FieldsVisitor rootFieldsVisitor = new FieldsVisitor(needSource);
-            loadStoredFields(context.shardTarget(), context.mapperService(), subReaderContext, rootFieldsVisitor, rootDocId);
-            rootId = rootFieldsVisitor.id();
-
-            if (needSource) {
-                BytesReference rootSource = rootFieldsVisitor.source();
-                Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(rootSource, false);
-                rootSourceAsMap = tuple.v2();
-                rootSourceContentType = tuple.v1();
-            }
-        }
-
-        Map<String, DocumentField> docFields = emptyMap();
-        Map<String, DocumentField> metaFields = emptyMap();
-        if (context.hasStoredFields() && !context.storedFieldsContext().fieldNames().isEmpty()) {
-            FieldsVisitor nestedFieldsVisitor = new CustomFieldsVisitor(storedToRequestedFields.keySet(), false);
-            loadStoredFields(context.shardTarget(), context.mapperService(), subReaderContext, nestedFieldsVisitor, nestedDocId);
-            if (nestedFieldsVisitor.fields().isEmpty() == false) {
-                docFields = new HashMap<>();
-                metaFields = new HashMap<>();
-                fillDocAndMetaFields(context, nestedFieldsVisitor, storedToRequestedFields, docFields, metaFields);
-            }
-        }
-
-        DocumentMapper documentMapper = context.mapperService().documentMapper();
-        ObjectMapper nestedObjectMapper
-            = documentMapper.findNestedObjectMapper(nestedDocId, context, subReaderContext);
-        assert nestedObjectMapper != null;
-        SearchHit.NestedIdentity nestedIdentity =
-                getInternalNestedIdentity(context, nestedDocId, subReaderContext, context.mapperService(), nestedObjectMapper);
-
-        SearchHit hit = new SearchHit(nestedTopDocId, rootId, nestedIdentity, docFields, metaFields);
-        HitContext hitContext = new HitContext(hit, subReaderContext, nestedDocId, context.searcher(), sharedCache);
-
-        if (rootSourceAsMap != null) {
-            // Isolate the nested json array object that matches with nested hit and wrap it back into the same json
-            // structure with the nested json array object being the actual content. The latter is important, so that
-            // features like source filtering and highlighting work consistent regardless of whether the field points
-            // to a json object array for consistency reasons on how we refer to fields
-            Map<String, Object> nestedSourceAsMap = new HashMap<>();
-            Map<String, Object> current = nestedSourceAsMap;
-            for (SearchHit.NestedIdentity nested = nestedIdentity; nested != null; nested = nested.getChild()) {
-                String nestedPath = nested.getField().string();
-                current.put(nestedPath, new HashMap<>());
-                Object extractedValue = XContentMapValues.extractValue(nestedPath, rootSourceAsMap);
-                List<?> nestedParsedSource;
-                if (extractedValue instanceof List) {
-                    // nested field has an array value in the _source
-                    nestedParsedSource = (List<?>) extractedValue;
-                } else if (extractedValue instanceof Map) {
-                    // nested field has an object value in the _source. This just means the nested field has just one inner object,
-                    // which is valid, but uncommon.
-                    nestedParsedSource = Collections.singletonList(extractedValue);
-                } else {
-                    throw new IllegalStateException("extracted source isn't an object or an array");
-                }
-                if ((nestedParsedSource.get(0) instanceof Map) == false &&
-                    nestedObjectMapper.parentObjectMapperAreNested(context.mapperService()) == false) {
-                    // When one of the parent objects are not nested then XContentMapValues.extractValue(...) extracts the values
-                    // from two or more layers resulting in a list of list being returned. This is because nestedPath
-                    // encapsulates two or more object layers in the _source.
-                    //
-                    // This is why only the first element of nestedParsedSource needs to be checked.
-                    throw new IllegalArgumentException("Cannot execute inner hits. One or more parent object fields of nested field [" +
-                        nestedObjectMapper.name() + "] are not nested. All parent fields need to be nested fields too");
-                }
-                rootSourceAsMap = (Map<String, Object>) nestedParsedSource.get(nested.getOffset());
-                if (nested.getChild() == null) {
-                    current.put(nestedPath, rootSourceAsMap);
-                } else {
-                    Map<String, Object> next = new HashMap<>();
-                    current.put(nestedPath, next);
-                    current = next;
-                }
-            }
-
-            hitContext.sourceLookup().setSource(nestedSourceAsMap);
-            hitContext.sourceLookup().setSourceContentType(rootSourceContentType);
-        }
-        return hitContext;
-    }
-
-    private SearchHit.NestedIdentity getInternalNestedIdentity(SearchContext context, int nestedSubDocId,
-                                                               LeafReaderContext subReaderContext,
-                                                               MapperService mapperService,
-                                                               ObjectMapper nestedObjectMapper) throws IOException {
-        int currentParent = nestedSubDocId;
-        ObjectMapper nestedParentObjectMapper;
-        ObjectMapper current = nestedObjectMapper;
-        String originalName = nestedObjectMapper.name();
-        SearchHit.NestedIdentity nestedIdentity = null;
-        do {
-            Query parentFilter;
-            nestedParentObjectMapper = current.getParentObjectMapper(mapperService);
-            if (nestedParentObjectMapper != null) {
-                if (nestedParentObjectMapper.nested().isNested() == false) {
-                    current = nestedParentObjectMapper;
-                    continue;
-                }
-                parentFilter = nestedParentObjectMapper.nestedTypeFilter();
-            } else {
-                parentFilter = Queries.newNonNestedFilter();
-            }
-
-            Query childFilter = nestedObjectMapper.nestedTypeFilter();
-            if (childFilter == null) {
-                current = nestedParentObjectMapper;
-                continue;
-            }
-            final Weight childWeight = context.searcher()
-                .createWeight(context.searcher().rewrite(childFilter), ScoreMode.COMPLETE_NO_SCORES, 1f);
-            Scorer childScorer = childWeight.scorer(subReaderContext);
-            if (childScorer == null) {
-                current = nestedParentObjectMapper;
-                continue;
-            }
-            DocIdSetIterator childIter = childScorer.iterator();
-
-            BitSet parentBits = context.bitsetFilterCache().getBitSetProducer(parentFilter).getBitSet(subReaderContext);
-
-            int offset = 0;
-            /*
-             * Starts from the previous parent and finds the offset of the
-             * <code>nestedSubDocID</code> within the nested children. Nested documents
-             * are indexed in the same order than in the source array so the offset
-             * of the nested child is the number of nested document with the same parent
-             * that appear before him.
-             */
-            int previousParent = parentBits.prevSetBit(currentParent);
-            for (int docId = childIter.advance(previousParent + 1); docId < nestedSubDocId && docId != DocIdSetIterator.NO_MORE_DOCS;
-                 docId = childIter.nextDoc()) {
-                offset++;
-            }
-            currentParent = nestedSubDocId;
-            current = nestedObjectMapper = nestedParentObjectMapper;
-            int currentPrefix = current == null ? 0 : current.name().length() + 1;
-            nestedIdentity = new SearchHit.NestedIdentity(originalName.substring(currentPrefix), offset, nestedIdentity);
-            if (current != null) {
-                originalName = current.name();
-            }
-        } while (current != null);
-        return nestedIdentity;
-    }
-
-    private void loadStoredFields(SearchShardTarget shardTarget,
-                                  MapperService mapperService,
-                                  LeafReaderContext readerContext,
-                                  FieldsVisitor fieldVisitor, int docId) {
-        fieldVisitor.reset();
-        try {
-            readerContext.reader().document(docId, fieldVisitor);
-        } catch (IOException e) {
-            throw new FetchPhaseExecutionException(shardTarget, "Failed to fetch doc id [" + docId + "]", e);
-        }
-        fieldVisitor.postProcess(mapperService);
-    }
-
-    private static void fillDocAndMetaFields(SearchContext context, FieldsVisitor fieldsVisitor,
-            Map<String, Set<String>> storedToRequestedFields,
-            Map<String, DocumentField> docFields, Map<String, DocumentField> metaFields) {
-        for (Map.Entry<String, List<Object>> entry : fieldsVisitor.fields().entrySet()) {
-            String storedField = entry.getKey();
-            List<Object> storedValues = entry.getValue();
-            if (storedToRequestedFields.containsKey(storedField)) {
-                for (String requestedField : storedToRequestedFields.get(storedField)) {
-                    if (context.mapperService().isMetadataField(requestedField)) {
-                        metaFields.put(requestedField, new DocumentField(requestedField, storedValues));
-                    } else {
-                        docFields.put(requestedField, new DocumentField(requestedField, storedValues));
-                    }
-                }
-            } else {
-                if (context.mapperService().isMetadataField(storedField)) {
-                    metaFields.put(storedField, new DocumentField(storedField, storedValues));
-                } else {
-                    docFields.put(storedField, new DocumentField(storedField, storedValues));
-                }
-            }
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -39,14 +39,16 @@ public interface FetchSubPhase {
         private final IndexSearcher searcher;
         private final LeafReaderContext readerContext;
         private final int docId;
+        private final int rootId;   // root doc id for nested documents
         private final SourceLookup sourceLookup = new SourceLookup();
         private final Map<String, Object> cache;
 
-        public HitContext(SearchHit hit, LeafReaderContext context, int docId, IndexSearcher searcher,
+        public HitContext(SearchHit hit, LeafReaderContext context, int docId, int rootId, IndexSearcher searcher,
                           Map<String, Object> cache) {
             this.hit = hit;
             this.readerContext = context;
             this.docId = docId;
+            this.rootId = rootId;
             this.searcher = searcher;
             this.sourceLookup.setSegmentAndDocument(context, docId);
             this.cache = cache;
@@ -69,6 +71,14 @@ public interface FetchSubPhase {
          */
         public int docId() {
             return docId;
+        }
+
+        public int rootId() {
+            return rootId;
+        }
+
+        public boolean isNested() {
+            return rootId != -1;
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/StoredFieldsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/StoredFieldsContext.java
@@ -42,7 +42,7 @@ public class StoredFieldsContext implements Writeable {
     public static final String _NONE_ = "_none_";
 
     private final List<String> fieldNames;
-    private boolean fetchFields;
+    private final boolean fetchFields;
 
     private StoredFieldsContext(boolean fetchFields) {
         this.fetchFields = fetchFields;
@@ -171,7 +171,7 @@ public class StoredFieldsContext implements Writeable {
             return fromList(Collections.singletonList(parser.text()));
         } else if (token == XContentParser.Token.START_ARRAY) {
             ArrayList<String> list = new ArrayList<>();
-            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                 list.add(parser.text());
             }
             return fromList(list);

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.internal;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Nullable;
@@ -229,6 +230,10 @@ public abstract class SearchContext implements Releasable {
     public abstract BigArrays bigArrays();
 
     public abstract BitsetFilterCache bitsetFilterCache();
+
+    public BitSetProducer getBitSetProducer(Query query) {
+        return bitsetFilterCache().getBitSetProducer(query);
+    }
 
     public abstract <IFD extends IndexFieldData<?>> IFD getForField(MappedFieldType fieldType);
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
@@ -159,7 +159,7 @@ public class FetchSourcePhaseTests extends ESTestCase {
         // We don't need a real index, just a LeafReaderContext which cannot be mocked.
         MemoryIndex index = new MemoryIndex();
         LeafReaderContext leafReaderContext = index.createSearcher().getIndexReader().leaves().get(0);
-        HitContext hitContext = new HitContext(searchHit, leafReaderContext, 1, null, new HashMap<>());
+        HitContext hitContext = new HitContext(searchHit, leafReaderContext, 1, -1, null, new HashMap<>());
         hitContext.sourceLookup().setSource(source == null ? null : BytesReference.bytes(source));
 
         FetchSourcePhase phase = new FetchSourcePhase();

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/LoadStoredFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/LoadStoredFieldsPhaseTests.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.subphase;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.util.BitSet;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
+import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
+import org.elasticsearch.search.fetch.StoredFieldsContext;
+import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.TestSearchContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+public class LoadStoredFieldsPhaseTests extends MapperServiceTestCase {
+
+    // test for regular doc with no special request - should get metadata fields + source
+    public void testStandardRequest() throws IOException {
+
+        MapperService mapperService = nonNestedMapperService();
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(new LoadStoredFieldsTestSearchContext(mapperService));
+
+        doNonNestedTest(mapperService, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            assertFalse(hc.sourceLookup().isEmpty());
+            assertThat(hc.sourceLookup().get("keyword"), equalTo("foo"));
+            Map<String, DocumentField> loadedFields = hc.hit().getFields();
+            assertThat(loadedFields.size(), equalTo(0));
+        });
+    }
+
+    // test for regular doc with specific fields incl aliases - should get metadata fields + source + specific fields
+    public void testLoadNamedFields() throws IOException {
+
+        MapperService mapperService = nonNestedMapperService();
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        StoredFieldsContext sfc = StoredFieldsContext.fromList(List.of("key*"));
+        context.storedFieldsContext(sfc);
+
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNonNestedTest(mapperService, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            assertFalse(hc.sourceLookup().isEmpty());
+            assertThat(hc.sourceLookup().get("keyword"), equalTo("foo"));
+            Map<String, DocumentField> loadedFields = hc.hit().getFields();
+            assertThat(loadedFields.size(), equalTo(1));
+            DocumentField k = loadedFields.get("keyword");
+            assertThat(k.getValue(), equalTo("foo"));
+        });
+    }
+
+    // test for regular doc with _none_ - should get no source
+    public void testFieldsNone() throws IOException {
+        MapperService mapperService = nonNestedMapperService();
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        StoredFieldsContext sfc = StoredFieldsContext.fromList(List.of("_none_"));
+        context.storedFieldsContext(sfc);
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        assertNull(processor);
+    }
+
+    // test for regular doc with no source - should get only metadata fields
+    public void testNoSource() throws IOException {
+
+        MapperService mapperService = nonNestedMapperService();
+
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        context.fetchSourceContext(new FetchSourceContext(false));
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNonNestedTest(mapperService, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            assertNull(hc.sourceLookup().source());
+        });
+    }
+
+    public void testEmptySearchHit() {
+        SearchHit hit = new SearchHit(0);
+        assertNull(hit.getId());
+    }
+
+    private void doNonNestedTest(MapperService mapperService,
+                                 FetchSubPhaseProcessor processor,
+                                 Consumer<HitContext> test) throws IOException {
+        withLuceneIndex(mapperService, iw -> indexNonNestedDocs(mapperService, iw), reader -> {
+            for (LeafReaderContext ctx : reader.leaves()) {
+                for (int i = 0; i < ctx.reader().maxDoc(); i++) {
+                    HitContext hc = new HitContext(new SearchHit(i), ctx, i, -1, null, null);
+                    processor.process(hc);
+                    test.accept(hc);
+                }
+            }
+        });
+    }
+
+    private static final QueryCachingPolicy qcp = new QueryCachingPolicy() {
+        @Override
+        public void onUse(Query query) {
+
+        }
+
+        @Override
+        public boolean shouldCache(Query query) throws IOException {
+            return false;
+        }
+    };
+
+    private void doNestedTest(MapperService mapperService,
+                              LoadStoredFieldsTestSearchContext context,
+                              FetchSubPhaseProcessor processor,
+                              Consumer<HitContext> test) throws IOException {
+        withLuceneIndex(mapperService, iw -> indexNestedDocs(mapperService, iw), reader -> {
+            context.setSearcher(new ContextIndexSearcher(reader, new BM25Similarity(), null, qcp, false));
+            for (LeafReaderContext ctx : reader.leaves()) {
+                BitSet bits = BitsetFilterCache.bitsetFromQuery(Queries.newNonNestedFilter(), ctx);
+                assertNotNull(bits);
+                for (int i = 0; i < ctx.reader().maxDoc(); i++) {
+                    HitContext hc;
+                    if (bits.get(i)) {
+                        // parent doc
+                        hc = new HitContext(new SearchHit(i), ctx, i, -1, null, null);
+                    } else {
+                        hc = new HitContext(new SearchHit(i), ctx, i, bits.nextSetBit(i), null, null);
+                    }
+                    processor.process(hc);
+                    test.accept(hc);
+                }
+            }
+        });
+    }
+
+    private MapperService nonNestedMapperService() throws IOException {
+        return createMapperService(mapping(b -> {
+            b.startObject("keyword");
+            {
+                b.field("type", "keyword");
+                b.field("store", "true");
+            }
+            b.endObject();
+            b.startObject("long").field("type", "long").endObject();
+        }));
+    }
+
+    private void indexNonNestedDocs(MapperService m, RandomIndexWriter iw) throws IOException {
+        int numDocs = randomIntBetween(5, 50);
+        for (int i = 0; i < numDocs; i++) {
+            int val = i;
+            iw.addDocuments(m.documentMapper().parse(source(b -> b.field("keyword", "foo").field("long", val))).docs());
+        }
+    }
+
+    private MapperService nestedMapperService() throws IOException {
+        return createMapperService(mapping(b -> {
+            b.startObject("keyword");
+            {
+                b.field("type", "keyword");
+                b.field("store", "true");
+            }
+            b.endObject();
+            b.startObject("long").field("type", "long").endObject();
+            b.startObject("subdocs");
+            {
+                b.field("type", "nested");
+                b.startObject("properties");
+                {
+                    b.startObject("child");
+                    {
+                        b.field("type", "long");
+                        b.field("store", "true");
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+    }
+
+    private void indexNestedDocs(MapperService m, RandomIndexWriter iw) throws IOException {
+        int numDocs = randomIntBetween(5, 50);
+        for (int i = 0; i < numDocs; i++) {
+            int parent = i;
+            int numChildren = randomIntBetween(1, 10);
+            iw.addDocuments(m.documentMapper().parse(source(b -> {
+                b.field("keyword", "foo");
+                b.field("long", parent);
+                b.startArray("subdocs");
+                for (int j = 0; j <= numChildren; j++) {
+                    b.startObject().field("child", j).endObject();
+                }
+                b.endArray();
+            })).docs());
+        }
+    }
+
+    // test for nested doc - should get metadata fields + nested source
+    public void testStandardNestedDoc() throws IOException {
+        MapperService mapperService = nestedMapperService();
+
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNestedTest(mapperService, context, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            assertFalse(hc.sourceLookup().isEmpty());
+            if (hc.rootId() == -1) {
+                assertThat(hc.sourceLookup().get("keyword"), equalTo("foo"));
+            } else {
+                assertTrue(hc.sourceLookup().containsKey("subdocs"));
+                assertThat(hc.sourceLookup().get("subdocs").toString(), startsWith("{child="));
+            }
+            Map<String, DocumentField> loadedFields = hc.hit().getFields();
+            assertThat(loadedFields.size(), equalTo(0));
+        });
+
+    }
+
+    // test for nested doc with specific fields - should get metadata fields + nested source + specific fields
+    public void testNestedDocWithSpecifiedFields() throws IOException {
+        MapperService mapperService = nestedMapperService();
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        StoredFieldsContext sfc = StoredFieldsContext.fromList(List.of("chi*"));
+        context.storedFieldsContext(sfc);
+
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNestedTest(mapperService, context, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            Map<String, DocumentField> loadedFields = hc.hit().getFields();
+            if (hc.rootId() == -1) {
+                assertThat(loadedFields.size(), equalTo(0));
+            } else {
+                // this does not appear to work! we expand the fields list from the root doc,
+                // so nested fields do not get picked up.
+                // assertThat(loadedFields.size(), equalTo(1));
+                // DocumentField k = loadedFields.get("child");
+                // assertNotNull(k.getValue());
+            }
+        });
+    }
+
+    // test for nested doc with no source - should get only metadata fields
+    public void testNestedNoSource() throws IOException {
+
+        MapperService mapperService = nonNestedMapperService();
+
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        context.fetchSourceContext(new FetchSourceContext(false));
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNestedTest(mapperService, context, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            assertNull(hc.sourceLookup().source());
+        });
+    }
+
+    // test for nested doc with no source but highlighting - should get metadata fields + nested source
+    // for nested docs, but no source for parent docs
+    public void testNestedNoSourceWithHighlighting() throws IOException {
+
+        MapperService mapperService = nonNestedMapperService();
+
+        LoadStoredFieldsTestSearchContext context = new LoadStoredFieldsTestSearchContext(mapperService);
+        context.fetchSourceContext(new FetchSourceContext(false));
+        context.highlight(true);
+
+        LoadStoredFieldsPhase phase = new LoadStoredFieldsPhase();
+        FetchSubPhaseProcessor processor = phase.getProcessor(context);
+
+        doNestedTest(mapperService, context, processor, hc -> {
+            assertNotNull(hc.hit().getId());
+            if (hc.rootId() == -1) {
+                assertNull(hc.sourceLookup().source());
+                assertThat(hc.sourceLookup().get("keyword"), equalTo("foo"));
+            } else {
+                assertNotNull(hc.sourceLookup().source());
+                assertTrue(hc.sourceLookup().containsKey("subdocs"));
+                assertThat(hc.sourceLookup().get("subdocs").toString(), startsWith("{child="));
+            }
+            Map<String, DocumentField> loadedFields = hc.hit().getFields();
+            assertThat(loadedFields.size(), equalTo(0));
+        });
+    }
+
+    private static class LoadStoredFieldsTestSearchContext extends TestSearchContext {
+
+        boolean highlight;
+        FetchSourceContext fetchSourceContext;
+        StoredFieldsContext storedFields;
+        final MapperService mapperService;
+
+        LoadStoredFieldsTestSearchContext(MapperService mapperService) {
+            super(null);
+            this.mapperService = mapperService;
+        }
+
+        @Override
+        public BitSetProducer getBitSetProducer(Query query) {
+            return new BitSetProducer() {
+                @Override
+                public BitSet getBitSet(LeafReaderContext context) throws IOException {
+                    return BitsetFilterCache.bitsetFromQuery(query, context);
+                }
+            };
+        }
+
+        @Override
+        public MapperService mapperService() {
+            return mapperService;
+        }
+
+        void highlight(boolean highlight) {
+            this.highlight = highlight;
+        }
+
+        @Override
+        public SearchHighlightContext highlight() {
+            if (highlight) {
+                return new SearchHighlightContext(Collections.emptyList(), false);
+            }
+            return null;
+        }
+
+        @Override
+        public boolean sourceRequested() {
+            return fetchSourceContext != null && fetchSourceContext.fetchSource();
+        }
+
+        @Override
+        public boolean hasFetchSourceContext() {
+            return fetchSourceContext != null;
+        }
+
+        @Override
+        public FetchSourceContext fetchSourceContext() {
+            return this.fetchSourceContext;
+        }
+
+        @Override
+        public SearchContext fetchSourceContext(FetchSourceContext fetchSourceContext) {
+            this.fetchSourceContext = fetchSourceContext;
+            return this;
+        }
+
+        @Override
+        public boolean hasStoredFields() {
+            return storedFields != null && storedFields.fieldNames() != null;
+        }
+
+        @Override
+        public boolean hasStoredFieldsContext() {
+            return storedFields != null;
+        }
+
+        @Override
+        public StoredFieldsContext storedFieldsContext() {
+            return storedFields;
+        }
+
+        @Override
+        public SearchContext storedFieldsContext(StoredFieldsContext storedFieldsContext) {
+            this.storedFields = storedFieldsContext;
+            return this;
+        }
+
+        @Override
+        public boolean storedFieldsRequested() {
+            return storedFields == null || storedFields.fetchFields();
+        }
+
+    }
+}


### PR DESCRIPTION
Stored fields are currently loaded by `FetchPhase` when building a `HitContext` to be
passed to the various sub phases.  This means that we can't add any steps to be 
executed before stored fields are loaded, and it mixes up what is essentially a hit-by-hit
subphase with the overall FetchPhase, making it difficult to test in isolation.

This commit pulls stored field loading into its own FetchSubPhase, and adds unit tests
specifically for this phase.