### PR TITLE
BACKPORT 7.10 Fix doc-update interceptor for indices with DLS and FLS (#61516)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -151,7 +152,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testUpdatesAreRejected() {
-        for (String indexName : List.of("<test-{2015.05.05||+1d}>", "test")) {
+        for (String indexName : Arrays.asList("<test-{2015.05.05||+1d}>", "test")) {
             assertAcked(client().admin().indices().prepareCreate(indexName)
                     .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text")
                     .setSettings(Settings.builder()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
@@ -46,29 +46,30 @@ public class BulkShardRequestInterceptor implements RequestInterceptor {
         MemoizedSupplier<Boolean> licenseChecker = new MemoizedSupplier<>(() -> licenseState.checkFeature(Feature.SECURITY_DLS_FLS));
         if (requestInfo.getRequest() instanceof BulkShardRequest && shouldIntercept) {
             IndicesAccessControl indicesAccessControl = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
-
-            final BulkShardRequest bulkShardRequest = (BulkShardRequest) requestInfo.getRequest();
-            for (BulkItemRequest bulkItemRequest : bulkShardRequest.items()) {
-                IndicesAccessControl.IndexAccessControl indexAccessControl =
-                    indicesAccessControl.getIndexPermissions(bulkItemRequest.index());
-                boolean found = false;
-                if (indexAccessControl != null) {
-                    boolean fls = indexAccessControl.getFieldPermissions().hasFieldLevelSecurity();
-                    boolean dls = indexAccessControl.getDocumentPermissions().hasDocumentLevelPermissions();
-                    if (fls || dls) {
-                        if (licenseChecker.get() && bulkItemRequest.request() instanceof UpdateRequest) {
+            BulkShardRequest bulkShardRequest = (BulkShardRequest) requestInfo.getRequest();
+            // this uses the {@code BulkShardRequest#index()} because the {@code bulkItemRequest#index()}
+            // can still be an unresolved date math expression
+            IndicesAccessControl.IndexAccessControl indexAccessControl = indicesAccessControl.getIndexPermissions(bulkShardRequest.index());
+            // TODO replace if condition with assertion
+            if (indexAccessControl != null) {
+                for (BulkItemRequest bulkItemRequest : bulkShardRequest.items()) {
+                    boolean found = false;
+                    if (bulkItemRequest.request() instanceof UpdateRequest) {
+                        boolean fls = indexAccessControl.getFieldPermissions().hasFieldLevelSecurity();
+                        boolean dls = indexAccessControl.getDocumentPermissions().hasDocumentLevelPermissions();
+                        // the feature usage checker is a "last-ditch" verification, it doesn't have practical importance
+                        if ((fls || dls) && licenseChecker.get()) {
                             found = true;
-                            logger.trace("aborting bulk item update request for index [{}]", bulkItemRequest.index());
+                            logger.trace("aborting bulk item update request for index [{}]", bulkShardRequest.index());
                             bulkItemRequest.abort(bulkItemRequest.index(), new ElasticsearchSecurityException("Can't execute a bulk " +
-                                "item request with update requests embedded if field or document level security is enabled",
-                                RestStatus.BAD_REQUEST));
+                                    "item request with update requests embedded if field or document level security is enabled",
+                                    RestStatus.BAD_REQUEST));
                         }
                     }
-                }
-
-                if (found == false) {
-                    logger.trace("intercepted bulk request for index [{}] without any update requests, continuing execution",
-                        bulkItemRequest.index());
+                    if (found == false) {
+                        logger.trace("intercepted bulk request for index [{}] without any update requests, continuing execution",
+                                bulkShardRequest.index());
+                    }
                 }
             }
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
@@ -45,7 +45,7 @@ abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements Reques
             if (supports(indicesRequest) && shouldIntercept) {
                 final IndicesAccessControl indicesAccessControl =
                     threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
-                for (String index : indicesRequest.indices()) {
+                for (String index : requestIndices(indicesRequest)) {
                     IndicesAccessControl.IndexAccessControl indexAccessControl = indicesAccessControl.getIndexPermissions(index);
                     if (indexAccessControl != null) {
                         boolean fieldLevelSecurityEnabled = indexAccessControl.getFieldPermissions().hasFieldLevelSecurity();
@@ -63,6 +63,10 @@ abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements Reques
             }
         }
         listener.onResponse(null);
+    }
+
+    String[] requestIndices(IndicesRequest indicesRequest) {
+        return indicesRequest.indices();
     }
 
     abstract void disableFeatures(IndicesRequest request, boolean fieldLevelSecurityEnabled, boolean documentLevelSecurityEnabled,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/UpdateRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/UpdateRequestInterceptor.java
@@ -34,6 +34,17 @@ public class UpdateRequestInterceptor extends FieldAndDocumentLevelSecurityReque
     }
 
     @Override
+    String[] requestIndices(IndicesRequest indicesRequest) {
+        if (indicesRequest instanceof UpdateRequest) {
+            UpdateRequest updateRequest = (UpdateRequest) indicesRequest;
+            if (updateRequest.getShardId() != null) {
+                return new String[]{updateRequest.getShardId().getIndexName()};
+            }
+        }
+        return new String[0];
+    }
+
+    @Override
     public boolean supports(IndicesRequest request) {
         return request instanceof UpdateRequest;
     }


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/61516

This fixes the protection against updates (and bulk updates) for indices with DLS
and/or FLS, when the request uses date math expressions.