### PR TITLE
Fix logstash plugin unit test error

### DIFF
--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequestTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequestTests.java
@@ -28,10 +28,11 @@ public class GetPipelineRequestTests extends AbstractWireSerializingTestCase<Get
     @Override
     protected GetPipelineRequest mutateInstance(GetPipelineRequest instance) {
         List<String> ids = new ArrayList<>(instance.ids());
-        if (randomBoolean()) {
+        if (randomBoolean() || ids.size() == 0) {
             // append another ID
             ids.add(randomAlphaOfLengthBetween(2, 10));
         } else {
+            // change the strings in the request
             ids = ids.stream().map(id -> id + randomAlphaOfLength(1)).collect(Collectors.toList());
         }
         return new GetPipelineRequest(ids);


### PR DESCRIPTION
The `GetPipelineRequest` class wraps a list of string IDs. For a unit test, I wrote a `mutateInstance` method that randomly either adds a new ID to the list in the request or mutates the strings in the request. However, I failed to account for the case where the request has zero IDs in the list. If there are zero IDs in the list, there are no IDs to mutate. This commit makes sure that if there are no IDs in the list, we always add an ID rather than trying to mutate an existing ID.

Closes #62343 