### PR TITLE
Cleanup on integtest distribution setup

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import org.elasticsearch.gradle.MavenFilteringHack
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -185,41 +184,4 @@ subprojects {
   apply plugin: 'elasticsearch.internal-distribution-archive-check'
 
   group = "org.elasticsearch.distribution.${name.startsWith("oss-") ? "oss" : "default"}"
-}
-
-/*****************************************************************************
- *                            Rest test config                               *
- *****************************************************************************/
-project('integ-test-zip') {
-  apply plugin: 'elasticsearch.standalone-rest-test'
-  apply plugin: 'elasticsearch.rest-test'
-
-  group = "org.elasticsearch.distribution.integ-test-zip"
-
-  integTest {
-    dependsOn assemble
-  }
-
-  processTestResources {
-    inputs.properties(project(':distribution').restTestExpansions)
-    MavenFilteringHack.filter(it, project(':distribution').restTestExpansions)
-  }
-
-  // The integ-test-distribution is published to maven
-  apply plugin: 'elasticsearch.publish'
-
-  // make the pom file name use elasticsearch instead of the project name
-  archivesBaseName = "elasticsearch${it.name.contains('oss') ? '-oss' : ''}"
-
-  String buildTask = "build${it.name.replaceAll(/-[a-z]/) { it.substring(1).toUpperCase() }.capitalize()}"
-  ext.buildDist = parent.tasks.named(buildTask)
-
-  publishing {
-    publications {
-      nebula {
-        pom.packaging = 'zip'
-        artifact(buildDist.flatMap { it.archiveFile })
-      }
-    }
-  }
 }

--- a/distribution/archives/integ-test-zip/build.gradle
+++ b/distribution/archives/integ-test-zip/build.gradle
@@ -16,6 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import org.elasticsearch.gradle.MavenFilteringHack
+
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+
+// The integ-test-distribution is published to maven
+apply plugin: 'elasticsearch.publish'
+
+group = "org.elasticsearch.distribution.integ-test-zip"
+
+integTest {
+  dependsOn assemble
+}
+
+processTestResources {
+  inputs.properties(project(':distribution').restTestExpansions)
+  MavenFilteringHack.filter(it, project(':distribution').restTestExpansions)
+}
+
+// make the pom file name use elasticsearch instead of the project name
+archivesBaseName = "elasticsearch"
+ext.buildDist = parent.tasks.named("buildIntegTestZip")
+
+publishing {
+  publications {
+    nebula {
+      pom.packaging = 'zip'
+      artifact(buildDist.flatMap { it.archiveFile })
+    }
+  }
+}
 
 integTest {
   /*


### PR DESCRIPTION
- simplify build task and archive base name calculation
- move integ test zip project only setup into integ test zip build script