### PR TITLE
SQL: Allow skip of bwc tests on `check` task

### DIFF
--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -132,3 +132,11 @@ tasks.register("regen") {
     }
   }
 }
+
+task checkNoBwc {
+  dependsOn 'check'
+  ext.bwc_tests_enabled = false
+  subprojects {
+    ext.bwc_tests_enabled = false
+  }
+}

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -133,10 +133,8 @@ tasks.register("regen") {
   }
 }
 
-task checkNoBwc {
-  dependsOn 'check'
-  ext.bwc_tests_enabled = false
-  subprojects {
-    ext.bwc_tests_enabled = false
+allprojects {
+  task checkNoBwc {
+    dependsOn tasks.withType(Test).matching { it.name.contains('bwc') == false }
   }
 }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -69,29 +69,31 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-      // Compatibility testing for JDBC driver started with version 7.9.0
-      if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
-        String baseName = "v${bwcVersion}"
-        UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
-        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
-        Object driverDependency = null
+    if (project.hasProperty('skipBwc') == false) {
+      for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+        // Compatibility testing for JDBC driver started with version 7.9.0
+        if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
+          String baseName = "v${bwcVersion}"
+          UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
+          Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
+          Object driverDependency = null
 
-        if (unreleasedVersion) {
-          // For unreleased snapshot versions, build them from source
-          driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
-        } else {
-          // For released versions, download it
-          driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
-        }
+          if (unreleasedVersion) {
+            // For unreleased snapshot versions, build them from source
+            driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
+          } else {
+            // For released versions, download it
+            driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
+          }
 
-        dependencies {
-          "jdbcDriver${baseName}"(driverDependency)
-        }
+          dependencies {
+            "jdbcDriver${baseName}"(driverDependency)
+          }
 
-        tasks.create(bwcTaskName(bwcVersion), RestIntegTestTask) {
+          tasks.create(bwcTaskName(bwcVersion), RestIntegTestTask) {
             classpath += driverConfiguration
             systemProperty 'jdbc.driver.version', bwcVersion.toString()
+          }
         }
       }
     }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -69,31 +69,29 @@ subprojects {
     }
 
     // Configure compatibility testing tasks
-    if (project.hasProperty('skipBwc') == false) {
-      for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-        // Compatibility testing for JDBC driver started with version 7.9.0
-        if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
-          String baseName = "v${bwcVersion}"
-          UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
-          Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
-          Object driverDependency = null
+    for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+      // Compatibility testing for JDBC driver started with version 7.9.0
+      if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
+        String baseName = "v${bwcVersion}"
+        UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
+        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
+        Object driverDependency = null
 
-          if (unreleasedVersion) {
-            // For unreleased snapshot versions, build them from source
-            driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
-          } else {
-            // For released versions, download it
-            driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
-          }
+        if (unreleasedVersion) {
+          // For unreleased snapshot versions, build them from source
+          driverDependency = files(project(unreleasedVersion.gradleProjectPath).tasks.named('buildBwcJdbc'))
+        } else {
+          // For released versions, download it
+          driverDependency = "org.elasticsearch.plugin:x-pack-sql-jdbc:${bwcVersion}"
+        }
 
-          dependencies {
-            "jdbcDriver${baseName}"(driverDependency)
-          }
+        dependencies {
+          "jdbcDriver${baseName}"(driverDependency)
+        }
 
-          tasks.create(bwcTaskName(bwcVersion), RestIntegTestTask) {
-            classpath += driverConfiguration
-            systemProperty 'jdbc.driver.version', bwcVersion.toString()
-          }
+        tasks.create(bwcTaskName(bwcVersion), RestIntegTestTask) {
+          classpath += driverConfiguration
+          systemProperty 'jdbc.driver.version', bwcVersion.toString()
         }
       }
     }

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -90,8 +90,8 @@ subprojects {
         }
 
         tasks.create(bwcTaskName(bwcVersion), RestIntegTestTask) {
-          classpath += driverConfiguration
-          systemProperty 'jdbc.driver.version', bwcVersion.toString()
+            classpath += driverConfiguration
+            systemProperty 'jdbc.driver.version', bwcVersion.toString()
         }
       }
     }


### PR DESCRIPTION
Bwc tests can consume much time to build and to run so it's nice to be
able to skip them when running the `check` task on the SQL module.

Introduce a project property `skipBwc` so one can use:
```
./gradlew -p x-pack/plugin/sql check -PskipBwc
```
to skip them.
