### PR TITLE
Wraps timestamp value in quotes in runtime_fields/40_date YAML test.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -146,7 +146,7 @@ setup:
   - match: {hits.total.value: 6}
   - match: {aggregations.v10.buckets.0.key_as_string: "2018-01-19T17:41:34.000Z"}
   - match: {aggregations.v10.buckets.0.doc_count: 1}
-  - match: {aggregations.v10.buckets.1.key_as_string: 2018-01-20T17:41:34.000Z}
+  - match: {aggregations.v10.buckets.1.key_as_string: "2018-01-20T17:41:34.000Z"}
   - match: {aggregations.v10.buckets.1.doc_count: 1}
 
 ---


### PR DESCRIPTION
I missed one value in #62153.

I also updated the backport to `7.x` to include this change: #62155 