### PR TITLE
Adds bucketOrd back to cardinality algorithms (#62389)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractCardinalityAlgorithm.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractCardinalityAlgorithm.java
@@ -45,7 +45,7 @@ abstract class AbstractCardinalityAlgorithm {
     }
 
     /** Returns the current computed cardinality */
-    public abstract long cardinality();
+    public abstract long cardinality(long bucketOrd);
 
     static long linearCounting(long m, long v) {
         return Math.round(m * Math.log((double) m / v));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
@@ -42,26 +42,26 @@ public abstract class AbstractLinearCounting extends AbstractCardinalityAlgorith
      * Add encoded value to the linear counting. Implementor should only accept the value if it has not been
      * seen before.
      */
-    protected abstract int addEncoded(int encoded);
+    protected abstract int addEncoded(long bucketOrd, int encoded);
 
     /**
      * number of values in the counter.
      */
-    protected abstract int size();
+    protected abstract int size(long bucketOrd);
 
     /**
      * return the current values in the counter.
      */
-    protected abstract HashesIterator values();
+    protected abstract HashesIterator values(long bucketOrd);
 
-    public int collect(long hash) {
+    public int collect(long bucketOrd, long hash) {
         final int k = encodeHash(hash, p);
-        return addEncoded(k);
+        return addEncoded(bucketOrd, k);
     }
 
-    public long cardinality() {
+    public long cardinality(long bucketOrd) {
         final long m = 1 << P2;
-        final long v = m - size();
+        final long v = m - size(bucketOrd);
         return linearCounting(m, v);
     }
 


### PR DESCRIPTION
In #60104, we refactor the HLL++ algorithm to spare the log with the internal data structure. During that process we remove the bucketOrd from the caller methods that allow having multiple structures.

The current implementation of HyperLogLogPlusPlus uses some mutable property in the implementation to achieve that but I think we better add back the bucketed to the interface calls.

backport #62389