### PR TITLE
[7.9] [ML] Add an assertion on annotations mappings to upgrade test

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -51,6 +51,7 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
                 break;
             case UPGRADED:
                 assertUpgradedResultsMappings();
+                assertUpgradedAnnotationsMappings();
                 closeAndReopenTestJob();
                 assertUpgradedConfigMappings();
                 break;
@@ -121,6 +122,37 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
             // to the most recent field we've added that is NOT of type "keyword"
             assertEquals("Incorrect type for peak_model_bytes in " + responseLevel, "long",
                 extractValue("mappings.properties.model_size_stats.properties.peak_model_bytes.type", indexLevel));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertUpgradedAnnotationsMappings() throws Exception {
+
+        assertBusy(() -> {
+            Request getMappings = new Request("GET", ".ml-annotations-write/_mappings");
+            Response response = client().performRequest(getMappings);
+
+            Map<String, Object> responseLevel = entityAsMap(response);
+            assertNotNull(responseLevel);
+            Map<String, Object> indexLevel = null;
+            // The name of the concrete index underlying the annotations index write alias may or may not have been
+            // changed by the upgrade process (depending on what other tests are being run and the order they're run
+            // in), so navigating to the next level of the tree must account for both cases
+            for (Map.Entry<String, Object> entry : responseLevel.entrySet()) {
+                if (entry.getKey().startsWith(".ml-annotations-")) {
+                    indexLevel = (Map<String, Object>) entry.getValue();
+                    break;
+                }
+            }
+            assertNotNull(indexLevel);
+
+            assertEquals(Version.CURRENT.toString(), extractValue("mappings._meta.version", indexLevel));
+
+            // TODO: as the years go by, the field we assert on here should be changed
+            // to the most recent field we've added that would be incorrectly mapped by dynamic
+            // mappings, for example a field we want to be "keyword" incorrectly mapped as "text"
+            assertEquals("Incorrect type for event in " + responseLevel, "keyword",
+                extractValue("mappings.properties.event.type", indexLevel));
         });
     }
 


### PR DESCRIPTION
The annotations index is not covered by the comparison between
mappings and templates, as it does not use an index template.

This commit adds an assertion on annotations index mappings
that will fail if the mappings are not upgraded as expected.

Backport of #62325