### PR TITLE
Fix API key role descriptors rewrite bug for upgraded clusters

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.node.Node;
@@ -167,19 +168,36 @@ public class SecurityContext {
 
     private Map<String, Object> rewriteMetadataForApiKeyRoleDescriptors(Version streamVersion, Authentication authentication) {
         Map<String, Object> metadata = authentication.getMetadata();
-        if (authentication.getAuthenticationType() == AuthenticationType.API_KEY
-            && authentication.getVersion().onOrAfter(VERSION_API_KEY_ROLES_AS_BYTES)
-            && streamVersion.before(VERSION_API_KEY_ROLES_AS_BYTES)) {
-            metadata = new HashMap<>(metadata);
-            metadata.put(
-                API_KEY_ROLE_DESCRIPTORS_KEY,
-                XContentHelper.convertToMap(
-                    (BytesReference) metadata.get(API_KEY_ROLE_DESCRIPTORS_KEY), false, XContentType.JSON).v2());
-            metadata.put(
-                API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY,
-                XContentHelper.convertToMap(
-                    (BytesReference) metadata.get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY), false, XContentType.JSON).v2());
+        if (authentication.getAuthenticationType() == AuthenticationType.API_KEY) {
+            if (authentication.getVersion().onOrAfter(VERSION_API_KEY_ROLES_AS_BYTES)
+                && streamVersion.before(VERSION_API_KEY_ROLES_AS_BYTES)) {
+                metadata = new HashMap<>(metadata);
+                metadata.put(API_KEY_ROLE_DESCRIPTORS_KEY,
+                    convertRoleDescriptorsBytesToMap((BytesReference) metadata.get(API_KEY_ROLE_DESCRIPTORS_KEY)));
+                metadata.put(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY,
+                    convertRoleDescriptorsBytesToMap((BytesReference) metadata.get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY)));
+            } else if (authentication.getVersion().before(VERSION_API_KEY_ROLES_AS_BYTES)
+                && streamVersion.onOrAfter(VERSION_API_KEY_ROLES_AS_BYTES)) {
+                metadata = new HashMap<>(metadata);
+                metadata.put(API_KEY_ROLE_DESCRIPTORS_KEY,
+                    convertRoleDescriptorsMapToBytes((Map<String, Object>)metadata.get(API_KEY_ROLE_DESCRIPTORS_KEY)));
+                metadata.put(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY,
+                    convertRoleDescriptorsMapToBytes((Map<String, Object>) metadata.get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY)));
+            }
         }
         return metadata;
+    }
+
+    private Map<String, Object> convertRoleDescriptorsBytesToMap(BytesReference roleDescriptorsBytes) {
+        return XContentHelper.convertToMap(roleDescriptorsBytes, false, XContentType.JSON).v2();
+    }
+
+    private BytesReference convertRoleDescriptorsMapToBytes(Map<String, Object> roleDescriptorsMap) {
+        try(final XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.map(roleDescriptorsMap);
+            return BytesReference.bytes(builder);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
@@ -193,7 +193,7 @@ public class SecurityContext {
     }
 
     private BytesReference convertRoleDescriptorsMapToBytes(Map<String, Object> roleDescriptorsMap) {
-        try(final XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+        try(XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.map(roleDescriptorsMap);
             return BytesReference.bytes(builder);
         } catch (IOException e) {

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -63,6 +63,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
       setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
+
+      setting 'xpack.security.authc.api_key.enabled', 'true'
     }
   }
 


### PR DESCRIPTION
This PR ensures that API key role descriptors are always rewritten to a target node compatible format before a request is sent.

Resolves: #62911