### PR TITLE
Fix link to Filebeat docs

### DIFF
--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -53,7 +53,7 @@ node.attr.data: "warm"
 --------------------------------------------------------------------------------
 
 * A server with {filebeat} installed and configured to send logs to the `elasticsearch`
-output as described in {filebeat-ref}/filebeat-getting-started.html[Getting Started with {filebeat}].
+output as described in the {filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start].
 
 [discrete]
 [[example-using-index-lifecycle-policy-view-fb-ilm-policy]]


### PR DESCRIPTION
This link fix is required before we remove the redirects page in the Filebeat docs. See https://github.com/elastic/beats/pull/19574.