### PR TITLE
Fix AllocationRoutedStep equals and hashcode

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -89,20 +89,4 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
         }
         return allocationPendingAllShards;
     }
-
-    @Override
-    public int hashCode() {
-        return 611;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        return super.equals(obj);
-    }
 }


### PR DESCRIPTION
Use the "super" implementations instead as they take the current 
and next step key into account.