### PR TITLE
Handle JAVA_HOME better in packaging tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -283,9 +283,8 @@ public class DistroTestPlugin implements Plugin<Project> {
         vagrant.setBox(box);
 
         vagrant.vmEnv("SYSTEM_JAVA_HOME", convertPath(project, vagrant, systemJdkProvider, "", ""));
-        vagrant.vmEnv("JAVA_HOME", ""); // make sure any default java on the system is ignored
-        vagrant.vmEnv("PATH", convertPath(project, vagrant, gradleJdkProvider, "/bin:$PATH", "\\bin;$Env:PATH"));
-        // pass these along to get correct build scans
+        // set java home for gradle to use. package tests will overwrite/remove this for each test case
+        vagrant.vmEnv("JAVA_HOME", convertPath(project, vagrant, gradleJdkProvider, "", ""));
         if (System.getenv("JENKINS_URL") != null) {
             Stream.of("JOB_NAME", "JENKINS_URL", "BUILD_NUMBER", "BUILD_URL").forEach(name -> vagrant.vmEnv(name, System.getenv(name)));
         }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -166,6 +166,7 @@ public class Shell {
         if (workingDirectory != null) {
             setWorkingDirectory(builder, workingDirectory);
         }
+        builder.environment().keySet().remove("JAVA_HOME"); // start with a fresh environment
         for (Map.Entry<String, String> entry : env.entrySet()) {
             builder.environment().put(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
JAVA_HOME is set as necessary in packaging tests, depending on whether
it is needed for no-jdk distributions or testing override behavior. We
currently rely on gradle finding java through PATH. However, JAVA_HOME
can sometimes be set by the system itself, which then leaks through to
the packaging test. This commit reworks our handling of JAVA_HOME to
pass it through for gradle, and then explicitly clear it whenever
running shell commands in packaging tests.