### PR TITLE
[Transform] fix possible NPE if transform task has no node assigned

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
@@ -17,8 +17,7 @@ import java.util.Set;
 
 public final class TransformNodes {
 
-    private TransformNodes() {
-    }
+    private TransformNodes() {}
 
     /**
      * Get the list of nodes transforms are executing on
@@ -31,14 +30,15 @@ public final class TransformNodes {
 
         Set<String> executorNodes = new HashSet<>();
 
-        PersistentTasksCustomMetadata tasksMetadata =
-                PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
+        PersistentTasksCustomMetadata tasksMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
 
         if (tasksMetadata != null) {
             Set<String> transformIdsSet = new HashSet<>(transformIds);
 
-            Collection<PersistentTasksCustomMetadata.PersistentTask<?>> tasks =
-                    tasksMetadata.findTasks(TransformField.TASK_NAME, t -> transformIdsSet.contains(t.getId()));
+            Collection<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = tasksMetadata.findTasks(
+                TransformField.TASK_NAME,
+                t -> transformIdsSet.contains(t.getId()) && t.isAssigned()
+            );
 
             for (PersistentTasksCustomMetadata.PersistentTask<?> task : tasks) {
                 executorNodes.add(task.getExecutorNode());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -217,6 +217,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                 // - transform is not failed (stopped transforms do not have a task)
                 // - the node where transform is executed on is at least 7.8.0 in order to understand the request
                 if (transformTask != null
+                    && transformTask.isAssigned()
                     && transformTask.getState() instanceof TransformState
                     && ((TransformState) transformTask.getState()).getTaskState() != TransformTaskState.FAILED
                     && clusterState.nodes().get(transformTask.getExecutorNode()).getVersion().onOrAfter(Version.V_7_8_0)) {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
@@ -20,14 +20,17 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 
 import java.util.Arrays;
 import java.util.Collections;
-
-import static org.hamcrest.Matchers.hasItemInArray;
+import java.util.HashSet;
+import java.util.Set;
 
 public class TransformNodesTests extends ESTestCase {
 
     public void testTransformNodes() {
         String transformIdFoo = "df-id-foo";
         String transformIdBar = "df-id-bar";
+        String transformIdFailed = "df-id-failed";
+        String transformIdBaz = "df-id-baz";
+        String transformIdOther = "df-id-other";
 
         PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
         tasksBuilder.addTask(
@@ -63,15 +66,40 @@ public class TransformNodesTests extends ESTestCase {
                 return null;
             }
         }, new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment"));
+        tasksBuilder.addTask(
+            transformIdFailed,
+            TransformField.TASK_NAME,
+            new TransformTaskParams(transformIdFailed, Version.CURRENT, null, false),
+            new PersistentTasksCustomMetadata.Assignment(null, "awaiting reassignment after node loss")
+        );
+        tasksBuilder.addTask(
+            transformIdBaz,
+            TransformField.TASK_NAME,
+            new TransformTaskParams(transformIdBaz, Version.CURRENT, null, false),
+            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+        );
+        tasksBuilder.addTask(
+            transformIdOther,
+            TransformField.TASK_NAME,
+            new TransformTaskParams(transformIdOther, Version.CURRENT, null, false),
+            new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment")
+        );
 
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))
             .metadata(Metadata.builder().putCustom(PersistentTasksCustomMetadata.TYPE, tasksBuilder.build()))
             .build();
 
-        String[] nodes = TransformNodes.transformTaskNodes(Arrays.asList(transformIdFoo, transformIdBar), cs);
-        assertEquals(2, nodes.length);
-        assertThat(nodes, hasItemInArray("node-1"));
-        assertThat(nodes, hasItemInArray("node-2"));
+        // don't ask for transformIdOther
+        String[] nodes = TransformNodes.transformTaskNodes(
+            Arrays.asList(transformIdFoo, transformIdBar, transformIdFailed, transformIdBaz),
+            cs
+        );
+        // assertEquals(2, nodes.length);
+        Set<String> nodesSet = new HashSet<>(Arrays.asList(nodes));
+        assertTrue(nodesSet.contains("node-1"));
+        assertTrue(nodesSet.contains("node-2"));
+        assertFalse(nodesSet.contains(null));
+        assertFalse(nodesSet.contains("node-3"));
     }
 
     public void testTransformNodes_NoTasks() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
@@ -94,7 +94,7 @@ public class TransformNodesTests extends ESTestCase {
             Arrays.asList(transformIdFoo, transformIdBar, transformIdFailed, transformIdBaz),
             cs
         );
-        // assertEquals(2, nodes.length);
+        assertEquals(2, nodes.length);
         Set<String> nodesSet = new HashSet<>(Arrays.asList(nodes));
         assertTrue(nodesSet.contains("node-1"));
         assertTrue(nodesSet.contains("node-2"));


### PR DESCRIPTION
ignore transform tasks that do not have a node assigned when collecting
nodes to forward the request for `_stop`, `_stats` and `_update`

fixes #62847
