### PR TITLE
Fix condition in ILM step that cannot be met (#62377)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStep.java
@@ -75,7 +75,7 @@ public class ReplaceDataStreamBackingIndexStep extends ClusterStateActionStep {
         }
 
         assert dataStream.getWriteIndex() != null : dataStream.getName() + " has no write index";
-        if (dataStream.getWriteIndex().getIndex().equals(originalIndex)) {
+        if (dataStream.getWriteIndex().getIndex().equals(index)) {
             String errorMessage = String.format(Locale.ROOT, "index [%s] is the write index for data stream [%s], pausing " +
                 "ILM execution of lifecycle [%s] until this index is no longer the write index for the data stream via manual or " +
                 "automated rollover", originalIndex, dataStream.getName(), policyName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
@@ -188,7 +188,10 @@ public class ReplaceDataStreamBackingIndexStepTests extends AbstractStepTestCase
         IndexMetadata targetIndexMetadata = IndexMetadata.builder(targetIndex).settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
 
-        List<Index> backingIndices = List.of(sourceIndexMetadata.getIndex(), writeIndexMetadata.getIndex());
+        List<Index> backingIndices = org.elasticsearch.common.collect.List.of(
+            sourceIndexMetadata.getIndex(),
+            writeIndexMetadata.getIndex()
+        );
         ClusterState clusterState = ClusterState.builder(emptyClusterState()).metadata(
             Metadata.builder()
                 .put(sourceIndexMetadata, true)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
@@ -163,4 +163,55 @@ public class ReplaceDataStreamBackingIndexStepTests extends AbstractStepTestCase
         assertThat(updatedDataStream.getIndices().size(), is(2));
         assertThat(updatedDataStream.getIndices().get(0), is(targetIndexMetadata.getIndex()));
     }
+
+    /**
+     * test IllegalStateException is thrown when original index and write index name are the same
+     */
+    public void testPerformActionSameOriginalTargetError() {
+        String dataStreamName = randomAlphaOfLength(10);
+        String writeIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 2);
+        String indexName = writeIndexName;
+        String policyName = "test-ilm-policy";
+        IndexMetadata sourceIndexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+
+        IndexMetadata writeIndexMetadata = IndexMetadata.builder(writeIndexName)
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+
+        String indexPrefix = "test-prefix-";
+        String targetIndex = indexPrefix + indexName;
+
+        IndexMetadata targetIndexMetadata = IndexMetadata.builder(targetIndex).settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+
+        List<Index> backingIndices = List.of(sourceIndexMetadata.getIndex(), writeIndexMetadata.getIndex());
+        ClusterState clusterState = ClusterState.builder(emptyClusterState()).metadata(
+            Metadata.builder()
+                .put(sourceIndexMetadata, true)
+                .put(writeIndexMetadata, true)
+                .put(new DataStream(dataStreamName, createTimestampField("@timestamp"), backingIndices))
+                .put(targetIndexMetadata, true)
+                .build()
+        ).build();
+
+        ReplaceDataStreamBackingIndexStep replaceSourceIndexStep =
+            new ReplaceDataStreamBackingIndexStep(randomStepKey(), randomStepKey(), indexPrefix);
+        IllegalStateException ex = expectThrows(
+            IllegalStateException.class,
+            () -> replaceSourceIndexStep.performAction(sourceIndexMetadata.getIndex(), clusterState)
+        );
+        assertEquals(
+            "index ["
+                + writeIndexName
+                + "] is the write index for data stream ["
+                + dataStreamName
+                + "], pausing ILM execution of lifecycle [test-ilm-policy] until this index is no longer the write index for the data "
+                + "stream via manual or automated rollover",
+            ex.getMessage()
+        );
+    }
 }


### PR DESCRIPTION
ReplaceDataStreamBackingIndexStep#performAction seems to perform an equality
check on an original Index and the write indexes names, but because this
compares an Index instance to a String, the condition can never be met. This PR
changes this comparison.