### PR TITLE
VersionFieldIT should register transportClientPlugins

### DIFF
--- a/x-pack/plugin/versionfield/src/internalClusterTest/java/org/elasticsearch/xpack/versionfield/VersionFieldIT.java
+++ b/x-pack/plugin/versionfield/src/internalClusterTest/java/org/elasticsearch/xpack/versionfield/VersionFieldIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -24,10 +25,14 @@ public class VersionFieldIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return org.elasticsearch.common.collect.List.of(VersionFieldPlugin.class, LocalStateCompositeXPackPlugin.class);
+        return Arrays.asList(VersionFieldPlugin.class, LocalStateCompositeXPackPlugin.class);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/62705")
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Arrays.asList(VersionFieldPlugin.class);
+    }
+
     public void testTermsAggregation() throws Exception {
         String indexName = "test";
         createIndex(indexName);

--- a/x-pack/plugin/versionfield/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldPlugin.java
+++ b/x-pack/plugin/versionfield/src/main/java/org/elasticsearch/xpack/versionfield/VersionFieldPlugin.java
@@ -13,6 +13,7 @@ import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.DocValueFormat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class VersionFieldPlugin extends Plugin implements MapperPlugin {
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return org.elasticsearch.common.collect.List.of(
+        return Arrays.asList(
             new NamedWriteableRegistry.Entry(
                 DocValueFormat.class,
                 VersionStringFieldMapper.VERSION_DOCVALUE.getWriteableName(),


### PR DESCRIPTION
On 7.x this integration test needs to overwrite `transportClientPlugins()` so the NamedWritables from the VersionFieldPlugin
get registered with the transport client. This wasn't an issue on master since transport client isn't used there anymore but
needs to be added on 7.x.

Closes #62705 