### PR TITLE
Search case insensitivity - complete the version dance now the back port is complete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/62764" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -84,7 +84,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         fieldName = in.readString();
         value = in.readString();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             caseInsensitive = in.readBoolean();
         }        
     }
@@ -94,7 +94,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         out.writeString(fieldName);
         out.writeString(value);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeBoolean(caseInsensitive);
         }    
     }

--- a/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -104,14 +104,14 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
      */
     public TermQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             caseInsensitive = in.readBoolean();
         }        
     }
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         super.doWriteTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeBoolean(caseInsensitive);
         }    
     }    

--- a/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -94,7 +94,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         fieldName = in.readString();
         value = in.readString();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             caseInsensitive = in.readBoolean();
         }        
     }
@@ -104,7 +104,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         out.writeString(fieldName);
         out.writeString(value);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeBoolean(caseInsensitive);
         }    
     }

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -45,9 +45,6 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         if (randomBoolean()) {
             query.rewrite(getRandomRewriteMethod());
         }
-        if (randomBoolean()) {
-            query.caseInsensitive(true);
-        }         
         return query;
     }
 
@@ -76,7 +73,8 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
     protected void doAssertLuceneQuery(PrefixQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         assertThat(query, Matchers.anyOf(instanceOf(PrefixQuery.class), instanceOf(MatchNoDocsQuery.class), 
             instanceOf(AutomatonQuery.class)));
-        if (context.fieldMapper(queryBuilder.fieldName()) != null) { // The field is mapped
+        if (context.fieldMapper(queryBuilder.fieldName()) != null 
+            && queryBuilder.caseInsensitive() == false) { // The field is mapped and case sensitive
             PrefixQuery prefixQuery = (PrefixQuery) query;
 
             String expectedFieldName = expectedFieldName(queryBuilder.fieldName());

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -44,13 +44,9 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         if (randomBoolean()) {
             query.rewrite(getRandomRewriteMethod());
         }
-        //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-        // 1) Commit PR 61596 with this code commented out in master
-        // 2) Backport PR 61596 to 7.x, uncommented
-        // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.
-//        if (randomBoolean()) {
-//            query.caseInsensitive(true);
-//        }         
+        if (randomBoolean()) {
+            query.caseInsensitive(true);
+        }         
         return query;
     }
 
@@ -108,13 +104,8 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     public void testFromJson() throws IOException {
         String json =
-                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\", \"boost\" : 2.0 "
-            //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-            // 1) Commit PR 61596 with this code commented out in master
-            // 2) Backport PR 61596 to 7.x, uncommented
-            // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.                
-//            "      \"case_insensitive\" : true\n" +
-            
+                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\", \"boost\" : 2.0, "
+                + "     \"case_insensitive\" : true\n" 
                 + "} }}";
 
         PrefixQueryBuilder parsed = (PrefixQueryBuilder) parseQuery(json);

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -73,7 +74,8 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     @Override
     protected void doAssertLuceneQuery(PrefixQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
-        assertThat(query, Matchers.anyOf(instanceOf(PrefixQuery.class), instanceOf(MatchNoDocsQuery.class)));
+        assertThat(query, Matchers.anyOf(instanceOf(PrefixQuery.class), instanceOf(MatchNoDocsQuery.class), 
+            instanceOf(AutomatonQuery.class)));
         if (context.fieldMapper(queryBuilder.fieldName()) != null) { // The field is mapped
             PrefixQuery prefixQuery = (PrefixQuery) query;
 
@@ -104,8 +106,9 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     public void testFromJson() throws IOException {
         String json =
-                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\", \"boost\" : 2.0, "
-                + "     \"case_insensitive\" : true\n" 
+                "{    \"prefix\" : { \"user\" :  { \"value\" : \"ki\",\n"
+                + "     \"case_insensitive\" : true,\n" 
+                + " \"boost\" : 2.0"
                 + "} }}";
 
         PrefixQueryBuilder parsed = (PrefixQueryBuilder) parseQuery(json);

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -89,9 +89,6 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
     @Override
     protected TermQueryBuilder createQueryBuilder(String fieldName, Object value) {
         TermQueryBuilder result = new TermQueryBuilder(fieldName, value);
-        if (randomBoolean()) {
-            result.caseInsensitive(true);
-        }
         return result;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -135,8 +135,8 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
                 "  \"term\" : {\n" +
                 "    \"exact_value\" : {\n" +
                 "      \"value\" : \"Quick Foxes!\",\n" +
-                "      \"boost\" : 1.0,\n" +
-                "      \"case_insensitive\" : true\n" +
+                "      \"case_insensitive\" : true,\n" +
+                "      \"boost\" : 1.0\n" +
                 "    }\n" +
                 "  }\n" +
                 "}";

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -89,13 +89,9 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
     @Override
     protected TermQueryBuilder createQueryBuilder(String fieldName, Object value) {
         TermQueryBuilder result = new TermQueryBuilder(fieldName, value);
-        //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-        // 1) Commit PR 61596 with this code commented out in master
-        // 2) Backport PR 61596 to 7.x, uncommented
-        // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.
-//        if (randomBoolean()) {
-//            result.caseInsensitive(true);
-//        }
+        if (randomBoolean()) {
+            result.caseInsensitive(true);
+        }
         return result;
     }
 
@@ -142,12 +138,8 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
                 "  \"term\" : {\n" +
                 "    \"exact_value\" : {\n" +
                 "      \"value\" : \"Quick Foxes!\",\n" +
-                "      \"boost\" : 1.0\n" +
-                //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-                // 1) Commit PR 61596 with this code commented out in master
-                // 2) Backport PR 61596 to 7.x, uncommented
-                // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.                
-//                "      \"case_insensitive\" : true\n" +
+                "      \"boost\" : 1.0,\n" +
+                "      \"case_insensitive\" : true\n" +
                 "    }\n" +
                 "  }\n" +
                 "}";

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -42,9 +42,6 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         if (randomBoolean()) {
             query.rewrite(randomFrom(getRandomRewriteMethod()));
         }
-        if (randomBoolean()) {
-            query.caseInsensitive(true);
-        }         
         return query;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
@@ -74,14 +75,18 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
 
         if (expectedFieldName.equals(TEXT_FIELD_NAME)) {
-            assertThat(query, instanceOf(WildcardQuery.class));
-            WildcardQuery wildcardQuery = (WildcardQuery) query;
-
-            assertThat(wildcardQuery.getField(), equalTo(expectedFieldName));
-            assertThat(wildcardQuery.getTerm().field(), equalTo(expectedFieldName));
-            // wildcard queries get normalized
-            String text = wildcardQuery.getTerm().text().toLowerCase(Locale.ROOT);
-            assertThat(text, equalTo(text));
+            if (queryBuilder.caseInsensitive()) {
+                assertThat(query, instanceOf(AutomatonQuery.class));
+            } else {
+                assertThat(query, instanceOf(WildcardQuery.class));
+                WildcardQuery wildcardQuery = (WildcardQuery) query;
+    
+                assertThat(wildcardQuery.getField(), equalTo(expectedFieldName));
+                assertThat(wildcardQuery.getTerm().field(), equalTo(expectedFieldName));
+                // wildcard queries get normalized
+                String text = wildcardQuery.getTerm().text().toLowerCase(Locale.ROOT);
+                assertThat(text, equalTo(text));
+            }
         } else {
             Query expected = new MatchNoDocsQuery("unknown field [" + expectedFieldName + "]");
             assertEquals(expected, query);
@@ -106,8 +111,9 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     public void testFromJson() throws IOException {
-        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\", \"boost\" : 2.0,"
-            + "      \"case_insensitive\" : true\n"             
+        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\","
+            + " \"case_insensitive\" : true,\n"             
+            + " \"boost\" : 2.0"
             + " } }}";
         WildcardQueryBuilder parsed = (WildcardQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -41,13 +41,9 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         if (randomBoolean()) {
             query.rewrite(randomFrom(getRandomRewriteMethod()));
         }
-        //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-        // 1) Commit PR 61596 with this code commented out in master
-        // 2) Backport PR 61596 to 7.x, uncommented
-        // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.
-//        if (randomBoolean()) {
-//            query.caseInsensitive(true);
-//        }         
+        if (randomBoolean()) {
+            query.caseInsensitive(true);
+        }         
         return query;
     }
 
@@ -110,13 +106,8 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     public void testFromJson() throws IOException {
-        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\", \"boost\" : 2.0"
-            //TODO code below is commented out while we do the Version dance for PR 61596. Steps are
-            // 1) Commit PR 61596 with this code commented out in master
-            // 2) Backport PR 61596 to 7.x, uncommented
-            // 3) New PR on master to uncomment this code now that 7.x has support for case insensitive flag.                
-//            "      \"case_insensitive\" : true\n" +
-            
+        String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\", \"boost\" : 2.0,"
+            + "      \"case_insensitive\" : true\n"             
             + " } }}";
         WildcardQueryBuilder parsed = (WildcardQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);


### PR DESCRIPTION
Add the testing support now that 7.x has the search-time case insensitivity feature backported
Relates to #61546