### PR TITLE
[7.9] [DOCS] EQL: Use consistent string notation (#62472)

### DIFF
--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -303,8 +303,8 @@ GET /my-index-000001/_eql/search
 {
   "query": """
     sequence by process.pid
-      [process where process.name == 'regsvr32.exe']
-      [library where dll.name == 'scrobj.dll']
+      [process where process.name == "regsvr32.exe"]
+      [library where dll.name == "scrobj.dll"]
       [network where true]
   """
 }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] EQL: Use consistent string notation (#62472)