### PR TITLE
[7.x] [DOCS] Remove redundant index.blocks.read_only_allow_delete setting (#62392)

### DIFF
--- a/docs/reference/index-modules/blocks.asciidoc
+++ b/docs/reference/index-modules/blocks.asciidoc
@@ -47,26 +47,6 @@ IMPORTANT: {es} adds and removes the read-only index block automatically when th
 
     Set to `true` to disable index metadata reads and writes.
 
-`index.blocks.read_only_allow_delete`::
-
-    Similar to `index.blocks.read_only`, but also allows deleting the index to
-    make more resources available. The <<disk-based-shard-allocation,disk-based shard
-    allocator>> adds and removes this block automatically.
-
-Deleting documents from an index - rather than deleting the index itself - can
-in fact increase the index size. When you are running out of disk space
-`index.blocks.read_only_allow_delete` is set to `true`, preventing you from
-consuming more disk space by deleting some documents. However, this block does
-permit you to delete the index itself since this does not require any extra
-disk space. When you delete an index the data is removed from disk almost
-immediately, freeing the space it consumes.
-
-IMPORTANT: {es} adds the read-only-allow-delete index block automatically when
-disk utilisation exceeds the <<cluster-routing-flood-stage,flood-stage
-watermark>> and removes it again when disk utilisation is below the
-<<cluster-routing-watermark-high,high watermark>>. You should not apply this
-block yourself.
-
 [discrete]
 [[add-index-block]]
 === Add index block API


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove redundant index.blocks.read_only_allow_delete setting (#62392)