### PR TITLE
Rollup V2 end-to-end POC

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -54,6 +54,7 @@ testClusters.integTest {
     setting 'indices.lifecycle.history_index_enabled', 'false'
     if (BuildParams.isSnapshotBuild() == false) {
       systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+      systemProperty 'es.rollup_v2_feature_enabled', 'true'
     }
     setting 'xpack.autoscaling.enabled', 'true'
     keystorePassword 's3cr3t'

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -59,6 +59,7 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
 
     private final Function<GroupShardsIterator<SearchShardIterator>, SearchPhase> phaseFactory;
     private final GroupShardsIterator<SearchShardIterator> shardsIts;
+    private final boolean preFilterRollup;
 
     CanMatchPreFilterSearchPhase(Logger logger, SearchTransportService searchTransportService,
                                  BiFunction<String, String, Transport.Connection> nodeIdToConnection,
@@ -68,13 +69,14 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
                                  ActionListener<SearchResponse> listener, GroupShardsIterator<SearchShardIterator> shardsIts,
                                  TransportSearchAction.SearchTimeProvider timeProvider, ClusterState clusterState,
                                  SearchTask task, Function<GroupShardsIterator<SearchShardIterator>, SearchPhase> phaseFactory,
-                                 SearchResponse.Clusters clusters) {
+                                 SearchResponse.Clusters clusters, boolean preFilterRollup) {
         //We set max concurrent shard requests to the number of shards so no throttling happens for can_match requests
         super("can_match", logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, indexRoutings,
                 executor, request, listener, shardsIts, timeProvider, clusterState, task,
                 new CanMatchSearchPhaseResults(shardsIts.size()), shardsIts.size(), clusters);
         this.phaseFactory = phaseFactory;
         this.shardsIts = shardsIts;
+        this.preFilterRollup = preFilterRollup;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -365,6 +365,7 @@ public class SearchTransportService {
         TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, FetchSearchResult::new);
 
         // this is cheap, it does not fetch during the rewrite phase, so we can let it quickly execute on a networking thread
+        // TODO(talevy): update request here potentially to pass parameters to the can match phase to say whether to filter rollup or not
         transportService.registerRequestHandler(QUERY_CAN_MATCH_NAME, ThreadPool.Names.SAME, ShardSearchRequest::new,
             (request, channel, task) -> {
                 searchService.canMatch(request, new ChannelActionListener<>(channel, QUERY_CAN_MATCH_NAME, request));

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.MetadataMappingService;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
+import org.elasticsearch.cluster.metadata.RollupMetadata;
 import org.elasticsearch.cluster.routing.DelayedAllocationService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -140,6 +141,7 @@ public class ClusterModule extends AbstractModule {
         registerMetadataCustom(entries, ComposableIndexTemplateMetadata.TYPE, ComposableIndexTemplateMetadata::new,
             ComposableIndexTemplateMetadata::readDiffFrom);
         registerMetadataCustom(entries, DataStreamMetadata.TYPE, DataStreamMetadata::new, DataStreamMetadata::readDiffFrom);
+        registerMetadataCustom(entries, RollupMetadata.TYPE, RollupMetadata::new, RollupMetadata::readDiffFrom);
         // Task Status (not Diffable)
         entries.add(new Entry(Task.Status.class, PersistentTasksNodeService.Status.NAME, PersistentTasksNodeService.Status::new));
         return entries;
@@ -164,6 +166,8 @@ public class ClusterModule extends AbstractModule {
             ComposableIndexTemplateMetadata::fromXContent));
         entries.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(DataStreamMetadata.TYPE),
             DataStreamMetadata::fromXContent));
+        entries.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(RollupMetadata.TYPE),
+            RollupMetadata::fromXContent));
         return entries;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1407,6 +1407,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
 
         private SortedMap<String, IndexAbstraction> buildIndicesLookup() {
+            // TODO(talevy) include rollup indices here
             SortedMap<String, IndexAbstraction> indicesLookup = new TreeMap<>();
             Map<String, DataStream> indexToDataStreamLookup = new HashMap<>();
             DataStreamMetadata dataStreamMetadata = (DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RollupGroup.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RollupGroup.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+
+// TODO(talevy): optimize for fast lookup speed
+public class RollupGroup extends AbstractDiffable<RollupGroup> implements ToXContentObject {
+    private static final ParseField GROUP = new ParseField("group");
+
+    private List<String> group;
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<RollupGroup, Void> PARSER =
+        new ConstructingObjectParser<>("rollup_group", false,
+            a -> new RollupGroup((List<String>) a[0]));
+
+    static {
+        PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), GROUP);
+    }
+
+    public RollupGroup(List<String> group) {
+        this.group = group;
+    }
+
+    public RollupGroup(StreamInput in) throws IOException {
+        this.group = in.readStringList();
+    }
+
+    public void add(String name) {
+        group.add(name);
+    }
+
+    public void remove(String name) {
+        group.remove(name);
+    }
+
+    public boolean contains(String name) {
+        return group.contains(name);
+    }
+
+    static Diff<RollupGroup> readDiffFrom(StreamInput in) throws IOException {
+        return AbstractDiffable.readDiffFrom(RollupGroup::new, in);
+    }
+
+    public static RollupGroup parse(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeStringCollection(group);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject().array(GROUP.getPreferredName(), group).endObject();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RollupMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RollupMetadata.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.DiffableUtils;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Custom {@link Metadata} implementation for storing a map of {@link DataStream}s and their names.
+ */
+public class RollupMetadata implements Metadata.Custom {
+    public static final String TYPE = "rollup";
+    public static final String SOURCE_INDEX_NAME_META_FIELD = "source_index";
+    private static final ParseField ROLLUP = new ParseField("rollup");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RollupMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE, false,
+        a -> new RollupMetadata((Map<String, RollupGroup>) a[0]));
+
+    static {
+        PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> {
+            Map<String, RollupGroup> rollupGroups = new HashMap<>();
+            while (p.nextToken() != XContentParser.Token.END_OBJECT) {
+                String name = p.currentName();
+                rollupGroups.put(name, RollupGroup.parse(p));
+            }
+            return rollupGroups;
+        }, ROLLUP);
+    }
+
+    private final Map<String, RollupGroup> rollupIndices;
+
+    public RollupMetadata(Map<String, RollupGroup> rollupIndices) {
+        this.rollupIndices = rollupIndices;
+    }
+
+    public RollupMetadata(StreamInput in) throws IOException {
+        this.rollupIndices = in.readMap(StreamInput::readString, RollupGroup::new);
+    }
+
+    public Map<String, RollupGroup> rollupGroups() {
+        return this.rollupIndices;
+    }
+
+    public boolean contains(String index) {
+        return this.rollupIndices.containsKey(index);
+    }
+
+    @Override
+    public Diff<Metadata.Custom> diff(Metadata.Custom before) {
+        return new RollupMetadata.RollupMetadataDiff((RollupMetadata) before, this);
+    }
+
+    public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+        return new RollupMetadataDiff(in);
+    }
+
+    @Override
+    public EnumSet<Metadata.XContentContext> context() {
+        return Metadata.ALL_CONTEXTS;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_0_0;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(this.rollupIndices, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+    }
+
+    public static RollupMetadata fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(ROLLUP.getPreferredName());
+        for (Map.Entry<String, RollupGroup> rollup : rollupIndices.entrySet()) {
+            builder.field(rollup.getKey(), rollup.getValue());
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.rollupIndices);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        RollupMetadata other = (RollupMetadata) obj;
+        return Objects.equals(this.rollupIndices, other.rollupIndices);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    public static class Builder {
+
+        private final Map<String, RollupGroup> rollupIndices = new HashMap<>();
+
+        public Builder putRollupGroup(String name, RollupGroup group) {
+            rollupIndices.put(name,  group);
+            return this;
+        }
+
+        public RollupMetadata build() {
+            return new RollupMetadata(rollupIndices);
+        }
+    }
+
+    static class RollupMetadataDiff implements NamedDiff<Metadata.Custom> {
+
+        final Diff<Map<String, RollupGroup>> rollupIndicesDiff;
+
+        RollupMetadataDiff(RollupMetadata before, RollupMetadata after) {
+            this.rollupIndicesDiff = DiffableUtils.diff(before.rollupIndices, after.rollupIndices, DiffableUtils.getStringKeySerializer());
+        }
+
+        RollupMetadataDiff(StreamInput in) throws IOException {
+            this.rollupIndicesDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
+                RollupGroup::new, RollupGroup::readDiffFrom);
+        }
+
+        @Override
+        public Metadata.Custom apply(Metadata.Custom part) {
+            return new RollupMetadata(rollupIndicesDiff.apply(((RollupMetadata) part).rollupIndices));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            rollupIndicesDiff.writeTo(out);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rollup/RollupShardDecider.java
+++ b/server/src/main/java/org/elasticsearch/rollup/RollupShardDecider.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rollup;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.RollupGroup;
+import org.elasticsearch.cluster.metadata.RollupMetadata;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationInitializationException;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.SortedMap;
+
+public class RollupShardDecider {
+    private static final Logger logger = LogManager.getLogger(RollupShardDecider.class);
+
+    public static boolean shouldMatchRollup(QueryShardContext context,
+                                            QueryBuilder queryBuilder,
+                                            AggregatorFactories.Builder aggFactoryBuilders,
+                                            RollupMetadata rollupMetadata,
+                                            Map<String, String> indexRollupMetadata,
+                                            IndexMetadata requestIndexMetadata,
+                                            String[] indices,
+                                            SortedMap<String, IndexAbstraction> indexLookup) {
+        // TODO(talevy): currently assumes that all indices part of the same rollup group are searched as well, since this is the case
+        //  for data-streams. should not be here in the non-datastream case...
+
+        if (aggFactoryBuilders == null && indexRollupMetadata != null) {
+            return false;
+        } else if (aggFactoryBuilders != null && rollupMetadata != null && indexRollupMetadata != null && queryBuilder != null) {
+            Query query = context.toQuery(queryBuilder).query();
+            try {
+                AggregatorFactory[] factories = aggFactoryBuilders
+                    .build(new AggregationContext.ProductionAggregationContext(context, query), null)
+                    .factories();
+            } catch (IOException e) {
+                throw new AggregationInitializationException("Failed to create aggregators, shard not supported", e);
+            }
+
+            if (queryShard(rollupMetadata, indices, requestIndexMetadata, aggFactoryBuilders) == false) {
+                return false;
+            }
+            // do something with query?
+            query.visit(new QueryVisitor() {
+                @Override
+                public void consumeTerms(Query query, Term... terms) {
+                    super.consumeTerms(query, terms);
+                }
+            });
+        } else if (aggFactoryBuilders != null && rollupMetadata != null) {
+            if (queryShard(rollupMetadata, indices, requestIndexMetadata, aggFactoryBuilders) == false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static boolean queryShard(RollupMetadata rollupMetadata, String[] indices, IndexMetadata requestIndexMetadata,
+                              AggregatorFactories.Builder aggFactoryBuilders) {
+        String requestIndexName = requestIndexMetadata.getIndex().getName();
+        Map<String, String> indexRollupMetadata = requestIndexMetadata.getCustomData(RollupMetadata.TYPE);
+        boolean isRollupIndex = requestIndexMetadata.getCustomData(RollupMetadata.TYPE) != null;
+        final String originalIndexName;
+        final RollupGroup rollupGroup;
+        if (isRollupIndex) {
+            // rollup is being searched
+            originalIndexName = indexRollupMetadata.get(RollupMetadata.SOURCE_INDEX_NAME_META_FIELD);
+            rollupGroup = rollupMetadata.rollupGroups().get(originalIndexName);
+        } else if (rollupMetadata.contains(requestIndexName)) {
+            originalIndexName = requestIndexName;
+            rollupGroup = rollupMetadata.rollupGroups().get(requestIndexName);
+        } else {
+            // not part of a rollup group, search away!
+            return true;
+        }
+        String bestIndexForAgg = bestIndexForAgg(originalIndexName, rollupGroup, aggFactoryBuilders);
+        logger.warn("original index: " + originalIndexName);
+        logger.warn("best index: " + bestIndexForAgg);
+        return requestIndexName.equals(bestIndexForAgg);
+    }
+
+    static String bestIndexForAgg(String originalIndexName, RollupGroup rollupGroup, AggregatorFactories.Builder aggFactoryBuilders) {
+        for (AggregationBuilder builder : aggFactoryBuilders.getAggregatorFactories()) {
+            if (builder.getWriteableName().equals(DateHistogramAggregationBuilder.NAME)) {
+                return bestIndexForDateHisto(originalIndexName, rollupGroup, (DateHistogramAggregationBuilder) builder);
+            }
+        }
+        return originalIndexName;
+    }
+
+    static String bestIndexForDateHisto(String originalIndexName, RollupGroup rollupGroup, DateHistogramAggregationBuilder source) {
+        DateHistogramInterval maxInterval = null;
+        String bestIndex = originalIndexName;
+        for (String rollupIndex : rollupGroup.getIndices()) {
+            DateHistogramInterval thisInterval = new DateHistogramInterval(rollupGroup.getDateInterval(rollupIndex));
+            ZoneId thisTimezone = ZoneId.of(rollupGroup.getDateTimezone(rollupIndex));
+
+            ZoneId sourceTimeZone = source.timeZone() == null ? ZoneOffset.UTC : ZoneId.of(source.timeZone().toString(), ZoneId.SHORT_IDS);
+            DateHistogramInterval sourceInterval = source.getCalendarInterval();
+
+            if (thisTimezone.getRules().equals(sourceTimeZone.getRules()) == false) {
+                continue;
+            }
+            if (validateCalendarInterval(sourceInterval, thisInterval)) {
+                if (maxInterval == null) {
+                    bestIndex = rollupIndex;
+                    maxInterval = thisInterval;
+                } else if (validateCalendarInterval(thisInterval, maxInterval)) {
+                    bestIndex = rollupIndex;
+                    maxInterval = thisInterval;
+                }
+            }
+        }
+        return bestIndex;
+    }
+
+    static boolean validateCalendarInterval(DateHistogramInterval requestInterval,
+                                            DateHistogramInterval configInterval) {
+        if (requestInterval == null || configInterval == null) {
+            return false;
+        }
+
+        // The request must be gte the config.  The CALENDAR_ORDERING map values are integers representing
+        // relative orders between the calendar units
+        Rounding.DateTimeUnit requestUnit = DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(requestInterval.toString());
+        if (requestUnit == null) {
+            return false;
+        }
+        Rounding.DateTimeUnit configUnit = DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(configInterval.toString());
+        if (configUnit == null) {
+            return false;
+        }
+
+        long requestOrder = requestUnit.getField().getBaseUnit().getDuration().toMillis();
+        long configOrder = configUnit.getField().getBaseUnit().getDuration().toMillis();
+
+        // All calendar units are multiples naturally, so we just care about gte
+        return requestOrder >= configOrder;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -208,7 +208,7 @@ public class AggregatorFactories {
         for (int i = 0; i < factories.length; i++) {
             /*
              * Top level aggs only collect from owningBucketOrd 0 which is
-             * *exactly* what CardinalityUpperBound.ONE *means*.  
+             * *exactly* what CardinalityUpperBound.ONE *means*.
              */
             Aggregator factory = factories[i].create(searchContext, null, CardinalityUpperBound.ONE);
             Profilers profilers = factory.context().getProfilers();
@@ -225,6 +225,11 @@ public class AggregatorFactories {
      */
     public int countAggregators() {
         return factories.length;
+    }
+
+    // TODO(talevy) check aggregator factories
+    public AggregatorFactory[] factories() {
+        return factories;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -185,6 +185,10 @@ public class Task {
         return headers.get(header);
     }
 
+    public Map<String, String> headers() {
+        return headers;
+    }
+
     public TaskResult result(DiscoveryNode node, Exception error) throws IOException {
         return new TaskResult(taskInfo(node.getId(), true), error);
     }

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -132,7 +132,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         final boolean shard1 = randomBoolean();
         final boolean shard2 = randomBoolean();
 
-        SearchTransportService searchTransportService = new SearchTransportService(null, null) {
+        SearchTransportService searchTransportService = new SearchTransportService(null, null, null) {
             @Override
             public void sendCanMatch(Transport.Connection connection, ShardSearchRequest request, SearchTask task,
                                      ActionListener<SearchService.CanMatchResponse> listener) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -148,6 +148,7 @@ import org.elasticsearch.xpack.core.rollup.action.GetRollupCapsAction;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction;
 import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Action;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
@@ -377,6 +378,8 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 DeleteRollupJobAction.INSTANCE,
                 GetRollupJobsAction.INSTANCE,
                 GetRollupCapsAction.INSTANCE,
+                // rollupV2
+                RollupV2Action.INSTANCE,
                 // ILM
                 DeleteLifecycleAction.INSTANCE,
                 GetLifecycleAction.INSTANCE,
@@ -544,7 +547,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                         RollupJobStatus::fromXContent),
                 new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(RollupJobStatus.NAME),
                         RollupJobStatus::fromXContent),
-                // Transforms
+            // Transforms
                 new NamedXContentRegistry.Entry(PersistentTaskParams.class, new ParseField(TransformField.TASK_NAME),
                         TransformTaskParams::fromXContent),
                 new NamedXContentRegistry.Entry(Task.Status.class, new ParseField(TransformField.TASK_NAME),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleType;
 import org.elasticsearch.xpack.core.ilm.MigrateAction;
 import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.RollupAction;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
@@ -485,6 +486,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             new NamedWriteableRegistry.Entry(LifecycleAction.class, WaitForSnapshotAction.NAME, WaitForSnapshotAction::new),
             new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
             new NamedWriteableRegistry.Entry(LifecycleAction.class, MigrateAction.NAME, MigrateAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, RollupAction.NAME, RollupAction::new),
             // Transforms
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.TRANSFORM, TransformFeatureSetUsage::new),
             new NamedWriteableRegistry.Entry(PersistentTaskParams.class, TransformField.TASK_NAME, TransformTaskParams::new),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link LifecycleAction} which sets the index's priority. The higher the priority, the faster the recovery.
+ */
+public class RollupAction implements LifecycleAction {
+    public static final String NAME = "rollup";
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RollupAction, Void> PARSER = new ConstructingObjectParser<>(NAME,
+        a -> new RollupAction((RollupV2Config) a[0]));
+
+    //package private for testing
+    final RollupV2Config config;
+
+    static {
+        PARSER.declareField(ConstructingObjectParser.constructorArg(),
+            (p, c) -> RollupV2Config.fromXContent(p, "_source_index_todo"),
+            new ParseField("config"), ObjectParser.ValueType.OBJECT);
+    }
+
+    public static RollupAction parse(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    public RollupAction(RollupV2Config config) {
+        this.config = config;
+    }
+
+    public RollupAction(StreamInput in) throws IOException {
+        this(new RollupV2Config(in));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("config", config);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        config.writeTo(out);
+    }
+
+    @Override
+    public boolean isSafeAction() {
+        return false;
+    }
+
+    @Override
+    public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {
+        StepKey checkNotWriteIndex = new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME);
+        StepKey readOnlyKey = new StepKey(phase, NAME, ReadOnlyAction.NAME);
+        StepKey rollupKey = new StepKey(phase, NAME, NAME);
+        CheckNotDataStreamWriteIndexStep checkNotWriteIndexStep = new CheckNotDataStreamWriteIndexStep(checkNotWriteIndex,
+            readOnlyKey);
+        Settings readOnlySettings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build();
+        UpdateSettingsStep readOnlyStep = new UpdateSettingsStep(readOnlyKey, nextStepKey, client, readOnlySettings);
+        RollupStep rollupStep = new RollupStep(rollupKey, nextStepKey, client, config);
+        return List.of(checkNotWriteIndexStep, readOnlyStep, rollupStep);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RollupAction that = (RollupAction) o;
+
+        return Objects.equals(this.config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(config);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupAction.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * A {@link LifecycleAction} which sets the index's priority. The higher the priority, the faster the recovery.
+ * A {@link LifecycleAction} which calls {@link org.elasticsearch.xpack.core.rollup.v2.RollupV2Action} on an index
  */
 public class RollupAction implements LifecycleAction {
     public static final String NAME = "rollup";
@@ -86,7 +86,7 @@ public class RollupAction implements LifecycleAction {
         CheckNotDataStreamWriteIndexStep checkNotWriteIndexStep = new CheckNotDataStreamWriteIndexStep(checkNotWriteIndex,
             readOnlyKey);
         Settings readOnlySettings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build();
-        UpdateSettingsStep readOnlyStep = new UpdateSettingsStep(readOnlyKey, nextStepKey, client, readOnlySettings);
+        UpdateSettingsStep readOnlyStep = new UpdateSettingsStep(readOnlyKey, rollupKey, client, readOnlySettings);
         RollupStep rollupStep = new RollupStep(rollupKey, nextStepKey, client, config);
         return List.of(checkNotWriteIndexStep, readOnlyStep, rollupStep);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Action;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.util.Objects;
+
+/**
+ * Rolls up index using a {@link RollupV2Config}
+ */
+public class RollupStep extends AsyncActionStep {
+    public static final String NAME = "rollup";
+
+    private final RollupV2Config config;
+
+    public RollupStep(StepKey key, StepKey nextStepKey, Client client, RollupV2Config config) {
+        super(key, nextStepKey, client);
+        this.config = config;
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return false;
+    }
+
+    @Override
+    public void performAction(IndexMetadata indexMetadata, ClusterState currentState, ClusterStateObserver observer, Listener listener) {
+        config.setSourceIndex(indexMetadata.getIndex().getName());
+        RollupV2Action.Request request = new RollupV2Action.Request(config);
+        getClient().execute(RollupV2Action.INSTANCE, request,
+                ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure));
+    }
+
+    public RollupV2Config getConfig() {
+        return config;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        RollupStep other = (RollupStep) obj;
+        return super.equals(obj) &&
+                Objects.equals(config, other.config);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RollupStep.java
@@ -35,7 +35,9 @@ public class RollupStep extends AsyncActionStep {
 
     @Override
     public void performAction(IndexMetadata indexMetadata, ClusterState currentState, ClusterStateObserver observer, Listener listener) {
-        config.setSourceIndex(indexMetadata.getIndex().getName());
+        String originalIndex = indexMetadata.getIndex().getName();
+        config.setSourceIndex(originalIndex);
+        config.setRollupIndex(originalIndex + "-rollup");
         RollupV2Action.Request request = new RollupV2Action.Request(config);
         getClient().execute(RollupV2Action.INSTANCE, request,
                 ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -44,7 +44,9 @@ public class TimeseriesLifecycleType implements LifecycleType {
     static final List<String> ORDERED_VALID_WARM_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, ReadOnlyAction.NAME,
         AllocateAction.NAME, MigrateAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME);
     static final List<String> ORDERED_VALID_COLD_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
-        MigrateAction.NAME, FreezeAction.NAME, SearchableSnapshotAction.NAME);
+        MigrateAction.NAME, FreezeAction.NAME, SearchableSnapshotAction.NAME, RollupAction.NAME);
+    static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
+        FreezeAction.NAME, SearchableSnapshotAction.NAME);
     static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);
     static final Set<String> VALID_HOT_ACTIONS = Sets.newHashSet(ORDERED_VALID_HOT_ACTIONS);
     static final Set<String> VALID_WARM_ACTIONS = Sets.newHashSet(ORDERED_VALID_WARM_ACTIONS);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -45,15 +45,14 @@ public class TimeseriesLifecycleType implements LifecycleType {
     static final List<String> ORDERED_VALID_WARM_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, ReadOnlyAction.NAME,
         AllocateAction.NAME, MigrateAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME);
     static final List<String> ORDERED_VALID_COLD_ACTIONS;
-    static final List<String> ORDERED_VALID_FROZEN_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
-        FreezeAction.NAME, SearchableSnapshotAction.NAME);
     static final List<String> ORDERED_VALID_DELETE_ACTIONS = Arrays.asList(WaitForSnapshotAction.NAME, DeleteAction.NAME);
     static final Set<String> VALID_HOT_ACTIONS = Sets.newHashSet(ORDERED_VALID_HOT_ACTIONS);
     static final Set<String> VALID_WARM_ACTIONS = Sets.newHashSet(ORDERED_VALID_WARM_ACTIONS);
+    static final Set<String> VALID_COLD_ACTIONS; // set in static block below
     static final Set<String> VALID_DELETE_ACTIONS = Sets.newHashSet(ORDERED_VALID_DELETE_ACTIONS);
     private static final Map<String, Set<String>> ALLOWED_ACTIONS = new HashMap<>();
-
     private static final boolean ROLLUP_V2_FEATURE_ENABLED;
+
     static {
         final String property = System.getProperty("es.rollup_v2_feature_enabled");
         if ("true".equals(property)) {
@@ -67,17 +66,14 @@ public class TimeseriesLifecycleType implements LifecycleType {
                 "expected es.rollup_v2_feature_enabled to be unset or [true|false] but was [" + property + "]"
             );
         }
-    }
-
-    static {
         if (ROLLUP_V2_FEATURE_ENABLED) {
             ORDERED_VALID_COLD_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
-                MigrateAction.NAME, FreezeAction.NAME, RollupAction.NAME, SearchableSnapshotAction.NAME);
+                RollupAction.NAME, MigrateAction.NAME, FreezeAction.NAME, SearchableSnapshotAction.NAME);
         } else {
             ORDERED_VALID_COLD_ACTIONS = Arrays.asList(SetPriorityAction.NAME, UnfollowAction.NAME, AllocateAction.NAME,
                 MigrateAction.NAME, FreezeAction.NAME, SearchableSnapshotAction.NAME);
         }
-        final Set<String> VALID_COLD_ACTIONS = Sets.newHashSet(ORDERED_VALID_COLD_ACTIONS);
+        VALID_COLD_ACTIONS = Sets.newHashSet(ORDERED_VALID_COLD_ACTIONS);
         ALLOWED_ACTIONS.put(HOT_PHASE, VALID_HOT_ACTIONS);
         ALLOWED_ACTIONS.put(WARM_PHASE, VALID_WARM_ACTIONS);
         ALLOWED_ACTIONS.put(COLD_PHASE, VALID_COLD_ACTIONS);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
@@ -50,8 +50,8 @@ public class MetricConfig implements Writeable, ToXContentObject {
     public static final ParseField SUM = new ParseField("sum");
     public static final ParseField AVG = new ParseField("avg");
     public static final ParseField VALUE_COUNT = new ParseField("value_count");
+    public static final String NAME = "metrics";
 
-    static final String NAME = "metrics";
     private static final String FIELD = "field";
     private static final String METRICS = "metrics";
     private static final ConstructingObjectParser<MetricConfig, Void> PARSER;
@@ -84,7 +84,7 @@ public class MetricConfig implements Writeable, ToXContentObject {
         this.metrics = metrics;
     }
 
-    MetricConfig(final StreamInput in) throws IOException {
+    public MetricConfig(final StreamInput in) throws IOException {
         field = in.readString();
         metrics = in.readStringList();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Action.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Action.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class RollupV2Action extends ActionType<RollupV2Action.Response> {
+
+    public static final RollupV2Action INSTANCE = new RollupV2Action();
+    public static final String NAME = "cluster:admin/xpack/rollupV2";
+
+    private RollupV2Action() {
+        super(NAME, RollupV2Action.Response::new);
+    }
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+        private RollupV2Config rollupConfig;
+
+        public Request(RollupV2Config rollupConfig) {
+            this.rollupConfig = rollupConfig;
+        }
+
+        public Request() {}
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            rollupConfig = new RollupV2Config(in);
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new RollupV2Task(id, type, action, parentTaskId, rollupConfig, headers);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            rollupConfig.writeTo(out);
+        }
+
+        public RollupV2Config getRollupConfig() {
+            return rollupConfig;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            rollupConfig.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rollupConfig);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(rollupConfig, other.rollupConfig);
+        }
+    }
+
+    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
+
+        protected RequestBuilder(ElasticsearchClient client, RollupV2Action action) {
+            super(client, action, new Request());
+        }
+    }
+
+    public static class Response extends ActionResponse implements Writeable, ToXContentObject {
+
+        private final boolean created;
+
+        public Response(boolean created) {
+            this.created = created;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            created = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(created);
+        }
+
+        public boolean isCreated() {
+            return created;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("created", created);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return created == response.created;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(created);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
@@ -54,6 +54,7 @@ public class RollupV2Config implements NamedWriteable, ToXContentObject {
     private static final ConstructingObjectParser<RollupV2Config, String> PARSER;
     static {
         PARSER = new ConstructingObjectParser<>(NAME, false, (args, sourceIndex) -> {
+            // TODO(talevy): fix RollupV2Config to include the target index so that it can be completely read from XContent
             String rollupIndex = (String) args[0];
             GroupConfig groupConfig = (GroupConfig) args[1];
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
@@ -45,10 +45,10 @@ public class RollupV2Config implements NamedWriteable, ToXContentObject {
     private static final String TIMEOUT = "timeout";
     private static final String ROLLUP_INDEX = "rollup_index";
 
-    private final String rollupIndex;
     private final GroupConfig groupConfig;
     private final List<MetricConfig> metricsConfig;
     private final TimeValue timeout;
+    private String rollupIndex;
     private String sourceIndex;
 
     private static final ConstructingObjectParser<RollupV2Config, String> PARSER;
@@ -105,6 +105,10 @@ public class RollupV2Config implements NamedWriteable, ToXContentObject {
 
     public void setSourceIndex(String sourceIndex) {
         this.sourceIndex = sourceIndex;
+    }
+
+    public void setRollupIndex(String rollupIndex) {
+        this.rollupIndex = rollupIndex;
     }
 
     public GroupConfig getGroupConfig() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * This class holds the configuration details of a rollup V2 job, such as the groupings, metrics, what
+ * index to rollup and where to roll them to.
+ */
+public class RollupV2Config implements NamedWriteable, ToXContentObject {
+
+    private static final String NAME = "xpack/rollupv2/config";
+    private static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(20);
+    private static final String TIMEOUT = "timeout";
+    private static final String ROLLUP_INDEX = "rollup_index";
+
+    private final String rollupIndex;
+    private final GroupConfig groupConfig;
+    private final List<MetricConfig> metricsConfig;
+    private final TimeValue timeout;
+    private String sourceIndex;
+
+    private static final ConstructingObjectParser<RollupV2Config, String> PARSER;
+    static {
+        PARSER = new ConstructingObjectParser<>(NAME, false, (args, sourceIndex) -> {
+            String rollupIndex = (String) args[0];
+            GroupConfig groupConfig = (GroupConfig) args[1];
+            @SuppressWarnings("unchecked")
+            List<MetricConfig> metricsConfig = (List<MetricConfig>) args[2];
+            TimeValue timeout = (TimeValue) args[3];
+            return new RollupV2Config(sourceIndex, groupConfig, metricsConfig, timeout, rollupIndex);
+        });
+        PARSER.declareString(constructorArg(), new ParseField(ROLLUP_INDEX));
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> GroupConfig.fromXContent(p), new ParseField(GroupConfig.NAME));
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> MetricConfig.fromXContent(p), new ParseField(MetricConfig.NAME));
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> TimeValue.parseTimeValue(p.textOrNull(), TIMEOUT),
+            new ParseField(TIMEOUT), ObjectParser.ValueType.STRING_OR_NULL);
+    }
+
+    public RollupV2Config(String sourceIndex, final GroupConfig groupConfig, final List<MetricConfig> metricsConfig,
+                          final @Nullable TimeValue timeout, final String rollupIndex) {
+        if (sourceIndex == null || sourceIndex.isEmpty()) {
+            throw new IllegalArgumentException("The source index must be a non-null, non-empty string");
+        }
+        if (rollupIndex == null || rollupIndex.isEmpty()) {
+            throw new IllegalArgumentException("Rollup index must be a non-null, non-empty string");
+        }
+        if (groupConfig == null && (metricsConfig == null || metricsConfig.isEmpty())) {
+            throw new IllegalArgumentException("At least one grouping or metric must be configured");
+        }
+        this.sourceIndex = sourceIndex;
+        this.rollupIndex = rollupIndex;
+        this.groupConfig = groupConfig;
+        this.metricsConfig = metricsConfig != null ? metricsConfig : Collections.emptyList();
+        this.timeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
+    }
+
+    public RollupV2Config(final StreamInput in) throws IOException {
+        this.sourceIndex = in.readString();
+        rollupIndex = in.readString();
+        groupConfig = in.readOptionalWriteable(GroupConfig::new);
+        metricsConfig = in.readList(MetricConfig::new);
+        timeout = in.readTimeValue();
+    }
+
+    public String getId() {
+        return RollupField.NAME + "_" + sourceIndex + "_" + rollupIndex;
+    }
+
+    public String getSourceIndex() {
+        return sourceIndex;
+    }
+
+    public void setSourceIndex(String sourceIndex) {
+        this.sourceIndex = sourceIndex;
+    }
+
+    public GroupConfig getGroupConfig() {
+        return groupConfig;
+    }
+
+    public List<MetricConfig> getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    public String getRollupIndex() {
+        return rollupIndex;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public Set<String> getAllFields() {
+        final Set<String> fields = new HashSet<>();
+        if (groupConfig != null) {
+            fields.addAll(groupConfig.getAllFields());
+        }
+        if (metricsConfig != null) {
+            for (MetricConfig metric : metricsConfig) {
+                fields.add(metric.getField());
+            }
+        }
+        return Collections.unmodifiableSet(fields);
+    }
+
+    public void validateMappings(final Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,
+                                 final ActionRequestValidationException validationException) {
+        groupConfig.validateMappings(fieldCapsResponse, validationException);
+        for (MetricConfig m : metricsConfig) {
+            m.validateMappings(fieldCapsResponse, validationException);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(ROLLUP_INDEX, rollupIndex);
+            if (groupConfig != null) {
+                builder.field(GroupConfig.NAME, groupConfig);
+            }
+            if (metricsConfig != null) {
+                builder.startArray(MetricConfig.NAME);
+                for (MetricConfig metric : metricsConfig) {
+                    metric.toXContent(builder, params);
+                }
+                builder.endArray();
+            }
+            if (timeout != null) {
+                builder.field(TIMEOUT, timeout.getStringRep());
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeString(sourceIndex);
+        out.writeString(rollupIndex);
+        out.writeOptionalWriteable(groupConfig);
+        out.writeList(metricsConfig);
+        out.writeTimeValue(timeout);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        final RollupV2Config that = (RollupV2Config) other;
+        return Objects.equals(this.sourceIndex, that.sourceIndex)
+                && Objects.equals(this.rollupIndex, that.rollupIndex)
+                && Objects.equals(this.groupConfig, that.groupConfig)
+                && Objects.equals(this.metricsConfig, that.metricsConfig)
+                && Objects.equals(this.timeout, that.timeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceIndex, rollupIndex, groupConfig, metricsConfig, timeout);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
+    }
+
+    /**
+     * Same as toString() but more explicitly named so the caller knows this is turned into JSON
+     */
+    public String toJSONString() {
+        return toString();
+    }
+
+    public static RollupV2Config fromXContent(final XContentParser parser, final String sourceIndex) throws IOException {
+        return PARSER.parse(parser, sourceIndex);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Task.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Task.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.RollupJobStatus;
+
+import java.util.Map;
+
+/**
+ * This class contains the high-level logic that drives the rollup job. The allocated task contains transient state
+ * which drives the indexing, and periodically updates it's parent PersistentTask with the indexing's current position.
+ */
+public class RollupV2Task extends CancellableTask {
+    private static final Logger logger = LogManager.getLogger(RollupV2Task.class.getName());
+
+    private RollupV2Config config;
+    private RollupJobStatus status;
+
+    RollupV2Task(long id, String type, String action, TaskId parentTask, RollupV2Config config, Map<String, String> headers) {
+        super(id, type, action, RollupField.NAME + "_" + config.getRollupIndex(), parentTask, headers);
+        this.config = config;
+    }
+
+    public RollupV2Config config() {
+        return config;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public boolean shouldCancelChildrenOnCancellation() {
+        return true;
+    }
+
+    @Override
+    public void onCancelled() {
+        // TODO(talevy): make things cancellable
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -58,7 +58,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, UnfollowAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, MigrateAction.NAME, MigrateAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new)
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, RollupAction.NAME, RollupAction::new)
             ));
     }
 
@@ -81,7 +82,9 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
-                SearchableSnapshotAction::parse)
+                SearchableSnapshotAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
+
         ));
         return new NamedXContentRegistry(entries);
     }
@@ -138,6 +141,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                     return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
                 case MigrateAction.NAME:
                     return new MigrateAction(false);
+                case RollupAction.NAME:
+                    return RollupActionTests.randomInstance();
                 default:
                     throw new IllegalArgumentException("invalid action [" + action + "]");
             }};
@@ -196,6 +201,8 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                     return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
                 case MigrateAction.NAME:
                     return new MigrateAction(false);
+                case RollupAction.NAME:
+                    return RollupActionTests.randomInstance();
                 default:
                     throw new IllegalArgumentException("invalid action [" + action + "]");
             }};

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupActionTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2ConfigTests;
+
+import java.util.List;
+
+public class RollupActionTests extends AbstractActionTestCase<RollupAction> {
+
+    static RollupAction randomInstance() {
+        return new RollupAction(RollupV2ConfigTests.randomConfig(random()));
+    }
+
+    @Override
+    protected RollupAction doParseInstance(XContentParser parser) {
+        return RollupAction.parse(parser);
+    }
+
+    @Override
+    protected RollupAction createTestInstance() {
+        return randomInstance();
+    }
+
+    @Override
+    protected Reader<RollupAction> instanceReader() {
+        return RollupAction::new;
+    }
+
+    @Override
+    public boolean isSafeAction() {
+        return false;
+    }
+
+    public void testToSteps() {
+        RollupAction action = createTestInstance();
+        String phase = randomAlphaOfLengthBetween(1, 10);
+        StepKey nextStepKey = new StepKey(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
+            randomAlphaOfLengthBetween(1, 10));
+        List<Step> steps = action.toSteps(null, phase, nextStepKey);
+        assertNotNull(steps);
+        assertEquals(3, steps.size());
+    }
+
+    public void testEqualsAndHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::notCopy);
+    }
+
+    RollupAction copy(RollupAction rollupAction) {
+        return new RollupAction(rollupAction.config);
+    }
+
+    RollupAction notCopy(RollupAction rollupAction) {
+        RollupV2Config newConfig = new RollupV2Config(rollupAction.config.getSourceIndex() + "not",
+            rollupAction.config.getGroupConfig(), rollupAction.config.getMetricsConfig(), rollupAction.config.getTimeout(),
+            rollupAction.config.getRollupIndex());
+        return new RollupAction(newConfig);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -7,7 +7,11 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,6 +58,9 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     // keeping the migrate action disabled as otherwise it could conflict with the allocate action if both are randomly selected for the
     // same phase
     private static final MigrateAction TEST_MIGRATE_ACTION = new MigrateAction(false);
+    private static final RollupAction TEST_ROLLUP_ACTION =new RollupAction(new RollupV2Config("source",
+        new GroupConfig(new DateHistogramGroupConfig.FixedInterval("field", DateHistogramInterval.DAY)),
+        Collections.emptyList(), null, "rollup"));
 
     public void testValidatePhases() {
         boolean invalid = randomBoolean();
@@ -677,6 +684,8 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
                 return TEST_SEARCHABLE_SNAPSHOT_ACTION;
             case MigrateAction.NAME:
                 return TEST_MIGRATE_ACTION;
+            case RollupAction.NAME:
+                return TEST_ROLLUP_ACTION;
             default:
                 throw new IllegalArgumentException("unsupported timeseries phase action [" + actionName + "]");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+
+
+public class RollupV2ConfigTests extends AbstractSerializingTestCase<RollupV2Config> {
+
+    String sourceIndex;
+
+    @Before
+    void setUpSourceIndex() {
+        sourceIndex = randomAlphaOfLength(10);
+    }
+
+    @Override
+    protected RollupV2Config createTestInstance() {
+        return randomConfig(random());
+    }
+
+    public static RollupV2Config randomConfig(Random random) {
+        final String sourceIndex = randomAlphaOfLength(10);
+        final String rollupIndex = "rollup-" + sourceIndex;
+        final TimeValue timeout = random.nextBoolean() ? null : ConfigTestHelpers.randomTimeout(random);
+        final GroupConfig groupConfig = ConfigTestHelpers.randomGroupConfig(random);
+        final List<MetricConfig> metricConfigs = ConfigTestHelpers.randomMetricsConfigs(random);
+        return new RollupV2Config(sourceIndex, groupConfig, metricConfigs, timeout, rollupIndex);
+    }
+
+    @Override
+    protected Writeable.Reader<RollupV2Config> instanceReader() {
+        return RollupV2Config::new;
+    }
+
+    @Override
+    protected RollupV2Config doParseInstance(final XContentParser parser) throws IOException {
+        return RollupV2Config.fromXContent(parser, sourceIndex);
+    }
+
+    public void testEmptySourceIndex() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(randomBoolean() ? null : "", sample.getGroupConfig(), sample.getMetricsConfig(), sample.getTimeout(),
+                sample.getRollupIndex()));
+        assertThat(e.getMessage(), equalTo("The source index must be a non-null, non-empty string"));
+    }
+
+    public void testEmptyRollupIndex() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(sample.getSourceIndex(), sample.getGroupConfig(), sample.getMetricsConfig(), sample.getTimeout(),
+                randomBoolean() ? null : ""));
+        assertThat(e.getMessage(), equalTo("Rollup index must be a non-null, non-empty string"));
+    }
+
+    public void testEmptyGroupAndMetrics() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(sample.getSourceIndex(), null, randomBoolean() ? null : emptyList(), sample.getTimeout(),
+                sample.getRollupIndex()));
+        assertThat(e.getMessage(), equalTo("At least one grouping or metric must be configured"));
+    }
+}

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
@@ -26,3 +28,9 @@ gradle.projectsEvaluated {
     .each { check.dependsOn it.check }
 }
 
+// TODO(talevy): should this even be here? TBD
+test {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.rollup_v2_feature_enabled', 'true'
+  }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleType;
 import org.elasticsearch.xpack.core.ilm.MigrateAction;
 import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.RollupAction;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
@@ -233,7 +234,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
                 SearchableSnapshotAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME),
-                MigrateAction::parse)
+                MigrateAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
         );
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.RollupAction;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
@@ -94,7 +95,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, UnfollowAction::new),
                 new NamedWriteableRegistry.Entry(LifecycleAction.class, MigrateAction.NAME, MigrateAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new)
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
+                new NamedWriteableRegistry.Entry(LifecycleAction.class, RollupAction.NAME, RollupAction::new)
             ));
     }
 
@@ -117,7 +119,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse),
             new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SearchableSnapshotAction.NAME),
