### PR TITLE
Log alloc description after netty processors set

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -149,6 +149,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                                      SharedGroupFactory sharedGroupFactory) {
         super(settings, networkService, bigArrays, threadPool, xContentRegistry, dispatcher, clusterSettings);
         Netty4Utils.setAvailableProcessors(EsExecutors.NODE_PROCESSORS_SETTING.get(settings));
+        NettyAllocator.logAllocatorDescriptionIfNeeded();
         this.sharedGroupFactory = sharedGroupFactory;
 
         this.maxChunkSize = SETTING_HTTP_MAX_CHUNK_SIZE.get(settings);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.transport;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -51,13 +49,7 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
     public static final String NETTY_TRANSPORT_NAME = "netty4";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty4";
 
-    private static final Logger logger = LogManager.getLogger(Netty4Plugin.class);
-
     private final SetOnce<SharedGroupFactory> groupFactory = new SetOnce<>();
-
-    public Netty4Plugin() {
-        logger.info("creating NettyAllocator with the following configs: " + NettyAllocator.getAllocatorDescription());
-    }
 
     @Override
     public List<Setting<?>> getSettings() {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
@@ -27,11 +27,18 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class NettyAllocator {
+
+    private static final Logger logger = LogManager.getLogger(NettyAllocator.class);
+    private static final AtomicBoolean descriptionLogged = new AtomicBoolean(false);
 
     private static final ByteBufAllocator ALLOCATOR;
     private static final String DESCRIPTION;
@@ -92,6 +99,12 @@ public class NettyAllocator {
                     + ", g1gc_region_size=" + g1gcRegionSize + "}]";
             }
             ALLOCATOR = new NoDirectBuffers(delegate);
+        }
+    }
+
+    public static void logAllocatorDescriptionIfNeeded() {
+        if (descriptionLogged.compareAndSet(false, true)) {
+            logger.info("creating NettyAllocator with the following configs: " + NettyAllocator.getAllocatorDescription());
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -104,6 +104,7 @@ public class Netty4Transport extends TcpTransport {
                            CircuitBreakerService circuitBreakerService, SharedGroupFactory sharedGroupFactory) {
         super(settings, version, threadPool, pageCacheRecycler, circuitBreakerService, namedWriteableRegistry, networkService);
         Netty4Utils.setAvailableProcessors(EsExecutors.NODE_PROCESSORS_SETTING.get(settings));
+        NettyAllocator.logAllocatorDescriptionIfNeeded();
         this.sharedGroupFactory = sharedGroupFactory;
 
         // See AdaptiveReceiveBufferSizePredictor#DEFAULT_XXX for default values in netty..., we can use higher ones for us, even fixed one

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Netty4Utils {
 
-    private static AtomicBoolean isAvailableProcessorsSet = new AtomicBoolean();
+    private static final AtomicBoolean isAvailableProcessorsSet = new AtomicBoolean();
 
     /**
      * Set the number of available processors that Netty uses for sizing various resources (e.g., thread pools).


### PR DESCRIPTION
Currently we log the NettyAllocator description when the netty plugin is
created. Unfortunately, this hits certain static fields in Netty which
triggers the settings of the number of CPU processors. This conflicts
with out Elasticsearch behavior to override this based on a setting.

This commit resolves the issue by logging after the processors have been
set.