### PR TITLE
[DOCS] Minor typo in ML API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -30,8 +30,8 @@ built-in roles and privileges:
 For more information, see <<built-in-roles>>, <<security-privileges>>, and
 {ml-docs-setup-privileges}.
 
-NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
-the time of creation. When you start the job, it performs the analysis using
+NOTE: The {dfanalytics-job} remembers which roles the user who updated it had at
+the time of the update. When you start the job, it performs the analysis using
 those same roles. If you provide
 <<http-clients-secondary-authorization,secondary authorization headers>>, 
 those credentials are used instead.


### PR DESCRIPTION
This PR updates a minor typo in the update data frame analytics job API (https://www.elastic.co/guide/en/elasticsearch/reference/7.9/update-dfanalytics.html). In particular, it clarifies that the job remembers which roles the user who *updated* it had at that time. This change aligns with similar text in the update datafeed API (https://www.elastic.co/guide/en/elasticsearch/reference/7.9/ml-update-datafeed.html).

### Preview

https://elasticsearch_62414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html