### PR TITLE
Adds quotes to timestamp values in runtime_fields/40_date YAML test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -118,9 +118,9 @@ setup:
           sort: timestamp
           fields: [tomorrow, tomorrow_from_source, the_past, all_week, formatted_tomorrow]
   - match: {hits.total.value: 6}
-  - match: {hits.hits.0.fields.tomorrow: [2018-01-19T17:41:34.000Z] }
-  - match: {hits.hits.0.fields.tomorrow_from_source: [2018-01-19T17:41:34.000Z] }
-  - match: {hits.hits.0.fields.the_past: [2018-01-18T17:41:33.000Z] }
+  - match: {hits.hits.0.fields.tomorrow: ["2018-01-19T17:41:34.000Z"] }
+  - match: {hits.hits.0.fields.tomorrow_from_source: ["2018-01-19T17:41:34.000Z"] }
+  - match: {hits.hits.0.fields.the_past: ["2018-01-18T17:41:33.000Z"] }
   - match:
       hits.hits.0.fields.all_week:
         - 2018-01-18T17:41:34.000Z


### PR DESCRIPTION
Pinging @nik9000 since you might have missed https://github.com/elastic/elasticsearch/pull/62153.

Timestamp values without surrounding quotes make the client YAML parsers error.