### PR TITLE
Initialise BitArray storage as number of bits

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BitArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BitArray.java
@@ -34,11 +34,11 @@ public final class BitArray implements Releasable {
 
     /**
      * Create the {@linkplain BitArray}.
-     * @param initialSize the initial size of underlying storage.
+     * @param initialSize the initial size of underlying storage expressed in bits.
      */
     public BitArray(long initialSize, BigArrays bigArrays) {
         this.bigArrays = bigArrays;
-        this.bits = bigArrays.newLongArray(initialSize, true);
+        this.bits = bigArrays.newLongArray(wordNum(initialSize) + 1, true);
     }
 
     /**


### PR DESCRIPTION
Currently the initial size for BitArray is treated as number of longs in the underlying storage but looking into how it is used, it is assumed to be the number of bits, so in some case there might be some misuse of heap space.

This PR just change the way we initialise the storage space for BitArray to consider it as number of bits.
