### PR TITLE
EQL: Allow requests with size 0

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -157,10 +157,10 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
     }
 
     public EqlSearchRequest size(int size) {
-        this.size = size;
-        if (fetchSize < 0) {
+        if (size < 0) {
             throw new IllegalArgumentException("size must be greater than or equal to 0");
         }
+        this.size = size;
         return this;
     }
 
@@ -169,10 +169,10 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
     }
 
     public EqlSearchRequest fetchSize(int fetchSize) {
-        this.fetchSize = fetchSize;
         if (fetchSize < 2) {
             throw new IllegalArgumentException("fetch size must be greater than 1");
         }
+        this.fetchSize = fetchSize;
         return this;
     }
 
@@ -226,6 +226,8 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
                 Arrays.equals(indices, that.indices) &&
                 Objects.equals(indicesOptions, that.indicesOptions) &&
                 Objects.equals(filter, that.filter) &&
+                Objects.equals(size, that.size) &&
+                Objects.equals(fetchSize, that.fetchSize) &&
                 Objects.equals(timestampField, that.timestampField) &&
                 Objects.equals(tiebreakerField, that.tiebreakerField) &&
                 Objects.equals(eventCategoryField, that.eventCategoryField) &&

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -158,8 +158,8 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
 
     public EqlSearchRequest size(int size) {
         this.size = size;
-        if (fetchSize <= 0) {
-            throw new IllegalArgumentException("size must be greater than 0");
+        if (fetchSize < 0) {
+            throw new IllegalArgumentException("size must be greater than or equal to 0");
         }
         return this;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/eql/EqlSearchRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/eql/EqlSearchRequestTests.java
@@ -35,30 +35,33 @@ public class EqlSearchRequestTests extends AbstractRequestTestCase<EqlSearchRequ
 
     @Override
     protected EqlSearchRequest createClientTestInstance() {
-        EqlSearchRequest EqlSearchRequest = new EqlSearchRequest("testindex", randomAlphaOfLength(40));
+        EqlSearchRequest eqlSearchRequest = new EqlSearchRequest("testindex", randomAlphaOfLength(40));
         if (randomBoolean()) {
-            EqlSearchRequest.fetchSize(randomIntBetween(1, Integer.MAX_VALUE));
+            eqlSearchRequest.fetchSize(randomIntBetween(1, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            EqlSearchRequest.eventCategoryField(randomAlphaOfLength(10));
+            eqlSearchRequest.size(randomInt(Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            EqlSearchRequest.query(randomAlphaOfLength(10));
+            eqlSearchRequest.eventCategoryField(randomAlphaOfLength(10));
         }
         if (randomBoolean()) {
-            EqlSearchRequest.timestampField(randomAlphaOfLength(10));
+            eqlSearchRequest.query(randomAlphaOfLength(10));
         }
         if (randomBoolean()) {
-            EqlSearchRequest.tiebreakerField(randomAlphaOfLength(10));
+            eqlSearchRequest.timestampField(randomAlphaOfLength(10));
+        }
+        if (randomBoolean()) {
+            eqlSearchRequest.tiebreakerField(randomAlphaOfLength(10));
         }
         if (randomBoolean()) {
             if (randomBoolean()) {
-                EqlSearchRequest.filter(QueryBuilders.matchAllQuery());
+                eqlSearchRequest.filter(QueryBuilders.matchAllQuery());
             } else {
-                EqlSearchRequest.filter(QueryBuilders.termQuery(randomAlphaOfLength(10), randomInt(100)));
+                eqlSearchRequest.filter(QueryBuilders.termQuery(randomAlphaOfLength(10), randomInt(100)));
             }
         }
-        return EqlSearchRequest;
+        return eqlSearchRequest;
     }
 
     @Override
@@ -77,6 +80,7 @@ public class EqlSearchRequestTests extends AbstractRequestTestCase<EqlSearchRequ
         assertThat(serverInstance.indicesOptions(), equalTo(clientTestInstance.indicesOptions()));
         assertThat(serverInstance.indices(), equalTo(clientTestInstance.indices()));
         assertThat(serverInstance.fetchSize(), equalTo(clientTestInstance.fetchSize()));
+        assertThat(serverInstance.size(), equalTo(clientTestInstance.size()));
     }
 
     @Override

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlRestTestCase.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.not;
 public abstract class CommonEqlRestTestCase extends ESRestTestCase {
 
     private static final String defaultValidationIndexName = "eql_search_validation_test";
-    private static final String validQuery = "process where user = 'SYSTEM'";
+    private static final String validQuery = "process where user = \\\"SYSTEM\\\"";
 
     @After
     public void checkSearchContent() throws Exception {
@@ -42,8 +42,7 @@ public abstract class CommonEqlRestTestCase extends ESRestTestCase {
             {"{\"query\": \"\"}", "query is null or empty"},
             {"{\"query\": \"" + validQuery + "\", \"timestamp_field\": \"\"}", "timestamp field is null or empty"},
             {"{\"query\": \"" + validQuery + "\", \"event_category_field\": \"\"}", "event category field is null or empty"},
-            {"{\"query\": \"" + validQuery + "\", \"size\": 0}", "size must be greater than 0"},
-            {"{\"query\": \"" + validQuery + "\", \"size\": -1}", "size must be greater than 0"},
+            {"{\"query\": \"" + validQuery + "\", \"size\": -1}", "size must be greater than or equal to 0"},
             {"{\"query\": \"" + validQuery + "\", \"filter\": null}", "filter doesn't support values of type: VALUE_NULL"},
             {"{\"query\": \"" + validQuery + "\", \"filter\": {}}", "query malformed, empty clause found"}
     };

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -137,8 +137,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             validationException = addValidationError("event category field is null or empty", validationException);
         }
 
-        if (size <= 0) {
-            validationException = addValidationError("size must be greater than 0", validationException);
+        if (size < 0) {
+            validationException = addValidationError("size must be greater than or equal to 0", validationException);
         }
 
         if (fetchSize < 2) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -329,6 +329,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
                 Arrays.equals(indices, that.indices) &&
                 Objects.equals(indicesOptions, that.indicesOptions) &&
                 Objects.equals(filter, that.filter) &&
+                Objects.equals(size, that.size) &&
+                Objects.equals(fetchSize, that.fetchSize) &&
                 Objects.equals(timestampField, that.timestampField) &&
                 Objects.equals(tiebreakerField, that.tiebreakerField) &&
                 Objects.equals(eventCategoryField, that.eventCategoryField) &&
@@ -337,6 +339,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
                 Objects.equals(keepAlive, that.keepAlive) &&
                 Objects.equals(isCaseSensitive, that.isCaseSensitive);
     }
+
 
     @Override
     public int hashCode() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -62,6 +62,7 @@ public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearch
                 .timestampField(randomAlphaOfLength(10))
                 .eventCategoryField(randomAlphaOfLength(10))
                 .fetchSize(randomIntBetween(1, 50))
+                .size(randomInt(50))
                 .query(randomAlphaOfLength(10));
 
             return request;


### PR DESCRIPTION
The purpose for this change is to allow validation of queries without
having to actually execute them. The optimizer already picks up this
case.

Fix #62494
