### PR TITLE
Take into account sas tokens while metering put object requests on azure. 7.x

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -119,11 +119,7 @@ public class AzureBlobStore implements BlobStore {
         };
         this.uploadMetricsCollector = (httpURLConnection -> {
            assert httpURLConnection.getRequestMethod().equals("PUT");
-            String queryParams = httpURLConnection.getURL().getQuery();
-            if (queryParams == null) {
-                stats.putOperations.incrementAndGet();
-                return;
-            }
+            String queryParams = httpURLConnection.getURL().getQuery() == null ? "" : httpURLConnection.getURL().getQuery();
 
             // https://docs.microsoft.com/en-us/rest/api/storageservices/put-block
             // https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list
@@ -131,6 +127,11 @@ public class AzureBlobStore implements BlobStore {
                 stats.putBlockOperations.incrementAndGet();
             } else if (queryParams.contains("comp=blocklist")) {
                 stats.putBlockListOperations.incrementAndGet();
+            } else {
+                // https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob#uri-parameters
+                // The only URI parameter allowed for put-blob operation is "timeout", but if a sas token is used,
+                // it's possible that the URI parameters contain additional parameters unrelated to the upload type.
+                stats.putOperations.incrementAndGet();
             }
         });
     }


### PR DESCRIPTION
Backport of #62225
Closes #62208
