### PR TITLE
Change approach to checking GID in Docker

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -639,7 +639,7 @@ public class Docker {
         return sh.run("docker logs " + containerId);
     }
 
-    private static String getImageName(Distribution distribution) {
+    public static String getImageName(Distribution distribution) {
         return distribution.flavor.name + (distribution.packaging == Distribution.Packaging.DOCKER_UBI ? "-ubi8" : "") + ":test";
     }
 }


### PR DESCRIPTION
Closes #62466. Since we're still seeing occasional failures when
checking the GID of all files in the Docker image due to Elasticsearch
running in the background, instead run a new container with ES running
at all.
