### PR TITLE
[7.x] [DOCS] EQL: Improve regsvr32 misuse explanation (#62722)

### DIFF
--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -7,7 +7,7 @@ experimental::[]
 
 This example tutorial shows you how you can use EQL to detect security threats
 and other suspicious behavior. In the scenario, you're tasked with detecting
-https://attack.mitre.org/techniques/T1218/010/[`regsvr32` misuse] in Windows
+https://attack.mitre.org/techniques/T1218/010/[regsvr32 misuse] in Windows
 event logs.
 
 `regsvr32.exe` is a built-in command-line utility used to register `.dll`
@@ -17,7 +17,7 @@ Attackers with access to a user's command line can use `regsvr32.exe` to run
 malicious scripts using `.dll` libraries, even on machines that otherwise
 disallow such scripts.
 
-One common variant of `regsvr32` misuse is a
+One common variant of regsvr32 misuse is a
 https://attack.mitre.org/techniques/T1218/010/[Squiblydoo attack]. In a
 Squiblydoo attack, a `regsvr32.exe` command uses the `scrobj.dll` library to
 register and run a remote script. These commands often look like this:
@@ -31,11 +31,11 @@ register and run a remote script. These commands often look like this:
 [[eql-ex-threat-detection-setup]]
 === Setup
 
-This tutorial uses a test dataset for `regsvr32` misuse from
+This tutorial uses a test dataset for regsvr32 misuse from
 https://github.com/redcanaryco/atomic-red-team[Atomic Red Team]. The dataset has
 been normalized and mapped to use fields from the {ecs-ref}[Elastic Common
 Schema (ECS)], including the `@timestamp` and `event.category` fields. The
-dataset includes events that imitate behaviors related to `regsvr32` misuse, as
+dataset includes events that imitate behaviors of a Squiblydoo attack, as
 documented by the https://attack.mitre.org[MITRE ATT&CK®] knowledge base.
 
 To get started, download and index the dataset:
@@ -72,9 +72,9 @@ yellow open   my-index-000001         150
 
 [discrete]
 [[eql-ex-get-a-count-of-regsvr32-events]]
-=== Get a count of `regsvr32` events
+=== Get a count of regsvr32 events
 
-Since you're looking for `regsvr32` misuse, start by getting a count of any
+Since you're looking for regsvr32 misuse, start by getting a count of any
 events associated with a `regsvr32.exe` process.
 
 The following <<eql-search-api,EQL search API>> request uses an EQL query to
@@ -126,11 +126,11 @@ query.
 [[eql-ex-check-for-command-line-artifacts]]
 === Check for command line artifacts
 
-Based on your previous query, you know `regsvr32` processes were associated with
+Based on your previous query, you know regsvr32 processes were associated with
 143 events. But how was `regsvr32.exe` first called? And who called it?
 
-`regsvr32` is a command-line utility so it may help to narrow your results to
-processes where the command line was used.
+`regsvr32.exe` is a command-line utility so it may help to narrow your results
+to processes where the command line was used.
 
 Update the previous EQL query as follows:
 

--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -6,12 +6,26 @@
 experimental::[]
 
 This example tutorial shows you how you can use EQL to detect security threats
-and other suspicious behavior.
+and other suspicious behavior. In the scenario, you're tasked with detecting
+https://attack.mitre.org/techniques/T1218/010/[`regsvr32` misuse] in Windows
+event logs.
 
-In the scenario, you're tasked with detecting
-https://attack.mitre.org/techniques/T1218/010/[`regsvr32` misuse] in Windows event
-logs. `regsvr32` misuse is a known adversary technique documented in the
-https://attack.mitre.org[MITRE ATT&CK®] knowledge base.
+`regsvr32.exe` is a built-in command-line utility used to register `.dll`
+libraries in Windows. As a native tool, `regsvr32.exe` has a trusted status in
+Windows, letting it bypass most allowlist software and script blockers.
+Attackers with access to a user's command line can use `regsvr32.exe` to run
+malicious scripts using `.dll` libraries, even on machines that otherwise
+disallow such scripts.
+
+One common variant of `regsvr32` misuse is a
+https://attack.mitre.org/techniques/T1218/010/[Squiblydoo attack]. In a
+Squiblydoo attack, a `regsvr32.exe` command uses the `scrobj.dll` library to
+register and run a remote script. These commands often look like this:
+
+[source,sh]
+----
+"regsvr32.exe  /s /u /i:<script-url> scrobj.dll"
+----
 
 [discrete]
 [[eql-ex-threat-detection-setup]]
@@ -22,7 +36,7 @@ https://github.com/redcanaryco/atomic-red-team[Atomic Red Team]. The dataset has
 been normalized and mapped to use fields from the {ecs-ref}[Elastic Common
 Schema (ECS)], including the `@timestamp` and `event.category` fields. The
 dataset includes events that imitate behaviors related to `regsvr32` misuse, as
-documented by MITRE ATT&CK®.
+documented by the https://attack.mitre.org[MITRE ATT&CK®] knowledge base.
 
 To get started, download and index the dataset:
 
@@ -144,8 +158,7 @@ The query matches one process event. The event has an `event.type` of
 
 Based on the `process.command_line` value in the response, `regsvr32.exe` used
 `scrobj.dll` to register a script, `RegSvr32.sct`. This fits the behavior of a
-https://attack.mitre.org/techniques/T1218/010/["Squiblydoo" attack], a known
-variant of `regsvr32` misuse.
+Squiblydoo attack.
 
 The response also includes other valuable information about how the
 `regsvr32.exe` process started, such as the `@timestamp`, the associated


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Improve regsvr32 misuse explanation (#62722)