### PR TITLE
[DOCS] Document `toJSON` function for role query

### DIFF
--- a/x-pack/docs/en/security/authorization/role-templates.asciidoc
+++ b/x-pack/docs/en/security/authorization/role-templates.asciidoc
@@ -67,3 +67,26 @@ POST /_security/role/example2
   ]
 }
 --------------------------------------------------
+
+If your metadata field contains an object or array, you can access it using the
+`{{#toJson}}parameter{{/toJson}}` function.
+
+[source,console]
+----
+POST /_security/role/example3
+{
+  "indices" : [
+    {
+      "names" : [ "my-index-000001" ],
+      "privileges" : [ "read" ],
+      "query" : {
+        "template" : {
+          "source" : {
+            "terms" : { "group.statuses" : "{{#toJson}}_user.metadata.statuses{{/toJson}}" }
+          }
+        }
+      }
+    }
+  ]
+}
+----


### PR DESCRIPTION
Adds an example for the `toJSON` mustache function to the role query docs.

Closes #61669

### Preview
https://elasticsearch_62257.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query