### PR TITLE
Unmute rollover docs test

### DIFF
--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -372,7 +372,7 @@ index is rolled over. For instance:
 [source,console]
 --------------------------------------------------
 # PUT /<logs-{now/d}-1> with URI encoding:
-PUT /%3Clogs-%7Bnow%2Fd%7D-1%3E <1>
+PUT /%3Clogs_%7Bnow%2Fd%7D-1%3E <1>
 {
   "aliases": {
     "logs_write": {}
@@ -395,10 +395,10 @@ POST /logs_write/_rollover <2>
   }
 }
 --------------------------------------------------
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/62043"]
+// TEST[s/now/2016.10.31%7C%7C/]
 
-<1> Creates an index named with today's date (e.g.) `logs-2016.10.31-1`
-<2> Rolls over to a new index with today's date, e.g. `logs-2016.10.31-000002` if run immediately, or `logs-2016.11.01-000002` if run after 24 hours
+<1> Creates an index named with today's date (e.g.) `logs_2016.10.31-1`
+<2> Rolls over to a new index with today's date, e.g. `logs_2016.10.31-000002` if run immediately, or `logs-2016.11.01-000002` if run after 24 hours
 
 //////////////////////////
 
@@ -411,12 +411,12 @@ GET _alias
 [source,console-result]
 --------------------------------------------------
 {
-  "logs-2016.10.31-000002": {
+  "logs_2016.10.31-000002": {
     "aliases": {
       "logs_write": {}
     }
   },
-  "logs-2016.10.31-1": {
+  "logs_2016.10.31-1": {
     "aliases": {}
   }
 }


### PR DESCRIPTION
Backport of #62603 to 7.x branch.

The underlying issue was fixed a while ago in Lucene:
https://issues.apache.org/jira/browse/LUCENE-9517

and went away when lucene snapshot version was upgraded.

Also the name of the index to rollover had to be slightly changed,
so that it doesn't collide with data stream template's namespace.
(a regular index can't be created in the namespace that is managed
by a template that creates data streams)

Closes #62043