### PR TITLE
Make keep alive of point in time optional in search

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
@@ -75,7 +75,7 @@ public final class SearchShardIterator implements Comparable<SearchShardIterator
         this.clusterAlias = clusterAlias;
         this.searchContextId = searchContextId;
         this.searchContextKeepAlive = searchContextKeepAlive;
-        assert (searchContextId == null) == (searchContextKeepAlive == null);
+        assert searchContextKeepAlive == null || searchContextId != null;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1676,33 +1676,35 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         public PointInTimeBuilder(String id, TimeValue keepAlive) {
             this.id = Objects.requireNonNull(id);
-            this.keepAlive = Objects.requireNonNull(keepAlive);
+            this.keepAlive = keepAlive;
         }
 
         public PointInTimeBuilder(StreamInput in) throws IOException {
             id = in.readString();
-            keepAlive = in.readTimeValue();
+            keepAlive = in.readOptionalTimeValue();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(id);
-            out.writeTimeValue(keepAlive);
+            out.writeOptionalTimeValue(keepAlive);
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject(POINT_IN_TIME.getPreferredName());
             builder.field(ID_FIELD.getPreferredName(), id);
-            builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive);
+            if (keepAlive != null) {
+                builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive);
+            }
             builder.endObject();
             return builder;
         }
 
         public static PointInTimeBuilder fromXContent(XContentParser parser) throws IOException {
             final XContentParams params = PARSER.parse(parser, null);
-            if (params.id == null || params.keepAlive == null) {
-                throw new IllegalArgumentException("id and keep_alive must be specified");
+            if (params.id == null) {
+                throw new IllegalArgumentException("point int time id is not provided");
             }
             return new PointInTimeBuilder(params.id, params.keepAlive);
         }

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -175,7 +175,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.originalIndices = originalIndices;
         this.readerId = readerId;
         this.keepAlive = keepAlive;
-        assert (readerId != null) == (keepAlive != null);
+        assert keepAlive == null || readerId != null : "readerId: " + readerId + " keepAlive: " + keepAlive;
     }
 
     public ShardSearchRequest(StreamInput in) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -371,8 +371,8 @@ public class RandomSearchRequestGenerator {
             builder.collapse(randomCollapseBuilder.get());
         }
         if (randomBoolean()) {
-            builder.pointInTimeBuilder(new SearchSourceBuilder.PointInTimeBuilder(randomAlphaOfLengthBetween(3, 10),
-                TimeValue.timeValueMinutes(randomIntBetween(1, 60))));
+            TimeValue keepAlive = randomBoolean() ? TimeValue.timeValueMinutes(randomIntBetween(1, 60)) : null;
+            builder.pointInTimeBuilder(new SearchSourceBuilder.PointInTimeBuilder(randomAlphaOfLengthBetween(3, 10), keepAlive));
         }
         return builder;
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/search/point_in_time.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/search/point_in_time.yml
@@ -86,7 +86,6 @@ setup:
           search_after: [24, 172]
           pit:
             id: "$point_in_time_id"
-            keep_alive: 1m
 
   - match: {hits.total: 3 }
   - length: {hits.hits: 1 }
@@ -106,7 +105,6 @@ setup:
           search_after: [18, 42]
           pit:
             id: "$point_in_time_id"
-            keep_alive: 1m
 
   - match: {hits.total: 3}
   - length: {hits.hits: 1 }


### PR DESCRIPTION
A search request should not be required to extend the keep_alive of a point in time. This change makes that parameter optional.