### PR TITLE
Add host.ip and observer.ip fields to the synthetics-*-* mappings

### DIFF
--- a/x-pack/plugin/core/src/main/resources/synthetics-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/synthetics-mappings.json
@@ -38,6 +38,20 @@
               "type": "keyword"
             }
           }
+        },
+        "host": {
+          "properties": {
+            "ip": {
+              "type": "ip"
+            }
+          }
+        },
+        "observer": {
+          "properties": {
+            "ip": {
+              "type": "ip"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
We need to ensure these are mapped as 'ip' instead of a keyword, even if they do end up not being
used.

Relates to #62193
