### PR TITLE
Copy Key Certs for javaRestTest

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -125,6 +125,7 @@ tasks.register("copyKeyCerts", Copy) {
 // Add keystores to test classpath: it expects it there
 sourceSets.yamlRestTest.resources.srcDir(keystoreDir)
 processYamlRestTestResources.dependsOn("copyKeyCerts")
+processJavaRestTestResources.dependsOn("copyKeyCerts")
 
 yamlRestTest {
   /*


### PR DESCRIPTION
Running `./gradlew clean :x-pack:plugin:javaRestTest` on the 7.x branch yielded the following error:

```
Some problems were found with the configuration of task ':x-pack:plugin:javaRestTest' (type 'RestIntegTestTask').
> File '/Users/wbrafford/work/repos/elasticsearch-7.x/x-pack/plugin/build/keystore/testnode.crt' specified for property 'clusters.javaRestTest$0.nodes.$0.extraConfigFiles.testnode.crt$1.file' does not exist.
> File '/Users/wbrafford/work/repos/elasticsearch-7.x/x-pack/plugin/build/keystore/testnode.pem' specified for property 'clusters.javaRestTest$0.nodes.$0.extraConfigFiles.testnode.pem$0.file' does not exist.
```

There's a line on the `master` branch that is missing on the `7.x` branch. This PR adds it.