### PR TITLE
[DOCS] Formatting fix in get trained model API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -139,6 +139,7 @@ The license level of the trained model.
 (object)
 An object containing metadata about the trained model. For example, models
 created by {dfanalytics} contain `analysis_config` and `input` objects.
++
 .Properties of metadata
 [%collapsible%open]
 =====

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -786,7 +786,7 @@ used to train the model, which defaults to `<dependent_variable>_prediction`.
 end::inference-config-results-field-processor[]
 
 tag::inference-metadata-feature-importance-feature-name[]
-The training feature name for which this importance was calculated.
+The feature for which this importance was calculated.
 end::inference-metadata-feature-importance-feature-name[]
 tag::inference-metadata-feature-importance-magnitude[]
 The average magnitude of this feature across all the training data.


### PR DESCRIPTION
This PR fixes minor issues in the get trained model API (elastic.co/guide/en/elasticsearch/reference/master/get-inference.html), which were introduced in https://github.com/elastic/elasticsearch/pull/61922

### Preview

https://elasticsearch_62643.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-inference.html