### PR TITLE
Runtime fields: fix a test name

### DIFF
--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptMappedFieldTypeTests.java
@@ -295,7 +295,7 @@ public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMapp
         }
     }
 
-    public void randomTermsQueryDegeneratesIntoMatchNone() throws IOException {
+    public void testEmptyTermsQueryDegeneratesIntoMatchNone() throws IOException {
         assertThat(simpleMappedFieldType().termsQuery(List.of(), mockContext()), instanceOf(MatchNoDocsQuery.class));
     }
 


### PR DESCRIPTION
This fixes the name of a test method so we actually run it. I broke it a
few commits ago without realizing it.
