### PR TITLE
SQL: Do not resolve self-referencing aliases

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -867,7 +867,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
                     // don't replace field with their own aliases (it creates infinite cycles)
-                    if (u != alias.child() &&
+                    if (alias.anyMatch(e -> e == u) == false &&
                            (qualified ?
                                Objects.equals(alias.qualifiedName(), u.qualifiedName()) :
                                Objects.equals(alias.name(), u.name()))) {


### PR DESCRIPTION
Prevent the analyzer for trying to resolve aliases on expressions that
reference themselves (or fields within themselves) as that causes
infinite recursion.

Fix #62296