### PR TITLE
Runtime Field: Centralize LeafFactory construction

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptMappedFieldType.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -35,17 +34,10 @@ import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
  */
 abstract class AbstractScriptMappedFieldType<LeafFactory> extends MappedFieldType {
     protected final Script script;
-    private final TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory;
 
-    AbstractScriptMappedFieldType(
-        String name,
-        Script script,
-        TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory,
-        Map<String, String> meta
-    ) {
+    AbstractScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
         super(name, false, false, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
         this.script = script;
-        this.factory = factory;
     }
 
     protected abstract String runtimeType();
@@ -73,9 +65,7 @@ abstract class AbstractScriptMappedFieldType<LeafFactory> extends MappedFieldTyp
     /**
      * Create a script leaf factory.
      */
-    protected final LeafFactory leafFactory(SearchLookup searchLookup) {
-        return factory.apply(name(), script.getParams(), searchLookup);
-    }
+    protected abstract LeafFactory leafFactory(SearchLookup searchLookup);
 
     /**
      * Create a script leaf factory for queries.

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptMappedFieldType.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class BooleanScriptMappedFieldType extends AbstractScriptMappedFieldType<BooleanFieldScript.LeafFactory> {
-    BooleanScriptMappedFieldType(String name, Script script, BooleanFieldScript.Factory scriptFactory, Map<String, String> meta) {
-        super(name, script, scriptFactory::newFactory, meta);
+public abstract class BooleanScriptMappedFieldType extends AbstractScriptMappedFieldType<BooleanFieldScript.LeafFactory> {
+    BooleanScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, script, meta);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptMappedFieldType.java
@@ -35,17 +35,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class DateScriptMappedFieldType extends AbstractScriptMappedFieldType<DateFieldScript.LeafFactory> {
+public abstract class DateScriptMappedFieldType extends AbstractScriptMappedFieldType<DateFieldScript.LeafFactory> {
     private final DateFormatter dateTimeFormatter;
 
-    DateScriptMappedFieldType(
-        String name,
-        Script script,
-        DateFieldScript.Factory scriptFactory,
-        DateFormatter dateTimeFormatter,
-        Map<String, String> meta
-    ) {
-        super(name, script, (n, params, ctx) -> scriptFactory.newFactory(n, params, ctx, dateTimeFormatter), meta);
+    DateScriptMappedFieldType(String name, Script script, DateFormatter dateTimeFormatter, Map<String, String> meta) {
+        super(name, script, meta);
         this.dateTimeFormatter = dateTimeFormatter;
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptMappedFieldType.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<DoubleFieldScript.LeafFactory> {
-    DoubleScriptMappedFieldType(String name, Script script, DoubleFieldScript.Factory scriptFactory, Map<String, String> meta) {
-        super(name, script, scriptFactory::newFactory, meta);
+public abstract class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<DoubleFieldScript.LeafFactory> {
+    DoubleScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, script, meta);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptMappedFieldType.java
@@ -36,9 +36,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public final class IpScriptMappedFieldType extends AbstractScriptMappedFieldType<IpFieldScript.LeafFactory> {
-    IpScriptMappedFieldType(String name, Script script, IpFieldScript.Factory scriptFactory, Map<String, String> meta) {
-        super(name, script, scriptFactory::newFactory, meta);
+public abstract class IpScriptMappedFieldType extends AbstractScriptMappedFieldType<IpFieldScript.LeafFactory> {
+    IpScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, script, meta);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptMappedFieldType.java
@@ -35,9 +35,9 @@ import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toSet;
 
-public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFieldType<StringFieldScript.LeafFactory> {
-    KeywordScriptMappedFieldType(String name, Script script, StringFieldScript.Factory scriptFactory, Map<String, String> meta) {
-        super(name, script, scriptFactory::newFactory, meta);
+public abstract class KeywordScriptMappedFieldType extends AbstractScriptMappedFieldType<StringFieldScript.LeafFactory> {
+    KeywordScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, script, meta);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptMappedFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptMappedFieldType.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<LongFieldScript.LeafFactory> {
-    LongScriptMappedFieldType(String name, Script script, LongFieldScript.Factory scriptFactory, Map<String, String> meta) {
-        super(name, script, scriptFactory::newFactory, meta);
+public abstract class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<LongFieldScript.LeafFactory> {
+    LongScriptMappedFieldType(String name, Script script, Map<String, String> meta) {
+        super(name, script, meta);
     }
 
     @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
@@ -86,17 +86,20 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             BooleanFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
-                BooleanFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), BooleanFieldScript.CONTEXT);
-                return new BooleanScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
+                BooleanFieldScript.Factory factory = builder.scriptCompiler.compile(script, BooleanFieldScript.CONTEXT);
+                return new BooleanScriptMappedFieldType(name, script, builder.meta.getValue()) {
+                    @Override
+                    protected BooleanFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup);
+                    }
+                };
             },
             DateFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
-                DateFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), DateFieldScript.CONTEXT);
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
                 String format = builder.format.getValue();
                 if (format == null) {
                     format = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern();
@@ -106,57 +109,65 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
                     locale = Locale.ROOT;
                 }
                 DateFormatter dateTimeFormatter = DateFormatter.forPattern(format).withLocale(locale);
-                return new DateScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    dateTimeFormatter,
-                    builder.meta.getValue()
-                );
+                DateFieldScript.Factory factory = builder.scriptCompiler.compile(script, DateFieldScript.CONTEXT);
+                return new DateScriptMappedFieldType(name, script, dateTimeFormatter, builder.meta.getValue()) {
+                    @Override
+                    protected DateFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup, dateTimeFormatter);
+                    }
+                };
             },
             NumberType.DOUBLE.typeName(),
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
-                DoubleFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), DoubleFieldScript.CONTEXT);
-                return new DoubleScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
+                DoubleFieldScript.Factory factory = builder.scriptCompiler.compile(script, DoubleFieldScript.CONTEXT);
+                return new DoubleScriptMappedFieldType(name, script, builder.meta.getValue()) {
+                    @Override
+                    protected DoubleFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup);
+                    }
+                };
             },
             IpFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
-                IpFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), IpFieldScript.CONTEXT);
-                return new IpScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
+                IpFieldScript.Factory factory = builder.scriptCompiler.compile(script, IpFieldScript.CONTEXT);
+                return new IpScriptMappedFieldType(name, script, builder.meta.getValue()) {
+                    @Override
+                    protected IpFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup);
+                    }
+                };
             },
             KeywordFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
-                StringFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), StringFieldScript.CONTEXT);
-                return new KeywordScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
+                StringFieldScript.Factory factory = builder.scriptCompiler.compile(script, StringFieldScript.CONTEXT);
+                return new KeywordScriptMappedFieldType(name, script, builder.meta.getValue()) {
+                    @Override
+                    protected StringFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup);
+                    }
+                };
             },
             NumberType.LONG.typeName(),
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
-                LongFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), LongFieldScript.CONTEXT);
-                return new LongScriptMappedFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                String name = builder.buildFullName(context);
+                Script script = builder.script.getValue();
+                LongFieldScript.Factory factory = builder.scriptCompiler.compile(script, LongFieldScript.CONTEXT);
+                return new LongScriptMappedFieldType(name, script, builder.meta.getValue()) {
+                    @Override
+                    protected LongFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                        return factory.newFactory(name, script.getParams(), searchLookup);
+                    }
+                };
             }
         );
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptMappedFieldTypeTests.java
@@ -29,22 +29,16 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.runtimefields.fielddata.DateScriptFieldData;
 
 import java.io.IOException;
@@ -53,10 +47,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -420,86 +412,41 @@ public class DateScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     }
 
     private static DateScriptMappedFieldType build(Script script, DateFormatter dateTimeFormatter) throws IOException {
-        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+        return new DateScriptMappedFieldType("test", script, dateTimeFormatter, emptyMap()) {
             @Override
-            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
-                return new ScriptEngine() {
-                    @Override
-                    public String getType() {
-                        return "test";
-                    }
-
-                    @Override
-                    public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(DateFieldScript.CONTEXT);
-                    }
-
-                    @Override
-                    public <FactoryType> FactoryType compile(
-                        String name,
-                        String code,
-                        ScriptContext<FactoryType> context,
-                        Map<String, String> params
-                    ) {
-                        @SuppressWarnings("unchecked")
-                        FactoryType factory = (FactoryType) factory(code);
-                        return factory;
-                    }
-
-                    private DateFieldScript.Factory factory(String code) {
-                        switch (code) {
-                            case "read_timestamp":
-                                return (fieldName, params, lookup, formatter) -> ctx -> new DateFieldScript(
-                                    fieldName,
-                                    params,
-                                    lookup,
-                                    formatter,
-                                    ctx
-                                ) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
-                                            DateFieldScript.Parse parse = new DateFieldScript.Parse(this);
-                                            emit(parse.parse(timestamp));
-                                        }
-                                    }
-                                };
-                            case "add_days":
-                                return (fieldName, params, lookup, formatter) -> ctx -> new DateFieldScript(
-                                    fieldName,
-                                    params,
-                                    lookup,
-                                    formatter,
-                                    ctx
-                                ) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
-                                            long epoch = (Long) timestamp;
-                                            ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
-                                            dt = dt.plus(((Number) params.get("days")).longValue(), ChronoUnit.DAYS);
-                                            emit(toEpochMilli(dt));
-                                        }
-                                    }
-                                };
-                            case "loop":
-                                return (fieldName, params, lookup, formatter) -> {
-                                    // Indicate that this script wants the field call "test", which *is* the name of this field
-                                    lookup.forkAndTrackFieldReferences("test");
-                                    throw new IllegalStateException("shoud have thrown on the line above");
-                                };
-                            default:
-                                throw new IllegalArgumentException("unsupported script [" + code + "]");
-                        }
-                    }
-                };
+            protected DateFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                switch (script.getIdOrCode()) {
+                    case "read_timestamp":
+                        return ctx -> new DateFieldScript("test", script.getParams(), searchLookup, dateTimeFormatter, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                    DateFieldScript.Parse parse = new DateFieldScript.Parse(this);
+                                    emit(parse.parse(timestamp));
+                                }
+                            }
+                        };
+                    case "add_days":
+                        return ctx -> new DateFieldScript("test", script.getParams(), searchLookup, dateTimeFormatter, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                    long epoch = (Long) timestamp;
+                                    ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
+                                    dt = dt.plus(((Number) getParams().get("days")).longValue(), ChronoUnit.DAYS);
+                                    emit(toEpochMilli(dt));
+                                }
+                            }
+                        };
+                    case "loop":
+                        // Indicate that this script wants the field call "test", which *is* the name of this field
+                        searchLookup.forkAndTrackFieldReferences("test");
+                        throw new IllegalStateException("shoud have thrown on the line above");
+                    default:
+                        throw new IllegalArgumentException("unsupported script [" + script.getIdOrCode() + "]");
+                }
             }
         };
-        ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
-        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            DateFieldScript.Factory factory = scriptService.compile(script, DateFieldScript.CONTEXT);
-            return new DateScriptMappedFieldType("test", script, factory, dateTimeFormatter, emptyMap());
-        }
     }
 
     private static long randomDate() {

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptMappedFieldTypeTests.java
@@ -24,29 +24,22 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.runtimefields.fielddata.DoubleScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.mapper.DoubleFieldScript.LeafFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -246,69 +239,36 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
     }
 
     private static DoubleScriptMappedFieldType build(Script script) throws IOException {
-        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+        return new DoubleScriptMappedFieldType("test", script, emptyMap()) {
             @Override
-            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
-                return new ScriptEngine() {
-                    @Override
-                    public String getType() {
-                        return "test";
-                    }
-
-                    @Override
-                    public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(DoubleFieldScript.CONTEXT);
-                    }
-
-                    @Override
-                    public <FactoryType> FactoryType compile(
-                        String name,
-                        String code,
-                        ScriptContext<FactoryType> context,
-                        Map<String, String> params
-                    ) {
-                        @SuppressWarnings("unchecked")
-                        FactoryType factory = (FactoryType) factory(code);
-                        return factory;
-                    }
-
-                    private DoubleFieldScript.Factory factory(String code) {
-                        switch (code) {
-                            case "read_foo":
-                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).doubleValue());
-                                        }
-                                    }
-                                };
-                            case "add_param":
-                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
-                                        }
-                                    }
-                                };
-                            case "loop":
-                                return (fieldName, params, lookup) -> {
-                                    // Indicate that this script wants the field call "test", which *is* the name of this field
-                                    lookup.forkAndTrackFieldReferences("test");
-                                    throw new IllegalStateException("shoud have thrown on the line above");
-                                };
-                            default:
-                                throw new IllegalArgumentException("unsupported script [" + code + "]");
-                        }
-                    }
-                };
+            protected LeafFactory leafFactory(SearchLookup searchLookup) {
+                switch (script.getIdOrCode()) {
+                    case "read_foo":
+                        return ctx -> new DoubleFieldScript("test", script.getParams(), searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object foo : (List<?>) getSource().get("foo")) {
+                                    emit(((Number) foo).doubleValue());
+                                }
+                            }
+                        };
+                    case "add_param":
+                        return ctx -> new DoubleFieldScript("test", script.getParams(), searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object foo : (List<?>) getSource().get("foo")) {
+                                    emit(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
+                                }
+                            }
+                        };
+                    case "loop":
+                        // Indicate that this script wants the field call "test", which *is* the name of this field
+                        searchLookup.forkAndTrackFieldReferences("test");
+                        throw new IllegalStateException("shoud have thrown on the line above");
+                    default:
+                        throw new IllegalArgumentException("unsupported script [" + script.getIdOrCode() + "]");
+                }
             }
         };
-        ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
-        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            DoubleFieldScript.Factory factory = scriptService.compile(script, DoubleFieldScript.CONTEXT);
-            return new DoubleScriptMappedFieldType("test", script, factory, emptyMap());
-        }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptMappedFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptMappedFieldTypeTests.java
@@ -24,31 +24,23 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.runtimefields.fielddata.BinaryScriptFieldData;
 import org.elasticsearch.xpack.runtimefields.fielddata.IpScriptFieldData;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -263,69 +255,36 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
     }
 
     private static IpScriptMappedFieldType build(Script script) throws IOException {
-        ScriptPlugin scriptPlugin = new ScriptPlugin() {
+        return new IpScriptMappedFieldType("test", script, emptyMap()) {
             @Override
-            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
-                return new ScriptEngine() {
-                    @Override
-                    public String getType() {
-                        return "test";
-                    }
-
-                    @Override
-                    public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(StringFieldScript.CONTEXT);
-                    }
-
-                    @Override
-                    public <FactoryType> FactoryType compile(
-                        String name,
-                        String code,
-                        ScriptContext<FactoryType> context,
-                        Map<String, String> params
-                    ) {
-                        @SuppressWarnings("unchecked")
-                        FactoryType factory = (FactoryType) factory(code);
-                        return factory;
-                    }
-
-                    private IpFieldScript.Factory factory(String code) {
-                        switch (code) {
-                            case "read_foo":
-                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(foo.toString());
-                                        }
-                                    }
-                                };
-                            case "append_param":
-                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(foo.toString() + getParams().get("param"));
-                                        }
-                                    }
-                                };
-                            case "loop":
-                                return (fieldName, params, lookup) -> {
-                                    // Indicate that this script wants the field call "test", which *is* the name of this field
-                                    lookup.forkAndTrackFieldReferences("test");
-                                    throw new IllegalStateException("shoud have thrown on the line above");
-                                };
-                            default:
-                                throw new IllegalArgumentException("unsupported script [" + code + "]");
-                        }
-                    }
-                };
+            protected IpFieldScript.LeafFactory leafFactory(SearchLookup searchLookup) {
+                switch (script.getIdOrCode()) {
+                    case "read_foo":
+                        return ctx -> new IpFieldScript("test", script.getParams(), searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object foo : (List<?>) getSource().get("foo")) {
+                                    emit(foo.toString());
+                                }
+                            }
+                        };
+                    case "append_param":
+                        return ctx -> new IpFieldScript("test", script.getParams(), searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                for (Object foo : (List<?>) getSource().get("foo")) {
+                                    emit(foo.toString() + getParams().get("param"));
+                                }
+                            }
+                        };
+                    case "loop":
+                        // Indicate that this script wants the field call "test", which *is* the name of this field
+                        searchLookup.forkAndTrackFieldReferences("test");
+                        throw new IllegalStateException("shoud have thrown on the line above");
+                    default:
+                        throw new IllegalArgumentException("unsupported script [" + script.getIdOrCode() + "]");
+                }
             }
         };
-        ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
-        try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            IpFieldScript.Factory factory = scriptService.compile(script, IpFieldScript.CONTEXT);
-            return new IpScriptMappedFieldType("test", script, factory, emptyMap());
-        }
     }
 }


### PR DESCRIPTION
This moves the logic to construct a `LeafFactory` from a `TriFunction`
abstract function. I think this is cleaner because:
1. It moves all of the "funny" script handling stuff like dealing with
   `script.getParameters()` into `RuntimeFieldMapper`. Specifically
   into the bit of `RuntimeFieldMapper` involved with compiling the
   script in the first place.
2. Which makes the `MappedFieldType`s fairly unaware that the
   `LeafFactory` comes from a script. I'm convinced this'll let us reuse
   them for "source only" style fields which don't use a "script" and
   I'm fairly sure we'll be able to *mostly* reuse them for "grok" style
   fields as well.
3. It makes it fairly obvious that we can simplify the tests, removing
   the `Plugin` subclass and `ScriptService` entirely.
