### PR TITLE
LocalNodeMasterListener is a regular listener

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
@@ -36,9 +36,11 @@ public interface LocalNodeMasterListener extends ClusterStateListener {
 
     @Override
     default void clusterChanged(ClusterChangedEvent event) {
-        if (!event.previousState().nodes().isLocalNodeElectedMaster() && event.localNodeMaster()) {
+        final boolean wasMaster = event.previousState().nodes().isLocalNodeElectedMaster();
+        final boolean isMaster = event.localNodeMaster();
+        if (wasMaster == false && isMaster) {
             onMaster();
-        } else if (event.previousState().nodes().isLocalNodeElectedMaster() && !event.localNodeMaster()) {
+        } else if (wasMaster && isMaster == false) {
             offMaster();
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
@@ -22,7 +22,7 @@ package org.elasticsearch.cluster;
  * Enables listening to master changes events of the local node (when the local node becomes the master, and when the local
  * node cease being a master).
  */
-public interface LocalNodeMasterListener {
+public interface LocalNodeMasterListener extends ClusterStateListener {
 
     /**
      * Called when local node is elected to be the master
@@ -33,5 +33,14 @@ public interface LocalNodeMasterListener {
      * Called when the local node used to be the master, a new master was elected and it's no longer the local node.
      */
     void offMaster();
+
+    @Override
+    default void clusterChanged(ClusterChangedEvent event) {
+        if (!event.previousState().nodes().isLocalNodeElectedMaster() && event.localNodeMaster()) {
+            onMaster();
+        } else if (event.previousState().nodes().isLocalNodeElectedMaster() && !event.localNodeMaster()) {
+            offMaster();
+        }
+    }
 }
 


### PR DESCRIPTION
This commit makes the LocalNodeMasterListener interface extend the
ClusterStateListener interface and use a default implementation for
detecting whether the local node master status changed.