### PR TITLE
Remove invalid assertion in SearchService

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -300,8 +300,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         // this is important to ensure store can be cleaned up, in particular if the search is a scroll with a long timeout.
         final Index index = context.indexShard().shardId().getIndex();
         if (indicesService.hasIndex(index) == false) {
-            final ReaderContext removed = removeReaderContext(context.id().getId());
-            assert removed == context;
+            removeReaderContext(context.id().getId());
             throw new IndexNotFoundException(index);
         }
     }


### PR DESCRIPTION
This assertion does not always hold because there can be a race between [putReaderContext](https://github.com/elastic/elasticsearch/blob/b857768bb5bc1561c5c599897a9adb12048ee375/server/src/main/java/org/elasticsearch/search/SearchService.java#L296) and [afterIndexRemoved](https://github.com/elastic/elasticsearch/blob/b857768bb5bc1561c5c599897a9adb12048ee375/server/src/main/java/org/elasticsearch/search/SearchService.java#L285) when an index is deleted.

Closes #62624