### PR TITLE
Convert ConstantKeywordFieldMapper to parametrized form

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -147,7 +148,8 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         private Consumer<T> validator = null;
         private Serializer<T> serializer = XContentBuilder::field;
         private BooleanSupplier serializerPredicate = () -> true;
-        private Function<T, String> conflictSerializer = Object::toString;
+        private Function<T, String> conflictSerializer = Objects::toString;
+        private BiPredicate<T, T> mergeValidator;
         private T value;
         private boolean isSet;
 
@@ -167,6 +169,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             this.parser = parser;
             this.initializer = initializer;
             this.updateable = updateable;
+            this.mergeValidator = (previous, toMerge) -> updateable || Objects.equals(previous, toMerge);
         }
 
         /**
@@ -240,6 +243,15 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             return this;
         }
 
+        /**
+         * Sets a custom merge validator.  By default, merges are accepted if the
+         * parameter is updateable, or if the previous and new values are equal
+         */
+        public Parameter<T> setMergeValidator(BiPredicate<T, T> mergeValidator) {
+            this.mergeValidator = mergeValidator;
+            return this;
+        }
+
         private void validate() {
             if (validator != null) {
                 validator.accept(getValue());
@@ -257,10 +269,10 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         private void merge(FieldMapper toMerge, Conflicts conflicts) {
             T value = initializer.apply(toMerge);
             T current = getValue();
-            if (updateable == false && Objects.equals(current, value) == false) {
-                conflicts.addConflict(name, conflictSerializer.apply(current), conflictSerializer.apply(value));
-            } else {
+            if (mergeValidator.test(current, value)) {
                 setValue(value);
+            } else {
+                conflicts.addConflict(name, conflictSerializer.apply(current), conflictSerializer.apply(value));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -37,7 +36,6 @@ import org.elasticsearch.index.mapper.ParametrizedFieldMapper.Parameter;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -46,11 +44,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ParametrizedMapperTests extends ESSingleNodeTestCase {
+public class ParametrizedMapperTests extends MapperServiceTestCase {
 
     public static class TestPlugin extends Plugin implements MapperPlugin {
         @Override
@@ -60,8 +59,8 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
     }
 
     @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return List.of(TestPlugin.class);
+    protected Collection<Plugin> getPlugins() {
+        return List.of(new TestPlugin());
     }
 
     private static class StringWrapper {
@@ -110,7 +109,8 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
                 if (n > 50) {
                     throw new IllegalArgumentException("Value of [n] cannot be greater than 50");
                 }
-            });
+            })
+            .setMergeValidator((o, n) -> n >= o);
         final Parameter<NamedAnalyzer> analyzer
             = Parameter.analyzerParam("analyzer", false, m -> toType(m).analyzer, () -> Lucene.KEYWORD_ANALYZER);
         final Parameter<NamedAnalyzer> searchAnalyzer
@@ -333,8 +333,6 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
 
     public void testObjectSerialization() throws IOException {
 
-        IndexService indexService = createIndex("test");
-
         String mapping = "{\"_doc\":{" +
             "\"properties\":{" +
             "\"actual\":{\"type\":\"double\"}," +
@@ -343,11 +341,12 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
             "\"anomaly_score\":{\"type\":\"double\"}," +
             "\"bucket_span\":{\"type\":\"long\"}," +
             "\"is_interim\":{\"type\":\"boolean\"}}}}}}";
-        indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-        assertEquals(mapping, Strings.toString(indexService.mapperService().documentMapper()));
 
-        indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-        assertEquals(mapping, Strings.toString(indexService.mapperService().documentMapper()));
+        MapperService mapperService = createMapperService(mapping);
+        assertEquals(mapping, Strings.toString(mapperService.documentMapper()));
+
+        mapperService.merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        assertEquals(mapping, Strings.toString(mapperService.documentMapper()));
     }
 
     // test custom serializer
@@ -485,6 +484,21 @@ public class ParametrizedMapperTests extends ESSingleNodeTestCase {
             TestMapper mapper = fromMapping(mapping);
             assertEquals("foo", mapper.restricted);
         }
+    }
+
+    public void testCustomMergeValidation() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            b.field("type", "test_mapper");
+            b.field("required", "a");
+            b.field("int_value", 10);
+        }));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, fieldMapping(b -> {
+            b.field("type", "test_mapper");
+            b.field("required", "a");
+            b.field("int_value", 5);    // custom merge validator says that int_value can only increase
+        })));
+        assertThat(e.getMessage(), containsString("int_value"));
     }
 
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/internalClusterTest/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/internalClusterTest/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -7,59 +7,30 @@
 package org.elasticsearch.xpack.constantkeyword.mapper;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.FieldMapperTestCase2;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
