### PR TITLE
Doc: Clarify top level meta element for source only repo restores

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -240,8 +240,28 @@ When you restore a source only snapshot:
 
  * Queries other than `match_all` and `_get` requests are not supported.
 
- * The mapping of the restored index is empty, but the original mapping is available from the types top
-   level `meta` element.
+ * The mapping of the restored index is empty, but the original mapping is available from the top
+   level `_meta` element.
+   
+[source,console-result]
+--------------------------------------------------
+{
+  "restored_index" : {
+    "mappings" : {
+      "enabled" : false,
+      "_meta" : {
+        "_doc" : {
+          "properties" : {
+            "field" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
 
 ==================================================
 


### PR DESCRIPTION
>The original mapping is available from the types top level meta element

This question comes up from time to time.  Users don't always know what this means above.
https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshots-register-repository.html#snapshots-source-only-repository

This PR clarifies the above statement by referencing `_meta` and providing a sample GET mapping of the restored index from a source only repo.  Also removed the mention of "types" to be consistent with the types deprecation/removal.

Please also back-port this doc change to 7.5-7.x branches.
