### PR TITLE
Tidy up fillInStackTrace implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
@@ -41,6 +41,6 @@ public class NotMasterException extends ElasticsearchException {
 
     @Override
     public Throwable fillInStackTrace() {
-        return null;
+        return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
@@ -59,7 +59,7 @@ public class VersionConflictEngineException extends EngineException {
     }
 
     @Override
-    public synchronized Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {
         // This is on the hot path for updates; stack traces are expensive to compute and not very useful for VCEEs, so don't fill it in.
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
@@ -38,6 +38,6 @@ public class NodeDisconnectedException extends ConnectTransportException {
 
     @Override
     public Throwable fillInStackTrace() {
-        return null;
+        return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/NotSerializableTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NotSerializableTransportException.java
@@ -31,7 +31,7 @@ public class NotSerializableTransportException extends TransportException {
 
     @Override
     public Throwable fillInStackTrace() {
-        return null;
+        return this;
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/transport/ReceiveTimeoutTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ReceiveTimeoutTransportException.java
@@ -34,7 +34,4 @@ public class ReceiveTimeoutTransportException extends ActionTransportException {
         super(in);
     }
 
-//    @Override public Throwable fillInStackTrace() {
-//        return fillStack();
-//    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -48,6 +48,6 @@ public class RemoteTransportException extends ActionTransportException implement
     @Override
     public Throwable fillInStackTrace() {
         // no need for stack trace here, we always have cause
-        return null;
+        return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
@@ -38,6 +38,6 @@ public class ResponseHandlerFailureTransportException extends TransportException
 
     @Override
     public Throwable fillInStackTrace() {
-        return null;
+        return this;
     } // why is this?
 }


### PR DESCRIPTION
Removes the unnecessary `synchronized` introduced in #62433 and adjusts
the others to return `this` not `null` as required by the parent
method's Javadocs.