### PR TITLE
Fix testMappingVersionAfterDynamicMappingUpdate

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -160,11 +160,11 @@ public class DynamicMappingIT extends ESIntegTestCase {
         }
     }
 
-    public void testMappingVersionAfterDynamicMappingUpdate() {
+    public void testMappingVersionAfterDynamicMappingUpdate() throws Exception {
         createIndex("test");
         final ClusterService clusterService = internalCluster().clusterService();
         final long previousVersion = clusterService.state().metadata().index("test").getMappingVersion();
         client().prepareIndex("test").setId("1").setSource("field", "text").get();
-        assertThat(clusterService.state().metadata().index("test").getMappingVersion(), equalTo(1 + previousVersion));
+        assertBusy(() -> assertThat(clusterService.state().metadata().index("test").getMappingVersion(), equalTo(1 + previousVersion)));
     }
 }


### PR DESCRIPTION
There is a race in this test where the index request will return
once the dynamic mapping update has been observed by the cluster
state observer internally used by the indexing but not hit all
state appliers and thus isn't showing up as the applied state returned
by `clusterService.state()` yet.
