### PR TITLE
[7.9][Transform]disable optimizations when using scripts in group_by

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
@@ -21,6 +21,11 @@ public class TermsGroupSourceTests extends AbstractSerializingTestCase<TermsGrou
         return new TermsGroupSource(field, scriptConfig);
     }
 
+    public static TermsGroupSource randomTermsGroupSourceNoScript() {
+        String field = randomAlphaOfLengthBetween(1, 20);
+        return new TermsGroupSource(field, null);
+    }
+
     @Override
     protected TermsGroupSource doParseInstance(XContentParser parser) throws IOException {
         return TermsGroupSource.fromXContent(parser, false);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollector.java
@@ -381,6 +381,11 @@ public class CompositeBucketsChangeCollector implements ChangeCollector {
         Map<String, FieldCollector> fieldCollectors = new HashMap<>();
 
         for (Entry<String, SingleGroupSource> entry : groups.entrySet()) {
+            // skip any fields that use scripts
+            if (entry.getValue().getScriptConfig() != null) {
+                continue;
+            }
+
             switch (entry.getValue().getType()) {
                 case TERMS:
                     fieldCollectors.put(


### PR DESCRIPTION
disable optimizations when using scripts in group_by, when scripts using scripts we can not predict
the outcome and we have no query counterpart. Other optimizations for other group_by's are not
affected.

relates #57332
backport #60724