### PR TITLE
[DOCS] Update multi-target syntax page

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -27,7 +27,7 @@ wildcard (`*`) expressions to target any resources that match the pattern:
 You can exclude targets using the `-` character: `test*,-test3`.
 
 IMPORTANT: Index aliases are resolved after wildcard expressions. This can
-result in a request that targets an excluded alias. For example, if `-test3` is
+result in a request that targets an excluded alias. For example, if `test3` is
 an index alias, the pattern `test*,-test3` still targets the indices for
 `test3`. To avoid this, exclude the concrete indices for the alias instead.
 

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -18,13 +18,18 @@ API, unless otherwise specified.
 Most APIs that accept a `<data-stream>`, `<index>`, or `<target>` request path
 parameter also support _multi-target syntax_.
 
-In multi-target syntax, you can use a comma-separated list to execute a request across multiple resources, such as
-data streams, indices, or index aliases: `test1,test2,test3`. You can also use
-{wikipedia}/Glob_(programming)[glob-like] wildcard (`*`)
-expressions to target any
-resources that match the pattern: `test*` or `*test` or `te*t` or `*test*`.
+In multi-target syntax, you can use a comma-separated list to execute a request
+across multiple resources, such as data streams, indices, or index aliases:
+`test1,test2,test3`. You can also use {wikipedia}/Glob_(programming)[glob-like]
+wildcard (`*`) expressions to target any resources that match the pattern:
+`test*` or `*test` or `te*t` or `*test*`.
 
-You can exclude targets using the `-` character: `test*,-test3`.  If the other target is an index alias, the alias will be resolved after the wildcards resulting in an excluded target being added back.
+You can exclude targets using the `-` character: `test*,-test3`.
+
+IMPORTANT: Index aliases are resolved after wildcard patterns. This can result
+in a request that targets an excluded alias. For example, if `-test3` is an
+index alias, the pattern `test*,-test3` still targets the indices for `test3`.
+To avoid this, exclude the concrete indices for the alias instead.
 
 Multi-target APIs that can target indices support the following query
 string parameters:

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -18,11 +18,10 @@ API, unless otherwise specified.
 Most APIs that accept a `<data-stream>`, `<index>`, or `<target>` request path
 parameter also support _multi-target syntax_.
 
-In multi-target syntax, you can use a comma-separated list to execute a request
-across multiple resources, such as data streams, indices, or index aliases:
-`test1,test2,test3`. You can also use {wikipedia}/Glob_(programming)[glob-like]
-wildcard (`*`) expressions to target any resources that match the pattern:
-`test*` or `*test` or `te*t` or `*test*`.
+In multi-target syntax, you can use a comma-separated list to run a request on
+multiple data streams, indices, or index aliases: `test1,test2,test3`. You can
+also use {wikipedia}/Glob_(programming)[glob-like] wildcard (`*`) expressions to
+target resources that match a pattern: `test*` or `*test` or `te*t` or `*test*`.
 
 You can exclude targets using the `-` character: `test*,-test3`.
 

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -22,9 +22,9 @@ In multi-target syntax, you can use a comma-separated list to execute a request 
 data streams, indices, or index aliases: `test1,test2,test3`. You can also use
 {wikipedia}/Glob_(programming)[glob-like] wildcard (`*`)
 expressions to target any
-resources that match the pattern: `test*` or `*test` or `te*t` or `*test*.
+resources that match the pattern: `test*` or `*test` or `te*t` or `*test*`.
 
-You can exclude targets using the `-` character: `test*,-test3`.
+You can exclude targets using the `-` character: `test*,-test3`.  If the other target is an index alias, the alias will be resolved after the wildcards resulting in an excluded target being added back.
 
 Multi-target APIs that can target indices support the following query
 string parameters:

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -26,10 +26,10 @@ wildcard (`*`) expressions to target any resources that match the pattern:
 
 You can exclude targets using the `-` character: `test*,-test3`.
 
-IMPORTANT: Index aliases are resolved after wildcard patterns. This can result
-in a request that targets an excluded alias. For example, if `-test3` is an
-index alias, the pattern `test*,-test3` still targets the indices for `test3`.
-To avoid this, exclude the concrete indices for the alias instead.
+IMPORTANT: Index aliases are resolved after wildcard expressions. This can
+result in a request that targets an excluded alias. For example, if `-test3` is
+an index alias, the pattern `test*,-test3` still targets the indices for
+`test3`. To avoid this, exclude the concrete indices for the alias instead.
 
 Multi-target APIs that can target indices support the following query
 string parameters:


### PR DESCRIPTION
Update [Multi-target syntax](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/multi-index.html) page to include note about alias resolution.