### PR TITLE
[7.x] Add an additional cancellation check to the fetch phase (#62577)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -95,6 +95,10 @@ public class FetchPhase {
             LOGGER.trace("{}", new SearchContextSourcePrinter(context));
         }
 
+        if (context.isCancelled()) {
+            throw new TaskCancelledException("cancelled");
+        }
+
         if (context.docIdsToLoadSize() == 0) {
             // no individual hits to process, so we shortcut
             context.fetchResult().hits(new SearchHits(new SearchHit[0], context.queryResult().getTotalHits(),


### PR DESCRIPTION
In #62357 we introduced an additional optimization that allows us to skip the
most of the fetch phase early if no results are found. This change caused
some cancellation test failures that were relying on definitive cancellation
during the fetch phase. This commit adds an additional quick cancellation
check at the very beginning of the fetch phase to make cancellation process
more deterministic.

Fixes #62530
