### PR TITLE
[7.9] [DOCS] Add static/dynamic type to audit logging settings (#61235)

### DIFF
--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -4,20 +4,30 @@
 ++++
 <titleabbrev>Auditing settings</titleabbrev>
 ++++
+
 [[auditing-settings-description]]
-// tag::auditing-settings-description-tag[]
-You configure security auditing settings in the `elasticsearch.yml` configuration file
-on each node in the cluster. For more information, see <<enable-audit-logging>>.
-// end::auditing-settings-description-tag[]
+You can use <<enable-audit-logging,audit logging>> to record security-related
+events, such as authentication failures, refused connections, and data-access
+events.
+
+If configured, auditing settings must be set on every node in the cluster.
+Static settings, such as `xpack.security.audit.enabled`, must be configured in
+`elasticsearch.yml` on each node. For dynamic auditing settings, use the
+<<cluster-update-settings,cluster update settings API>> to ensure the setting is
+the same on all nodes.
 
 [[general-audit-settings]]
 ==== General Auditing Settings
 [[xpack-security-audit-enabled]]
 // tag::xpack-security-audit-enabled-tag[]
 `xpack.security.audit.enabled`::
-Set to `true` to enable auditing on the node. The default value is `false`.
-This puts the auditing events in a dedicated file named `<clustername>_audit.json`
-on each node.
+(<<static-cluster-setting,Static>>)
+Set to `true` to enable auditing on the node. The default value is `false`. This
+puts the auditing events in a dedicated file named `<clustername>_audit.json` on
+each node.
++
+If enabled, this setting must be configured in `elasticsearch.yml` on all nodes
+in the cluster.
 // end::xpack-security-audit-enabled-tag[]
 
 [[event-audit-settings]]
@@ -29,6 +39,7 @@ by using the following settings:
 [[xpack-sa-lf-events-include]]
 // tag::xpack-sa-lf-events-include-tag[]
 `xpack.security.audit.logfile.events.include`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies which events to include in the auditing output. The default value is:
 `access_denied, access_granted, anonymous_access_denied, authentication_failed,
 connection_denied, tampered_request, run_as_denied, run_as_granted`.
@@ -37,6 +48,7 @@ connection_denied, tampered_request, run_as_denied, run_as_granted`.
 [[xpack-sa-lf-events-exclude]]
 // tag::xpack-sa-lf-events-exclude-tag[]
 `xpack.security.audit.logfile.events.exclude`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Excludes the specified events from the output. By default, no events are
 excluded.
 // end::xpack-sa-lf-events-exclude-tag[]
@@ -44,6 +56,7 @@ excluded.
 [[xpack-sa-lf-events-emit-request]]
 // tag::xpack-sa-lf-events-emit-request-tag[]
 `xpack.security.audit.logfile.events.emit_request_body`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies whether to include the request body from REST requests on certain
 event types such as `authentication_failed`. The default value is `false`.
 +
@@ -60,6 +73,7 @@ audited in plain text when including the request body in audit events.
 [[xpack-sa-lf-emit-node-name]]
 // tag::xpack-sa-lf-emit-node-name-tag[]
 `xpack.security.audit.logfile.emit_node_name`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies whether to include the <<node.name,node name>> as a field in
 each audit event. The default value is `false`.
 // end::xpack-sa-lf-emit-node-name-tag[]
@@ -67,6 +81,7 @@ each audit event. The default value is `false`.
 [[xpack-sa-lf-emit-node-host-address]]
 // tag::xpack-sa-lf-emit-node-host-address-tag[]
 `xpack.security.audit.logfile.emit_node_host_address`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies whether to include the node's IP address as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-address-tag[]
@@ -74,6 +89,7 @@ The default value is `false`.
 [[xpack-sa-lf-emit-node-host-name]]
 // tag::xpack-sa-lf-emit-node-host-name-tag[]
 `xpack.security.audit.logfile.emit_node_host_name`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies whether to include the node's host name as a field in each audit event.
 The default value is `false`.
 // end::xpack-sa-lf-emit-node-host-name-tag[]
@@ -81,6 +97,7 @@ The default value is `false`.
 [[xpack-sa-lf-emit-node-id]]
 // tag::xpack-sa-lf-emit-node-id-tag[]
 `xpack.security.audit.logfile.emit_node_id`::
+(<<dynamic-cluster-setting,Dynamic>>)
 Specifies whether to include the node id as a field in each audit event.
 This is available for the new format only. That is to say, this information
 does not exist in the `<clustername>_access.log` file.
@@ -102,6 +119,7 @@ and not printed.
 [[xpack-sa-lf-events-ignore-users]]
 // tag::xpack-sa-lf-events-ignore-users-tag[]
 `xpack.security.audit.logfile.events.ignore_filters.<policy_name>.users`::
+(<<dynamic-cluster-setting,Dynamic>>)
 A list of user names or wildcards. The specified policy will
 not print audit events for users matching these values.
 // end::xpack-sa-lf-events-ignore-users-tag[]
@@ -109,6 +127,7 @@ not print audit events for users matching these values.
 [[xpack-sa-lf-events-ignore-realms]]
 // tag::xpack-sa-lf-events-ignore-realms-tag[]
 `xpack.security.audit.logfile.events.ignore_filters.<policy_name>.realms`::
+(<<dynamic-cluster-setting,Dynamic>>)
 A list of authentication realm names or wildcards. The specified policy will
 not print audit events for users in these realms.
 // end::xpack-sa-lf-events-ignore-realms-tag[]
@@ -116,6 +135,7 @@ not print audit events for users in these realms.
 [[xpack-sa-lf-events-ignore-roles]]
 // tag::xpack-sa-lf-events-ignore-roles-tag[]
 `xpack.security.audit.logfile.events.ignore_filters.<policy_name>.roles`::
+(<<dynamic-cluster-setting,Dynamic>>)
 A list of role names or wildcards. The specified policy will
 not print audit events for users that have these roles. If the user has several
 roles, some of which are *not* covered by the policy, the policy will
@@ -125,6 +145,7 @@ roles, some of which are *not* covered by the policy, the policy will
 [[xpack-sa-lf-events-ignore-indices]]
 // tag::xpack-sa-lf-events-ignore-indices-tag[]
 `xpack.security.audit.logfile.events.ignore_filters.<policy_name>.indices`::
+(<<dynamic-cluster-setting,Dynamic>>)
 A list of index names or wildcards. The specified policy will
 not print audit events when all the indices in the event match
 these values. If the event concerns several indices, some of which are


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Add static/dynamic type to audit logging settings (#61235)