### PR TITLE
Refactor PointParser to not take FieldMapper as a parameter

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.FieldType;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -34,9 +35,11 @@ import org.elasticsearch.geometry.Point;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.index.mapper.TypeParsers.parseField;
 
@@ -154,8 +157,6 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         return nullValue;
     }
 
-    protected abstract ParsedPoint newParsedPoint();
-
     /** represents a Point that has been parsed by {@link PointParser} */
     public interface ParsedPoint {
         void validate(String fieldName);
@@ -167,87 +168,80 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         }
     }
 
-    protected void parsePointIgnoringMalformed(XContentParser parser, ParsedPoint point) throws IOException {
-        try {
-            if (ignoreMalformed.value() == false) {
-                point.validate(name());
-            } else {
-                point.normalize(name());
-            }
-        } catch (ElasticsearchParseException e) {
-            if (ignoreMalformed.value() == false) {
-                throw e;
-            }
-        }
-    }
-
     /** A parser implementation that can parse the various point formats */
     public static class PointParser<P extends ParsedPoint> extends Parser<List<P>> {
         /**
          * Note that this parser is only used for formatting values.
          */
         private final GeometryParser geometryParser;
+        private final String field;
+        private final Supplier<P> pointSupplier;
+        private final CheckedBiFunction<XContentParser, P, P, IOException> objectParser;
+        private final P nullValue;
+        private final boolean ignoreZValue;
+        private final boolean ignoreMalformed;
 
-        public PointParser() {
+        public PointParser(String field,
+                           Supplier<P> pointSupplier,
+                           CheckedBiFunction<XContentParser, P, P, IOException> objectParser,
+                           P nullValue,
+                           boolean ignoreZValue,
+                           boolean ignoreMalformed) {
+            this.field = field;
+            this.pointSupplier = pointSupplier;
+            this.objectParser = objectParser;
+            this.nullValue = nullValue;
+            this.ignoreZValue = ignoreZValue;
+            this.ignoreMalformed = ignoreMalformed;
             this.geometryParser = new GeometryParser(true, true, true);
         }
 
+        private P process(P in) {
+            if (ignoreMalformed == false) {
+                in.validate(field);
+            } else {
+                in.normalize(field);
+            }
+            return in;
+        }
+
         @Override
-        public List<P> parse(XContentParser parser, AbstractGeometryFieldMapper geometryMapper) throws IOException, ParseException {
-            AbstractPointGeometryFieldMapper mapper = (AbstractPointGeometryFieldMapper) geometryMapper;
+        public List<P> parse(XContentParser parser) throws IOException, ParseException {
 
             if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
                 XContentParser.Token token = parser.nextToken();
-                P point = (P)(mapper.newParsedPoint());
-                ArrayList<P> points = new ArrayList();
+                P point = pointSupplier.get();
+                ArrayList<P> points = new ArrayList<>();
                 if (token == XContentParser.Token.VALUE_NUMBER) {
                     double x = parser.doubleValue();
                     parser.nextToken();
                     double y = parser.doubleValue();
                     token = parser.nextToken();
                     if (token == XContentParser.Token.VALUE_NUMBER) {
-                        GeoPoint.assertZValue((Boolean)(mapper.ignoreZValue().value()), parser.doubleValue());
+                        GeoPoint.assertZValue(ignoreZValue, parser.doubleValue());
                     } else if (token != XContentParser.Token.END_ARRAY) {
-                        throw new ElasticsearchParseException("[{}] field type does not accept > 3 dimensions",
-                            mapper.contentType());
+                        throw new ElasticsearchParseException("field type does not accept > 3 dimensions");
                     }
 
                     point.resetCoords(x, y);
-                    if ((Boolean)(mapper.ignoreMalformed().value()) == false) {
-                        point.validate(mapper.name());
-                    } else {
-                        point.normalize(mapper.name());
-                    }
-                    points.add(point);
+                    points.add(process(point));
                 } else {
                     while (token != XContentParser.Token.END_ARRAY) {
-                        mapper.parsePointIgnoringMalformed(parser, point);
-                        points.add(point);
-                        point = (P)(mapper.newParsedPoint());
+                        points.add(process(objectParser.apply(parser, point)));
+                        point = pointSupplier.get();
                         token = parser.nextToken();
                     }
                 }
                 return points;
             } else if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
-                P point = null;
-                ArrayList<P> points = null;
-                if (mapper.nullValue != null) {
-                    point = (P)(mapper.nullValue);
-                    if ((Boolean)(mapper.ignoreMalformed().value()) == false) {
-                        point.validate(mapper.name());
-                    } else {
-                        point.normalize(mapper.name());
-                    }
-                    points = new ArrayList<>();
-                    points.add(point);
+                if (nullValue == null) {
+                    return Collections.emptyList();
                 }
-                return points;
+                else {
+                    return Collections.singletonList(nullValue);
+                }
             } else {
-                P point = (P)mapper.newParsedPoint();
-                mapper.parsePointIgnoringMalformed(parser, point);
-                ArrayList<P> points = new ArrayList();
-                points.add(point);
-                return points;
+                return Collections.singletonList(process(objectParser.apply(parser, pointSupplier.get())));
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
@@ -41,7 +41,7 @@ public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry>
     }
 
     @Override
-    public Geometry parse(XContentParser parser, AbstractGeometryFieldMapper mapper) throws IOException, ParseException {
+    public Geometry parse(XContentParser parser) throws IOException, ParseException {
         return geometryParser.parse(parser);
     }
 
@@ -51,7 +51,7 @@ public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry>
     }
 
     @Override
-    public Object parseAndFormatObject(Object value, AbstractGeometryFieldMapper mapper, String format) {
+    public Object parseAndFormatObject(Object value, String format) {
         try (XContentParser parser = new MapXContentParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
             Collections.singletonMap("dummy_field", value), XContentType.JSON)) {
             parser.nextToken(); // start object

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -296,7 +296,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
 
         @Override
-        public ShapeBuilder<?, ?, ?> parse(XContentParser parser, AbstractGeometryFieldMapper mapper) throws IOException, ParseException {
+        public ShapeBuilder<?, ?, ?> parse(XContentParser parser) throws IOException, ParseException {
             return ShapeParser.parse(parser);
         }
 


### PR DESCRIPTION
Passing FieldMappers to point parsing functions makes trying to build source-only
fields from MappedFieldTypes more complicated.  This small refactoring changes
things so that the relevant parsing and factory functions from
AbstractGeometryFieldMapper are instead passed as lambdas to the PointParser
constructor.