### PR TITLE
Binary field mapper to carry stored parameter value

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectArrayList;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
@@ -78,8 +79,14 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public BinaryFieldMapper build(BuilderContext context) {
-            return new BinaryFieldMapper(name, new BinaryFieldType(buildFullName(context), hasDocValues.getValue(), meta.getValue()),
-                    multiFieldsBuilder.build(this, context), copyTo.build(), this);
+            FieldType fieldType;
+            if (stored.getValue()) {
+                fieldType = StoredField.TYPE;
+            } else {
+                fieldType = new FieldType();
+            }
+            return new BinaryFieldMapper(name, new BinaryFieldType(buildFullName(context), hasDocValues.getValue(), fieldType,
+                meta.getValue()), multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
     }
 
@@ -87,12 +94,12 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
 
     public static final class BinaryFieldType extends MappedFieldType {
 
-        public BinaryFieldType(String name, boolean hasDocValues, Map<String, String> meta) {
-            super(name, false, hasDocValues, TextSearchInfo.NONE, meta);
+        public BinaryFieldType(String name, boolean hasDocValues, FieldType fieldType, Map<String, String> meta) {
+            super(name, false, hasDocValues, new TextSearchInfo(fieldType, null, null, null), meta);
         }
 
         public BinaryFieldType(String name) {
-            this(name, true, Collections.emptyMap());
+            super(name, false, true, TextSearchInfo.NONE, Collections.emptyMap());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -55,6 +55,8 @@ public class BinaryFieldMapperTests extends MapperTestCase {
             b.field("store", "true");
         }));
 
+        assertTrue(mapperService.fieldType("field").getTextSearchInfo().isStored());
+
         // case 1: a simple binary value
         final byte[] binaryValue1 = new byte[100];
         binaryValue1[56] = 1;


### PR DESCRIPTION
The binary field can be configured to be stored, in which case a lucene stored field is created. Though the value for the store flag is lost when the field type is created, which is not so bad as the stored field has already been created, but it is advisable to align fieldType.getTextSearchInfo().isStored() .