### PR TITLE
Only call reduce on a single InternalAggregation when needed (#62525)

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
@@ -255,6 +255,11 @@ public class InternalMatrixStats extends InternalAggregation implements MatrixSt
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), stats, results);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -255,8 +255,16 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
      * aggregations are of the same type (the same type as this aggregation). For best efficiency, when implementing,
      * try reusing an existing instance (typically the first in the given list) to save on redundant object
      * construction.
+     *
+     * @see #mustReduceOnSingleInternalAgg()
      */
     public abstract InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext);
+
+    /**
+     * Signal the framework if the {@linkplain InternalAggregation#reduce(List, ReduceContext)} phase needs to be called
+     * when there is only one {@linkplain InternalAggregation}.
+     */
+    protected abstract boolean mustReduceOnSingleInternalAgg();
 
     /**
      * Return true if this aggregation is mapped, and can lead a reduction.  If this agg returns

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -255,7 +255,12 @@ public final class InternalAggregations extends Aggregations implements Writeabl
             // If all aggs are unmapped, the agg that leads the reduction will just return itself
             aggregations.sort(INTERNAL_AGG_COMPARATOR);
             InternalAggregation first = aggregations.get(0); // the list can't be empty as it's created on demand
-            reducedAggregations.add(first.reduce(aggregations, context));
+            if (first.mustReduceOnSingleInternalAgg() || aggregations.size() > 1) {
+                reducedAggregations.add(first.reduce(aggregations, context));
+            } else {
+                // no need for reduce phase
+                reducedAggregations.add(first);
+            }
         }
 
         return ctor.apply(reducedAggregations);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -178,6 +178,11 @@ public abstract class InternalMultiBucketAggregation<A extends InternalMultiBuck
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
+    }
+
+    @Override
     public void forEachBucket(Consumer<InternalAggregations> consumer) {
         for (B bucket : getBuckets()) {
             consumer.accept((InternalAggregations) bucket.getAggregations());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -177,6 +177,11 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
+    }
+
+    @Override
     public InternalAggregation copyWithRewritenBuckets(Function<InternalAggregations, InternalAggregations> rewriter) {
         InternalAggregations rewritten = rewriter.apply(aggregations);
         if (rewritten == null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
@@ -117,6 +117,11 @@ public class InternalGeoBounds extends InternalAggregation implements GeoBounds 
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+
+    @Override
     public Object getProperty(List<String> path) {
         if (path.isEmpty()) {
             return this;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
@@ -134,6 +134,11 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+
+    @Override
     public Object getProperty(List<String> path) {
         if (path.isEmpty()) {
             return this;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -129,6 +129,11 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), format);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -74,7 +74,7 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
                 /*
                  * I *believe* that this situation can only happen in cross
                  * cluster search right now. Thus the message. But computers
-                 * are hard. 
+                 * are hard.
                  */
                 throw new IllegalArgumentException("scripted_metric doesn't support cross cluster search until 7.8.0");
             }
@@ -132,6 +132,11 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
             aggregation = aggregationObjects;
         }
         return new InternalScriptedMetric(firstAggregation.getName(), aggregation, firstAggregation.reduceScript, getMetadata());
+    }
+
+    @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -41,7 +41,8 @@ import java.util.Map;
 /**
  * Results of the {@link TopHitsAggregator}.
  */
-public class InternalTopHits extends InternalAggregation implements TopHits {
+public class
+InternalTopHits extends InternalAggregation implements TopHits {
     private int from;
     private int size;
     private TopDocsAndMaxScore topDocs;
@@ -160,6 +161,11 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
         return new InternalTopHits(name, this.from, this.size,
             new TopDocsAndMaxScore(reducedTopDocs, maxScore),
             new SearchHits(hits, reducedTopDocs.totalHits, maxScore), getMetadata());
+    }
+
+    @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -41,8 +41,7 @@ import java.util.Map;
 /**
  * Results of the {@link TopHitsAggregator}.
  */
-public class
-InternalTopHits extends InternalAggregation implements TopHits {
+public class InternalTopHits extends InternalAggregation implements TopHits {
     private int from;
     private int size;
     private TopDocsAndMaxScore topDocs;

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -1008,6 +1008,11 @@ public class SearchPhaseControllerTests extends ESTestCase {
         }
 
         @Override
+        protected boolean mustReduceOnSingleInternalAgg() {
+            return true;
+        }
+
+        @Override
         public Object getProperty(List<String> path) {
             return null;
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -994,6 +994,11 @@ public abstract class AggregatorTestCase extends ESTestCase {
         }
 
         @Override
+        protected boolean mustReduceOnSingleInternalAgg() {
+            return true;
+        }
+
+        @Override
         public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
             return builder.array("cardinality", cardinality);
         }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -215,6 +215,11 @@ public class InternalStringStats extends InternalAggregation {
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+
+    @Override
     public Object getProperty(List<String> path) {
         if (path.isEmpty()) {
             return this;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InternalInferenceAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InternalInferenceAggregation.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class InternalInferenceAggregation extends InternalAggregation {
+public  class InternalInferenceAggregation extends InternalAggregation {
 
     private final InferenceResults inferenceResult;
 
@@ -47,6 +47,10 @@ public class InternalInferenceAggregation extends InternalAggregation {
         throw new UnsupportedOperationException("Reducing an inference aggregation is not supported");
     }
 
+    @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
+    }
 
     @Override
     public Object getProperty(List<String> path) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestSingleValueAggregation.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestSingleValueAggregation.java
@@ -41,6 +41,11 @@ public class TestSingleValueAggregation extends InternalAggregation {
     }
 
     @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return true;
+    }
+
+    @Override
     public Object getProperty(List<String> path) {
         if (this.path.equals(path)) {
             return value;


### PR DESCRIPTION
Currently we always call reduce even when we only have one InternalAggregation. In some cases this is necessary but in others the reduce method is just making a copy of itself. This is normally not too expensive excepts for aggregations that hold expensive objects, for example cardinality or percentile aggregations.

In order to prevent this necessary step this PR adds a new abstract method in InternalAggregation that flags the framework if it needs to reduce on a single InternalAggregation.

backport #62525

