### PR TITLE
[7.x] Make yamlRestTest and javaRestTest tasks lazy (#62515)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/RestTestBasePlugin.java
@@ -41,7 +41,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
                 .getExtensions()
                 .getByName(TestClustersPlugin.EXTENSION_NAME);
-            ElasticsearchCluster cluster = testClusters.create(restIntegTestTask.getName());
+            ElasticsearchCluster cluster = testClusters.maybeCreate(restIntegTestTask.getName());
             restIntegTestTask.useCluster(cluster);
             restIntegTestTask.include("**/*IT.class");
             restIntegTestTask.systemProperty("tests.rest.load_packaged", Boolean.FALSE.toString());

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -27,12 +27,13 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.createTestCluster;
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupRunnerTask;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupTask;
 
 /**
  * Apply this plugin to run the Java based REST tests.
@@ -52,11 +53,11 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        // setup the javaRestTest task
-        RestIntegTestTask javaRestTestTask = setupTask(project, SOURCE_SET_NAME);
+        // create the test cluster container
+        createTestCluster(project, javaTestSourceSet);
 
-        // setup the runner task
-        setupRunnerTask(project, javaRestTestTask, javaTestSourceSet);
+        // setup the javaRestTest task
+        Provider<RestIntegTestTask> javaRestTestTask = registerTask(project, javaTestSourceSet);
 
         // setup dependencies
         setupDependencies(project, javaTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -27,12 +27,13 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.createTestCluster;
+import static org.elasticsearch.gradle.test.rest.RestTestUtil.registerTask;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupRunnerTask;
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupTask;
 
 /**
  * Apply this plugin to run the YAML based REST tests.
@@ -53,11 +54,11 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        // setup the yamlRestTest task
-        RestIntegTestTask yamlRestTestTask = setupTask(project, SOURCE_SET_NAME);
+        // create the test cluster container
+        createTestCluster(project, yamlTestSourceSet);
 
-        // setup the runner task
-        setupRunnerTask(project, yamlRestTestTask, yamlTestSourceSet);
+        // setup the yamlRestTest task
+        Provider<RestIntegTestTask> yamlRestTestTask = registerTask(project, yamlTestSourceSet);
 
         // setup the dependencies
         setupDependencies(project, yamlTestSourceSet);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make yamlRestTest and javaRestTest tasks lazy (#62515)