### PR TITLE
[DOCS] EQL: Make case sensitivity more visible

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -134,7 +134,8 @@ used.
 `case_sensitive`::
 (Optional, boolean)
 If `true`, matching for the <<eql-search-api-request-query-param,EQL query>> is
-case sensitive. Defaults to `false`.
+case sensitive. Defaults to `false`. This affects all comparisons and functions
+in the EQL query.
 
 `event_category_field`::
 (Required*, string)

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -56,6 +56,10 @@ The following request searches `my-index-000001` for events with an
 document in `my-index-000001` includes a `@timestamp` and `event.category`
 field.
 
+TIP: By default, EQL queries are case-insensitive. To run a case-sensitive
+search, include `case_sensitive: true` as a request body argument. See
+<<eql-search-case-sensitive>>.
+
 [source,console]
 ----
 GET /my-index-000001/_eql/search
@@ -449,8 +453,10 @@ GET /my-index-000001/_eql/search
 [[eql-search-case-sensitive]]
 === Run a case-sensitive EQL search
 
-By default, matching for EQL queries is case-insensitive. You can use the
-`case_sensitive` parameter to toggle case sensitivity on or off.
+By default, matching for EQL <<eql-syntax-comparison-operators,comparison
+operators>> and <<eql-function-ref,functions>> is case-insensitive. You can use
+the `case_sensitive` parameter to toggle this case sensitivity on or off. This
+affects all comparisons and functions in the EQL query.
 
 The following search request contains a query that matches `process` events
 with a `process.executable` containing `System32`.

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -10,6 +10,10 @@ experimental::[]
 
 {es} supports the following <<eql-functions,EQL functions>>.
 
+TIP: By default, matching for functions is case-insensitive. You can control
+case sensitivity using the EQL search API's
+<<eql-search-case-sensitive,`case_sensitive`>> parameter.
+
 [discrete]
 [[eql-fn-add]]
 === `add`
@@ -155,7 +159,9 @@ in regular expressions. Defaults to `false`.
 
 `<case_sensitive>`::
 (Optional, boolean)
-If `true`, matching is case-sensitive. Defaults to `false`.
+If `true`, matching for the function is case-sensitive. Defaults to `false`.
+This overrides the EQL search request's
+<<eql-search-case-sensitive,`case_sensitive`>> argument.
 
 *Returns:* string or `null`
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -69,6 +69,38 @@ You can specify and combine these criteria using the following operators:
 <   <=   ==   !=   >=   >
 ----
 
+.*Definitions*
+[%collapsible]
+====
+`<` (less than)::
+Returns `true` if the value to the left of the operator is less than the value
+to the right. Otherwise returns `false`.
+
+`<=` (less than or equal) ::
+Returns `true` if the value to the left of the operator is less than or equal to
+the value to the right. Otherwise returns `false`.
+
+`==` (equal)::
+Returns `true` if the values to the left and right of the operator are equal.
+Otherwise returns `false`. Used for exact matching.
+
+`!=` (not equal)::
+Returns `true` if the values to the left and right of the operator are not
+equal. Otherwise returns `false`.
+
+`>=` (greater than or equal) ::
+Returns `true` if the value to the left of the operator is greater than or equal
+to the value to the right. Otherwise returns `false`.
+
+`>` (greater than)::
+Returns `true` if the value to the left of the operator is greater than the
+value to the right. Otherwise returns `false`.
+====
+
+By default, matching for comparisons is case-insensitive. You can control case
+sensitivity using the EQL search API's
+<<eql-search-case-sensitive,`case_sensitive`>> parameter.
+
 You cannot use comparison operators to compare a variable, such as a field
 value, to another variable, even if those variables are modified using a
 <<eql-functions,function>>.
@@ -105,34 +137,6 @@ difficult.
 
 To search `text` fields, consider using a <<eql-search-filter-query-dsl,query
 DSL filter>> that contains a <<query-dsl-match-query,`match`>> query.
-====
-
-.*Definitions*
-[%collapsible]
-====
-`<` (less than)::
-Returns `true` if the value to the left of the operator is less than the value
-to the right. Otherwise returns `false`.
-
-`<=` (less than or equal) ::
-Returns `true` if the value to the left of the operator is less than or equal to
-the value to the right. Otherwise returns `false`.
-
-`==` (equal)::
-Returns `true` if the values to the left and right of the operator are equal.
-Otherwise returns `false`.
-
-`!=` (not equal)::
-Returns `true` if the values to the left and right of the operator are not
-equal. Otherwise returns `false`.
-
-`>=` (greater than or equal) ::
-Returns `true` if the value to the left of the operator is greater than or equal
-to the value to the right. Otherwise returns `false`.
-
-`>` (greater than)::
-Returns `true` if the value to the left of the operator is greater than the
-value to the right. Otherwise returns `false`.
 ====
 
 [discrete]


### PR DESCRIPTION
Adds some clarifications and additional mentions to make the case sensitivity default and API flag more prominent.

Any feedback welcome!

### Previews:
EQL search API: https://elasticsearch_62239.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html

EQL page: https://elasticsearch_62239.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html

EQL fn ref: https://elasticsearch_62239.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-function-ref.html#eql-function-ref

EQL syntax ref: https://elasticsearch_62239.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-syntax-comparison-operators