### PR TITLE
Log Successful Snapshot Abort

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1248,6 +1248,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                if (completedNoCleanup.isEmpty() == false) {
+                    logger.info("snapshots {} aborted", completedNoCleanup);
+                }
                 for (Snapshot snapshot : completedNoCleanup) {
                     failSnapshotCompletionListeners(snapshot,
                         new SnapshotException(snapshot, SnapshotsInProgress.ABORTED_FAILURE_TEXT));


### PR DESCRIPTION
We were missing a log statement for snapshots that could be aborted
directly due to the optimization in #62173. Without logging added
we get no logging whatsoever and snapshots disappear without
anything logged at info level which makes debugging unnecessarily
complex.
