### PR TITLE
Small refactoring of unsinged_long

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -398,6 +398,8 @@ public class Lucene {
             return in.readBoolean();
         } else if (type == 9) {
             return in.readBytesRef();
+        } else if (type == 10) {
+            return new BigInteger(in.readString());
         } else {
             throw new IOException("Can't match type [" + type + "]");
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -159,7 +159,8 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             DocumentMapper mapper = createDocumentMapper(
                 fieldMapping(b -> b.field("type", "unsigned_long").field("null_value", "18446744073709551615"))
             );
-            ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));;
+            ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
+            ;
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(2, fields.length);
             IndexableField pointField = fields[0];
@@ -206,7 +207,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
     public void testIndexingOutOfRangeValues() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         for (Object outOfRangeValue : new Object[] { "-1", -1L, "18446744073709551616", new BigInteger("18446744073709551616") }) {
-            ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", outOfRangeValue)));;
+            ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", outOfRangeValue)));
             expectThrows(MapperParsingException.class, runnable);
         }
     }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -11,11 +11,8 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.Mapper;
@@ -23,7 +20,6 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 import org.elasticsearch.plugins.Plugin;
 
@@ -32,7 +28,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.BIGINTEGER_2_64_MINUS_ONE;
 import static org.hamcrest.Matchers.containsString;
 
@@ -72,14 +67,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
         // test indexing of values as string
         {
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "18446744073709551615").endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.field("field", "18446744073709551615")));
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(2, fields.length);
             IndexableField pointField = fields[0];
@@ -94,14 +82,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
         // test indexing values as integer numbers
         {
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "2",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", 9223372036854775807L).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.field("field", 9223372036854775807L)));
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(2, fields.length);
             IndexableField pointField = fields[0];
@@ -112,14 +93,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
         // test that indexing values as number with decimal is not allowed
         {
-            ThrowingRunnable runnable = () -> mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "3",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", 10.5).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", 10.5)));
             MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
             assertThat(e.getCause().getMessage(), containsString("For input string: [10.5]"));
         }
@@ -127,15 +101,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
     public void testNotIndexed() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "unsigned_long").field("index", false)));
-
-        ParsedDocument doc = mapper.parse(
-            new SourceToParse(
-                "test",
-                "1",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "18446744073709551615").endObject()),
-                XContentType.JSON
-            )
-        );
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "18446744073709551615")));
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         IndexableField dvField = fields[0];
@@ -145,15 +111,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
     public void testNoDocValues() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "unsigned_long").field("doc_values", false)));
-
-        ParsedDocument doc = mapper.parse(
-            new SourceToParse(
-                "test",
-                "1",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "18446744073709551615").endObject()),
-                XContentType.JSON
-            )
-        );
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "18446744073709551615")));
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         IndexableField pointField = fields[0];
@@ -163,15 +121,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
 
     public void testStore() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "unsigned_long").field("store", true)));
-
-        ParsedDocument doc = mapper.parse(
-            new SourceToParse(
-                "test",
-                "1",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "18446744073709551615").endObject()),
-                XContentType.JSON
-            )
-        );
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "18446744073709551615")));
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(3, fields.length);
         IndexableField pointField = fields[0];
@@ -200,14 +150,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
         // test that if null value is not defined, field is not indexed
         {
             DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().nullField("field").endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
             assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
         }
 
@@ -216,14 +159,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             DocumentMapper mapper = createDocumentMapper(
                 fieldMapping(b -> b.field("type", "unsigned_long").field("null_value", "18446744073709551615"))
             );
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().nullField("field").endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));;
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(2, fields.length);
             IndexableField pointField = fields[0];
@@ -238,26 +174,12 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
         {
             DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
             Object malformedValue1 = "a";
-            ThrowingRunnable runnable = () -> mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue1).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", malformedValue1)));
             MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
             assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
 
             Object malformedValue2 = Boolean.FALSE;
