### PR TITLE
[DOCS] Make it more obvious that the Java API is deprecated.

### DIFF
--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -1,4 +1,4 @@
-= Java API
+= Java API (deprecated)
 
 include::{elasticsearch-root}/docs/Versions.asciidoc[]
 


### PR DESCRIPTION
While there is a deprecation notice in the preface, it's not obvious from the top level that the Java API/transport client is deprecation. This adds "(deprecated)" to the title.

https://github.com/elastic/docs/pull/1956 updates the title on the doc landing page and moves the book to the bottom of the clients list. 

FYI @dadoonet 