### PR TITLE
Emit deprecation warnings when boosts are defined in mappings

### DIFF
--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -63,6 +63,21 @@ The `enabled` setting for `_field_names` should be removed from templates and ma
 Disabling _field_names is not necessary because it no longer carries a large index overhead.
 ====
 
+[[mapping-boosts]]
+.The `boost` parameter on field mappings has been deprecated
+[%collapsible]
+====
+*Details* +
+Index-time boosts have been deprecated since the 5x line, but it is still possible
+to declare field-specific boosts in the mappings.  This is now deprecated as well,
+and will be removed entirely in 8.0.  Mappings containing field boosts will continue
+to work in 7.x but will emit a deprecation warning.
+
+*Impact* +
+The `boost` setting should be removed from templates and mappings.  Use boosts
+directly on queries instead.
+====
+
 //tag::notable-breaking-changes[]
 .Java-time date formats replace joda-time formats
 [%collapsible]

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -571,7 +571,10 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                         + "] on mapper [" + name + "] of type [" + type + "]");
                 }
                 if (Objects.equals("boost", propName)) {
-                    deprecationLogger.deprecate("boost", "Parameter [boost] on field [{}] is deprecated", name);
+                    deprecationLogger.deprecate(
+                        "boost",
+                        "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                        name);
                 }
                 if (propNode == null && parameter.acceptsNull == false) {
                     throw new MapperParsingException("[" + propName + "] on mapper [" + name

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -570,6 +570,9 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                     throw new MapperParsingException("unknown parameter [" + propName
                         + "] on mapper [" + name + "] of type [" + type + "]");
                 }
+                if (Objects.equals("boost", propName)) {
+                    deprecationLogger.deprecate("boost", "Parameter [boost] on field [{}] is deprecated", name);
+                }
                 if (propNode == null && parameter.acceptsNull == false) {
                     throw new MapperParsingException("[" + propName + "] on mapper [" + name
                         + "] of type [" + type + "] must not have a [null] value");

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -246,7 +246,10 @@ public class TypeParsers {
                 iterator.remove();
             } else if (propName.equals("boost")) {
                 builder.boost(nodeFloatValue(propNode));
-                deprecationLogger.deprecate("boost", "Parameter [boost] on field [{}] is deprecated", name);
+                deprecationLogger.deprecate(
+                    "boost",
+                    "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                    name);
                 iterator.remove();
             } else if (propName.equals("index_options")) {
                 builder.indexOptions(nodeIndexOptionValue(propNode));

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -246,6 +246,7 @@ public class TypeParsers {
                 iterator.remove();
             } else if (propName.equals("boost")) {
                 builder.boost(nodeFloatValue(propNode));
+                deprecationLogger.deprecate("boost", "Parameter [boost] on field [{}] is deprecated", name);
                 iterator.remove();
             } else if (propName.equals("index_options")) {
                 builder.indexOptions(nodeIndexOptionValue(propNode));

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -50,7 +50,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
     }
 
     public void testDefaults() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -48,6 +48,11 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         b.field("type", "boolean");
     }
 
+    @Override
+    protected void assertParseMaximalWarnings() {
+        assertWarnings("Parameter [boost] on field [field] is deprecated");
+    }
+
     public void testDefaults() throws IOException {
 
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
@@ -170,6 +175,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
 
         MappedFieldType ft = mapperService.fieldType("field");
         assertEquals(new BoostQuery(new TermQuery(new Term("field", "T")), 2.0f), ft.termQuery("true", null));
+        assertParseMaximalWarnings();
     }
 
     public void testFetchSourceValue() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -52,7 +52,7 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
     }
 
     public void testDefaults() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -50,6 +50,11 @@ public class DateFieldMapperTests extends MapperTestCase {
         b.field("type", "date");
     }
 
+    @Override
+    protected void assertParseMaximalWarnings() {
+        assertWarnings("Parameter [boost] on field [field] is deprecated");
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -133,7 +133,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
     }
 
     public void testDefaults() throws Exception {
@@ -240,7 +240,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testBoost() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("boost", 2f)));
         assertThat(mapperService.fieldType("field").boost(), equalTo(2f));
-        assertWarnings("Parameter [boost] on field [field] is deprecated");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
     }
 
     public void testEnableNorms() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -131,6 +131,11 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         b.field("type", "keyword");
     }
 
+    @Override
+    protected void assertParseMaximalWarnings() {
+        assertWarnings("Parameter [boost] on field [field] is deprecated");
+    }
+
     public void testDefaults() throws Exception {
         XContentBuilder mapping = fieldMapping(this::minimalMapping);
         DocumentMapper mapper = createDocumentMapper(mapping);
@@ -235,6 +240,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testBoost() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("boost", 2f)));
         assertThat(mapperService.fieldType("field").boost(), equalTo(2f));
+        assertWarnings("Parameter [boost] on field [field] is deprecated");
     }
 
     public void testEnableNorms() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -75,7 +75,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
     }
 
     private Object getFrom(String type) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -73,6 +73,11 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         b.field("type", "long_range");
     }
 
+    @Override
+    protected void assertParseMaximalWarnings() {
+        assertWarnings("Parameter [boost] on field [field] is deprecated");
+    }
+
     private Object getFrom(String type) {
         if (type.equals("date_range")) {
             return FROM_DATE;

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -350,7 +350,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge("_doc", new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(
-            "string_boost", "type=text,boost=4", "string_no_pos",
+            "string_boost", "type=text", "string_no_pos",
             "type=text,index_options=docs"))
             ),
             MapperService.MergeReason.MAPPING_UPDATE);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -82,10 +83,14 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         createMapperService(orig).documentMapper().mapping().toXContent(parsedFromOrig, INCLUDE_DEFAULTS);
         parsedFromOrig.endObject();
         assertEquals(Strings.toString(orig), Strings.toString(parsedFromOrig));
-        assertParseMinimalWarnings();
+        assertParseMaximalWarnings();
     }
 
     protected void assertParseMinimalWarnings() {
+        // Most mappers don't emit any warnings
+    }
+
+    protected void assertParseMaximalWarnings() {
         // Most mappers don't emit any warnings
     }
 
@@ -130,6 +135,22 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             XContentHelper.convertToMap(BytesReference.bytes(mapping), false, mapping.contentType()).v2(),
             XContentHelper.convertToMap(mapperService.documentMapper().mappingSource().uncompressed(), false, mapping.contentType()).v2()
         );
+    }
+
+    public final void testDeprecatedBoost() throws IOException {
+        try {
+            createMapperService(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("boost", 2.0);
+            }));
+            assertWarnings("Parameter [boost] on field [field] is deprecated");
+        }
+        catch (MapperParsingException e) {
+            assertThat(e.getMessage(), anyOf(
+                containsString("unknown parameter [boost]"),
+                containsString("[boost : 2.0]")));
+        }
+        assertParseMinimalWarnings();
     }
 
     public static List<?> fetchSourceValue(FieldMapper mapper, Object sourceValue) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -143,7 +143,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 minimalMapping(b);
                 b.field("boost", 2.0);
             }));
-            assertWarnings("Parameter [boost] on field [field] is deprecated");
+            assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
         }
         catch (MapperParsingException e) {
             assertThat(e.getMessage(), anyOf(


### PR DESCRIPTION
We removed index-time boosting back in 5x, and we no longer document the 'boost'
parameter on any of our mapping types.  However, it is still possible to define an
index-time boost on a field mapper for a surprisingly large number of field types, and
they even have an effect (sometimes, on some queries).

As a first step in finally removing all traces of index time boosting, this comment emits
a deprecation warning whenever a boost parameter is found on a mapping definition.