### PR TITLE
[7.x] Add index.routing.allocation.include._tier_preference setting (#62589)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -396,7 +396,7 @@ Returns:
       "index.creation_date": "1474389951325",
       "index.uuid": "n6gzFZTgS664GUfx0Xrpjw",
       "index.version.created": ...,
-      "index.routing.allocation.include._tier" : "data_content",
+      "index.routing.allocation.include._tier_preference" : "data_content",
       "index.provided_name" : "my-index-000001"
     }
   }
@@ -433,7 +433,7 @@ Returns:
         "routing": {
           "allocation": {
             "include": {
-              "_tier": "data_content"
+              "_tier_preference": "data_content"
             }
           }
         },

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -116,7 +116,7 @@ PUT /my-index-000001?master_timeout=1s&timeout=1s
 {
   "settings": {
     "index.routing.allocation.include._name": "non_existent_node",
-    "index.routing.allocation.include._tier": null
+    "index.routing.allocation.include._tier_preference": null
   }
 }
 

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -250,7 +250,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                     // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                     // before timing out
                     .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
-                    .put("index.routing.allocation.include._tier", "")
+                    .put("index.routing.allocation.include._tier_preference", "")
                     .put(SETTING_ALLOCATION_MAX_RETRY.getKey(), "0"); // fail faster
                 createIndex(index, settings.build());
                 indexDocs(index, 0, 10);
@@ -267,7 +267,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
                     .put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String)null)
                     .put("index.routing.allocation.include._id", oldNode)
-                    .putNull("index.routing.allocation.include._tier")
+                    .putNull("index.routing.allocation.include._tier_preference")
                 );
                 ensureGreen(index); // wait for the primary to be assigned
                 ensureNoInitializingShards(); // wait for all other shard activity to finish
@@ -290,7 +290,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 updateIndexSettings(index, Settings.builder()
                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2)
                     .put("index.routing.allocation.include._id", (String)null)
-                    .putNull("index.routing.allocation.include._tier")
+                    .putNull("index.routing.allocation.include._tier_preference")
                 );
                 asyncIndexDocs(index, 60, 45).get();
                 ensureGreen(index);

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -181,7 +181,7 @@ public class DiscoveryNodeFilters {
                         }
                     }
                 }
-            } else if ("_tier".equals(attr)) {
+            } else if (attr != null && attr.startsWith("_tier")) {
                 // Always allow _tier as an attribute, will be handled elsewhere
                 return true;
             } else {

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
@@ -50,7 +50,7 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         final PutFollowAction.Request putFollowRequest = putFollow(leaderIndex, followerIndex);
         putFollowRequest.setSettings(Settings.builder()
             .put("index.routing.allocation.include._name", String.join(",", dataOnlyNodes))
-            .putNull("index.routing.allocation.include._tier")
+            .putNull("index.routing.allocation.include._tier_preference")
             .build());
         putFollowRequest.waitForActiveShards(ActiveShardCount.ONE);
         putFollowRequest.timeout(TimeValue.timeValueSeconds(2));
@@ -84,7 +84,7 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
             .put("index.routing.rebalance.enable", "none")
             .put("index.routing.allocation.include._name",
                 Stream.concat(dataOnlyNodes.stream(), dataAndRemoteNodes.stream()).collect(Collectors.joining(",")))
-            .putNull("index.routing.allocation.include._tier")
+            .putNull("index.routing.allocation.include._tier_preference")
             .build());
         final PutFollowAction.Response response = followerClient().execute(PutFollowAction.INSTANCE, putFollowRequest).get();
         assertTrue(response.isFollowIndexShardsAcked());