+import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
-public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<ConstantKeywordFieldMapper.Builder> {
+public class ConstantKeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Collection<Plugin> getPlugins() {
         return List.of(new ConstantKeywordMapperPlugin());
-    }
-
-    @Override
-    protected Set<String> unsupportedProperties() {
-        return Set.of("analyzer", "similarity", "store", "doc_values", "index");
-    }
-
-    @Override
-    protected ConstantKeywordFieldMapper.Builder newBuilder() {
-        return new ConstantKeywordFieldMapper.Builder("constant");
-    }
-
-    @Before
-    public void addModifiers() {
-        addModifier("value", false, (a, b) -> {
-            a.setValue("foo");
-            b.setValue("bar");
-        });
-        addModifier("unset", false, (a, b) -> {
-            a.setValue("foo");
-            ;
-        });
-        addModifier("value-from-null", true, (a, b) -> { b.setValue("bar"); });
     }
 
     public void testDefaults() throws Exception {
@@ -67,18 +38,15 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
         DocumentMapper mapper = createDocumentMapper(mapping);
         assertEquals(Strings.toString(mapping), mapper.mappingSource().toString());
 
-        BytesReference source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().endObject());
-        ParsedDocument doc = mapper.parse(new SourceToParse("test", "1", source, XContentType.JSON));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
         assertNull(doc.rootDoc().getField("field"));
 
-        source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "foo").endObject());
-        doc = mapper.parse(new SourceToParse("test", "1", source, XContentType.JSON));
+        doc = mapper.parse(source(b -> b.field("field", "foo")));
         assertNull(doc.rootDoc().getField("field"));
 
-        BytesReference illegalSource = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "bar").endObject());
         MapperParsingException e = expectThrows(
             MapperParsingException.class,
-            () -> mapper.parse(new SourceToParse("test", "1", illegalSource, XContentType.JSON))
+            () -> mapper.parse(source(b -> b.field("field", "bar")))
         );
         assertEquals(
             "[constant_keyword] field [field] only accepts values that are equal to the value defined in the mappings [foo], "
@@ -90,8 +58,7 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
     public void testDynamicValue() throws Exception {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword")));
 
-        BytesReference source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "foo").endObject());
-        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "1", source, XContentType.JSON));
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", "foo")));
         assertNull(doc.rootDoc().getField("field"));
         assertNotNull(doc.dynamicMappingsUpdate());
 
@@ -100,9 +67,53 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase2<Consta
         String expectedMapping = Strings.toString(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         assertEquals(expectedMapping, updatedMapper.mappingSource().toString());
 
-        doc = updatedMapper.parse(new SourceToParse("test", "1", source, XContentType.JSON));
+        doc = updatedMapper.parse(source(b -> b.field("field", "foo")));
         assertNull(doc.rootDoc().getField("field"));
         assertNull(doc.dynamicMappingsUpdate());
+    }
+
+    public void testBadValues() {
+        {
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                b.field("type", "constant_keyword");
+                b.nullField("value");
+            })));
+            assertEquals(e.getMessage(),
+                "Failed to parse mapping: [value] on mapper [field] of type [constant_keyword] must not have a [null] value");
+        }
+        {
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                b.field("type", "constant_keyword");
+                b.startObject("value").field("foo", "bar").endObject();
+            })));
+            assertEquals(e.getMessage(),
+                "Failed to parse mapping: Property [value] on field [field] must be a number or a string, but got [{foo=bar}]");
+        }
+    }
+
+    public void testNumericValue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            b.field("type", "constant_keyword");
+            b.field("value", 74);
+        }));
+        ConstantKeywordFieldMapper.ConstantKeywordFieldType ft
+            = (ConstantKeywordFieldMapper.ConstantKeywordFieldType) mapperService.fieldType("field");
+        assertEquals("74", ft.value());
+    }
+
+    public void testUpdate() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            b.field("type", "constant_keyword");
+            b.field("value", "foo");
+        }));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, fieldMapping(b -> {
+            b.field("type", "constant_keyword");
+            b.field("value", "bar");
+        })));
+        assertEquals(e.getMessage(),
+            "Mapper for [field] conflicts with existing mapper:\n" +
+            "\tCannot update parameter [value] from [foo] to [bar]");
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/ConstantKeywordMapperPlugin.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/ConstantKeywordMapperPlugin.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonMap;
 public class ConstantKeywordMapperPlugin extends Plugin implements MapperPlugin {
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return singletonMap(ConstantKeywordFieldMapper.CONTENT_TYPE, new ConstantKeywordFieldMapper.TypeParser());
+        return singletonMap(ConstantKeywordFieldMapper.CONTENT_TYPE, ConstantKeywordFieldMapper.PARSER);
     }
 
 }


### PR DESCRIPTION
As part of the conversion, adds the ability to customize merge validation - in this case, we
allow an update to the constant value if it is currently set to `null`, but refuse further
updates once it has been set once.

This commit also converts ParametrizedMapperTests to use MapperServiceTestCase.