### PR TITLE
Fix docvalue fetch for scaled floats

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -544,5 +544,25 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
             }
         }
 
+        @Override
+        public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+            SortedNumericDoubleValues values = getDoubleValues();
+            return new DocValueFetcher.Leaf() {
+                @Override
+                public boolean advanceExact(int docId) throws IOException {
+                    return values.advanceExact(docId);
+                }
+
+                @Override
+                public int docValueCount() throws IOException {
+                    return values.docValueCount();
+                }
+
+                @Override
+                public Object nextValue() throws IOException {
+                    return format.format(values.nextValue());
+                }
+            };
+        }
     }
 }

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
@@ -122,3 +122,15 @@ setup:
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.0.sort.0: -2 }
+
+---
+"docvalue_fields":
+
+  - do:
+      search:
+        body:
+          docvalue_fields: [ "number" ]
+          sort:
+            number:
+              order: asc
+  - match: { hits.hits.0.fields.number: [-2.1] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -183,5 +183,8 @@ setup:
       search:
         body:
           docvalue_fields: [ "d" ]
-  - match: { hits.hits.0.fields.d: [3.140000104904175] }
+  # Doc values produce floating point errors.
+  # When this test is run during runtime-field's tests we *don't* get floating point errors. Thus the funny assertion here that matches both.
+  - lt: { hits.hits.0.fields.d.0: 3.141 }
+  - gte: { hits.hits.0.fields.d.0: 3.14 }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -14,7 +14,7 @@ setup:
       index:
         index:  test_1
         id:     1
-        body:   { "include": { "field1": "v1", "field2": "v2" }, "count": 1, "bigint": 72057594037927936 }
+        body:   { "include": { "field1": "v1", "field2": "v2" }, "count": 1, "bigint": 72057594037927936, d: 3.14 }
   - do:
       indices.refresh: {}
 
@@ -175,3 +175,13 @@ setup:
             - field: "count"
               format: "#.0"
   - match: { hits.hits.0.fields.count: ["1.0"] }
+
+---
+"docvalue_fields - double":
+
+  - do:
+      search:
+        body:
+          docvalue_fields: [ "d" ]
+  - match: { hits.hits.0.fields.d: [3.140000104904175] }
+


### PR DESCRIPTION
In #61995 I moved the `docvalue_field` fetch code into a place where I
could share it with the fancy new `fields` fetch API. Specifically,
runtime fields can use it all that doc values code now. But I broke
`scaled_floats` by switching them how they are fetched from `double` to
`string`. This adds the override you need to switch them back.
