### PR TITLE
Sparse vector to throw exception consistently

### DIFF
--- a/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -15,7 +15,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -40,6 +42,14 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
     @Override
     protected boolean forbidPrivateIndexSettings() {
         return false;
+    }
+
+    public void testValueFetcherIsNotSupported() {
+        SparseVectorFieldMapper.Builder builder = new SparseVectorFieldMapper.Builder("field");
+        SparseVectorFieldMapper fieldMapper = builder.build(new Mapper.BuilderContext(Settings.EMPTY, new ContentPath()));
+        UnsupportedOperationException exc = expectThrows(UnsupportedOperationException.class,
+            () -> fieldMapper.valueFetcher(null, null, null));
+        assertEquals(SparseVectorFieldMapper.ERROR_MESSAGE_7X, exc.getMessage());
     }
 
     public void testSparseVectorWith8xIndex() throws Exception {

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.vectors.mapper;
 
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -19,7 +18,6 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -98,19 +96,17 @@ public class SparseVectorFieldMapper extends FieldMapper {
 
         @Override
         public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
-            throw new UnsupportedOperationException(
-                "Field [" + name() + "] of type [" + typeName() + "] doesn't support docvalue_fields or aggregations");
+            throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            return new DocValuesFieldExistsQuery(name());
+            throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            throw new UnsupportedOperationException(
-                "Field [" + name() + "] of type [" + typeName() + "] doesn't support queries");
+            throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
     }
 
@@ -148,15 +144,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
 
     @Override
     public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-        if (format != null) {
-            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
-        }
-        return new SourceValueFetcher(name(), mapperService, parsesArrayValue()) {
-            @Override
-            protected Object parseSourceValue(Object value) {
-                return value;
-            }
-        };
+        throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
     }
 
     @Override

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldTypeTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldTypeTests.java
@@ -18,4 +18,22 @@ public class SparseVectorFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType("field", Collections.emptyMap());
         expectThrows(IllegalArgumentException.class, () -> fieldType.fielddataBuilder("index", null));
     }
+
+    public void testDocValueFormatIsNotSupported() {
+        MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType("field", Collections.emptyMap());
+        UnsupportedOperationException exc = expectThrows(UnsupportedOperationException.class, () -> fieldType.docValueFormat(null, null));
+        assertEquals(SparseVectorFieldMapper.ERROR_MESSAGE_7X, exc.getMessage());
+    }
+
+    public void testExistsQueryIsNotSupported() {
+        MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType("field", Collections.emptyMap());
+        UnsupportedOperationException exc = expectThrows(UnsupportedOperationException.class, () -> fieldType.existsQuery(null));
+        assertEquals(SparseVectorFieldMapper.ERROR_MESSAGE_7X, exc.getMessage());
+    }
+
+    public void testTermQueryIsNotSupported() {
+        MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType("field", Collections.emptyMap());
+        UnsupportedOperationException exc = expectThrows(UnsupportedOperationException.class, () -> fieldType.termQuery(null, null));
+        assertEquals(SparseVectorFieldMapper.ERROR_MESSAGE_7X, exc.getMessage());
+    }
 }


### PR DESCRIPTION
Sparse vector is no longer supported, and its existsQuery should throw exception as well as its valueFetcher method.
