### PR TITLE
Wait for relocations and disk threshold monitor in DiskThresholdDeciderIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -150,17 +150,13 @@ public class DiskThresholdDeciderIT extends ESIntegTestCase {
         // reduce disk size of node 0 so that no shards fit below the high watermark, forcing all shards onto the other data node
         // (subtract the translog size since the disk threshold decider ignores this and may therefore move the shard back again)
         fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES - 1L);
-        assertBusy(() -> {
-            refreshDiskUsage();
-            assertThat(getShardRoutings(dataNode0Id), empty());
-        });
+        refreshDiskUsage();
+        assertBusy(() -> assertThat(getShardRoutings(dataNode0Id), empty()));
 
         // increase disk size of node 0 to allow just enough room for one shard, and check that it's rebalanced back
         fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 1L);
-        assertBusy(() -> {
-            refreshDiskUsage();
-            assertThat(getShardRoutings(dataNode0Id), hasSize(1));
-        });
+        refreshDiskUsage();
+        assertBusy(() -> assertThat(getShardRoutings(dataNode0Id), hasSize(1)));
     }
 
     private Set<ShardRouting> getShardRoutings(String nodeId) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -25,7 +25,6 @@ import org.apache.lucene.mockfile.FilterPath;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -129,7 +128,7 @@ public class DiskThresholdDeciderIT extends ESIntegTestCase {
         return List.of(InternalSettingsPlugin.class);
     }
 
-    public void testHighWatermarkNotExceeded() throws InterruptedException {
+    public void testHighWatermarkNotExceeded() throws Exception {
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();
@@ -151,13 +150,17 @@ public class DiskThresholdDeciderIT extends ESIntegTestCase {
         // reduce disk size of node 0 so that no shards fit below the high watermark, forcing all shards onto the other data node
         // (subtract the translog size since the disk threshold decider ignores this and may therefore move the shard back again)
         fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES - 1L);
-        refreshDiskUsage();
-        assertThat(getShardRoutings(dataNode0Id), empty());
+        assertBusy(() -> {
+            refreshDiskUsage();
+            assertThat(getShardRoutings(dataNode0Id), empty());
+        });
 
         // increase disk size of node 0 to allow just enough room for one shard, and check that it's rebalanced back
         fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 1L);
-        refreshDiskUsage();
-        assertThat(getShardRoutings(dataNode0Id), hasSize(1));
+        assertBusy(() -> {
+            refreshDiskUsage();
+            assertThat(getShardRoutings(dataNode0Id), hasSize(1));
+        });
     }
 
     private Set<ShardRouting> getShardRoutings(String nodeId) {
@@ -202,11 +205,11 @@ public class DiskThresholdDeciderIT extends ESIntegTestCase {
     }
 
     private void refreshDiskUsage() {
-        ((InternalClusterInfoService) internalCluster().getMasterNodeInstance(ClusterInfoService.class)).refresh();
+        final ClusterInfoService clusterInfoService = internalCluster().getMasterNodeInstance(ClusterInfoService.class);
+        ((InternalClusterInfoService) clusterInfoService).refresh();
         // if the nodes were all under the low watermark already (but unbalanced) then a change in the disk usage doesn't trigger a reroute
         // even though it's now possible to achieve better balance, so we have to do an explicit reroute. TODO fix this?
-        final ClusterInfo clusterInfo = internalCluster().getMasterNodeInstance(ClusterInfoService.class).getClusterInfo();
-        if (StreamSupport.stream(clusterInfo.getNodeMostAvailableDiskUsages().values().spliterator(), false)
+        if (StreamSupport.stream(clusterInfoService.getClusterInfo().getNodeMostAvailableDiskUsages().values().spliterator(), false)
             .allMatch(cur -> cur.value.getFreeBytes() > WATERMARK_BYTES)) {
             assertAcked(client().admin().cluster().prepareReroute());
         }


### PR DESCRIPTION
Sadly I did not manage to reproduce #62326  on any of the computers I have, but the following log lines of the last CI failure makes me think that it is possible that the DiskThresholdMonitor is being processing a `reroute` (`checkInProgress` is `true`) after the last cluster update that detected that the disk has enough free space again to hold shard:

```
1> [2020-09-14T10:52:38,949][INFO ][o.e.c.r.a.d.DiskThresholdDeciderIT] [testHighWatermarkNotExceeded] Index [5067] docs async: [false] bulk: [true] partitions [6]
  1> [2020-09-14T10:52:42,460][INFO ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] skipping monitor as a check is already in progress
  1> [2020-09-14T10:52:42,462][INFO ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] high disk watermark [10kb] exceeded on [zlTDZ1KWRIOAD_Xs6J1-gA][node_t2][/dev/shm/elastic+elasticsearch+master+multijob+fast+part1/server/build/testrun/internalClusterTest/temp/org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT_60A6AF6A936EF834-001/tempDir-003/node-2] free: 0b[0%], shards will be relocated away from this node; currently relocating away shards totalling [75577] bytes; the node is expected to be below the high disk watermark when these relocations are complete
  1> [2020-09-14T10:52:42,710][INFO ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] skipping monitor as a check is already in progress
  1> [2020-09-14T10:52:42,906][INFO ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] skipping monitor as a check is already in progress
  1> [2020-09-14T10:52:43,071][WARN ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] high disk watermark [10kb] exceeded on [zlTDZ1KWRIOAD_Xs6J1-gA][node_t2][/dev/shm/elastic+elasticsearch+master+multijob+fast+part1/server/build/testrun/internalClusterTest/temp/org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT_60A6AF6A936EF834-001/tempDir-003/node-2] free: 7.1kb[8.7%], shards will be relocated away from this node; currently relocating away shards totalling [0] bytes; the node is expected to continue to exceed the high disk watermark when these relocations are complete
  1> [2020-09-14T10:52:43,096][WARN ][o.e.c.r.a.DiskThresholdMonitor] [node_t0] high disk watermark [10kb] exceeded on [zlTDZ1KWRIOAD_Xs6J1-gA][node_t2][/dev/shm/elastic+elasticsearch+master+multijob+fast+part1/server/build/testrun/internalClusterTest/temp/org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT_60A6AF6A936EF834-001/tempDir-003/node-2] free: 7.1kb[8.7%], shards will be relocated away from this node; currently relocating away shards totalling [0] bytes; the node is expected to continue to exceed the high disk watermark when these relocations are complete
  1> [2020-09-14T10:52:43,098][INFO ][o.e.c.r.a.d.DiskThresholdDeciderIT] [testHighWatermarkNotExceeded] [DiskThresholdDeciderIT#testHighWatermarkNotExceeded]: cleaning up after test
```

This pull request introduces some assertBusy() so that it gives a bit more time for the shards and the DiskThreshMonitor's reroute to be processed.

Closes #62326