### PR TITLE
BitArray#nextSetBit should check if the underlaying array contains the current word

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BitArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BitArray.java
@@ -66,6 +66,9 @@ public final class BitArray implements Releasable {
 
     public long nextSetBit(long index) {
         long wordNum = wordNum(index);
+        if (wordNum >= bits.size()) {
+            return Long.MAX_VALUE;
+        }
         long word = bits.get(wordNum) >> index;  // skip all the bits to the right of index
 
         if (word!=0) {


### PR DESCRIPTION
This is a recent addition and it is missing a check as the underlaying array can be smaller that the numBits capacity.

closes #62803
