### PR TITLE
[DOCS] Removes init_script line from example Painless aggregation

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -433,7 +433,6 @@ POST _transform/_preview
     "aggregations" : {
       "compare" : { <4>
         "scripted_metric" : {
-          "init_script" : "",
           "map_script" : "state.doc = new HashMap(params['_source'])", <5>
           "combine_script" : "return state", <6>
           "reduce_script" : """ <7>


### PR DESCRIPTION
## Overview

This PR removes the`init_script` line with empty value from the `Comparing indices by using scripted metric aggregations` Painless transform example as it causes an error ("Cannot generate an empty script.").

### Preview

[Comparing indices by using scripted metric aggregations](https://elasticsearch_62367.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-painless-examples.html#painless-compare)