### PR TITLE
Save Some Allocations when Working with ClusterState (#62060)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
@@ -31,17 +31,24 @@ import java.io.IOException;
  */
 public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffable<T> {
 
+    private static final Diff<?> EMPTY = new CompleteDiff<>();
+
+    @SuppressWarnings("unchecked")
     @Override
     public Diff<T> diff(T previousState) {
-        if (this.get().equals(previousState)) {
-            return new CompleteDiff<>();
+        if (this.equals(previousState)) {
+            return (Diff<T>) EMPTY;
         } else {
-            return new CompleteDiff<>(get());
+            return new CompleteDiff<>((T) this);
         }
     }
 
+    @SuppressWarnings("unchecked")
     public static <T extends Diffable<T>> Diff<T> readDiffFrom(Reader<T> reader, StreamInput in) throws IOException {
-        return new CompleteDiff<T>(reader, in);
+        if (in.readBoolean()) {
+            return new CompleteDiff<>(reader.read(in));
+        }
+        return (Diff<T>) EMPTY;
     }
 
     private static class CompleteDiff<T extends Diffable<T>> implements Diff<T> {
@@ -63,17 +70,6 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
             this.part = null;
         }
 
-        /**
-         * Read simple diff from the stream
-         */
-        CompleteDiff(Reader<T> reader, StreamInput in) throws IOException {
-            if (in.readBoolean()) {
-                this.part = reader.read(in);
-            } else {
-                this.part = null;
-            }
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             if (part != null) {
@@ -92,11 +88,6 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
                 return part;
             }
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    public T get() {
-        return (T) this;
     }
 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -705,7 +705,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         builder.metadata = Metadata.readFrom(in);
         builder.routingTable = RoutingTable.readFrom(in);
         builder.nodes = DiscoveryNodes.readFrom(in, localNode);
-        builder.blocks = new ClusterBlocks(in);
+        builder.blocks = ClusterBlocks.readFrom(in);
         int customSize = in.readVInt();
         for (int i = 0; i < customSize; i++) {
             Custom customIndexMetadata = in.readNamedWriteable(Custom.class);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -43,13 +43,14 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
     private final Map<String, String> innerMap;
 
-    DiffableStringMap(final Map<String, String> map) {
-        this.innerMap = Collections.unmodifiableMap(map);
+    @SuppressWarnings("unchecked")
+    public static DiffableStringMap readFrom(StreamInput in) throws IOException {
+        final Map<String, String> map = (Map) in.readMap();
+        return map.isEmpty() ? EMPTY : new DiffableStringMap(map);
     }
 
-    @SuppressWarnings("unchecked")
-    DiffableStringMap(final StreamInput in) throws IOException {
-        this((Map<String, String>) (Map) in.readMap());
+    DiffableStringMap(final Map<String, String> map) {
+        this.innerMap = Collections.unmodifiableMap(map);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -921,6 +921,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             customs = DiffableUtils.diff(before.customs, after.customs, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
         }
 
+        private static final DiffableUtils.DiffableValueReader<String, IndexMetadata> INDEX_METADATA_DIFF_VALUE_READER =
+                new DiffableUtils.DiffableValueReader<>(IndexMetadata::readFrom, IndexMetadata::readDiffFrom);
+        private static final DiffableUtils.DiffableValueReader<String, IndexTemplateMetadata> TEMPLATES_DIFF_VALUE_READER =
+                new DiffableUtils.DiffableValueReader<>(IndexTemplateMetadata::readFrom, IndexTemplateMetadata::readDiffFrom);
+
         MetadataDiff(StreamInput in) throws IOException {
             clusterUUID = in.readString();
             if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
@@ -939,10 +944,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             } else {
                 hashesOfConsistentSettings = DiffableStringMap.DiffableStringMapDiff.EMPTY;
             }
-            indices = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), IndexMetadata::readFrom,
-                IndexMetadata::readDiffFrom);
-            templates = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), IndexTemplateMetadata::readFrom,
-                IndexTemplateMetadata::readDiffFrom);
+            indices = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), INDEX_METADATA_DIFF_VALUE_READER);
+            templates = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), TEMPLATES_DIFF_VALUE_READER);
             customs = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
         }
 