-                SearchableSnapshotAction::parse)
+                SearchableSnapshotAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RollupAction.NAME), RollupAction::parse)
         ));
         return new NamedXContentRegistry(entries);
     }

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.esplugin'
 esplugin {
   name 'x-pack-rollup'
@@ -5,12 +7,21 @@ esplugin {
   classname 'org.elasticsearch.xpack.rollup.Rollup'
   extendedPlugins = ['x-pack-core']
 }
+
 archivesBaseName = 'x-pack-rollup'
 
 dependencies {
   compileOnly project(":server")
-
   compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('analytics'), configuration: 'default')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
+// add all sub-projects of the qa sub-project
+gradle.projectsEvaluated {
+  project.subprojects
+    .find { it.path == project.path + ":qa" }
+    .subprojects
+    .findAll { it.path.startsWith(project.path + ":qa") }
+    .each { check.dependsOn it.check }
+}

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -25,3 +25,9 @@ gradle.projectsEvaluated {
     .findAll { it.path.startsWith(project.path + ":qa") }
     .each { check.dependsOn it.check }
 }
+
+test {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.rollup_v2_feature_enabled', 'true'
+  }
+}

--- a/x-pack/plugin/rollup/qa/build.gradle
+++ b/x-pack/plugin/rollup/qa/build.gradle
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import org.elasticsearch.gradle.test.RestIntegTestTask
+
+apply plugin: 'elasticsearch.build'
+
+test.enabled = false
+
+dependencies {
+  api project(':test:framework')
+}

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
+
+dependencies {
+  testImplementation project(path: xpackModule('rollup'))
+}
+
+restResources {
+  restApi {
+    includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
+    includeXpack 'rollup'
+  }
+}
+
+testClusters.integTest {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.license.self_generated.type', 'basic'
+}

