### PR TITLE
[7.9] [DOCS] Clarify `http.max_content_length` def (#62562)

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -46,7 +46,7 @@ Used to set the `http.bind_host` and the `http.publish_host`.
 
 `http.max_content_length`::
 (<<static-cluster-setting,Static>>)
-The max content of an HTTP request. Defaults to `100MB`.
+Maximum length of an HTTP request body. Defaults to `100MB`.
 
 `http.max_initial_line_length`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Clarify `http.max_content_length` def (#62562)