### PR TITLE
[DOCS] [6.8] Remove wording that read-only index block is auto-released

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -156,13 +156,14 @@ specific index module:
 
 `index.blocks.read_only_allow_delete`::
 
-    Similar to `index.blocks.read_only`, but also allows deleting the index to
-    make more resources available. The <<disk-allocator,disk-based shard
-    allocator>> may add and remove this block automatically.
-
-Deleting documents from an index to release resources - rather than deleting the index itself - can increase the index size over time. When `index.blocks.read_only_allow_delete` is set to `true`, deleting documents is not permitted. However, deleting the index itself releases the read-only index block and makes resources available almost immediately.
-
-IMPORTANT: {es} adds and removes the read-only index block automatically when the disk utilization falls below the high watermark, controlled by <<cluster-routing-flood_stage,cluster.routing.allocation.disk.watermark.flood_stage>>.
+Similar to `index.blocks.read_only`, but also allows deleting the index to
+make more resources available.
++
+Deleting documents from an index to release resources - rather than deleting
+the index itself - can increase the index size over time. When
+`index.blocks.read_only_allow_delete` is set to `true`, deleting documents is
+not permitted. However, deleting the index itself releases the read-only index
+block and makes resources available almost immediately.
 
 `index.blocks.read`::
 

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -40,7 +40,7 @@ Controls the flood stage watermark, which defaults to 95%. {es} enforces a read-
 (`index.blocks.read_only_allow_delete`) on every index that has one or more
 shards allocated on the node, and that has at least one disk exceeding the flood
 stage. This setting is a last resort to prevent nodes from running out of disk space.
-The index block is automatically released when the disk utilization falls below
+The index block must be released manually when the disk utilization falls below
 the high watermark.
 
 NOTE: You cannot mix the usage of percentage values and byte values within


### PR DESCRIPTION
#57322 clarified wording for the flood stage watermark and indicated that Elasticsearch releases the read-only block automatically. However, the auto-release capability was added in Elasticsearch 7.4, so this wording should not be included in 6.8. This PR removes that wording and closes #62426.