--- a/x-pack/plugin/rollup/qa/rest/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupRestIT.java
+++ b/x-pack/plugin/rollup/qa/rest/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupRestIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.rollup.v2;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+public class RollupRestIT extends ESClientYamlSuiteTestCase {
+
+    public RollupRestIT(final ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+}

--- a/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -1,0 +1,87 @@
+setup:
+  - skip:
+      features: headers
+  - do:
+      indices.create:
+        index: docs
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              color:
+                type: keyword
+              price:
+                type: integer
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: docs
+              _id:    1
+          - timestamp: "2020-01-01T05:10:00Z"
+            color: "blue"
+            price: 10
+          - index:
+              _index: docs
+              _id:    2
+          - timestamp: "2020-01-01T05:30:00Z"
+            color: "blue"
+            price: 20
+          - index:
+              _index: docs
+              _id:    3
+          - timestamp: "2020-01-01T06:10:00Z"
+            color: "red"
+            price: 30
+          - index:
+              _index: docs
+              _id:    4
+          - timestamp: "2020-01-01T06:30:00Z"
+            color: "green"
+            price: 40
+
+---
+"Rollup index":
+  - skip:
+      version: " - 7.99.99"
+      reason: "rolling up an index directly is only supported in 8.0+"
+  - do:
+      rollup.rollup_vtwo:
+        index: docs
+        body:  >
+          {
+            "rollup_index": "rollup_docs",
+            "groups" : {
+              "date_histogram": {
+                "field": "timestamp",
+                "calendar_interval": "1h"
+              },
+              "terms": {
+                "fields": ["color"]
+              }
+            },
+            "metrics": [
+              {
+                "field": "price",
+                "metrics": ["max"]
+              }
+            ]
+          }
+  - is_true: created
+
+  - do:
+      indices.forcemerge:
+        index: rollup_docs
+        max_num_segments: 1
+
+  - do:
+      search:
+        index: rollup_docs
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 3  }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Action;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.rollup.action.TransportDeleteRollupJobAction;
 import org.elasticsearch.xpack.rollup.action.TransportGetRollupCapsAction;
