### PR TITLE
[DOCS] Terminology experiment

### DIFF
--- a/docs/reference/modules/discovery.asciidoc
+++ b/docs/reference/modules/discovery.asciidoc
@@ -2,7 +2,7 @@
 == Discovery and cluster formation
 
 The discovery and cluster formation processes are responsible for discovering
-nodes, electing a master, forming a cluster, and publishing the cluster state
+nodes, electing a manager, forming a cluster, and publishing the cluster state
 each time it changes. All communication between nodes is done using the
 <<modules-transport,transport>> layer.
 
@@ -11,9 +11,9 @@ formation:
 
 <<modules-discovery-hosts-providers>>::
 
-    Discovery is the process where nodes find each other when the master is
+    Discovery is the process where nodes find each other when the manager is
     unknown, such as when a node has just started up or when the previous
-    master has failed.
+    manager has failed.
 
 <<modules-discovery-quorums>>::
 
@@ -37,20 +37,20 @@ formation:
     <<modules-discovery-bootstrap-cluster,`cluster.initial_master_nodes`
     setting>>.
 
-<<modules-discovery-adding-removing-nodes,Adding and removing master-eligible nodes>>::
+<<modules-discovery-adding-removing-nodes,Adding and removing control nodes>>::
 
-    It is recommended to have a small and fixed number of master-eligible nodes
+    It is recommended to have a small and fixed number of control nodes
     in a cluster, and to scale the cluster up and down by adding and removing
-    master-ineligible nodes only. However there are situations in which it may
-    be desirable to add or remove some master-eligible nodes to or from a
-    cluster. This section describes the process for adding or removing
-    master-eligible nodes, including the extra steps that need to be performed
-    when removing more than half of the master-eligible nodes at the same time.
+    data nodes only. However there are situations in which it may
+    be desirable to add or remove control nodes. 
+    This section describes the process for adding or removing
+    control nodes, including the extra steps that need to be performed
+    when removing more than half of the control nodes at the same time.
 
 <<cluster-state-publishing>>::
 
-    Cluster state publishing is the process by which the elected master node
-    updates the cluster state on all the other nodes in the cluster.
+    Cluster state publishing is the process by which the manager node
+    updates the cluster state on all other nodes in the cluster.
 
 <<cluster-fault-detection>>::
 

--- a/docs/reference/modules/discovery.asciidoc
+++ b/docs/reference/modules/discovery.asciidoc
@@ -59,7 +59,7 @@ formation:
 <<modules-discovery-settings,Settings>>::
 
     There are settings that enable users to influence the discovery, cluster
-    formation, master election and fault detection processes.
+    formation, manager election, and fault detection processes.
 
 include::discovery/discovery.asciidoc[]
 

--- a/docs/reference/modules/discovery/discovery.asciidoc
+++ b/docs/reference/modules/discovery/discovery.asciidoc
@@ -3,27 +3,27 @@
 
 Discovery is the process by which the cluster formation module finds other
 nodes with which to form a cluster. This process runs when you start an
-Elasticsearch node or when a node believes the master node failed and continues
-until the master node is found or a new master node is elected.
+Elasticsearch node or when a node believes the manager node failed and continues
+until the manager node is found or a new manager node is elected.
 
 This process starts with a list of _seed_ addresses from one or more
 <<built-in-hosts-providers,seed hosts providers>>, together with the addresses
-of any master-eligible nodes that were in the last-known cluster. The process
+of any control nodes that were in the last-known cluster. The process
 operates in two phases: First, each node probes the seed addresses by
 connecting to each address and attempting to identify the node to which it is
-connected and to verify that it is master-eligible. Secondly, if successful, it
-shares with the remote node a list of all of its known master-eligible peers
+connected and to verify that it is a control node. Secondly, if successful, it
+shares with the remote node a list of all of its known control peers
 and the remote node responds with _its_ peers in turn. The node then probes all
 the new nodes that it just discovered, requests their peers, and so on.
 
