### PR TITLE
Unmute BasicLicenseUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/62299")
     public void testOldAndMixedClusterHaveActiveBasic() throws Exception {
         assumeTrue("only runs against old or mixed cluster", clusterType == CLUSTER_TYPE.OLD || clusterType == CLUSTER_TYPE.MIXED);
         assertBusy(this::checkBasicLicense);


### PR DESCRIPTION
Failure was temporary, caused by an unmerged BWC PR

Relates: #62301, #62286
Resolves: #62299
