### PR TITLE
[7.x] Add host.ip and observer.ip fields to the synthetics-*-* mappings (#62412)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/synthetics-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/synthetics-mappings.json
@@ -38,6 +38,20 @@
               "type": "keyword"
             }
           }
+        },
+        "host": {
+          "properties": {
+            "ip": {
+              "type": "ip"
+            }
+          }
+        },
+        "observer": {
+          "properties": {
+            "ip": {
+              "type": "ip"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add host.ip and observer.ip fields to the synthetics-*-* mappings (#62412)