-If the node is not master-eligible then it continues this discovery process
-until it has discovered an elected master node. If no elected master is
+If the node is not a control node then it continues this discovery process
+until it has discovered a manager node. If no manager is
 discovered then the node will retry after `discovery.find_peers_interval` which
 defaults to `1s`.
 
-If the node is master-eligible then it continues this discovery process until
-it has either discovered an elected master node or else it has discovered
-enough masterless master-eligible nodes to complete an election. If neither of
+If the node is a control node then it continues this discovery process until
+it has either discovered a manager node or else it has discovered
+enough control nodes with no manager to complete an election. If neither of
 these occur quickly enough then the node will retry after
 `discovery.find_peers_interval` which defaults to `1s`.
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -108,7 +108,7 @@ restarts.
 [[dedicated-control-node]]
 ===== Dedicated control nodes
 
-It is important for the health of the cluster that the manager node has
+It is important for the health of the cluster that the control nodes have
 the resources it needs to fulfill its responsibilities. If the manager
 is overloaded with other tasks then the cluster may not operate well. In
 particular, indexing and searching your data can be very resource-intensive, so

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -14,12 +14,12 @@ clients.
 All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
-By default, a node is all of the following types: master-eligible, data, ingest,
+By default, a node is all of the following types: control, data, ingest,
 and (if available) machine learning. All data nodes are also transform nodes.
 // end::modules-node-description-tag[]
 
 TIP: As the cluster grows and in particular if you have large {ml} jobs or
-{ctransforms}, consider separating dedicated master-eligible nodes from
+{ctransforms}, consider separating dedicated control nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 [[node-roles]]
@@ -27,29 +27,31 @@ dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 You can define the roles of a node by setting `node.roles`. If you don't 
 configure this setting, then the node has the following roles by default: 
-`master`, `data`, `ingest`, `ml`.
+`control`, `data`, `ingest`, `ml`.
 
 If you set node.roles, the node is assigned only the roles you specify.
 
-<<master-node,Master-eligible node>>::
+Control::
 
-A node that has the `master` role (default), which makes it eligible to be
-<<modules-discovery,elected as the _master_ node>>, which controls the cluster.
+A node that has the `control` role performs cluster control tasks 
+and participates in the <<modules-discovery, manager election process>>. 
+By default, a control node is eligible to become the cluster manager that
+facilitates cluster-wide actions.
 
-<<data-node,Data node>>::
+Data::
 
-A node that has the `data` role (default). Data nodes hold data and perform data
+A node that has the `data` role holds data and perform data
 related operations such as CRUD, search, and aggregations.
 
-<<node-ingest-node,Ingest node>>::
+Ingest::
 
 A node that has the `ingest` role (default). Ingest nodes are able to apply an
 <<pipeline,ingest pipeline>> to a document in order to transform and enrich the
 document before indexing. With a heavy ingest load, it makes sense to use
 dedicated ingest nodes and to not include the `ingest` role from nodes that have
-the `master` or `data` roles.
+the `control` or `data` roles.
 
-<<ml-node,Machine learning node>>::
+Machine learning::
 
 A node that has `xpack.ml.enabled` and the `ml` role, which is the default
 behavior in the {es} {default-dist}. If you want to use {ml-features}, there
@@ -89,93 +91,85 @@ memory and CPU in order to deal with the gather phase.
 ===============================================
 
 [[master-node]]
-==== Master-eligible node
+==== Manager node
 
-The master node is responsible for lightweight cluster-wide actions such as
+The manager node is responsible for lightweight cluster-wide actions such as
 creating or deleting an index, tracking which nodes are part of the cluster,
 and deciding which shards to allocate to which nodes. It is important for
-cluster health to have a stable master node.
+cluster health to have a stable manager node.
 
-Any master-eligible node that is not a <<voting-only-node,voting-only node>> may
-be elected to become the master node by the <<modules-discovery,master election
-process>>.
+Any control node that is not a <<voting-only-node,voting-only node>> can
+become the manager through the <<modules-discovery, election process>>.
 
