### PR TITLE
Enable searchable snapshots in release builds

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -54,7 +54,6 @@ testClusters.integTest {
     setting 'indices.lifecycle.history_index_enabled', 'false'
     if (BuildParams.isSnapshotBuild() == false) {
       systemProperty 'es.autoscaling_feature_flag_registered', 'true'
-      systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
     }
     setting 'xpack.autoscaling.enabled', 'true'
     setting 'xpack.eql.enabled', 'true'

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -126,9 +126,6 @@ testClusters.all {
   extraConfigFile nodeKey.name, nodeKey
   extraConfigFile nodeCert.name, nodeCert
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
 }
 
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoFeatureAction.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,11 +51,8 @@ public class XPackInfoFeatureAction extends ActionType<XPackInfoFeatureResponse>
         final List<XPackInfoFeatureAction> actions = new ArrayList<>();
         actions.addAll(Arrays.asList(
             SECURITY, MONITORING, WATCHER, GRAPH, MACHINE_LEARNING, LOGSTASH, EQL, SQL, ROLLUP, INDEX_LIFECYCLE, SNAPSHOT_LIFECYCLE, CCR,
-            TRANSFORM, VECTORS, VOTING_ONLY, FROZEN_INDICES, SPATIAL, ANALYTICS, ENRICH, DATA_STREAMS
+            TRANSFORM, VECTORS, VOTING_ONLY, FROZEN_INDICES, SPATIAL, ANALYTICS, ENRICH, DATA_STREAMS, SEARCHABLE_SNAPSHOTS
         ));
-        if (SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            actions.add(SEARCHABLE_SNAPSHOTS);
-        }
         ALL = Collections.unmodifiableList(actions);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,11 +51,8 @@ public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureRespons
         final List<XPackUsageFeatureAction> actions = new ArrayList<>();
         actions.addAll(Arrays.asList(
             SECURITY, MONITORING, WATCHER, GRAPH, MACHINE_LEARNING, LOGSTASH, EQL, SQL, ROLLUP, INDEX_LIFECYCLE, SNAPSHOT_LIFECYCLE, CCR,
-            TRANSFORM, VECTORS, VOTING_ONLY, FROZEN_INDICES, SPATIAL, ANALYTICS, DATA_STREAMS
+            TRANSFORM, VECTORS, VOTING_ONLY, FROZEN_INDICES, SPATIAL, ANALYTICS, DATA_STREAMS, SEARCHABLE_SNAPSHOTS
         ));
-        if (SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            actions.add(SEARCHABLE_SNAPSHOTS);
-        }
         ALL = Collections.unmodifiableList(actions);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsConstants.java
@@ -5,37 +5,18 @@
  */
 package org.elasticsearch.xpack.searchablesnapshots;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 
 public class SearchableSnapshotsConstants {
-    public static final boolean SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED;
-
-    static {
-        final String property = System.getProperty("es.searchable_snapshots_feature_enabled");
-        if ("true".equals(property)) {
-            SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED = true;
-        } else if ("false".equals(property)) {
-            SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED = false;
-        } else if (property == null) {
-            SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED = Build.CURRENT.isSnapshot();
-        } else {
-            throw new IllegalArgumentException(
-                "expected es.searchable_snapshots_feature_enabled to be unset or [true|false] but was [" + property + "]"
-            );
-        }
-    }
-
     public static final String SNAPSHOT_DIRECTORY_FACTORY_KEY = "snapshot";
 
     public static final String SNAPSHOT_RECOVERY_STATE_FACTORY_KEY = "snapshot_prewarm";
 
     public static boolean isSearchableSnapshotStore(Settings indexSettings) {
-        return SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED
-            && SNAPSHOT_DIRECTORY_FACTORY_KEY.equals(INDEX_STORE_TYPE_SETTING.get(indexSettings));
+        return SNAPSHOT_DIRECTORY_FACTORY_KEY.equals(INDEX_STORE_TYPE_SETTING.get(indexSettings));
     }
 
     public static final String CACHE_FETCH_ASYNC_THREAD_POOL_NAME = "searchable_snapshots_cache_fetch_async";

--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
-
 apply plugin: 'elasticsearch.java-rest-test'
 
 File repoDir = file("$buildDir/testclusters/repo")
@@ -11,9 +9,6 @@ javaRestTest {
 
 testClusters.javaRestTest {
   testDistribution = 'DEFAULT'
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
   numberOfNodes = 4
 
   setting 'path.repo', repoDir.absolutePath

--- a/x-pack/plugin/data-streams/qa/rest/build.gradle
+++ b/x-pack/plugin/data-streams/qa/rest/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
-
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 restResources {
@@ -14,9 +12,6 @@ restResources {
 
 testClusters.all {
   testDistribution = 'DEFAULT'
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
   // Data streams is basic, but a few tests test data streams in combination with paid features
   setting 'xpack.license.self_generated.type', 'trial'
   // disable ILM history, since it disturbs tests using _all

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
-
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
@@ -15,9 +13,6 @@ javaRestTest {
 
 testClusters.all {
   testDistribution = 'DEFAULT'
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
   numberOfNodes = 4
 
   setting 'path.repo', repoDir.absolutePath

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
-
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.esplugin'
 esplugin {
@@ -37,10 +35,3 @@ def testJar = tasks.register("testJar", Jar) {
 artifacts {
   testArtifacts testJar
 }
-
-internalClusterTest {
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
-}
-

--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -51,10 +51,6 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
-
   keystore 'azure.client.searchable_snapshots.account', azureAccount
   if (azureKey != null && azureKey.isEmpty() == false) {
     keystore 'azure.client.searchable_snapshots.key', azureKey

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -95,10 +95,6 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
-
   keystore 'gcs.client.searchable_snapshots.credentials_file', serviceAccountFile, IGNORE_VALUE
   if (useFixture) {
     tasks.integTest.dependsOn createServiceAccountFile

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
 import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
 
 apply plugin: 'elasticsearch.standalone-rest-test'
@@ -36,10 +35,6 @@ integTest {
 testClusters.integTest {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
-
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
 
   keystore 's3.client.searchable_snapshots.access_key', 'access_key'
   keystore 's3.client.searchable_snapshots.secret_key', 'secret_key'

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.info.BuildParams
-
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -17,9 +15,6 @@ integTest {
 
 testClusters.integTest {
   testDistribution = 'DEFAULT'
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -51,10 +51,6 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
-  }
-
   keystore 's3.client.searchable_snapshots.access_key', s3AccessKey
   keystore 's3.client.searchable_snapshots.secret_key', s3SecretKey
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -81,8 +81,6 @@ import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsCon
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_PREWARMING_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_PREWARMING_THREAD_POOL_SETTING;
-import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED;
-import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_BLOB_CACHE_INDEX;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
@@ -170,23 +168,19 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public List<Setting<?>> getSettings() {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return List.of(
-                SNAPSHOT_REPOSITORY_SETTING,
-                SNAPSHOT_SNAPSHOT_NAME_SETTING,
-                SNAPSHOT_SNAPSHOT_ID_SETTING,
-                SNAPSHOT_INDEX_NAME_SETTING,
-                SNAPSHOT_INDEX_ID_SETTING,
-                SNAPSHOT_CACHE_ENABLED_SETTING,
-                SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING,
-                SNAPSHOT_CACHE_EXCLUDED_FILE_TYPES_SETTING,
-                SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING,
-                CacheService.SNAPSHOT_CACHE_SIZE_SETTING,
-                CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            SNAPSHOT_REPOSITORY_SETTING,
+            SNAPSHOT_SNAPSHOT_NAME_SETTING,
+            SNAPSHOT_SNAPSHOT_ID_SETTING,
+            SNAPSHOT_INDEX_NAME_SETTING,
+            SNAPSHOT_INDEX_ID_SETTING,
+            SNAPSHOT_CACHE_ENABLED_SETTING,
+            SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING,
+            SNAPSHOT_CACHE_EXCLUDED_FILE_TYPES_SETTING,
+            SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING,
+            CacheService.SNAPSHOT_CACHE_SIZE_SETTING,
+            CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING
+        );
     }
 
     @Override
@@ -203,29 +197,19 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         final IndexNameExpressionResolver resolver,
         final Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            final CacheService cacheService = new CacheService(new NodeEnvironmentCacheCleaner(nodeEnvironment), settings);
-            this.cacheService.set(cacheService);
-            this.repositoriesServiceSupplier = repositoriesServiceSupplier;
-            this.threadPool.set(threadPool);
-            final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(
-                clusterService,
-                threadPool,
-                client,
-                SNAPSHOT_BLOB_CACHE_INDEX
-            );
-            this.blobStoreCacheService.set(blobStoreCacheService);
-            this.failShardsListener.set(
-                new FailShardsOnInvalidLicenseClusterListener(getLicenseState(), clusterService.getRerouteService())
-            );
-            return List.of(cacheService, blobStoreCacheService);
-        } else {
-            this.repositoriesServiceSupplier = () -> {
-                assert false : "searchable snapshots are disabled";
-                return null;
-            };
-            return List.of();
-        }
+        final CacheService cacheService = new CacheService(new NodeEnvironmentCacheCleaner(nodeEnvironment), settings);
+        this.cacheService.set(cacheService);
+        this.repositoriesServiceSupplier = repositoriesServiceSupplier;
+        this.threadPool.set(threadPool);
+        final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(
+            clusterService,
+            threadPool,
+            client,
+            SNAPSHOT_BLOB_CACHE_INDEX
+        );
+        this.blobStoreCacheService.set(blobStoreCacheService);
+        this.failShardsListener.set(new FailShardsOnInvalidLicenseClusterListener(getLicenseState(), clusterService.getRerouteService()));
+        return List.of(cacheService, blobStoreCacheService);
     }
 
     @Override
@@ -243,29 +227,25 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public Map<String, DirectoryFactory> getDirectoryFactories() {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return Map.of(SNAPSHOT_DIRECTORY_FACTORY_KEY, (indexSettings, shardPath) -> {
-                final RepositoriesService repositories = repositoriesServiceSupplier.get();
-                assert repositories != null;
-                final CacheService cache = cacheService.get();
-                assert cache != null;
-                final ThreadPool threadPool = this.threadPool.get();
-                assert threadPool != null;
-                final BlobStoreCacheService blobCache = blobStoreCacheService.get();
-                assert blobCache != null;
-                return SearchableSnapshotDirectory.create(
-                    repositories,
-                    cache,
-                    indexSettings,
-                    shardPath,
-                    System::nanoTime,
-                    threadPool,
-                    blobCache
-                );
-            });
-        } else {
-            return Map.of();
-        }
+        return Map.of(SNAPSHOT_DIRECTORY_FACTORY_KEY, (indexSettings, shardPath) -> {
+            final RepositoriesService repositories = repositoriesServiceSupplier.get();
+            assert repositories != null;
+            final CacheService cache = cacheService.get();
+            assert cache != null;
+            final ThreadPool threadPool = this.threadPool.get();
+            assert threadPool != null;
+            final BlobStoreCacheService blobCache = blobStoreCacheService.get();
+            assert blobCache != null;
+            return SearchableSnapshotDirectory.create(
+                repositories,
+                cache,
+                indexSettings,
+                shardPath,
+                System::nanoTime,
+                threadPool,
+                blobCache
+            );
+        });
     }
 
     @Override
@@ -281,18 +261,14 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return List.of(
-                new ActionHandler<>(SearchableSnapshotsStatsAction.INSTANCE, TransportSearchableSnapshotsStatsAction.class),
-                new ActionHandler<>(ClearSearchableSnapshotsCacheAction.INSTANCE, TransportClearSearchableSnapshotsCacheAction.class),
-                new ActionHandler<>(MountSearchableSnapshotAction.INSTANCE, TransportMountSearchableSnapshotAction.class),
-                new ActionHandler<>(RepositoryStatsAction.INSTANCE, TransportRepositoryStatsAction.class),
-                new ActionHandler<>(XPackUsageFeatureAction.SEARCHABLE_SNAPSHOTS, SearchableSnapshotsUsageTransportAction.class),
-                new ActionHandler<>(XPackInfoFeatureAction.SEARCHABLE_SNAPSHOTS, SearchableSnapshotsInfoTransportAction.class)
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            new ActionHandler<>(SearchableSnapshotsStatsAction.INSTANCE, TransportSearchableSnapshotsStatsAction.class),
+            new ActionHandler<>(ClearSearchableSnapshotsCacheAction.INSTANCE, TransportClearSearchableSnapshotsCacheAction.class),
+            new ActionHandler<>(MountSearchableSnapshotAction.INSTANCE, TransportMountSearchableSnapshotAction.class),
+            new ActionHandler<>(RepositoryStatsAction.INSTANCE, TransportRepositoryStatsAction.class),
+            new ActionHandler<>(XPackUsageFeatureAction.SEARCHABLE_SNAPSHOTS, SearchableSnapshotsUsageTransportAction.class),
+            new ActionHandler<>(XPackInfoFeatureAction.SEARCHABLE_SNAPSHOTS, SearchableSnapshotsInfoTransportAction.class)
+        );
     }
 
     public List<RestHandler> getRestHandlers(
@@ -304,25 +280,17 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return List.of(
-                new RestSearchableSnapshotsStatsAction(),
-                new RestClearSearchableSnapshotsCacheAction(),
-                new RestMountSearchableSnapshotAction(),
-                new RestRepositoryStatsAction()
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            new RestSearchableSnapshotsStatsAction(),
+            new RestClearSearchableSnapshotsCacheAction(),
+            new RestMountSearchableSnapshotAction(),
+            new RestRepositoryStatsAction()
+        );
     }
 
     @Override
     public Map<String, ExistingShardsAllocator> getExistingShardsAllocators() {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return Collections.singletonMap(SearchableSnapshotAllocator.ALLOCATOR_NAME, new SearchableSnapshotAllocator());
-        } else {
-            return Collections.emptyMap();
-        }
+        return Collections.singletonMap(SearchableSnapshotAllocator.ALLOCATOR_NAME, new SearchableSnapshotAllocator());
     }
 
     // overridable by tests
@@ -332,30 +300,18 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return List.of(
-                new SearchableSnapshotAllocationDecider(() -> getLicenseState().isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS))
-            );
-        } else {
-            return Collections.emptyList();
-        }
+        return List.of(
+            new SearchableSnapshotAllocationDecider(() -> getLicenseState().isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS))
+        );
     }
 
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return List.of(executorBuilders());
-        } else {
-            return List.of();
-        }
+        return List.of(executorBuilders());
     }
 
     @Override
     public Map<String, RecoveryStateFactory> getRecoveryStateFactories() {
-        if (SEARCHABLE_SNAPSHOTS_FEATURE_ENABLED) {
-            return Map.of(SNAPSHOT_RECOVERY_STATE_FACTORY_KEY, SearchableSnapshotRecoveryState::new);
-        } else {
-            return Map.of();
-        }
+        return Map.of(SNAPSHOT_RECOVERY_STATE_FACTORY_KEY, SearchableSnapshotRecoveryState::new);
     }
 
     public static ScalingExecutorBuilder[] executorBuilders() {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -290,7 +290,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public Map<String, ExistingShardsAllocator> getExistingShardsAllocators() {
-        return Collections.singletonMap(SearchableSnapshotAllocator.ALLOCATOR_NAME, new SearchableSnapshotAllocator());
+        return Map.of(SearchableSnapshotAllocator.ALLOCATOR_NAME, new SearchableSnapshotAllocator());
     }
 
     // overridable by tests


### PR DESCRIPTION
Enables searchable snapshot functionality not only in snapshot, but also release builds.