### PR TITLE
ILM: migrate action configures the _tier_preference setting

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -238,7 +238,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
      * exist. If no nodes for any of the tiers are available, returns an empty
      * {@code Optional<String>}.
      */
-    static Optional<String> preferredAvailableTier(String prioritizedTiers, DiscoveryNodes nodes) {
+    public static Optional<String> preferredAvailableTier(String prioritizedTiers, DiscoveryNodes nodes) {
         String[] tiers = Strings.tokenizeToStringArray(prioritizedTiers, ",");
         return Arrays.stream(tiers).filter(tier -> tierNodesPresent(tier, nodes)).findFirst();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -10,8 +10,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -26,7 +24,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
 import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING;
 import static org.elasticsearch.xpack.core.ilm.AllocationRoutedStep.getPendingAllocations;
 import static org.elasticsearch.xpack.core.ilm.step.info.AllocationInfo.waitingForActiveShardsAllocationInfo;
@@ -73,21 +70,30 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
             return new Result(false, null);
         }
-        String destinationTier = INDEX_ROUTING_PREFER_SETTING.get(idxMeta.getSettings());
+        String preferredTierConfiguration = INDEX_ROUTING_PREFER_SETTING.get(idxMeta.getSettings());
+        String availableDestinationTier = DataTierAllocationDecider.preferredAvailableTier(preferredTierConfiguration,
+            clusterState.getNodes()).orElse("");
+
         if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {
-            if (Strings.isEmpty(destinationTier)) {
+            if (Strings.isEmpty(preferredTierConfiguration)) {
                 logger.debug("[{}] lifecycle action for index [{}] cannot make progress because not all shards are active",
                     getKey().getAction(), index.getName());
             } else {
-                logger.debug("[{}] migration of index [{}] to the [{}] tier cannot progress, as not all shards are active",
-                    getKey().getAction(), index.getName(), destinationTier);
+                if (Strings.hasText(availableDestinationTier)) {
+                    logger.debug("[{}] migration of index [{}] to the [{}] tier cannot progress, as not all shards are active",
+                        getKey().getAction(), index.getName(), preferredTierConfiguration);
+                } else {
+                    logger.debug("[{}] migration of index [{}] to the next tier cannot progress as there is no available tier for the " +
+                            "configured preferred tiers [{}] and not all shards are active", getKey().getAction(), index.getName(),
+                        preferredTierConfiguration);
+                }
             }
             return new Result(false, waitingForActiveShardsAllocationInfo(idxMeta.getNumberOfReplicas()));
         }
 
-        if (Strings.isEmpty(destinationTier)) {
-            logger.debug("index [{}] has no data tier routing setting configured and all its shards are active. considering the [{}] " +
-                "step condition met and continuing to the next step", index.getName(), getKey().getName());
+        if (Strings.isEmpty(preferredTierConfiguration)) {
+            logger.debug("index [{}] has no data tier routing preference setting configured and all its shards are active. considering " +
+                "the [{}] step condition met and continuing to the next step", index.getName(), getKey().getName());
             // the user removed the tier routing setting and all the shards are active so we'll cary on
             return new Result(true, null);
         }
@@ -95,22 +101,18 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
         int allocationPendingAllShards = getPendingAllocations(index, ALLOCATION_DECIDERS, clusterState);
 
         if (allocationPendingAllShards > 0) {
-            boolean targetTierNodeFound = false;
-            for (DiscoveryNode node : clusterState.nodes()) {
-                for (DiscoveryNodeRole role : node.getRoles()) {
-                    if (role.roleName().equals(DATA_ROLE.roleName()) || role.roleName().equals(destinationTier)) {
-                        targetTierNodeFound = true;
-                        break;
-                    }
-                }
+            String statusMessage;
+            if (Strings.hasText(availableDestinationTier)) {
+                statusMessage = String.format(Locale.ROOT, "[%s] lifecycle action [%s] waiting for [%s] shards to be moved to the [%s] " +
+                    "tier", index.getName(), getKey().getAction(), allocationPendingAllShards, availableDestinationTier);
+            } else {
+                statusMessage = String.format(Locale.ROOT, "index [%s] has a preference for tiers [%s], " +
+                    "but no nodes for any of those tiers are available in the cluster", index.getName(), preferredTierConfiguration);
             }
-            String statusMessage = String.format(Locale.ROOT, "%s lifecycle action [%s] waiting for [%s] shards to be moved to the [%s] " +
-                    "tier" + (targetTierNodeFound ? "" : " but there are currently no [%s] nodes in the cluster"),
-                index, getKey().getAction(), allocationPendingAllShards, destinationTier, destinationTier);
             logger.debug(statusMessage);
             return new Result(false, new AllocationInfo(idxMeta.getNumberOfReplicas(), allocationPendingAllShards, true, statusMessage));
         } else {
-            logger.debug("[{}] migration of index [{}] to tier [{}] complete", getKey().getAction(), index, destinationTier);
+            logger.debug("[{}] migration of index [{}] to tier [{}] complete", getKey().getAction(), index, availableDestinationTier);
             return new Result(true, null);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -80,7 +80,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
                     getKey().getAction(), index.getName());
             } else {
                 if (Strings.hasText(availableDestinationTier)) {
-                    logger.debug("[{}] migration of index [{}] to the [{}] tier cannot progress, as not all shards are active",
+                    logger.debug("[{}] migration of index [{}] to the [{}] tier preference cannot progress, as not all shards are active",
                         getKey().getAction(), index.getName(), preferredTierConfiguration);
                 } else {
                     logger.debug("[{}] migration of index [{}] to the next tier cannot progress as there is no available tier for the " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -104,8 +104,8 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             String statusMessage;
             if (Strings.hasText(availableDestinationTier)) {
                 statusMessage = String.format(Locale.ROOT, "[%s] lifecycle action [%s] waiting for [%s] shards to be moved to the [%s] " +
-                        "tier (tier migration preference configuration is [{}])", index.getName(), getKey().getAction(),
-                    allocationPendingAllShards, availableDestinationTier, preferredTierConfiguration);
+                        "tier (tier migration preference configuration is [%s])", index.getName(), getKey().getAction(),
+                    allocationPendingAllShards, availableDestinationTier.get(), preferredTierConfiguration);
             } else {
                 statusMessage = String.format(Locale.ROOT, "index [%s] has a preference for tiers [%s], " +
                     "but no nodes for any of those tiers are available in the cluster", index.getName(), preferredTierConfiguration);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -112,7 +112,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             logger.debug(statusMessage);
             return new Result(false, new AllocationInfo(idxMeta.getNumberOfReplicas(), allocationPendingAllShards, true, statusMessage));
         } else {
-            logger.debug("[{}] migration of index [{}] to tier [{}] complete", getKey().getAction(), index, availableDestinationTier);
+            logger.debug("[{}] migration of index [{}] to tier [{}] (preference [{}]) complete", getKey().getAction(), index, availableDestinationTier, preferredTierConfiguration);
             return new Result(true, null);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -104,7 +104,8 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             String statusMessage;
             if (Strings.hasText(availableDestinationTier)) {
                 statusMessage = String.format(Locale.ROOT, "[%s] lifecycle action [%s] waiting for [%s] shards to be moved to the [%s] " +
-                    "tier", index.getName(), getKey().getAction(), allocationPendingAllShards, availableDestinationTier);
+                        "tier (tier migration preference configuration is [{}])", index.getName(), getKey().getAction(),
+                    allocationPendingAllShards, availableDestinationTier, preferredTierConfiguration);
             } else {
                 statusMessage = String.format(Locale.ROOT, "index [%s] has a preference for tiers [%s], " +
                     "but no nodes for any of those tiers are available in the cluster", index.getName(), preferredTierConfiguration);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A {@link LifecycleAction} which enables or disables the automatic migration of data between
@@ -30,6 +31,9 @@ import java.util.Objects;
 public class MigrateAction implements LifecycleAction {
     public static final String NAME = "migrate";
     public static final ParseField ENABLED_FIELD = new ParseField("enabled");
+
+    // Represents an ordered list of data tiers from cold to hot (or slow to fast)
+    private static final List<String> COLD_TO_HOT_TIERS = List.of(DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
 
     private static final ConstructingObjectParser<MigrateAction, Void> PARSER = new ConstructingObjectParser<>(NAME,
         a -> new MigrateAction(a[0] == null ? true : (boolean) a[0]));
@@ -92,7 +96,7 @@ public class MigrateAction implements LifecycleAction {
             Settings.Builder migrationSettings = Settings.builder();
             String dataTierName = "data_" + phase;
             assert DataTier.validTierName(dataTierName) : "invalid data tier name:" + dataTierName;
-            migrationSettings.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, dataTierName);
+            migrationSettings.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, getPreferredTiersConfiguration(dataTierName));
             UpdateSettingsStep updateMigrationSettingStep = new UpdateSettingsStep(migrationKey, migrationRoutedKey, client,
                 migrationSettings.build());
             DataTierMigrationRoutedStep migrationRoutedStep = new DataTierMigrationRoutedStep(migrationRoutedKey, nextStepKey);
@@ -100,6 +104,23 @@ public class MigrateAction implements LifecycleAction {
         } else {
             return List.of();
         }
+    }
+
+    /**
+     * Based on the provided target tier it will return a comma separated list of preferred tiers.
+     * ie. if `data_cold` is the target tier, it will return `data_cold,data_warm,data_hot`
+     * This is usually used in conjunction with {@link DataTierAllocationDecider#INDEX_ROUTING_PREFER_SETTING}
+     */
+    static String getPreferredTiersConfiguration(String targetTier) {
+        int indexOfTargetTier = COLD_TO_HOT_TIERS.indexOf(targetTier);
+        if(indexOfTargetTier == -1) {
+            throw new IllegalArgumentException("invalid data tier [" + targetTier + "]");
+        }
+        String preferredTiers = COLD_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));
+        if (Strings.hasText(preferredTiers) == false) {
+            return targetTier;
+        }
+        return preferredTiers;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -116,11 +116,7 @@ public class MigrateAction implements LifecycleAction {
         if(indexOfTargetTier == -1) {
             throw new IllegalArgumentException("invalid data tier [" + targetTier + "]");
         }
-        String preferredTiers = COLD_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));
-        if (Strings.hasText(preferredTiers) == false) {
-            return targetTier;
-        }
-        return preferredTiers;
+        return COLD_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -113,7 +113,7 @@ public class MigrateAction implements LifecycleAction {
      */
     static String getPreferredTiersConfiguration(String targetTier) {
         int indexOfTargetTier = COLD_TO_HOT_TIERS.indexOf(targetTier);
-        if(indexOfTargetTier == -1) {
+        if (indexOfTargetTier == -1) {
             throw new IllegalArgumentException("invalid data tier [" + targetTier + "]");
         }
         return COLD_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
@@ -137,9 +137,8 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
                 .build();
         DataTierMigrationRoutedStep step = createRandomInstance();
         Result expectedResult = new Result(false, new AllocationInfo(0, 1, true,
-            "[" + index.getName() + "] lifecycle action [" + step.getKey().getAction() + "] waiting for " +
-                "[1] shards to be moved to the [data_warm] tier but there are currently no [data_warm] nodes in the cluster")
-        );
+            "index [" + index.getName() + "] has a preference for tiers [data_warm], but no nodes for any of those tiers are available " +
+                "in the cluster"));
 
         Result actualResult = step.isConditionMet(index, clusterState);
         assertThat(actualResult.isComplete(), is(false));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
@@ -112,7 +112,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
         DataTierMigrationRoutedStep step = createRandomInstance();
         Result expectedResult = new Result(false, new AllocationInfo(0, 1, true,
             "[" + index.getName() + "] lifecycle action [" + step.getKey().getAction() + "] waiting for " +
-                "[1] shards to be moved to the [data_warm] tier")
+                "[1] shards to be moved to the [data_warm] tier (tier migration preference configuration is [data_warm])")
         );
 
         Result actualResult = step.isConditionMet(index, clusterState);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
@@ -7,12 +7,21 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.xpack.core.DataTier.DATA_COLD;
+import static org.elasticsearch.xpack.core.DataTier.DATA_HOT;
+import static org.elasticsearch.xpack.core.DataTier.DATA_WARM;
+import static org.elasticsearch.xpack.core.ilm.MigrateAction.getPreferredTiersConfiguration;
+import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.COLD_PHASE;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.DELETE_PHASE;
+import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.HOT_PHASE;
+import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.WARM_PHASE;
+import static org.hamcrest.CoreMatchers.is;
 
 public class MigrateActionTests extends AbstractActionTestCase<MigrateAction> {
 
@@ -54,6 +63,38 @@ public class MigrateActionTests extends AbstractActionTestCase<MigrateAction> {
             MigrateAction disabledMigrateAction = new MigrateAction(false);
             List<Step> steps = disabledMigrateAction.toSteps(null, phase, nextStepKey);
             assertEquals(0, steps.size());
+        }
+    }
+
+    public void testGetPreferredTiersConfiguration() {
+        assertThat(getPreferredTiersConfiguration(DATA_HOT), is(DATA_HOT));
+        assertThat(getPreferredTiersConfiguration(DATA_WARM), is(DATA_WARM + "," + DATA_HOT));
+        assertThat(getPreferredTiersConfiguration(DATA_COLD), is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> getPreferredTiersConfiguration("no_tier"));
+        assertThat(exception.getMessage(), is("invalid data tier [no_tier]"));
+    }
+
+    public void testMigrateActionsConfiguresTierPreference() {
+        StepKey nextStepKey = new StepKey(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
+            randomAlphaOfLengthBetween(1, 10));
+        MigrateAction action = new MigrateAction();
+        {
+            List<Step> steps = action.toSteps(null, HOT_PHASE, nextStepKey);
+            UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(0);
+            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+                is(DATA_HOT));
+        }
+        {
+            List<Step> steps = action.toSteps(null, WARM_PHASE, nextStepKey);
+            UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(0);
+            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+                is(DATA_WARM + "," + DATA_HOT));
+        }
+        {
+            List<Step> steps = action.toSteps(null, COLD_PHASE, nextStepKey);
+            UpdateSettingsStep firstStep = (UpdateSettingsStep) steps.get(0);
+            assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(firstStep.getSettings()),
+                is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
         }
     }
 }


### PR DESCRIPTION
The `migrate` action will now configure the
`index.routing.allocation.include._tier_preference` setting to the corresponding
tiers. For the HOT phase it will configure `data_hot`, for the WARM phase it will
configure `data_warm,data_hot` and for the COLD phase
`data_cold,data_warm,data_cold`.

Relates to #60848 