### PR TITLE
[7.x] [DOCS] Change index name from `index` to `my-index-000001` (#62678)

### DIFF
--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -456,7 +456,7 @@ See some examples of interactions with Elasticsearch with this option set to `fa
 
 [source,console]
 --------------------------------------------------
-PUT index?include_type_name=false
+PUT /my-index-000001?include_type_name=false
 {
   "mappings": {
     "properties": { <1>
@@ -472,7 +472,7 @@ PUT index?include_type_name=false
 
 [source,console]
 --------------------------------------------------
-PUT index/_mappings?include_type_name=false
+PUT /my-index-000001/_mappings?include_type_name=false
 {
   "properties": { <1>
     "bar": {
@@ -487,7 +487,7 @@ PUT index/_mappings?include_type_name=false
 
 [source,console]
 --------------------------------------------------
-GET index/_mappings?include_type_name=false
+GET /my-index-000001/_mappings?include_type_name=false
 --------------------------------------------------
 // TEST[continued]
 
@@ -496,7 +496,7 @@ The above call returns
 [source,console-result]
 --------------------------------------------------
 {
-  "index": {
+  "my-index-000001": {
     "mappings": {
       "properties": { <1>
         "foo": {
@@ -521,7 +521,7 @@ generation of the `_id` and `{index}/_doc/{id}` with explicit ids.
 
 [source,console]
 --------------------------------------------------
-PUT index/_doc/1
+PUT /my-index-000001/_doc/1
 {
   "foo": "baz"
 }
@@ -530,7 +530,7 @@ PUT index/_doc/1
 [source,console-result]
 --------------------------------------------------
 {
-  "_index": "index",
+  "_index": "my-index-000001",
   "_id": "1",
   "_type": "_doc",
   "_version": 1,
@@ -549,7 +549,7 @@ Similarly, the `get` and `delete` APIs use the path `{index}/_doc/{id}`:
 
 [source,console]
 --------------------------------------------------
-GET index/_doc/1
+GET /my-index-000001/_doc/1
 --------------------------------------------------
 // TEST[continued]
 
@@ -562,14 +562,14 @@ in 7.0 the endpoint will immediately follow the index name:
 
 [source,console]
 --------------------------------------------------
-POST index/_update/1
+POST /my-index-000001/_update/1
 {
   "doc" : {
     "foo" : "qux"
   }
 }
 
-GET /index/_source/1
+GET /my-index-000001/_source/1
 --------------------------------------------------
 // TEST[continued]
 
@@ -580,9 +580,9 @@ bulk commands:
 [source,console]
 --------------------------------------------------
 POST _bulk
-{ "index" : { "_index" : "index", "_id" : "3" } }
+{ "index" : { "_index" : "my-index-000001", "_id" : "3" } }
 { "foo" : "baz" }
-{ "index" : { "_index" : "index", "_id" : "4" } }
+{ "index" : { "_index" : "my-index-000001", "_id" : "4" } }
 { "foo" : "qux" }
 --------------------------------------------------
 
@@ -609,18 +609,18 @@ return `_doc` as the type, even if the mapping has a custom type name like
 
 [source,console]
 --------------------------------------------------
-PUT index/my_type/1
+PUT /my-index-000001/my_type/1
 {
   "foo": "baz"
 }
 
-GET index/_doc/1
+GET /my-index-000001/_doc/1
 --------------------------------------------------
 
 [source,console-result]
 --------------------------------------------------
 {
-  "_index" : "index",
+  "_index" : "my-index-000001",
   "_type" : "_doc",
   "_id" : "1",
   "_version" : 1,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Change index name from `index` to `my-index-000001` (#62678)