### PR TITLE
Fix S3BlobContainerRetriesTests

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
@@ -200,7 +200,7 @@ class S3RetryingInputStream extends InputStream {
      * suppressing all thrown exceptions.
      */
     private void maybeAbort(S3ObjectInputStream stream) {
-        if (eof) {
+        if (isEof()) {
             return;
         }
         try {
@@ -231,7 +231,7 @@ class S3RetryingInputStream extends InputStream {
 
     // package-private for tests
     boolean isEof() {
-        return eof;
+        return eof || start + currentOffset == currentStreamLastOffset;
     }
 
     // package-private for tests


### PR DESCRIPTION
The AssertingInputStream in S3BlobContainerRetriesTests verifies 
that InputStream are either fully consumed or aborted, but the 
eof flag is only set when the underlying stream returns it.

When buffered read are executed and when the exact number 
of remaining bytes are read, the eof flag is not set to true. Instead 
the test should rely on the total number of bytes read to know if 
the stream has been fully consumed.

Close #62390