### PR TITLE
Grok: Handle utf-8 natively

### DIFF
--- a/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureConfig.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureConfig.java
@@ -54,10 +54,10 @@ public final class GrokCaptureConfig {
         return type;
     }
 
-    Object extract(byte[] textAsBytes, Region region) {
+    Object extract(byte[] utf8Bytes, int offset, Region region) {
         for (int number : backRefs) {
             if (region.beg[number] >= 0) {
-                String matchValue = new String(textAsBytes, region.beg[number], region.end[number] - region.beg[number],
+                String matchValue = new String(utf8Bytes, offset + region.beg[number], region.end[number] - region.beg[number],
                     StandardCharsets.UTF_8);
                 return type.parse(matchValue);
             }


### PR DESCRIPTION
This adds a method to `Grok` that matches against sections offset from
utf-8 byte arrays:
```
Map<String, Object> captures(byte[] utf8Bytes, int offset, int length)
```

This'll be useful for the grok-flavored runtime fields because they
want to match against utf-8 encoded strings stored in a big array. And
joni already supports this.
