### PR TITLE
[7.9] [DOCS] Removes init_script line from example Painless aggregation. (#62367)

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -433,7 +433,6 @@ POST _transform/_preview
     "aggregations" : {
       "compare" : { <4>
         "scripted_metric" : {
-          "init_script" : "",
           "map_script" : "state.doc = new HashMap(params['_source'])", <5>
           "combine_script" : "return state", <6>
           "reduce_script" : """ <7>


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Removes init_script line from example Painless aggregation. (#62367)