### PR TITLE
Update the prereq for minimum privilege required

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -17,7 +17,7 @@ Creates an API key for access without requiring basic authentication.
 [[security-api-create-api-key-prereqs]]
 ==== {api-prereq-title}
 
-* To use this API, you must have at least the `manage_api_key` cluster privilege.
+* To use this API, you must have at least the `manage_own_api_key` cluster privilege.
 
 [[security-api-create-api-key-desc]]
 ==== {api-description-title}


### PR DESCRIPTION
The `manage_api_key` privilege allows viewing / invalidating the keys for other users, but `manage_own_api_key` doesn't and still allows you to create a key for yourself.