### PR TITLE
Add "content" tier as new "data_content" role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -19,16 +19,17 @@ import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDeci
 import java.util.Set;
 
 /**
- * The {@code DataTier} class encapsulates the formalization of the "hot",
- * "warm", "cold", and "frozen" tiers as node roles. In contains the roles
- * themselves as well as helpers for validation and determining if a node has
- * a tier configured.
+ * The {@code DataTier} class encapsulates the formalization of the "content",
+ * "hot", "warm", "cold", and "frozen" tiers as node roles. In contains the
+ * roles themselves as well as helpers for validation and determining if a node
+ * has a tier configured.
  *
  * Related:
  * {@link org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider}
  */
 public class DataTier {
 
+    public static final String DATA_CONTENT = "data_content";
     public static final String DATA_HOT = "data_hot";
     public static final String DATA_WARM = "data_warm";
     public static final String DATA_COLD = "data_cold";
@@ -38,7 +39,8 @@ public class DataTier {
      * Returns true if the given tier name is a valid tier
      */
     public static boolean validTierName(String tierName) {
-        return DATA_HOT.equals(tierName) ||
+        return DATA_CONTENT.equals(tierName) ||
+            DATA_HOT.equals(tierName) ||
             DATA_WARM.equals(tierName) ||
             DATA_COLD.equals(tierName) ||
             DATA_FROZEN.equals(tierName);
@@ -60,6 +62,23 @@ public class DataTier {
         }
         return false;
     }
+
+    public static DiscoveryNodeRole DATA_CONTENT_NODE_ROLE = new DiscoveryNodeRole("data_content", "s") {
+        @Override
+        public boolean isEnabledByDefault(final Settings settings) {
+            return false;
+        }
+
+        @Override
+        public Setting<Boolean> legacySetting() {
+            return null;
+        }
+
+        @Override
+        public boolean canContainData() {
+            return true;
+        }
+    };
 
     public static DiscoveryNodeRole DATA_HOT_NODE_ROLE = new DiscoveryNodeRole("data_hot", "h") {
         @Override
@@ -128,6 +147,10 @@ public class DataTier {
             return true;
         }
     };
+
+    public static boolean isContentNode(DiscoveryNode discoveryNode) {
+        return discoveryNode.getRoles().contains(DATA_CONTENT_NODE_ROLE) || discoveryNode.getRoles().contains(DiscoveryNodeRole.DATA_ROLE);
+    }
 
     public static boolean isHotNode(DiscoveryNode discoveryNode) {
         return discoveryNode.getRoles().contains(DATA_HOT_NODE_ROLE) || discoveryNode.getRoles().contains(DiscoveryNodeRole.DATA_ROLE);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -379,6 +379,7 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
     @Override
     public Set<DiscoveryNodeRole> getRoles() {
         return new HashSet<>(Arrays.asList(
+            DataTier.DATA_CONTENT_NODE_ROLE,
             DataTier.DATA_HOT_NODE_ROLE,
             DataTier.DATA_WARM_NODE_ROLE,
             DataTier.DATA_COLD_NODE_ROLE,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTierTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTierTests.java
@@ -40,6 +40,13 @@ public class DataTierTests extends ESTestCase {
                 .map(DiscoveryNode::getId)
                 .toArray(String[]::new);
 
+        final String[] contentNodes =
+            StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
+                .map(n -> n.value)
+                .filter(DataTier::isContentNode)
+                .map(DiscoveryNode::getId)
+                .toArray(String[]::new);
+
         final String[] hotNodes =
             StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
                 .map(n -> n.value)
@@ -69,11 +76,13 @@ public class DataTierTests extends ESTestCase {
                 .toArray(String[]::new);
 
         assertThat(discoveryNodes.resolveNodes("data:true"), arrayContainingInAnyOrder(dataNodes));
+        assertThat(discoveryNodes.resolveNodes("data_content:true"), arrayContainingInAnyOrder(contentNodes));
         assertThat(discoveryNodes.resolveNodes("data_hot:true"), arrayContainingInAnyOrder(hotNodes));
         assertThat(discoveryNodes.resolveNodes("data_warm:true"), arrayContainingInAnyOrder(warmNodes));
         assertThat(discoveryNodes.resolveNodes("data_cold:true"), arrayContainingInAnyOrder(coldNodes));
         assertThat(discoveryNodes.resolveNodes("data_frozen:true"), arrayContainingInAnyOrder(frozenNodes));
-        Set<String> allTiers = new HashSet<>(Arrays.asList(hotNodes));
+        Set<String> allTiers = new HashSet<>(Arrays.asList(contentNodes));
+        allTiers.addAll(Arrays.asList(hotNodes));
         allTiers.addAll(Arrays.asList(warmNodes));
         allTiers.addAll(Arrays.asList(coldNodes));
         allTiers.addAll(Arrays.asList(frozenNodes));
@@ -100,6 +109,7 @@ public class DataTierTests extends ESTestCase {
     private static List<DiscoveryNode> randomNodes(final int numNodes) {
         Set<DiscoveryNodeRole> allRoles = new HashSet<>(DiscoveryNodeRole.BUILT_IN_ROLES);
         allRoles.remove(DiscoveryNodeRole.DATA_ROLE);
+        allRoles.add(DataTier.DATA_CONTENT_NODE_ROLE);
         allRoles.add(DataTier.DATA_HOT_NODE_ROLE);
         allRoles.add(DataTier.DATA_WARM_NODE_ROLE);
         allRoles.add(DataTier.DATA_COLD_NODE_ROLE);


### PR DESCRIPTION
Similar to the work in #60994 where we introduced the `data_hot`, `data_warm`, etc node roles. This
introduces a new `data_content` node role to be used for the Content tier.

Currently this tier is not used anywhere, but subsequent work will use this tier.

Relates to #60848
