### PR TITLE
Re-enable testing conventions for x-pack:plugin:core

### DIFF
--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -162,5 +162,3 @@ testClusters.yamlRestTest {
   user username: "x_pack_rest_user", password: "x-pack-test-password"
 }
 
-tasks.named("testingConventions").configure { enabled = false }
-


### PR DESCRIPTION
Not sure why these were disabled, but they seem to work properly 
now so let's re-enable them. 

