### PR TITLE
Ignore 404 when wiping data streams.

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -666,8 +666,10 @@ public abstract class ESRestTestCase extends ESTestCase {
                 adminClient().performRequest(new Request("DELETE", "_data_stream/*"));
             }
         } catch (ResponseException e) {
-            // We hit a version of ES that doesn't have data streams enabled so it's safe to ignore
-            if (e.getResponse().getStatusLine().getStatusCode() != 405) {
+            // We hit a version of ES that doesn't serialize DeleteDataStreamAction.Request#wildcardExpressionsOriginallySpecified field or
+            // that doesn't support data streams so it's safe to ignore
+            int statusCode = e.getResponse().getStatusLine().getStatusCode();
+            if (statusCode < 404 || statusCode > 405) {
                 throw e;
             }
         }


### PR DESCRIPTION
It is possible in mixed version clusters (nodes prior to 7.10)
that a 404 is returned when wiping all data streams.

This is because there are no data streams and
the coordinator node is on a version that doesn't
mark the delete request for wildcard usage.

Causes build failure like this one: https://gradle-enterprise.elastic.co/s/ot4sj7kfctmww