### PR TITLE
[DOCS] Fix ILM force merge codec param

### DIFF
--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -26,8 +26,9 @@ Number of segments to merge to. To fully merge the index, set to `1`.
 `index_codec`::
 (Optional, string)
 Codec used to compress the document store. The only accepted value is
-`best_compression`. To use the default LZ4 compression codec, omit this
-argument.
+`best_compression`, which uses {wikipedia}/DEFLATE[DEFLATE] for a higher
+compression ratio but slower stored fields performance. To use the default LZ4
+codec, omit this argument.
 +
 WARNING: If using `best_compression`, {ilm-init} will <<indices-close,close>>
 and then <<indices-open-close,re-open>> the index prior to the force merge.

--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -23,16 +23,15 @@ shards are relocating, in which case they will not be merged.
 (Required, integer) 
 Number of segments to merge to. To fully merge the index, set to `1`.
 
-`codec`::
-(Optional, string)   
-Use the `best_compression` codec. Valid values: `best_compression`.
+`index_codec`::
+(Optional, string)
+Codec used to compress the document store. The only accepted value is
+`best_compression`. To use the default LZ4 compression codec, omit this
+argument.
 +
-[WARNING]
-======
-Setting `"codec": "best_compression"` in the {ilm-init} forcemerge action causes {ilm-int} to
-<<indices-close,close>> and then <<indices-open-close,re-open>> the index prior to the force merge.
-During this time, the index is unavailable for both read and write operations.
-======
+WARNING: If using `best_compression`, {ilm-init} will <<indices-close,close>>
+and then <<indices-open-close,re-open>> the index prior to the force merge.
+While closed, the index will be unavailable for read or write operations.
 
 [[ilm-forcemerge-action-ex]]
 ==== Example


### PR DESCRIPTION
Fixes the `index_codec` parameter name. Also updates the definition and admon for clarity.

Relates to #57034

### Preview
https://elasticsearch_62243.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-forcemerge.html#ilm-forcemerge-options