-            runnable = () -> mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue2).endObject()),
-                    XContentType.JSON
-                )
-            );
+            runnable = () -> mapper.parse(source(b -> b.field("field", malformedValue2)));
             e = expectThrows(MapperParsingException.class, runnable);
             assertThat(e.getCause().getMessage(), containsString("For input string: \"false\""));
         }
@@ -268,27 +190,13 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
                 fieldMapping(b -> b.field("type", "unsigned_long").field("ignore_malformed", true))
             );
             Object malformedValue1 = "a";
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue1).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.field("field", malformedValue1)));
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(0, fields.length);
             assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
 
             Object malformedValue2 = Boolean.FALSE;
-            ParsedDocument doc2 = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue2).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc2 = mapper.parse(source(b -> b.field("field", malformedValue2)));
             IndexableField[] fields2 = doc2.rootDoc().getFields("field");
             assertEquals(0, fields2.length);
             assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc2.rootDoc().getFields("_ignored")));
@@ -298,14 +206,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
     public void testIndexingOutOfRangeValues() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         for (Object outOfRangeValue : new Object[] { "-1", -1L, "18446744073709551616", new BigInteger("18446744073709551616") }) {
-            ThrowingRunnable runnable = () -> mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", outOfRangeValue).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", outOfRangeValue)));;
             expectThrows(MapperParsingException.class, runnable);
         }
     }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -241,7 +241,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             ThrowingRunnable runnable = () -> mapper.parse(
                 new SourceToParse(
                     "test",
-                    "_doc",
+                    "1",
                     BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue1).endObject()),
                     XContentType.JSON
                 )
@@ -253,7 +253,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             runnable = () -> mapper.parse(
                 new SourceToParse(
                     "test",
-                    "_doc",
+                    "1",
                     BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue2).endObject()),
                     XContentType.JSON
                 )
@@ -301,7 +301,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
             ThrowingRunnable runnable = () -> mapper.parse(
                 new SourceToParse(
                     "test",
-                    "_doc",
+                    "1",
                     BytesReference.bytes(jsonBuilder().startObject().field("field", outOfRangeValue).endObject()),
                     XContentType.JSON
                 )

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/10_basic.yml
@@ -1,8 +1,8 @@
 setup:
 
   - skip:
-      version: " - 7.99.99"
-      reason: "unsigned_long was added in 8.0"
+      version: " - 7.9.99"
+      reason: "unsigned_long was added in 7.10"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/20_null_value.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/20_null_value.yml
@@ -1,8 +1,8 @@
 ---
 "Null value":
   - skip:
-      version: " - 7.99.99"
-      reason: "unsigned_long was added in 8.0"
+      version: " - 7.9.99"
+      reason: "unsigned_long was added in 7.10"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/30_multi_fields.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/30_multi_fields.yml
@@ -1,8 +1,8 @@
 ---
 "Multi keyword and unsigned_long fields":
   - skip:
-      version: " - 7.99.99"
-      reason: "unsigned_long was added in 8.0"
+      version: " - 7.9.99"
+      reason: "unsigned_long was added in 7.10"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/40_different_numeric.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/40_different_numeric.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 7.99.99"
-      reason: "unsigned_long was added in 8.0"
+      version: " - 7.9.99"
+      reason: "unsigned_long was added in 7.10"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
@@ -1,8 +1,8 @@
 setup:
 
   - skip:
-      version: " - 7.99.99"
-      reason: "unsigned_long was added in 8.0"
+      version: " - 7.9.99"
+      reason: "unsigned_long was added in 7.10"
 
   - do:
       indices.create:


### PR DESCRIPTION
- Modify Lucene::readSortValue to read BigInteger as a sortValue.
In #60050 writeSortValue was modified, but readSortValue was forgotten.

- Adjust yml tests to v7.10 as unsigned_long has been backported

- Change MapperTests to use proper document IDs

Relates to #60050