### PR TITLE
Fix testQueuedSnapshotOperationsAndBrokenRepoOnMasterFailOverMultiple (#62713)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -806,7 +806,12 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         expectThrows(ElasticsearchException.class, snapshotThree::actionGet);
         expectThrows(ElasticsearchException.class, snapshotFour::actionGet);
         assertAcked(deleteFuture.get());
-        expectThrows(ElasticsearchException.class, createBlockedSnapshot::actionGet);
+        try {
+            createBlockedSnapshot.actionGet();
+        } catch (ElasticsearchException ex) {
+            // Ignored, thrown most of the time but due to retries when shutting down the master could randomly pass when the request is
+            // retried and gets executed after the above delete
+        }
     }
 
     public void testMultipleSnapshotsQueuedAfterDelete() throws Exception {


### PR DESCRIPTION
There's possible retries here that work out if both the snapshot and the delete
operation are retried when master shuts down and hits the unlikely case of the retried delete
executing before the retried snapshot, making both operations pass.

Closes #62686

backport of #62713
