### PR TITLE
Correct bad cross doc link

### DIFF
--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -40,7 +40,7 @@ To complete this tutorial, you'll need:
 awareness. 
 
 ** {ess}: 
-Choose the {cloud}/ec-getting-started-templates-hot-warm.html[hot-warm architecture] deployment template.
+Choose the Elastic Stack and then the {cloud}/ec-getting-started-profiles-hot-warm.html[hot-warm architecture] hardware profile.
 
 ** Self-managed cluster: 
 Add node attributes as described for {ref}/shard-allocation-filtering.html[shard allocation filtering].


### PR DESCRIPTION
The old link was ec-getting-started-templates-hot-warm.html, now it is ec-getting-started-profiles-hot-warm.html.

Also needs to be backported to 7.x-7.0

