### PR TITLE
[DOCS] Clarify `http.max_content_length` def

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -42,7 +42,7 @@ Used to set the `http.bind_host` and the `http.publish_host`.
 
 `http.max_content_length`::
 (<<static-cluster-setting,Static>>)
-The max content of an HTTP request. Defaults to `100MB`.
+Maximum length of an HTTP request body. Defaults to `100MB`.
 
 `http.max_initial_line_length`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
"content of an HTTP request" is vague. This clarifies that the limit applies to the request body.