### PR TITLE
Use BitArray instead of FixedBitSet for collecting ordinals in Cardinality Aggregator (#62600)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BitArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BitArray.java
@@ -50,6 +50,37 @@ public final class BitArray implements Releasable {
         bits.set(wordNum, bits.get(wordNum) | bitmask(index));
     }
 
+    /** this = this OR other */
+    public void or(BitArray other) {
+        or(other.bits);
+    }
+
+    private void or(final LongArray otherArr) {
+        long pos = otherArr.size();
+        bits = bigArrays.grow(bits, pos + 1);
+        final LongArray thisArr = this.bits;
+        while (--pos >= 0) {
+            thisArr.set(pos, thisArr.get(pos) | otherArr.get(pos));
+        }
+    }
+
+    public long nextSetBit(long index) {
+        long wordNum = wordNum(index);
+        long word = bits.get(wordNum) >> index;  // skip all the bits to the right of index
+
+        if (word!=0) {
+            return index + Long.numberOfTrailingZeros(word);
+        }
+
+        while (++wordNum < bits.size()) {
+            word = bits.get(wordNum);
+            if (word != 0) {
+                return (wordNum << 6) + Long.numberOfTrailingZeros(word);
+            }
+        }
+        return Long.MAX_VALUE;
+    }
+
     /**
      * Clear the {@code index}th bit.
      */

--- a/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
@@ -113,4 +113,55 @@ public class BitArrayTests extends ESTestCase {
             bitArray.clear(100000000);
         }
     }
+
+    public void testOr() {
+        try (BitArray bitArray1 = new BitArray(1, BigArrays.NON_RECYCLING_INSTANCE);
+             BitArray bitArray2 = new BitArray(1, BigArrays.NON_RECYCLING_INSTANCE);
+             BitArray bitArrayFull = new BitArray(1, BigArrays.NON_RECYCLING_INSTANCE)) {
+            int numBits = randomIntBetween(1000, 10000);
+            for (int step = 0; step < 3; step++) {
+                for (int i = 0; i < numBits; i++) {
+                    if (randomBoolean()) {
+                        if (rarely()) {
+                            bitArray1.set(i);
+                            bitArray2.set(i);
+                        } else if (randomBoolean()) {
+                            bitArray1.set(i);
+                        } else {
+                            bitArray2.set(i);
+                        }
+                        bitArrayFull.set(i);
+                    }
+                }
+                bitArray1.or(bitArray2);
+                for (int i = 0; i < numBits; i++) {
+                    assertEquals(bitArrayFull.get(i), bitArray1.get(i));
+                }
+            }
+        }
+    }
+
+    public void testNextBitSet() {
+        try (BitArray bitArray = new BitArray(1, BigArrays.NON_RECYCLING_INSTANCE)) {
+            int numBits = randomIntBetween(1000, 10000);
+            for (int step = 0; step < 3; step++) {
+                for (int i = 0; i < numBits; i++) {
+                    if (randomBoolean()) {
+                        bitArray.set(i);
+                    }
+                }
+                long next = bitArray.nextSetBit(0);
+                for (int i = 0; i < numBits; i++) {
+                    if (i == next) {
+                        assertEquals(true, bitArray.get(i));
+                        if (i < numBits - 1) {
+                            next = bitArray.nextSetBit(i + 1);
+                        }
+                    } else {
+                        assertEquals(false, bitArray.get(i));
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR changes the way we collecting ordinals in the Cardinality aggregation from Lucene FixedBitSet to BitArray. The benefit is that BitArray is tracked by our Circuit breakers so it is safer.

backport #62600
