### PR TITLE
Docs: Fix 404s

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -101,7 +101,7 @@ releases 2.0 and later do not support rivers.
 [discrete]
 ==== Supported by the community:
 
-* https://camel.apache.org/elasticsearch.html[Apache Camel Integration]:
+* https://camel.apache.org/components/2.x/elasticsearch-component.html[Apache Camel Integration]:
   An Apache camel component to integrate Elasticsearch
 
 * https://metacpan.org/pod/Catmandu::Store::ElasticSearch[Catmandu]:

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -238,7 +238,7 @@ fixes to the model and validated that the fixed design behaved as expected.
 We have increased our test coverage to include scenarios tested by Jepsen that demonstrate loss of acknowledged writes, as described in
 the Elasticsearch related blogs. We make heavy use of randomization to expand on the scenarios that can be tested and to introduce
 new error conditions.
-You can follow the work on the master branch of the
+You can view these changes on the `5.0` branch of the
 https://github.com/elastic/elasticsearch/blob/5.0/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java[`DiscoveryWithServiceDisruptionsIT` class],
 where the `testAckedIndexing` test was specifically added to check that we don't lose acknowledged writes in various failure scenarios.
 

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -239,7 +239,7 @@ We have increased our test coverage to include scenarios tested by Jepsen that d
 the Elasticsearch related blogs. We make heavy use of randomization to expand on the scenarios that can be tested and to introduce
 new error conditions.
 You can follow the work on the master branch of the
-https://github.com/elastic/elasticsearch/blob/master/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java[`DiscoveryWithServiceDisruptionsIT` class],
+https://github.com/elastic/elasticsearch/blob/5.0/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java[`DiscoveryWithServiceDisruptionsIT` class],
 where the `testAckedIndexing` test was specifically added to check that we don't lose acknowledged writes in various failure scenarios.
 
 


### PR DESCRIPTION
## What does this PR do?
Changes in this PR correct the URLs in docs that resulted in 404.

## Why is it important/What is the impact to the user?
Navigation in docs was compromised by the broken URLs.