### PR TITLE
[ML] Fix full cluster upgrade failure where index does not exist

### DIFF
--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
@@ -87,8 +87,11 @@ public class IndexMappingTemplateAsserter {
         assertLegacyTemplateMatchesIndexMappings(client, ".ml-meta", ".ml-meta", true, Collections.emptySet());
         assertLegacyTemplateMatchesIndexMappings(client, ".ml-stats", ".ml-stats-000001", true, statsIndexException);
         assertLegacyTemplateMatchesIndexMappings(client, ".ml-state", ".ml-state-000001", true, Collections.emptySet());
-        assertLegacyTemplateMatchesIndexMappings(client, ".ml-notifications-000001", ".ml-notifications-000001");
-        assertLegacyTemplateMatchesIndexMappings(client, ".ml-inference-000003", ".ml-inference-000003", true, Collections.emptySet());
+        // Depending on the order Full Cluster restart tests are run there may not be an notifications index yet
+        assertLegacyTemplateMatchesIndexMappings(client,
+            ".ml-notifications-000001", ".ml-notifications-000001", true, Collections.emptySet());
+        assertLegacyTemplateMatchesIndexMappings(client,
+            ".ml-inference-000003", ".ml-inference-000003", true, Collections.emptySet());
         // .ml-annotations-6 does not use a template
         // .ml-anomalies-shared uses a template but will have dynamically updated mappings as new jobs are opened
     }


### PR DESCRIPTION
Depending on the order in which the tests are run the `.ml-notifications-000001` may not have been created by the time the check on the mappings is done. It is not a failure if the index does not exist.

Relates to #62293
Closes #62415