### PR TITLE
Use the Elastic Docker registry for the UBI base image

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DockerBase.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DockerBase.java
@@ -25,7 +25,7 @@ package org.elasticsearch.gradle;
 public enum DockerBase {
     CENTOS("centos:8"),
     // "latest" here is intentional, since the image name specifies "8"
-    UBI("registry.access.redhat.com/ubi8/ubi-minimal:latest");
+    UBI("docker.elastic.co/ubi8/ubi-minimal:latest");
 
     private final String image;
 


### PR DESCRIPTION
This PR just swaps the base Docker image for UBI builds to point at Elastic's registry.