@@ -996,7 +999,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         builder.transientSettings(readSettingsFromStream(in));
         builder.persistentSettings(readSettingsFromStream(in));
         if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
-            builder.hashesOfConsistentSettings(new DiffableStringMap(in));
+            builder.hashesOfConsistentSettings(DiffableStringMap.readFrom(in));
         }
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -365,10 +365,12 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             indicesRouting = DiffableUtils.diff(before.indicesRouting, after.indicesRouting, DiffableUtils.getStringKeySerializer());
         }
 
+        private static final DiffableUtils.DiffableValueReader<String, IndexRoutingTable> DIFF_VALUE_READER =
+                new DiffableUtils.DiffableValueReader<>(IndexRoutingTable::readFrom, IndexRoutingTable::readDiffFrom);
+
         RoutingTableDiff(StreamInput in) throws IOException {
             version = in.readLong();
-            indicesRouting = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), IndexRoutingTable::readFrom,
-                IndexRoutingTable::readDiffFrom);
+            indicesRouting = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), DIFF_VALUE_READER);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DiffableStringMapTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DiffableStringMapTests.java
@@ -97,7 +97,7 @@ public class DiffableStringMapTests extends ESTestCase {
 
         BytesStreamOutput bso = new BytesStreamOutput();
         dsm.writeTo(bso);
-        DiffableStringMap deserialized = new DiffableStringMap(bso.bytes().streamInput());
+        DiffableStringMap deserialized = DiffableStringMap.readFrom(bso.bytes().streamInput());
         assertThat(deserialized, equalTo(dsm));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -113,7 +113,8 @@ public class DiffableTests extends ESTestCase {
             @Override
             protected MapDiff readDiff(StreamInput in) throws IOException {
                 return useProtoForDiffableSerialization
-                        ? DiffableUtils.readImmutableOpenMapDiff(in, keySerializer, TestDiffable::readFrom, TestDiffable::readDiffFrom)
+                        ? DiffableUtils.readImmutableOpenMapDiff(in, keySerializer,
+                        new DiffableUtils.DiffableValueReader<>(TestDiffable::readFrom, TestDiffable::readDiffFrom))
                         : DiffableUtils.readImmutableOpenMapDiff(in, keySerializer, diffableValueSerializer());
             }
         }.execute();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2872,7 +2872,7 @@ public class IndexShardTests extends IndexShardTestCase {
         }
 
         assertThat(requestedMappingUpdates, hasKey("_doc"));
-        assertThat(requestedMappingUpdates.get("_doc").get().source().string(),
+        assertThat(requestedMappingUpdates.get("_doc").source().string(),
             equalTo("{\"properties\":{\"foo\":{\"type\":\"text\"}}}"));
 
         closeShards(sourceShard, targetShard);

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -181,7 +181,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
             .map(policyConfig -> policyConfig.load(xContentRegistry))
             .collect(Collectors.toList());
         assertThat(policies, hasSize(2));
-        policies.forEach(p -> policyMap.put(p.getName(), p.get()));
+        policies.forEach(p -> policyMap.put(p.getName(), p));
 
         client.setVerifier((action, request, listener) -> {
             if (action instanceof PutComponentTemplateAction) {
@@ -210,7 +210,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
             .map(policyConfig -> policyConfig.load(xContentRegistry))
             .collect(Collectors.toList());
         assertThat(policies, hasSize(2));
-        policies.forEach(p -> policyMap.put(p.getName(), p.get()));
+        policies.forEach(p -> policyMap.put(p.getName(), p));
 
         client.setVerifier((action, request, listener) -> {
             if (action instanceof PutComponentTemplateAction) {


### PR DESCRIPTION
Just a number of obvious spots where we were allocating
duplicate empty structures or otherwise inefficient that I
found while investigating snapshot cluster state update performance.

backport of #62060 