@@ -108,8 +108,8 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         followerClient().admin().indices().prepareUpdateSettings(followerIndex)
             .setMasterNodeTimeout(TimeValue.MAX_VALUE)
             .setSettings(Settings.builder()
-                .put("index.routing.allocation.include._name", String.join(",", dataOnlyNodes))
-                .putNull("index.routing.allocation.include._tier"))
+                .putNull("index.routing.allocation.include._tier_preference")
+                .put("index.routing.allocation.include._name", String.join(",", dataOnlyNodes)))
             .get();
         assertBusy(() -> {
             final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -6,9 +6,11 @@
 
 package org.elasticsearch.xpack.cluster.routing.allocation;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -21,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.DataTier;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,6 +41,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
     public static final String CLUSTER_ROUTING_EXCLUDE = "cluster.routing.allocation.exclude._tier";
     public static final String INDEX_ROUTING_REQUIRE = "index.routing.allocation.require._tier";
     public static final String INDEX_ROUTING_INCLUDE = "index.routing.allocation.include._tier";
+    public static final String INDEX_ROUTING_PREFER = "index.routing.allocation.include._tier_preference";
     public static final String INDEX_ROUTING_EXCLUDE = "index.routing.allocation.exclude._tier";
 
     public static final Setting<String> CLUSTER_ROUTING_REQUIRE_SETTING = Setting.simpleString(CLUSTER_ROUTING_REQUIRE,
@@ -51,6 +55,8 @@ public class DataTierAllocationDecider extends AllocationDecider {
     public static final Setting<String> INDEX_ROUTING_INCLUDE_SETTING = Setting.simpleString(INDEX_ROUTING_INCLUDE,
         DataTierAllocationDecider::validateTierSetting, Setting.Property.Dynamic, Setting.Property.IndexScope);
     public static final Setting<String> INDEX_ROUTING_EXCLUDE_SETTING = Setting.simpleString(INDEX_ROUTING_EXCLUDE,
+        DataTierAllocationDecider::validateTierSetting, Setting.Property.Dynamic, Setting.Property.IndexScope);
+    public static final Setting<String> INDEX_ROUTING_PREFER_SETTING = Setting.simpleString(INDEX_ROUTING_PREFER,
         DataTierAllocationDecider::validateTierSetting, Setting.Property.Dynamic, Setting.Property.IndexScope);
 
     private static void validateTierSetting(String setting) {
@@ -101,7 +107,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
             return decision;
         }
 
-        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require tier filters");
+        decision = shouldIndexPreferTier(indexMetadata, node, allocation);
+        if (decision != null) {
+            return decision;
+        }
+
+        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
     }
 
     private Decision shouldFilter(ShardRouting shardRouting, DiscoveryNode node, RoutingAllocation allocation) {
@@ -115,7 +126,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
             return decision;
         }
 
-        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require tier filters");
+        decision = shouldIndexPreferTier(allocation.metadata().getIndexSafe(shardRouting.index()), node, allocation);
+        if (decision != null) {
+            return decision;
+        }
+
+        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
     }
 
     private Decision shouldFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
@@ -129,7 +145,37 @@ public class DataTierAllocationDecider extends AllocationDecider {
             return decision;
         }
 
-        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require tier filters");
+        decision = shouldIndexPreferTier(indexMd, node, allocation);
+        if (decision != null) {
+            return decision;
+        }
+
+        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
+    }
+
+    private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
+        Settings indexSettings = indexMetadata.getSettings();
+        String tierPreference = INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
+
+        if (Strings.hasText(tierPreference)) {
+            Optional<String> tier = preferredAvailableTier(tierPreference, allocation.nodes());
+            if (tier.isPresent()) {
+                String tierName = tier.get();
+                // The OpType doesn't actually matter here, because we have
+                // selected only a single tier as our "preferred" tier
+                if (allocationAllowed(OpType.AND, tierName, node)) {
+                    return allocation.decision(Decision.YES, NAME,
+                        "index has a preference for tiers [%s] and node has tier [%s]", tierPreference, tierName);
+                } else {
+                    return allocation.decision(Decision.NO, NAME,
+                        "index has a preference for tiers [%s] and node does not meet the required [%s] tier", tierPreference, tierName);
+                }
+            } else {
+                return allocation.decision(Decision.NO, NAME, "index has a preference for tiers [%s], " +
+                    "but no nodes for any of those tiers are available in the cluster", tierPreference);
+            }
+        }
+        return null;
     }
 
     private Decision shouldIndexFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