@@ -62,8 +63,11 @@ import org.elasticsearch.xpack.rollup.rest.RestPutRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestRollupSearchAction;
 import org.elasticsearch.xpack.rollup.rest.RestStartRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestStopRollupJobAction;
+import org.elasticsearch.xpack.rollup.v2.RestRollupV2Action;
+import org.elasticsearch.xpack.rollup.v2.TransportRollupV2Action;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -114,7 +118,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
                                              IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter,
                                              IndexNameExpressionResolver indexNameExpressionResolver,
                                              Supplier<DiscoveryNodes> nodesInCluster) {
-        return Arrays.asList(
+        List<RestHandler> handlers = new ArrayList<>(Arrays.asList(
             new RestRollupSearchAction(),
             new RestPutRollupJobAction(),
             new RestStartRollupJobAction(),
@@ -122,14 +126,16 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
             new RestDeleteRollupJobAction(),
             new RestGetRollupJobsAction(),
             new RestGetRollupCapsAction(),
-            new RestGetRollupIndexCapsAction()
-        );
+            new RestGetRollupIndexCapsAction()));
 
+        handlers.add(new RestRollupV2Action());
+
+        return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return Arrays.asList(
+        List<ActionHandler<?, ?>> actions = new ArrayList<>(Arrays.asList(
             new ActionHandler<>(RollupSearchAction.INSTANCE, TransportRollupSearchAction.class),
             new ActionHandler<>(PutRollupJobAction.INSTANCE, TransportPutRollupJobAction.class),
             new ActionHandler<>(StartRollupJobAction.INSTANCE, TransportStartRollupAction.class),
@@ -139,7 +145,11 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
             new ActionHandler<>(GetRollupCapsAction.INSTANCE, TransportGetRollupCapsAction.class),
             new ActionHandler<>(GetRollupIndexCapsAction.INSTANCE, TransportGetRollupIndexCapsAction.class),
             new ActionHandler<>(XPackUsageFeatureAction.ROLLUP, RollupUsageTransportAction.class),
-            new ActionHandler<>(XPackInfoFeatureAction.ROLLUP, RollupInfoTransportAction.class));
+            new ActionHandler<>(XPackInfoFeatureAction.ROLLUP, RollupInfoTransportAction.class)));
+
+        actions.add(new ActionHandler<>(RollupV2Action.INSTANCE, TransportRollupV2Action.class));
+
+        return actions;
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupV2Action.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupV2Action.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Action;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestRollupV2Action extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_rollup_vtwo/{index}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String index = restRequest.param("index");
+        RollupV2Config job = RollupV2Config.fromXContent(restRequest.contentParser(), index);
+        RollupV2Action.Request request = new RollupV2Action.Request(job);
+        return channel -> client.execute(RollupV2Action.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "rollupV2";
+    }
+
+}

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.shrink.ResizeAction;
+import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
+import org.elasticsearch.action.admin.indices.shrink.ResizeType;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.indexing.IterationResult;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+import org.elasticsearch.xpack.core.rollup.job.RollupIndexerJobStats;
+import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract implementation of {@link AsyncTwoPhaseIndexer} that builds a rollup index incrementally.
+ */
+public class RollupV2Indexer extends AsyncTwoPhaseIndexer<Map<String, Object>, RollupIndexerJobStats> {
+    private static final Logger logger = LogManager.getLogger(RollupV2Indexer.class);
+
+    static final String AGGREGATION_NAME = RollupField.NAME;
+    static final int PAGE_SIZE = 1000;
+
+    private final RollupV2Config job;
+    private final Client client;
+    private final Map<String, String> headers;
+    private final CompositeAggregationBuilder compositeBuilder;
+    private final String tmpIndex;
+    private final ActionListener<Void> completionListener;
+
+    /**
+     * Ctr
+     * @param client The Transport client
+     * @param threadPool ThreadPool to use to fire the first request of a background job.
+     * @param executorName Name of the executor to use to fire the first request of a background job.
+     * @param job The rollup job
+     */
+    RollupV2Indexer(Client client, ThreadPool threadPool, String executorName, RollupV2Config job, Map<String, String> headers,
+                    ActionListener<Void> completionListener) {
+        super(threadPool, executorName, new AtomicReference<>(IndexerState.STOPPED), null, new RollupIndexerJobStats());
+        this.client = client;
+        this.job = job;
+        this.headers = headers;
+        this.compositeBuilder = createCompositeBuilder(job);
+        this.tmpIndex = ".rolluptmp-" + job.getRollupIndex();
+        this.completionListener = completionListener;
+    }
+
+    @Override
+    protected String getJobId() {
+        return job.getId();
+    }
+
+    @Override
+    protected void onStart(long now, ActionListener<Boolean> listener) {
+        try {
+            createTempRollupIndex(ActionListener.wrap(resp -> listener.onResponse(true), e -> {
+                completionListener.onFailure(new ElasticsearchException("Unable to start rollup. index creation failed", e));
+                listener.onFailure(e);
+            }));
+        } catch (IOException e) {
+            listener.onFailure(new ElasticsearchException("Unable to start rollup. index creation failed", e));
+        }
+    }
+
+    XContentBuilder getMapping() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        String dateField = job.getGroupConfig().getDateHistogram().getField();
+        HistogramGroupConfig histogramGroupConfig = job.getGroupConfig().getHistogram();
+        TermsGroupConfig termsGroupConfig = job.getGroupConfig().getTerms();
+        List<MetricConfig> metricConfigs = job.getMetricsConfig();
+
+        builder.startObject(dateField).field("type", DateFieldMapper.CONTENT_TYPE).endObject();
+        if (histogramGroupConfig != null) {
+            for (String field : histogramGroupConfig.getFields()) {
+                builder.startObject(field).field("type", HistogramFieldMapper.CONTENT_TYPE).endObject();
+            }
+        }
+        if (termsGroupConfig != null) {
+            for (String field : termsGroupConfig.getFields()) {
+                // TODO(talevy): not just keyword, can be number?
+                builder.startObject(field).field("type", "keyword").endObject();
+            }
+        }
+        for (MetricConfig metricConfig : metricConfigs) {
+            // TODO(talevy): when aggregate_metric is usable
+            //builder.startObject(metricConfig.getField()).field("type", "aggregate_metric").endObject();
+        }
+
+
+        return builder.endObject().endObject();
+    }
+
+    void createTempRollupIndex(ActionListener<CreateIndexResponse> listener) throws IOException {
+        CreateIndexRequest req = new CreateIndexRequest(tmpIndex, Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_HIDDEN, true).build())
+            .mapping(getMapping());
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, CreateIndexAction.INSTANCE, req, listener);
+    }
+
+    @Override
+    protected void doNextSearch(long waitTimeInNanos, ActionListener<SearchResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, SearchAction.INSTANCE,
+            buildSearchRequest(waitTimeInNanos), nextPhase);
+    }
+
+    @Override
+    protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, BulkAction.INSTANCE, request, nextPhase);
+    }
+
+    @Override
+    protected void doSaveState(IndexerState state, Map<String, Object> stringObjectMap, Runnable next) {
+        assert state == IndexerState.INDEXING || state == IndexerState.STARTED || state == IndexerState.STOPPED;
+        next.run();
+    }
+
+    @Override
+    protected void onFailure(Exception exc) {
+        completionListener.onFailure(exc);
+    }
+
+    @Override
+    protected void onFinish(ActionListener<Void> listener) {
+        // "shrink index"
+        ResizeRequest resizeRequest = new ResizeRequest(job.getRollupIndex(), tmpIndex);
+        resizeRequest.setResizeType(ResizeType.CLONE);
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build());
+        UpdateSettingsRequest updateSettingsReq = new UpdateSettingsRequest(
+            Settings.builder().put("index.blocks.write", true).build(), tmpIndex);
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+            UpdateSettingsAction.INSTANCE, updateSettingsReq,
+            ActionListener.wrap(r -> {
+                ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+                    ResizeAction.INSTANCE, resizeRequest,
+                    ActionListener.wrap(rr -> { deleteTmpIndex(listener); }, e -> { deleteTmpIndex(listener); }));
+                }, e -> { deleteTmpIndex(listener); }));
+    }
+
+    private void deleteTmpIndex(ActionListener<Void> listener) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+            DeleteIndexAction.INSTANCE, new DeleteIndexRequest(tmpIndex),
+            ActionListener.wrap(r -> {
+                listener.onResponse(null);
+                completionListener.onResponse(null);
+            }, e -> {
+                listener.onFailure(e);
+                completionListener.onFailure(e);
+            }));
+    }
+
+    @Override
+    protected void onStop() {
+        completionListener.onFailure(new ElasticsearchException("rollup stopped before completion"));
+    }
+
+    @Override
+    protected void onAbort() {
+        completionListener.onFailure(new ElasticsearchException("rollup stopped before completion"));
+    }
+
+    protected SearchRequest buildSearchRequest(long waitTimeInNanos) {
+        final Map<String, Object> position = getPosition();
+        SearchSourceBuilder searchSource = new SearchSourceBuilder()
+                .size(0)
+                .trackTotalHits(false)
+                .aggregation(compositeBuilder.aggregateAfter(position));
+        return new SearchRequest(job.getSourceIndex()).source(searchSource);
+    }
+
+    @Override
+    protected IterationResult<Map<String, Object>> doProcess(SearchResponse searchResponse) {
+        final CompositeAggregation response = searchResponse.getAggregations().get(AGGREGATION_NAME);
+
+        if (response.getBuckets().isEmpty()) {
+            // do not reset the position as we want to continue from where we stopped
+            return new IterationResult<>(Collections.emptyList(), getPosition(), true);
+        }
+
+        return new IterationResult<>(processBuckets(response, tmpIndex, getStats()),
+                response.afterKey(), response.getBuckets().isEmpty());
+    }
+
+    static List<IndexRequest> processBuckets(CompositeAggregation agg, String rollupIndex, RollupIndexerJobStats stats) {
+
+        return agg.getBuckets().stream().map(b ->{
+            stats.incrementNumDocuments(b.getDocCount());
+
+            // Put the composite keys into a treemap so that the key iteration order is consistent
+            // TODO would be nice to avoid allocating this treemap in the future
+            TreeMap<String, Object> keys = new TreeMap<>(b.getKey());
+            List<Aggregation> metrics = b.getAggregations().asList();
+
+            Map<String, Object> doc = new HashMap<>(1 + keys.size() + metrics.size());
+            doc.put("_doc_count", b.getDocCount());
+            keys.forEach(doc::put);
+            // TODO(talevy): group sibling metrics by name into one aggregate_metric
+            metrics.forEach(a -> {
+                String name = a.getName();
+                if (a instanceof InternalNumericMetricsAggregation.SingleValue) {
+                    doc.put(name, ((InternalNumericMetricsAggregation.SingleValue) a).value());
+                } else {
+                    throw new IllegalStateException("invalid metric type [" + a.getClass().getName() + "]");
+                }
+            });
+            IndexRequest request = new IndexRequest(rollupIndex);
+            request.source(doc);
+            return request;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Creates a skeleton {@link CompositeAggregationBuilder} from the provided job config.
+     * @param config The config for the job.
+     * @return The composite aggregation that creates the rollup buckets
+     */
+    private CompositeAggregationBuilder createCompositeBuilder(RollupV2Config config) {
+        final GroupConfig groupConfig = config.getGroupConfig();
+        List<CompositeValuesSourceBuilder<?>> builders = createValueSourceBuilders(groupConfig);
+
+        CompositeAggregationBuilder composite = new CompositeAggregationBuilder(AGGREGATION_NAME, builders);
+
+        List<AggregationBuilder> aggregations = createAggregationBuilders(config.getMetricsConfig());
+        aggregations.forEach(composite::subAggregation);
+
+        final Map<String, Object> metadata = createMetadata(groupConfig);
+        if (metadata.isEmpty() == false) {
+            composite.setMetadata(metadata);
+        }
+        composite.size(PAGE_SIZE);
+
+        return composite;
+    }
+
+    static Map<String, Object> createMetadata(final GroupConfig groupConfig) {
+        final Map<String, Object> metadata = new HashMap<>();
+        if (groupConfig != null) {
+            // Add all the metadata in order: date_histo -> histo
+            final DateHistogramGroupConfig dateHistogram = groupConfig.getDateHistogram();
+            metadata.put(RollupField.formatMetaField(RollupField.INTERVAL), dateHistogram.getInterval().toString());
+
+            final HistogramGroupConfig histogram = groupConfig.getHistogram();
+            if (histogram != null) {
+                metadata.put(RollupField.formatMetaField(RollupField.INTERVAL), histogram.getInterval());
+            }
+        }
+        return metadata;
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final GroupConfig groupConfig) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        // Add all the agg builders to our request in order: date_histo -> histo -> terms
+        if (groupConfig != null) {
+            final DateHistogramGroupConfig dateHistogram = groupConfig.getDateHistogram();
+            builders.addAll(createValueSourceBuilders(dateHistogram));
+
+            final HistogramGroupConfig histogram = groupConfig.getHistogram();
+            builders.addAll(createValueSourceBuilders(histogram));
+
+            final TermsGroupConfig terms = groupConfig.getTerms();
+            builders.addAll(createValueSourceBuilders(terms));
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final DateHistogramGroupConfig dateHistogram) {
+        final String dateHistogramField = dateHistogram.getField();
+        final DateHistogramValuesSourceBuilder dateHistogramBuilder = new DateHistogramValuesSourceBuilder(dateHistogramField);
+        if (dateHistogram instanceof DateHistogramGroupConfig.FixedInterval) {
+            dateHistogramBuilder.fixedInterval(dateHistogram.getInterval());
+        } else if (dateHistogram instanceof DateHistogramGroupConfig.CalendarInterval) {
+            dateHistogramBuilder.calendarInterval(dateHistogram.getInterval());
+        } else {
+            dateHistogramBuilder.dateHistogramInterval(dateHistogram.getInterval());
+        }
+        dateHistogramBuilder.field(dateHistogramField);
+        dateHistogramBuilder.timeZone(ZoneId.of(dateHistogram.getTimeZone()));
+        return Collections.singletonList(dateHistogramBuilder);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final HistogramGroupConfig histogram) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        if (histogram != null) {
+            for (String field : histogram.getFields()) {
+                final HistogramValuesSourceBuilder histogramBuilder = new HistogramValuesSourceBuilder(field);
+                histogramBuilder.interval(histogram.getInterval());
+                histogramBuilder.field(field);
+                histogramBuilder.missingBucket(true);
+                builders.add(histogramBuilder);
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final TermsGroupConfig terms) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        if (terms != null) {
+            for (String field : terms.getFields()) {
+                final TermsValuesSourceBuilder termsBuilder = new TermsValuesSourceBuilder(field);
+                termsBuilder.field(field);
+                termsBuilder.missingBucket(true);
+                builders.add(termsBuilder);
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    /**
+     * This returns a set of aggregation builders which represent the configured
+     * set of metrics. Used to iterate over historical data.
+     */
+    static List<AggregationBuilder> createAggregationBuilders(final List<MetricConfig> metricsConfigs) {
+        final List<AggregationBuilder> builders = new ArrayList<>();
+        if (metricsConfigs != null) {
+            for (MetricConfig metricConfig : metricsConfigs) {
+                final List<String> metrics = metricConfig.getMetrics();
+                if (metrics.isEmpty() == false) {
+                    final String field = metricConfig.getField();
+                    for (String metric : metrics) {
+                        ValuesSourceAggregationBuilder.LeafOnly<? extends ValuesSource, ? extends AggregationBuilder> newBuilder;
+                        if (metric.equals(MetricConfig.MIN.getPreferredName())) {
+                            newBuilder = new MinAggregationBuilder(field);
+                        } else if (metric.equals(MetricConfig.MAX.getPreferredName())) {
+                            newBuilder = new MaxAggregationBuilder(field);
+                        } else if (metric.equals(MetricConfig.AVG.getPreferredName())) {
+                            // Avgs are sum + count
+                            newBuilder = new SumAggregationBuilder(field);
+                            ValuesSourceAggregationBuilder.LeafOnly<ValuesSource, ValueCountAggregationBuilder> countBuilder
+                                = new ValueCountAggregationBuilder(field + "_count");
+                            countBuilder.field(field);
+                            builders.add(countBuilder);
+                        } else if (metric.equals(MetricConfig.SUM.getPreferredName())) {
+                            newBuilder = new SumAggregationBuilder(field);
+                        } else if (metric.equals(MetricConfig.VALUE_COUNT.getPreferredName())) {
+                            newBuilder = new ValueCountAggregationBuilder(field);
+                        } else {
+                            throw new IllegalArgumentException("Unsupported metric type [" + metric + "]");
+                        }
+                        newBuilder.field(field);
+                        builders.add(newBuilder);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+}
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_vtwo.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_vtwo.json
@@ -1,0 +1,31 @@
+{
+  "rollup.rollup_vtwo":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-vtwo.html",
+      "description":"Rollup an index"
+    },
+    "stability":"experimental",
+    "url": {
+      "paths": [
+        {
+          "path": "/_rollup_vtwo/{index}",
+          "methods": [
+            "POST"
+          ],
+          "parts": {
+            "index": {
+              "type": "string",
+              "description": "The index to roll up",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "params":{},
+    "body":{
+      "description":"The rollup configuration",
+      "required":true
+    }
+  }
+}


### PR DESCRIPTION
This is an experimental PR to share work and highlight the touch points needed for rollups V2.

### Rolling up an Index

When an index is rolled up using a Rollup Config, it does the following

1. check that original index is read-only
2. runs an aggregation and indexes results into a temporary hidden rollup index
3. "resizes" the temporary index into the final rollup-index (in-place segment pointer juggling)
4. adds RollupMetadata about the rollup-group (keyed by original index name) and adds custom index-metadata with data about what the rollup index's original index is so that its group information in RollupMetadata can be looked up

### Rollup + Datastream query-time index resolution 

| Request indices          | Resolved indices         | Select best rollup                                                                                   |
|--------------------------|--------------------------|------------------------------------------------------------------------------------------------------|
| my-index                 | my-index                 | N/A                                                                                                  |
| my-index,my-rollup-index | my-index,my-rollup-index | No, will query both                                                                                  |
| my-rollup-index          | my-rollup-index          | No, will query just the provided rollup index                                                        |
| my-datastream            | my-index,my-rollup-index | Yes, datastreams will include rollup indices and skip other shards if rollup shards can answer query |

This PR highlights:

- RollupMetadata in Cluster State https://github.com/elastic/elasticsearch/pull/62910/commits/d0d385fc74e37877e1fa8a6bb85174f52978a557
- a Rollup V2 transport action (mostly there, depends on `aggregate_metric` work to finalize) https://github.com/elastic/elasticsearch/pull/62910/commits/adb9861da3b26f8552683e11f13dd45cca4e6604
- a Rollup V2 ILM Action (mostly there) https://github.com/elastic/elasticsearch/pull/62910/commits/38b1c76c81ce7acfd838403671c5f9dd767ee522
- a feature flag for developing Rollup V2 directly in `master` (incomplete) https://github.com/elastic/elasticsearch/pull/62910/commits/e40ac36d9489baf9b6c1ef1d47d8b7bcaf19d95f
- Hook-in points for filtering shards to be searched in the context of Rollups in the CanMatch phase (very rough, many TODOs) https://github.com/elastic/elasticsearch/pull/62910/commits/60778358eb86cfa8a0dc97c22f38104118fc58a0

Here is a sample flow for rolling up a DataStream

```
PUT /_cluster/settings?flat_settings=true
{
  "transient" : {
    "indices.lifecycle.poll_interval" : "10s"
  }
}

PUT /_ilm/policy/my-data-stream-policy
{
    "policy": {
        "phases": {
            "hot": {
                "actions": {
                    "rollover": {
                        "max_docs": 3
                    }
                }
            },
            "cold": {
                "actions": {
                    "rollup": {
                        "config": {
                            "groups": {
                                "date_histogram": {
                                    "field": "@timestamp",
                                    "calendar_interval": "1M"
                                },
                                "terms": {
                                    "fields": [
                                        "units"
                                    ]
                                }
                            },
                            "metrics": [
                                {
                                    "field": "temperature",
                                    "metrics": [
                                        "avg"
                                    ]
                                }
                            ]
                        }
                    }
                }
            },
            "delete": {
                "min_age": "30d",
                "actions": {
                    "delete": {}
                }
            }
        }
    }
}

PUT /_index_template/my-data-stream-template
{
  "index_patterns": [ "my-data-stream*" ],
  "data_stream": { },
  "priority": 200,
  "template": {
    "mappings": {
      "properties": {
        "@timestamp": { "type": "date" },
        "units": { "type": "keyword"}  
      }
    },
    "settings": {
      "index.lifecycle.name": "my-data-stream-policy"
    }
  }
}


POST /my-data-stream/_doc
{ "@timestamp": "2020-01-04T12:10:30Z", "units": "celcius", "temperature": 27.5 }

POST /my-data-stream/_doc
{ "@timestamp": "2020-01-08T07:12:25Z", "temperature": 28.1, "units": "celcius" }

POST /my-data-stream/_doc
{ "@timestamp": "2020-02-02T11:05:37Z", "temperature": 29.2, "units": "celcius" }

POST /my-data-stream/_doc
{ "@timestamp": "2020-02-10T08:05:20Z", "temperature": 19.5, "units": "celcius" }

GET _cat/indices

GET /_search
{
    "size": 0,
    "aggs": {
        "monthly_temperatures": {
            "date_histogram": {
                "field": "@timestamp",
                "calendar_interval": "1y"
            },
            "aggs": {
                "avg_temperature": {
                    "avg": {
                        "field": "temperature"
                    }
                }
            }
        }
    }
}
```