### PR TITLE
Add Missing Netty Runtime Proc Property to Security Tests (#62846)

### DIFF
--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -472,6 +472,14 @@ if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_1_8) {
   )
 }
 
+test {
+  /*
+   * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
+   * other if we allow them to set the number of available processors as it's set-once in Netty.
+   */
+  systemProperty 'es.set.netty.runtime.available.processors', 'false'
+}
+
 internalClusterTest {
   /*
    * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.security.transport.netty4;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -23,7 +22,6 @@ import org.elasticsearch.xpack.security.transport.AbstractSimpleSecurityTranspor
 
 import java.util.Collections;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/62298")
 public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleSecurityTransportTestCase {
 
     @Override


### PR DESCRIPTION
Same as in the normal Netty tests we have to disable the runtime proc
setting in the normal tests task just like we do for the internal cluster tests.

Closes #61919
Closes #62298

backport of #62846