### PR TITLE
[7.9][DOCS] Remove duplicate disk.threshold_enabled setting.

### DIFF
--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -8,10 +8,6 @@ from that node.
 
 You can use the following settings to control disk-based allocation:
 
-`cluster.routing.allocation.disk.threshold_enabled`::
-    (<<dynamic-cluster-setting,Dynamic>>)
-    Defaults to `true`.  Set to `false` to disable the disk allocation decider.
-
 [[cluster-routing-disk-threshold]]
 // tag::cluster-routing-disk-threshold-tag[]
 `cluster.routing.allocation.disk.threshold_enabled` {ess-icon}::


### PR DESCRIPTION
Remove duplicate disk.threshold_enabled setting for 7.9.