### PR TITLE
Skip release build tests for external test modules

### DIFF
--- a/test/external-modules/build.gradle
+++ b/test/external-modules/build.gradle
@@ -1,10 +1,17 @@
 
+import org.elasticsearch.gradle.info.BuildParams;
+
 subprojects {
   apply plugin: 'elasticsearch.esplugin'
+  apply plugin: 'elasticsearch.yaml-rest-test'
 
   esplugin {
     name it.name
     licenseFile rootProject.file('licenses/APACHE-LICENSE-2.0.txt')
     noticeFile rootProject.file('NOTICE.txt')
+  }
+
+  tasks.named('yamlRestTest').configure {
+    it.onlyIf { BuildParams.isSnapshotBuild() }
   }
 }

--- a/test/external-modules/delayed-aggs/build.gradle
+++ b/test/external-modules/delayed-aggs/build.gradle
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-apply plugin: 'elasticsearch.esplugin'
-apply plugin: 'elasticsearch.yaml-rest-test'
-
 esplugin {
   description 'A test module that allows to delay aggregations on shards with a configurable time'
   classname 'org.elasticsearch.search.aggregations.DelayedShardAggregationPlugin'


### PR DESCRIPTION
The tests don't make sense for release builds.

closes #62435