### PR TITLE
Fix resolve index data streams yaml test.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -109,12 +109,12 @@ setup:
 ---
 "Resolve index with hidden and closed indices":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/62190"
+      version: " - 7.8.99"
+      reason: "resolve index api only supported in 7.9+"
 
   - do:
       indices.resolve_index:
-        name: '*'
+        name: ['*','-.ml*']
         expand_wildcards: [all]
 
   - match: {indices.0.name: .ds-simple-data-stream1-000001}


### PR DESCRIPTION
Sometimes there are other hidden/system indices that may exist despite being cleaned up after tests.
This just ignores `.ml-*` indices, so that these don't interfere with the expected test output.

Closes #62190