### PR TITLE
EQL: Fetch sequence documents using Point-In-Time

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/QueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/QueryClient.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.eql.execution.search;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public interface QueryClient {
 
     void query(QueryRequest request, ActionListener<SearchResponse> listener);
 
-    void get(Iterable<List<HitReference>> refs, ActionListener<List<List<GetResponse>>> listener);
-
     default void close(ActionListener<Boolean> closed) {}
+
+    void fetchHits(Iterable<List<HitReference>> refs, ActionListener<List<List<SearchHit>>> listener);
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -64,7 +64,7 @@ public final class RuntimeUtils {
         }
         return extractors;
     }
-    
+
     public static HitExtractor createExtractor(FieldExtraction ref, EqlConfiguration cfg) {
         if (ref instanceof SearchHitFieldRef) {
             SearchHitFieldRef f = (SearchHitFieldRef) ref;
@@ -94,7 +94,7 @@ public final class RuntimeUtils {
 
         throw new EqlIllegalArgumentException("Unexpected value reference {}", ref.getClass());
     }
-    
+
 
     public static SearchRequest prepareRequest(Client client,
                                                SearchSourceBuilder source,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
@@ -6,8 +6,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Event;
 import org.elasticsearch.xpack.eql.execution.payload.AbstractPayload;
 
@@ -18,16 +18,16 @@ class SequencePayload extends AbstractPayload {
 
     private final List<org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence> values;
 
-    SequencePayload(List<Sequence> sequences, List<List<GetResponse>> docs, boolean timedOut, TimeValue timeTook) {
+    SequencePayload(List<Sequence> sequences, List<List<SearchHit>> docs, boolean timedOut, TimeValue timeTook) {
         super(timedOut, timeTook);
         values = new ArrayList<>(sequences.size());
-        
+
         for (int i = 0; i < sequences.size(); i++) {
             Sequence s = sequences.get(i);
-            List<GetResponse> hits = docs.get(i);
+            List<SearchHit> hits = docs.get(i);
             List<Event> events = new ArrayList<>(hits.size());
-            for (GetResponse hit : hits) {
-                events.add(new Event(hit.getIndex(), hit.getId(), hit.getSourceAsBytesRef()));
+            for (SearchHit hit : hits) {
+                events.add(new Event(hit.getIndex(), hit.getId(), hit.getSourceRef()));
             }
             values.add(new org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence(s.key().asList(), events));
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -301,8 +301,9 @@ public class TumblingWindow implements Executable {
             return;
         }
 
-        client.get(hits(completed), ActionListeners.map(listener, hits -> {
-            SequencePayload payload = new SequencePayload(completed, hits, false, timeTook());
+        // get results through search (to keep using PIT)
+        client.fetchHits(hits(completed), ActionListeners.map(listener, listOfHits -> {
+            SequencePayload payload = new SequencePayload(completed, listOfHits, false, timeTook());
             close(listener);
             return payload;
         }));

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchResponseSections;
@@ -82,7 +81,7 @@ public class SequenceSpecTests extends ESTestCase {
             return (long) hit.docId();
         }
     }
-    
+
     static class KeyExtractor extends EmptyHitExtractor {
         @Override
         public String extract(SearchHit hit) {
@@ -172,7 +171,7 @@ public class SequenceSpecTests extends ESTestCase {
                 r.searchSource().size(Integer.MAX_VALUE);
             }
             Map<Integer, Tuple<String, String>> evs = ordinal != Integer.MAX_VALUE ? events.get(ordinal) : emptyMap();
-            
+
             EventsAsHits eah = new EventsAsHits(evs);
             SearchHits searchHits = new SearchHits(eah.hits.toArray(new SearchHit[0]), new TotalHits(eah.hits.size(), Relation.EQUAL_TO),
                     0.0f);
@@ -182,8 +181,7 @@ public class SequenceSpecTests extends ESTestCase {
         }
 
         @Override
-        public void get(Iterable<List<HitReference>> refs, ActionListener<List<List<GetResponse>>> listener) {
-            //no-op
+        public void fetchHits(Iterable<List<HitReference>> refs, ActionListener<List<List<SearchHit>>> listener) {
         }
     }
 
@@ -202,7 +200,7 @@ public class SequenceSpecTests extends ESTestCase {
     public static Iterable<Object[]> parameters() throws Exception {
         return SeriesUtils.readSpec("/sequences.series-spec");
     }
-    
+
     public void test() {
         int stages = events.size();
         List<Criterion<BoxedQueryRequest>> criteria = new ArrayList<>(stages);
@@ -214,7 +212,7 @@ public class SequenceSpecTests extends ESTestCase {
 
         // convert the results through a test specific payload
         SequenceMatcher matcher = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null);
-        
+
         QueryClient testClient = new TestQueryClient();
         TumblingWindow window = new TumblingWindow(testClient, criteria, null, matcher);
 
@@ -229,7 +227,7 @@ public class SequenceSpecTests extends ESTestCase {
         String prefix = "Line " + lineNumber + ":";
         assertNotNull(prefix + "no matches found", seq);
         assertEquals(prefix + "different sequences matched ", matches.size(), seq.size());
-        
+
         for (int i = 0; i < seq.size(); i++) {
             Sequence s = seq.get(i);
             List<String> match = matches.get(i);


### PR DESCRIPTION
To preserve the PIT semantics, the retrieval of results has moved from
using multi-get to using an idsQuery.