### PR TITLE
Re-enable resolve index multi cluster test

### DIFF
--- a/x-pack/qa/multi-cluster-search-security/src/test/java/org/elasticsearch/xpack/security/MultiClusterSearchWithSecurityYamlTestSuiteIT.java
+++ b/x-pack/qa/multi-cluster-search-security/src/test/java/org/elasticsearch/xpack/security/MultiClusterSearchWithSecurityYamlTestSuiteIT.java
@@ -26,6 +26,11 @@ public class MultiClusterSearchWithSecurityYamlTestSuiteIT extends ESClientYamlS
         return true;
     }
 
+    @Override
+    protected boolean preserveDataStreamsUponCompletion() {
+        return true;
+    }
+
     public MultiClusterSearchWithSecurityYamlTestSuiteIT(
             @Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/100_resolve_index.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/100_resolve_index.yml
@@ -1,8 +1,8 @@
 ---
 "Resolve index with indices, aliases, and data streams":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/62210"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.resolve_index:


### PR DESCRIPTION
This test was fine and shouldn't have been muted.
The test case class should have preserved data streams as part of #62205

Closes #62210