### PR TITLE
Load version metadata even when stored fields are disabled

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MetadataFetchingIT extends ESIntegTestCase {
@@ -48,9 +49,11 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             .prepareSearch("test")
             .storedFields("_none_")
             .setFetchSource(false)
+            .setVersion(true)
             .get();
         assertThat(response.getHits().getAt(0).getId(), nullValue());
         assertThat(response.getHits().getAt(0).getSourceAsString(), nullValue());
+        assertThat(response.getHits().getAt(0).getVersion(), notNullValue());
 
         response = client()
             .prepareSearch("test")
@@ -127,15 +130,6 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             assertThat(rootCause.getClass(), equalTo(SearchException.class));
             assertThat(rootCause.getMessage(),
                 equalTo("[stored_fields] cannot be disabled if [_source] is requested"));
-        }
-        {
-            SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,
-                () -> client().prepareSearch("test").storedFields("_none_").setVersion(true).get());
-            Throwable rootCause = ExceptionsHelper.unwrap(exc, SearchException.class);
-            assertNotNull(rootCause);
-            assertThat(rootCause.getClass(), equalTo(SearchException.class));
-            assertThat(rootCause.getMessage(),
-                equalTo("[stored_fields] cannot be disabled if [version] is requested"));
         }
         {
             SearchPhaseExecutionException exc = expectThrows(SearchPhaseExecutionException.class,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1029,9 +1029,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         if (source.storedFields() != null) {
             if (source.storedFields().fetchFields() == false) {
-                if (context.version()) {
-                    throw new SearchException(shardTarget, "[stored_fields] cannot be disabled if [version] is requested");
-                }
                 if (context.sourceRequested()) {
                     throw new SearchException(shardTarget, "[stored_fields] cannot be disabled if [_source] is requested");
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -171,10 +171,7 @@ public class FetchContext {
      * Should the response include version metadata
      */
     public boolean version() {
-        // TODO version is loaded from docvalues, not stored fields, so why are we checking
-        // stored fields here?
-        return searchContext.version() &&
-            (searchContext.storedFieldsContext() == null || searchContext.storedFieldsContext().fetchFields());
+        return searchContext.version();
     }
 
     /**


### PR DESCRIPTION
Currently we throw an error if stored fields are disabled, but hit version metadata is
requested on a search.  This doesn't make much sense, as the version information
is stored in docvalues and so has no connection with stored fields.

This commit removes the link between the two, allowing version metadata to be loaded
even when stored fields are disabled in a request.

Fixes #62456 