### PR TITLE
Make yamlRestTest and javaRestTest tasks lazy

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestTestBasePlugin.java
@@ -41,7 +41,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
                 .getExtensions()
                 .getByName(TestClustersPlugin.EXTENSION_NAME);
-            ElasticsearchCluster cluster = testClusters.create(restIntegTestTask.getName());
+            ElasticsearchCluster cluster = testClusters.maybeCreate(restIntegTestTask.getName());
             restIntegTestTask.useCluster(cluster);
             restIntegTestTask.include("**/*IT.class");
             restIntegTestTask.systemProperty("tests.rest.load_packaged", Boolean.FALSE.toString());

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.createTestCluster;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
 
@@ -51,6 +52,9 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         // create source set
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
+
+        //create the test cluster container
+        createTestCluster(project, javaTestSourceSet);
 
         // setup the javaRestTest task
         Provider<RestIntegTestTask> javaRestTestTask = registerTask(project, javaTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -27,12 +27,12 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupRunnerTask;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupTask;
 
 /**
  * Apply this plugin to run the Java based REST tests.
@@ -53,10 +53,7 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
         // setup the javaRestTest task
-        RestIntegTestTask javaRestTestTask = setupTask(project, SOURCE_SET_NAME);
-
-        // setup the runner task
-        setupRunnerTask(project, javaRestTestTask, javaTestSourceSet);
+        Provider<RestIntegTestTask> javaRestTestTask = registerTask(project, javaTestSourceSet);
 
         // setup dependencies
         setupDependencies(project, javaTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -53,7 +53,7 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        //create the test cluster container
+        // create the test cluster container
         createTestCluster(project, javaTestSourceSet);
 
         // setup the javaRestTest task

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -38,18 +38,20 @@ public class RestTestUtil {
 
     private RestTestUtil() {}
 
-    static Provider<ElasticsearchCluster> createTestCluster(Project project, SourceSet sourceSet) {
+    static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet) {
+        // eagerly create the testCluster container so it is easily available for configuration
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
             .getExtensions()
             .getByName(TestClustersPlugin.EXTENSION_NAME);
-        return testClusters.register(sourceSet.getName());
+        return testClusters.create(sourceSet.getName());
     }
 
     /**
      * Creates a task with the source set name of type {@link RestIntegTestTask}
      */
     static Provider<RestIntegTestTask> registerTask(Project project, SourceSet sourceSet) {
+        // lazily create the test task
         Provider<RestIntegTestTask> testProvider = project.getTasks().register(sourceSet.getName(), RestIntegTestTask.class, testTask -> {
             testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             testTask.setDescription("Runs the REST tests against an external cluster");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -38,18 +38,19 @@ public class RestTestUtil {
 
     private RestTestUtil() {}
 
-    /**
-     * Creates a task with the source set name of type {@link RestIntegTestTask}
-     */
-    static Provider<RestIntegTestTask> registerTask(Project project, SourceSet sourceSet) {
-
+    static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet){
         // eagerly create the testCluster container so it is easily available for configuration
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
             .getExtensions()
             .getByName(TestClustersPlugin.EXTENSION_NAME);
-        testClusters.create(sourceSet.getName());
+        return testClusters.create(sourceSet.getName());
+    }
 
+    /**
+     * Creates a task with the source set name of type {@link RestIntegTestTask}
+     */
+    static Provider<RestIntegTestTask> registerTask(Project project, SourceSet sourceSet) {
         // lazily create the test task
         Provider<RestIntegTestTask> testProvider = project.getTasks().register(sourceSet.getName(), RestIntegTestTask.class, testTask -> {
             testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -22,8 +22,12 @@ package org.elasticsearch.gradle.test.rest;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.test.RestIntegTestTask;
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.bundling.Zip;
 
@@ -37,34 +41,35 @@ public class RestTestUtil {
     /**
      * Creates a task with the source set name of type {@link RestIntegTestTask}
      */
-    static RestIntegTestTask setupTask(Project project, String sourceSetName) {
-        // create task - note can not use .register due to the work in RestIntegTestTask's constructor :(
-        // see: https://github.com/elastic/elasticsearch/issues/47804
-        RestIntegTestTask testTask = project.getTasks().create(sourceSetName, RestIntegTestTask.class);
-        testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
-        testTask.setDescription("Runs the REST tests against an external cluster");
-        // make the new test run after unit tests
-        testTask.mustRunAfter(project.getTasks().named("test"));
-        return testTask;
-    }
+    static Provider<RestIntegTestTask> registerTask(Project project, SourceSet sourceSet) {
 
-    /**
-     * Creates the runner task and configures the test clusters
-     */
-    static void setupRunnerTask(Project project, RestIntegTestTask testTask, SourceSet sourceSet) {
-        testTask.setTestClassesDirs(sourceSet.getOutput().getClassesDirs());
-        testTask.setClasspath(sourceSet.getRuntimeClasspath());
+        // eagerly create the testCluster container so it is easily available for configuration
+        @SuppressWarnings("unchecked")
+        NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
+            .getExtensions()
+            .getByName(TestClustersPlugin.EXTENSION_NAME);
+        testClusters.create(sourceSet.getName());
 
-        // if this a module or plugin, it may have an associated zip file with it's contents, add that to the test cluster
-        project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
-            Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
-            testTask.dependsOn(bundle);
-            if (project.getPath().contains("modules:")) {
-                testTask.getClusters().forEach(c -> c.module(bundle.getArchiveFile()));
-            } else {
-                testTask.getClusters().forEach(c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile())));
-            }
+        // lazily create the test task
+        Provider<RestIntegTestTask> testProvider = project.getTasks().register(sourceSet.getName(), RestIntegTestTask.class, testTask -> {
+            testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+            testTask.setDescription("Runs the REST tests against an external cluster");
+            testTask.mustRunAfter(project.getTasks().named("test"));
+            testTask.setTestClassesDirs(sourceSet.getOutput().getClassesDirs());
+            testTask.setClasspath(sourceSet.getRuntimeClasspath());
+            // if this a module or plugin, it may have an associated zip file with it's contents, add that to the test cluster
+            project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
+                Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
+                testTask.dependsOn(bundle);
+                if (project.getPath().contains("modules:")) {
+                    testTask.getClusters().forEach(c -> c.module(bundle.getArchiveFile()));
+                } else {
+                    testTask.getClusters().forEach(c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile())));
+                }
+            });
         });
+
+        return testProvider;
     }
 
     /**

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -38,20 +38,18 @@ public class RestTestUtil {
 
     private RestTestUtil() {}
 
-    static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet) {
-        // eagerly create the testCluster container so it is easily available for configuration
+    static Provider<ElasticsearchCluster> createTestCluster(Project project, SourceSet sourceSet) {
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
             .getExtensions()
             .getByName(TestClustersPlugin.EXTENSION_NAME);
-        return testClusters.create(sourceSet.getName());
+        return testClusters.register(sourceSet.getName());
     }
 
     /**
      * Creates a task with the source set name of type {@link RestIntegTestTask}
      */
     static Provider<RestIntegTestTask> registerTask(Project project, SourceSet sourceSet) {
-        // lazily create the test task
         Provider<RestIntegTestTask> testProvider = project.getTasks().register(sourceSet.getName(), RestIntegTestTask.class, testTask -> {
             testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             testTask.setDescription("Runs the REST tests against an external cluster");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -38,7 +38,7 @@ public class RestTestUtil {
 
     private RestTestUtil() {}
 
-    static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet){
+    static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet) {
         // eagerly create the testCluster container so it is easily available for configuration
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -27,12 +27,12 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupRunnerTask;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupTask;
 
 /**
  * Apply this plugin to run the YAML based REST tests.
@@ -54,10 +54,7 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
         // setup the yamlRestTest task
-        RestIntegTestTask yamlRestTestTask = setupTask(project, SOURCE_SET_NAME);
-
-        // setup the runner task
-        setupRunnerTask(project, yamlRestTestTask, yamlTestSourceSet);
+        Provider<RestIntegTestTask> yamlRestTestTask = registerTask(project, yamlTestSourceSet);
 
         // setup the dependencies
         setupDependencies(project, yamlTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.createTestCluster;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
 
@@ -52,6 +53,9 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         // create source set
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
+
+        //create the test cluster container
+        createTestCluster(project, yamlTestSourceSet);
 
         // setup the yamlRestTest task
         Provider<RestIntegTestTask> yamlRestTestTask = registerTask(project, yamlTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -54,7 +54,7 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        //create the test cluster container
+        // create the test cluster container
         createTestCluster(project, yamlTestSourceSet);
 
         // setup the yamlRestTest task


### PR DESCRIPTION
This commit changes the yamlRestTest and javaRestTest tasks to be lazily created.
This change requires pro-actively creating the testClusters container so that the 
configuration can be applied without any changes to the build.gradle files.

related: #60261

=========
Here are some scans

before change:
https://gradle.com/s/bevt6ug46ohjw

after change:
https://gradle.com/s/4t6riz7m34ur2

I _think_ this is indeed lazily created (as evident by the scans) ... however, I am second guessing myself since I was a bit surprised that I did not have also have to change project specific task configuration from `yamlRestTest { ... ` to  `tasks.named("yamlRestTest").configure { ` in the build.gradle files. 

Also, I tried to `register` instead of `create` the testClusters container...but it did not work. Any suggestions for how to *not* pro-actively create the testClusters container ? 