### PR TITLE
Fix Eclipse build (backport #62733)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -15,8 +15,11 @@ dependencies {
   testImplementation project(xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  // let the yamlRestTest see the classpath of test
-  yamlRestTestImplementation project.sourceSets.test.runtimeClasspath
+  if (false == isEclipse) {
+    // let the yamlRestTest see the classpath of test
+    // Eclipse doesn't need this because it flattens test deps and gets very, very confused by it
+    yamlRestTestImplementation project.sourceSets.test.runtimeClasspath
+  }
 }
 
 subprojects {

--- a/x-pack/plugin/eql/qa/common/build.gradle
+++ b/x-pack/plugin/eql/qa/common/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   api project(':test:framework')
   api project(path: xpackModule('core'), configuration: 'default')
   api project(path: xpackModule('core'), configuration: 'testArtifacts')
-  api project(path: xpackModule('ql'), configuration: 'testArtifacts')
+  api project(xpackModule('ql:test'))
 
   // TOML parser for EqlActionIT tests
   api 'io.ous:jtoml:2.0.0'

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -12,6 +12,9 @@ dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
   testImplementation project(':test:framework')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation(project(xpackModule('ql:test'))) {
+    exclude group: 'org.elasticsearch.plugin', module: 'ql'
+  }
 }
 
 configurations {

--- a/x-pack/plugin/ql/test/build.gradle
+++ b/x-pack/plugin/ql/test/build.gradle
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+ 
+apply plugin: 'elasticsearch.build'
+
+dependencies {
+  api project(xpackModule('ql'))
+  api project(':test:framework')
+}
+
+test.enabled = false

--- a/x-pack/plugin/ql/test/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -44,15 +44,11 @@ public final class TestUtils {
     private TestUtils() {}
 
     public static Configuration randomConfiguration() {
-        return new Configuration(randomZone(),
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10));
+        return new Configuration(randomZone(), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public static Configuration randomConfiguration(ZoneId zoneId) {
-        return new Configuration(zoneId,
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10));
+        return new Configuration(zoneId, randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public static Literal of(Object value) {
@@ -100,7 +96,6 @@ public final class TestUtils {
     public static Range rangeOf(Expression value, Expression lower, boolean includeLower, Expression upper, boolean includeUpper) {
         return new Range(EMPTY, value, lower, includeLower, upper, includeUpper, randomZone());
     }
-
 
     //
     // Common methods / assertions

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   // JDBC testing dependencies
   api project(path: xpackModule('sql:jdbc'))
   // Common utilities from QL
-  api project(path: xpackModule('ql'), configuration: 'testArtifacts')
+  api project(xpackModule('ql:test'))
 
   api "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"
 
@@ -67,7 +67,7 @@ subprojects {
       transitive = false
     }
     testImplementation project(":test:framework")
-    testRuntimeOnly project(path: xpackModule('ql'), configuration: 'testArtifacts')
+    testRuntimeOnly project(xpackModule('ql:test'))
 
     // JDBC testing dependencies
     testRuntimeOnly "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"


### PR DESCRIPTION
Eclipse was confused for two reasons:
1. `:x-pack:plugin` depended on itself.
2. `ql`, `sql`, and `eql` couldn't see some methods.

I fixed problem 1 by only adding the "depends on itself" configuration
outside of eclipse. I fixed problem 2 by making a `test` sub-project in
`ql` that contains test utilities and depending on those where possible.
