### PR TITLE
[7.8] [DOCS] Fix issue link in redirects (#62654)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -674,10 +674,11 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference
-because it was out of date and erroneously implied that it should be used by application developers.
-There is an issue ({es-issue}[#55258])
-for providing general testing guidance for applications that communicate with {es}.
+({es-issue}55257[55257]) from the {es} Reference because it was out of date and
+erroneously implied that it should be used by application developers.
+
+There is an issue ({es-issue}55258[#55258]) for providing general testing
+guidance for applications that communicate with {es}.
 
 
 [role="exclude",id="why-randomized-testing"]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Fix issue link in redirects (#62654)