### PR TITLE
[7.9][ML] Reset reindexing progress when DFA job resumes with incompl…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -82,10 +82,7 @@ public class DataFrameAnalyticsManager {
         // With config in hand, determine action to take
         ActionListener<DataFrameAnalyticsConfig> configListener = ActionListener.wrap(
             config -> {
-                // At this point we have the config at hand and we can reset the progress tracker
-                // to use the analyses phases. We preserve reindexing progress as if reindexing was
-                // finished it will not be reset.
-                task.getStatsHolder().resetProgressTrackerPreservingReindexingProgress(config.getAnalysis().getProgressPhases(),
+                task.getStatsHolder().adjustProgressTracker(config.getAnalysis().getProgressPhases(),
                     config.getAnalysis().supportsInference());
 
                 switch(currentState) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
@@ -30,10 +30,14 @@ public class StatsHolder {
         dataCountsTracker = new DataCountsTracker();
     }
 
-    public void resetProgressTrackerPreservingReindexingProgress(List<String> analysisPhases, boolean hasInferencePhase) {
+    public void adjustProgressTracker(List<String> analysisPhases, boolean hasInferencePhase) {
         int reindexingProgressPercent = progressTracker.getReindexingProgressPercent();
         progressTracker = ProgressTracker.fromZeroes(analysisPhases, hasInferencePhase);
-        progressTracker.updateReindexingProgress(reindexingProgressPercent);
+
+        // If reindexing progress was less than 100 (ie not complete) we reset it to 1
+        // as we will have to do reindexing from scratch and at the same time we want
+        // to differentiate from a job that has never started before.
+        progressTracker.updateReindexingProgress(reindexingProgressPercent < 100 ? 1 : reindexingProgressPercent);
     }
 
     public ProgressTracker getProgressTracker() {


### PR DESCRIPTION
…ete reindexing (#62772)

This fixes reindexing progress in the scenario when a DFA job that had not finished
reindexing is resumed (either because the user called stop and start or because the
job was reassigned in the middle of reindexing). Before the fix reindexing progress
stays to the value it had reached before until it surpasses that value.

When we resume a data frame analytics job we want to preserve reindexing progress
and reset all other phases. Except for when reindexing was not completed.
In that case we are deleting the destination index and starting reindexing
from scratch. Thus we need to reset reindexing progress too.

Backport of #62772
