### PR TITLE
Override needsScore() on ValueCountAggregator

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
@@ -123,6 +124,11 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
             return buildEmptyAggregation();
         }
         return new InternalValueCount(name, counts.get(bucket), metadata());
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override


### PR DESCRIPTION
This aggregator does not implement needScore() and therefore it always return false as it cannot have sub-aggregations. The issue is that if it contains a script that needs scores, then the assumption is wrong. Note that this test has starting failing due to work on https://github.com/apache/lucene-solr/pull/1834

closes #62438