### PR TITLE
[DOCS] Add realm limitations for monitoring clusters

### DIFF
--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -128,9 +128,11 @@ a single {kib} instance to access both your production cluster and monitoring
 cluster.
 +
 --
-NOTE: If you use SAML, Kerberos, PKI, or OpenID Connect realms on your
-production or monitoring clusters, a dedicated {kib} instance is *required*. The security tokens that are used in these realms are cluster-specific, therefore
-you cannot use a single {kib} instance to connect to both clusters.
+NOTE: If you log in to {kib} using SAML, Kerberos, PKI, OpenID Connect, or token
+authentication providers, a dedicated {kib} instance is *required*. The security
+tokens that are used in these contexts are cluster-specific, therefore you
+cannot use a single {kib} instance to connect to both production and monitoring
+clusters.
 
 --
 

--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -128,10 +128,9 @@ a single {kib} instance to access both your production cluster and monitoring
 cluster.
 +
 --
-NOTE: If the monitoring cluster uses a SAML, Kerberos, PKI, or OpenID Connect
-realm, a dedicated {kib} instance is required. The security tokens that are used
-in these realms are cluster-specific and therefore cannot be used by a single
-{kib} instance to connect to both the production and monitoring clusters.
+NOTE: If you use SAML, Kerberos, PKI, or OpenID Connect realms on your
+production or monitoring clusters, a dedicated {kib} instance is *required*. The security tokens that are used in these realms are cluster-specific, therefore
+you cannot use a single {kib} instance to connect to both clusters.
 
 --
 

--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -126,6 +126,14 @@ cluster.
 . (Optional) Create a dedicated {kib} instance for monitoring, rather than using
 a single {kib} instance to access both your production cluster and monitoring
 cluster.
++
+--
+NOTE: If the monitoring cluster uses a SAML, Kerberos, PKI, or OpenID Connect
+realm, a dedicated {kib} instance is required. The security tokens that are used
+in these realms are cluster-specific and therefore cannot be used by a single
+{kib} instance to connect to both the production and monitoring clusters.
+
+--
 
 .. (Optional) Disable the collection of monitoring data in this {kib} instance.
 Set the `xpack.monitoring.kibana.collection.enabled` setting to `false` in the


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/77938 and https://github.com/elastic/kibana/issues/21611

This PR updates the instructions for [monitoring in a production environment](https://www.elastic.co/guide/en/elasticsearch/reference/master/monitoring-production.html) to clarify that the use of certain realms on the monitoring cluster necessitate the use of a dedicated Kibana instance.

### Preview

https://elasticsearch_62714.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/monitoring-production.html