-IMPORTANT: Master nodes must have access to the `data/` directory (just like
+IMPORTANT: Manager nodes must have access to the `data/` directory (just like
 `data` nodes) as this is where the cluster state is persisted between node
 restarts.
 
-[[dedicated-master-node]]
-===== Dedicated master-eligible node
+[[dedicated-control-node]]
+===== Dedicated control nodes
 
-It is important for the health of the cluster that the elected master node has
-the resources it needs to fulfill its responsibilities. If the elected master
-node is overloaded with other tasks then the cluster may not operate well. In
+It is important for the health of the cluster that the manager node has
+the resources it needs to fulfill its responsibilities. If the manager
+is overloaded with other tasks then the cluster may not operate well. In
 particular, indexing and searching your data can be very resource-intensive, so
 in large or high-throughput clusters it is a good idea to avoid using the
-master-eligible nodes for tasks such as indexing and searching. You can do this
-by configuring three of your nodes to be dedicated master-eligible nodes.
-Dedicated master-eligible nodes only have the `master` role, allowing them to
-focus on managing the cluster. While master nodes can also behave as
+control nodes for tasks such as indexing and searching. You can do this
+by configuring three of your nodes to be dedicated control nodes.
+Dedicated control nodes only have the `control` role, allowing them to
+focus on cluster management tasks. While control nodes can also behave as
 <<coordinating-node,coordinating nodes>> and route search and indexing requests
-from clients to data nodes, it is better _not_ to use dedicated master nodes for
+from clients to data nodes, it is better _not_ to use dedicated control nodes for
 this purpose.
 
-To create a dedicated master-eligible node, set:
+To create a dedicated control node, set:
 
 [source,yaml]
 -------------------
-node.roles: [ master ]
+node.roles: [ control ]
 -------------------
 
 [[voting-only-node]]
-===== Voting-only master-eligible node
+===== Voting-only control nodes
 
-A voting-only master-eligible node is a node that participates in
-<<modules-discovery,master elections>> but which will not act as the cluster's
-elected master node. In particular, a voting-only node can serve as a tiebreaker
+A voting-only control node participates in the
+<<modules-discovery,election process>> and cluster state publishing, 
+but can never become the manager node. 
+In particular, a voting-only node can serve as a tiebreaker
 in elections.
 
-It may seem confusing to use the term "master-eligible" to describe a
-voting-only node since such a node is not actually eligible to become the master
-at all. This terminology is an unfortunate consequence of history:
-master-eligible nodes are those nodes that participate in elections and perform
-certain tasks during cluster state publications, and voting-only nodes have the
-same responsibilities even if they can never become the elected master.
-
-To configure a master-eligible node as a voting-only node, include `master` and
-`voting_only` in the list of roles. For example to create a voting-only data
+To configure a control node as a voting-only node, include `control` and
+`voting_only` in its list of roles. For example to create a voting-only data
 node:
 
 [source,yaml]
 -------------------
-node.roles: [ data, master, voting_only ]
+node.roles: [ data, control, voting_only ]
 -------------------
 
 IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not
 supported in the {oss-dist}. If you use the {oss-dist} and add the `voting_only`
 role then the node will fail to start.  Also note that only nodes with the
-`master` role can be marked as having the `voting_only` role.
+`control` role can have the `voting_only` role.
 
-High availability (HA) clusters require at least three master-eligible nodes, at
-least two of which are not voting-only nodes. Such a cluster will be able to
-elect a master node even if one of the nodes fails.
+High availability (HA) clusters require at least three control nodes, at
+least two of which are not voting-only nodes. This enables a cluster to
+promote a control node to manager even if one of the control nodes fails.
 
-Since voting-only nodes never act as the cluster's elected master, they may
-require require less heap and a less powerful CPU than the true master nodes.
-However all master-eligible nodes, including voting-only nodes, require
+Since voting-only nodes never act as the cluster's manager, they may
+require less heap and a less powerful CPU.
+However all control nodes, including voting-only nodes, require
 reasonably fast persistent storage and a reliable and low-latency network
 connection to the rest of the cluster, since they are on the critical path for
 <<cluster-state-publishing,publishing cluster state updates>>.
 
-Voting-only master-eligible nodes may also fill other roles in your cluster.
-For instance, a node may be both a data node and a voting-only master-eligible
-node. A _dedicated_ voting-only master-eligible nodes is a voting-only
-master-eligible node that fills no other roles in the cluster. To create a
-dedicated voting-only master-eligible node in the {default-dist}, set:
+Voting-only control nodes may also fill other roles in your cluster.
+For instance, a node may be both a data node and a voting-only control
+node. A _dedicated_ voting-only control node fills no other roles in the cluster. 
+To create a dedicated voting-only control node in the {default-dist}, set:
 
 [source,yaml]
 -------------------
-node.roles: [ master, voting_only ]
+node.roles: [ control, voting_only ]
 -------------------
 
 [[data-node]]
@@ -186,7 +180,7 @@ nodes handle data related operations like CRUD, search, and aggregations.
 These operations are I/O-, memory-, and CPU-intensive. It is important to
 monitor these resources and to add more data nodes if they are overloaded.
 
-The main benefit of having dedicated data nodes is the separation of the master
+The main benefit of having dedicated data nodes is the separation of the control
 and data roles.
 
 To create a dedicated data node, set:
@@ -221,19 +215,19 @@ an ingest pipeline to transform and enrich a document before indexing. Default:
 [[coordinating-only-node]]
 ==== Coordinating only node
 
-If you take away the ability to be able to handle master duties, to hold data,
+If you take away the ability to be able to handle control duties, to hold data,
 and pre-process documents, then you are left with a _coordinating_ node that
 can only route requests, handle the search reduce phase, and distribute bulk
 indexing. Essentially, coordinating only nodes behave as smart load balancers.
 
 Coordinating only nodes can benefit large clusters by offloading the
-coordinating node role from data and master-eligible nodes.  They join the
+coordinating node role from data and control nodes.  They join the
 cluster and receive the full <<cluster-state,cluster state>>, like every other
 node, and they use the cluster state to route requests directly to the
 appropriate place(s).
 
 WARNING: Adding too many coordinating only nodes to a cluster can increase the
-burden on the entire cluster because the elected master node must await
+burden on the entire cluster because the manager node must await
 acknowledgement of cluster state updates from every node! The benefit of
 coordinating only nodes should not be overstated -- data nodes can happily
 serve the same purpose.
@@ -253,7 +247,7 @@ requests. If `xpack.ml.enabled` is set to `true` and the node does not have the
 `ml` role, the node can service API requests but it cannot run jobs.
 
 If you want to use {ml-features} in your cluster, you must enable {ml}
-(set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you want to
+(set `xpack.ml.enabled` to `true`) on all control nodes. If you want to
 use {ml-features} in clients (including {kib}), it must also be enabled on all
 coordinating nodes. If you have the {oss-dist}, do not use these settings.
 
@@ -291,7 +285,7 @@ Each data node maintains the following data on disk:
 * the index metadata corresponding with every shard allocated to that node, and
 * the cluster-wide metadata, such as settings and index templates.
 
-Similarly, each master-eligible node maintains the following data on disk:
+Similarly, each control node maintains the following data on disk:
 
 * the index metadata for every index in the cluster, and
 * the cluster-wide metadata, such as settings and index templates.
@@ -301,20 +295,20 @@ unexpected data then it will refuse to start. This is to avoid importing
 unwanted <<modules-gateway-dangling-indices,dangling indices>> which can lead
 to a red cluster health. To be more precise, nodes without the `data` role will
 refuse to start if they find any shard data on disk at startup, and nodes 
-without both the `master` and `data` roles will refuse to start if they have any 
+without both the `control` and `data` roles will refuse to start if they have any 
 index metadata on disk at startup.
 
 It is possible to change the roles of a node by adjusting its
 `elasticsearch.yml` file and restarting it. This is known as _repurposing_ a
 node. In order to satisfy the checks for unexpected data described above, you
 must perform some extra steps to prepare a node for repurposing when starting
-the node without the `data` or `master` roles.
+the node without the `data` or `control` roles.
 
 * If you want to repurpose a data node by removing the `data` role then you
   should first use an <<allocation-filtering,allocation filter>> to safely
   migrate all the shard data onto other nodes in the cluster.
 
-* If you want to repurpose a node to have neither the `data` nor `master` roles
+* If you want to repurpose a node to have neither the `data` nor `control` roles
   then it is simplest to start a brand-new node with an empty data path and the
   desired roles. You may find it safest to use an
   <<allocation-filtering,allocation filter>> to migrate the shard data elsewhere
@@ -330,7 +324,7 @@ excess data that prevents a node from starting.
 [[data-path]]
 ==== `path.data`
 
-Every data and master-eligible node requires access to a data directory where
+Every data and control node requires access to a data directory where
 shards and index and cluster metadata will be stored. The `path.data` defaults
 to `$ES_HOME/data` but can be configured in the `elasticsearch.yml` config
 file an absolute path or a path relative to `$ES_HOME` as follows:

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -101,7 +101,7 @@ cluster health to have a stable manager node.
 Any control node that is not a <<voting-only-node,voting-only node>> can
 become the manager through the <<modules-discovery, election process>>.
 
-IMPORTANT: Manager nodes must have access to the `data/` directory (just like
+IMPORTANT: Control nodes must have access to the `data/` directory (just like
 `data` nodes) as this is where the cluster state is persisted between node
 restarts.
 

--- a/docs/reference/setup/add-nodes.asciidoc
+++ b/docs/reference/setup/add-nodes.asciidoc
@@ -14,8 +14,8 @@ functional but is at risk of data loss in the event of a failure.
 image::setup/images/elas_0202.png["A cluster with one node and three primary shards"]
 
 You add nodes to a cluster to increase its capacity and reliability. By default,
-a node is both a data node and eligible to be elected as the master node that
-controls the cluster. You can also configure a new node for a specific purpose,
+a node is both a data node and eligible to act as the manager node that
+facilitates cluster-wide actions. You can also configure a new node for a specific purpose,
 such as handling ingest requests. For more information, see
 <<modules-node,Nodes>>.
 
@@ -44,53 +44,53 @@ For more information about discovery and shard allocation, see
 
 [discrete]
 [[add-elasticsearch-nodes-master-eligible]]
-=== Master-eligible nodes
+=== Control nodes
 
 As nodes are added or removed Elasticsearch maintains an optimal level of fault
 tolerance by automatically updating the cluster's _voting configuration_, which
-is the set of <<master-node,master-eligible nodes>> whose responses are counted
-when making decisions such as electing a new master or committing a new cluster
+is the set of <<master-node,control nodes>> whose responses are counted
+when making decisions such as selecting a new manager or committing a new cluster
 state.
 
-It is recommended to have a small and fixed number of master-eligible nodes in a
+It is recommended to have a small and fixed number of control nodes in a
 cluster, and to scale the cluster up and down by adding and removing
-master-ineligible nodes only. However there are situations in which it may be
-desirable to add or remove some master-eligible nodes to or from a cluster.
+non-control nodes. However, there are situations in which it may be
+desirable to add or remove control nodes.
 
 [discrete]
 [[modules-discovery-adding-nodes]]
-==== Adding master-eligible nodes
+==== Adding control nodes
 
 If you wish to add some nodes to your cluster, simply configure the new nodes
 to find the existing cluster and start them up. Elasticsearch adds the new nodes
 to the voting configuration if it is appropriate to do so.
 
-During master election or when joining an existing formed cluster, a node
-sends a join request to the master in order to be officially added to the
+When joining an existing cluster, a node
+sends a join request to the manager in order to be officially added to the
 cluster.
 
 [discrete]
 [[modules-discovery-removing-nodes]]
-==== Removing master-eligible nodes
+==== Removing control nodes
 
-When removing master-eligible nodes, it is important not to remove too many all
-at the same time. For instance, if there are currently seven master-eligible
+When removing control nodes, it is important not to remove too many all
+at the same time. For instance, if there are currently seven control
 nodes and you wish to reduce this to three, it is not possible simply to stop
 four of the nodes at once: to do so would leave only three nodes remaining,
 which is less than half of the voting configuration, which means the cluster
 cannot take any further actions.
 
-More precisely, if you shut down half or more of the master-eligible nodes all
+More precisely, if you shut down half or more of the control nodes all
 at the same time then the cluster will normally become unavailable. If this
 happens then you can bring the cluster back online by starting the removed
 nodes again.
 
-As long as there are at least three master-eligible nodes in the cluster, as a
+As long as there are at least three control nodes in the cluster, as a
 general rule it is best to remove nodes one-at-a-time, allowing enough time for
 the cluster to <<modules-discovery-quorums,automatically adjust>> the voting
 configuration and adapt the fault tolerance level to the new set of nodes.
 
-If there are only two master-eligible nodes remaining then neither node can be
+If there are only two control nodes remaining then neither node can be
 safely removed since both are required to reliably make progress. To remove one
 of these nodes you must first inform {es} that it should not be part of the
 voting configuration, and that the voting power should instead be given to the
@@ -101,7 +101,7 @@ from the voting configuration so its vote is no longer required. Importantly,
 {es} will never automatically move a node on the voting exclusions list back
 into the voting configuration. Once an excluded node has been successfully
 auto-reconfigured out of the voting configuration, it is safe to shut it down
-without affecting the cluster's master-level availability. A node can be added
+without affecting the cluster's availability. A node can be added
 to the voting configuration exclusion list using the
 <<voting-config-exclusions>> API. For example:
 
@@ -123,24 +123,24 @@ using the `?node_names` query parameter, or by their persistent node IDs using
 the `?node_ids` query parameter. If a call to the voting configuration
 exclusions API fails, you can safely retry it. Only a successful response
 guarantees that the node has actually been removed from the voting configuration
-and will not be reinstated. If the elected master node is excluded from the
-voting configuration then it will abdicate to another master-eligible node that
+and will not be reinstated. If the manager node is excluded from the
+voting configuration then it will abdicate to another control node that
 is still in the voting configuration if such a node is available.
 
 Although the voting configuration exclusions API is most useful for down-scaling
 a two-node to a one-node cluster, it is also possible to use it to remove
-multiple master-eligible nodes all at the same time. Adding multiple nodes to
+multiple control nodes at the same time. Adding multiple nodes to
 the exclusions list has the system try to auto-reconfigure all of these nodes
 out of the voting configuration, allowing them to be safely shut down while
 keeping the cluster available. In the example described above, shrinking a
-seven-master-node cluster down to only have three master nodes, you could add
+seven-control-node cluster down to only have three control nodes, you could add
 four nodes to the exclusions list, wait for confirmation, and then shut them
 down simultaneously.
 
 NOTE: Voting exclusions are only required when removing at least half of the
 master-eligible nodes from a cluster in a short time period. They are not
-required when removing master-ineligible nodes, nor are they required when
-removing fewer than half of the master-eligible nodes.
+required when removing nodes other than control nodes, nor are they required when
+removing less than half of the control nodes.
 
 Adding an exclusion for a node creates an entry for that node in the voting
 configuration exclusions list, which has the system automatically try to

--- a/docs/reference/setup/add-nodes.asciidoc
+++ b/docs/reference/setup/add-nodes.asciidoc
@@ -138,7 +138,7 @@ four nodes to the exclusions list, wait for confirmation, and then shut them
 down simultaneously.
 
 NOTE: Voting exclusions are only required when removing at least half of the
-master-eligible nodes from a cluster in a short time period. They are not
+control nodes from a cluster in a short time period. They are not
 required when removing nodes other than control nodes, nor are they required when
 removing less than half of the control nodes.
 


### PR DESCRIPTION
Updated a few of the node and discovery related topics to use _manager_ and _control_ in place of master and master-eligible. 

This is an exercise in test-driving the terms, not the work needed to make the switch. 