### PR TITLE
Hide c.a.s.s.i.UseArnRegionResolver noise

### DIFF
--- a/plugins/discovery-ec2/config/discovery-ec2/log4j2.properties
+++ b/plugins/discovery-ec2/config/discovery-ec2/log4j2.properties
@@ -9,3 +9,6 @@ logger.com_amazonaws_metrics_AwsSdkMetrics.level = error
 
 logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.name = com.amazonaws.auth.profile.internal.BasicProfileConfigFileLoader
 logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.level = error
+
+logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.name = com.amazonaws.services.s3.internal.UseArnRegionResolver
+logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.level = error

--- a/plugins/repository-s3/config/repository-s3/log4j2.properties
+++ b/plugins/repository-s3/config/repository-s3/log4j2.properties
@@ -9,3 +9,6 @@ logger.com_amazonaws_metrics_AwsSdkMetrics.level = error
 
 logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.name = com.amazonaws.auth.profile.internal.BasicProfileConfigFileLoader
 logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.level = error
+
+logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.name = com.amazonaws.services.s3.internal.UseArnRegionResolver
+logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.level = error


### PR DESCRIPTION
A recent AWS SDK upgrade has introduced a new source of spurious `WARN`
logs when the security manager prevents access to the user's home
directory and therefore to `$HOME/.aws/config`. This is the behaviour we
want, and it's harmless and handled by the SDK as if the config doesn't
exist, so this log message is unnecessary noise.  This commit suppresses
this noisy logging by default.

Relates #20313, #56346, #53962
Closes #62493