### PR TITLE
[7.9] [DOCS] Update multi-target syntax page (#62192)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -18,13 +18,17 @@ API, unless otherwise specified.
 Most APIs that accept a `<data-stream>`, `<index>`, or `<target>` request path
 parameter also support _multi-target syntax_.
 
-In multi-target syntax, you can use a comma-separated list to execute a request across multiple resources, such as
-data streams, indices, or index aliases: `test1,test2,test3`. You can also use
-{wikipedia}/Glob_(programming)[glob-like] wildcard (`*`)
-expressions to target any
-resources that match the pattern: `test*` or `*test` or `te*t` or `*test*.
+In multi-target syntax, you can use a comma-separated list to run a request on
+multiple data streams, indices, or index aliases: `test1,test2,test3`. You can
+also use {wikipedia}/Glob_(programming)[glob-like] wildcard (`*`) expressions to
+target resources that match a pattern: `test*` or `*test` or `te*t` or `*test*`.
 
 You can exclude targets using the `-` character: `test*,-test3`.
+
+IMPORTANT: Index aliases are resolved after wildcard expressions. This can
+result in a request that targets an excluded alias. For example, if `test3` is
+an index alias, the pattern `test*,-test3` still targets the indices for
+`test3`. To avoid this, exclude the concrete indices for the alias instead.
 
 Multi-target APIs that can target indices support the following query
 string parameters:

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -19,9 +19,10 @@ Most APIs that accept a `<data-stream>`, `<index>`, or `<target>` request path
 parameter also support _multi-target syntax_.
 
 In multi-target syntax, you can use a comma-separated list to run a request on
-multiple data streams, indices, or index aliases: `test1,test2,test3`. You can
-also use {wikipedia}/Glob_(programming)[glob-like] wildcard (`*`) expressions to
-target resources that match a pattern: `test*` or `*test` or `te*t` or `*test*`.
+multiple resources, such as data streams, indices, or index aliases:
+`test1,test2,test3`. You can also use {wikipedia}/Glob_(programming)[glob-like]
+wildcard (`*`) expressions to target resources that match a pattern: `test*` or
+`*test` or `te*t` or `*test*`.
 
 You can exclude targets using the `-` character: `test*,-test3`.
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Update multi-target syntax page (#62192)