### PR TITLE
Fix test error in InternalCardinalityTests#testEqualsAndHashcode (#62542)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -99,9 +99,7 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
         case 1:
             HyperLogLogPlusPlus newState = new HyperLogLogPlusPlus(state.precision(),
                     new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService()), 0);
-            newState.merge(0, state, 0);
-            int extraValues = between(10, 100);
-            for (int i = 0; i < extraValues; i++) {
+            for (int i = 0; i < 10; i++) {
                 newState.collect(0, BitMixer.mix64(randomIntBetween(500, 10000)));
             }
             algos.add(newState);


### PR DESCRIPTION
Make sure the the new HLL++ is different to the original one

backport #62542