@@ -185,6 +231,31 @@ public class DataTierAllocationDecider extends AllocationDecider {
         AND,
         OR
     }
+
+    /**
+     * Given a string of comma-separated prioritized tiers (highest priority
+     * first) and an allocation, find the highest priority tier for which nodes
+     * exist. If no nodes for any of the tiers are available, returns an empty
+     * {@code Optional<String>}.
+     */
+    static Optional<String> preferredAvailableTier(String prioritizedTiers, DiscoveryNodes nodes) {
+        String[] tiers = Strings.tokenizeToStringArray(prioritizedTiers, ",");
+        return Arrays.stream(tiers).filter(tier -> tierNodesPresent(tier, nodes)).findFirst();
+    }
+
+    static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
+        assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier) :
+            "tier " + singleTier + " is an invalid tier name";
+        for (ObjectCursor<DiscoveryNode> node : nodes.getNodes().values()) {
+            if (node.value.getRoles().stream()
+                .map(DiscoveryNodeRole::roleName)
+                .anyMatch(s -> s.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || s.equals(singleTier))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     private static boolean allocationAllowed(OpType opType, String tierSetting, DiscoveryNode node) {
         String[] values = Strings.tokenizeToStringArray(tierSetting, ",");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -156,9 +156,9 @@ public class DataTier {
         @Override
         public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings indexSettings) {
             Set<String> settings = indexSettings.keySet();
-            if (settings.contains(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE)) {
+            if (settings.contains(DataTierAllocationDecider.INDEX_ROUTING_PREFER)) {
                 // It's okay to put it, it will be removed or overridden by the template/request settings
-                return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE, DATA_HOT).build();
+                return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_HOT).build();
             } else if (settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + ".")) ||
                 settings.stream().anyMatch(s -> s.startsWith(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX + "."))) {
@@ -170,9 +170,9 @@ public class DataTier {
                 // tier if the index is part of a data stream, the "content"
                 // tier if it is not.
                 if (isDataStreamIndex) {
-                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE, DATA_HOT).build();
+                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_HOT).build();
                 } else {
-                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE, DATA_CONTENT).build();
+                    return Settings.builder().put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_CONTENT).build();
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -417,6 +417,7 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
         settings.add(DataTierAllocationDecider.INDEX_ROUTING_REQUIRE_SETTING);
         settings.add(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE_SETTING);
         settings.add(DataTierAllocationDecider.INDEX_ROUTING_EXCLUDE_SETTING);
+        settings.add(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING);
         return settings;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -92,7 +92,7 @@ public class MigrateAction implements LifecycleAction {
             Settings.Builder migrationSettings = Settings.builder();
             String dataTierName = "data_" + phase;
             assert DataTier.validTierName(dataTierName) : "invalid data tier name:" + dataTierName;
-            migrationSettings.put(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE, dataTierName);
+            migrationSettings.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, dataTierName);
             UpdateSettingsStep updateMigrationSettingStep = new UpdateSettingsStep(migrationKey, migrationRoutedKey, client,
                 migrationSettings.build());
             DataTierMigrationRoutedStep migrationRoutedStep = new DataTierMigrationRoutedStep(migrationRoutedKey, nextStepKey);

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
@@ -64,7 +64,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .get()
             .getSettings()
             .get(DataStream.getDefaultBackingIndexName(index, 1));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
+        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         logger.info("--> waiting for {} to be yellow", index);
         ensureYellow(index);
@@ -78,7 +78,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .get()
             .getSettings()
             .get(DataStream.getDefaultBackingIndexName(index, 2));
-        assertThat(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
+        assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         client().execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { index }));
     }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -657,7 +657,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         createIndexWithSettings(client(), index, alias, Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .putNull(DataTierAllocationDecider.INDEX_ROUTING_INCLUDE));
+            .putNull(DataTierAllocationDecider.INDEX_ROUTING_PREFER));
 
         ensureGreen(index);
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add index.routing.allocation.prefer._tier setting (#62589)