### PR TITLE
Adding script support for version parts

### DIFF
--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -68,3 +68,62 @@ This field type isn't optimized for heavy wildcard, regex or fuzzy searches. Whi
 type of queries work in this field, you should consider using a regular `keyword` field if
 you strongly rely on these kind of queries.
 
+==== Script support
+
+The `version` fields offers some specialized access to detailed information derived from
+valid version strings like the Major, Minor or Patch release number, whether the version value
+is valid according to Semver or if it is a pre-release version. This can be helpful when e.g.
+filtering for only released versions or running aggregations on parts of the version.
+The following query, for example, filters for released versions and groups them by Major version
+using a `terms` aggregation:
+
+[source,console]
+--------------------------------------------------
+POST my-index-000001/_search
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "script": {
+            "script": {
+              "source": "doc['my_version'].isRelease() == true"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "group_major": {
+      "terms": {
+        "script": { "source": "doc['my_version'].getMajor()"},
+        "order": {
+          "_key": "asc"
+        }
+      }
+    }
+  }
+}
+
+--------------------------------------------------
+// TEST[continued]
+
+Functions available on via doc values in scripting are:
+
+[horizontal]
+
+isValid()::
+    Returns `true` if the field contains a version thats legal according to the Semantic Versioning rules
+
+isRelease()::
+    Returns `true` if the field contains a valid release version, `false` if it is a pre-release version or invalid.
+
+getMajor()::
+    Returns an Integer value of the Major version if the version is valid, or null otherwise
+
+getMinor()::
+    Returns an Integer value of the Minor  version if the version is valid, or null otherwise.
+
+getPatch()::
+    Returns an Integer value of the Patch version if the version is valid, or null otherwise.

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.versionfield;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.xpack.versionfield.VersionEncoder.VersionParts;
 
 import java.io.IOException;
 
@@ -54,5 +55,64 @@ public final class VersionScriptDocValues extends ScriptDocValues<String> {
     @Override
     public int size() {
         return count;
+    }
+
+    public boolean isValid() {
+        return VersionEncoder.legalVersionString(VersionParts.ofVersion(getValue()));
+    }
+
+    public boolean isRelease() {
+        VersionParts parts = VersionParts.ofVersion(getValue());
+        return VersionEncoder.legalVersionString(parts) && parts.preRelease == null;
+    }
+
+    public Integer getMajor() {
+        VersionParts parts = VersionParts.ofVersion(getValue());
+        if (VersionEncoder.legalVersionString(parts) && parts.mainVersion != null) {
+            int firstDot = parts.mainVersion.indexOf(".");
+            if (firstDot > 0) {
+                return Integer.valueOf(parts.mainVersion.substring(0, firstDot));
+            } else {
+                return Integer.valueOf(parts.mainVersion);
+            }
+        }
+        return null;
+    }
+
+    public Integer getMinor() {
+        VersionParts parts = VersionParts.ofVersion(getValue());
+        Integer rc = null;
+        if (VersionEncoder.legalVersionString(parts) && parts.mainVersion != null) {
+            int firstDot = parts.mainVersion.indexOf(".");
+            if (firstDot > 0) {
+                int secondDot = parts.mainVersion.indexOf(".", firstDot + 1);
+                if (secondDot > 0) {
+                    rc = Integer.valueOf(parts.mainVersion.substring(firstDot + 1, secondDot));
+                } else {
+                    rc = Integer.valueOf(parts.mainVersion.substring(firstDot + 1));
+                }
+            }
+        }
+        return rc;
+    }
+
+    public Integer getPatch() {
+        VersionParts parts = VersionParts.ofVersion(getValue());
+        Integer rc = null;
+        if (VersionEncoder.legalVersionString(parts) && parts.mainVersion != null) {
+            int firstDot = parts.mainVersion.indexOf(".");
+            if (firstDot > 0) {
+                int secondDot = parts.mainVersion.indexOf(".", firstDot + 1);
+                if (secondDot > 0) {
+                    int thirdDot = parts.mainVersion.indexOf(".", secondDot + 1);
+                    if (thirdDot > 0) {
+                        rc = Integer.valueOf(parts.mainVersion.substring(secondDot + 1, thirdDot));
+                    } else {
+                        rc = Integer.valueOf(parts.mainVersion.substring(secondDot + 1));
+                    }
+                }
+            }
+        }
+        return rc;
     }
 }

--- a/x-pack/plugin/mapper-version/src/main/resources/org/elasticsearch/xpack/versionfield/whitelist.txt
+++ b/x-pack/plugin/mapper-version/src/main/resources/org/elasticsearch/xpack/versionfield/whitelist.txt
@@ -2,4 +2,9 @@
 class org.elasticsearch.xpack.versionfield.VersionScriptDocValues {
     String get(int)
     String getValue()
+    boolean isValid()
+    boolean isRelease()
+    Integer getMajor()
+    Integer getMinor()
+    Integer getPatch()
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/20_scripts.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/20_scripts.yml
@@ -52,3 +52,106 @@ setup:
   - match: { hits.hits.0._source.version: "3.1.0" }
   - match: { hits.hits.1._source.version: "1.1.12" }
   - match: { hits.hits.2._source.version: "2.0.0-beta" }
+
+---
+"Filter script for illegal versions":
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "test_index", "_id" : "4" } }'
+          - '{"version": "a123.2.2-beta" }'
+
+  - do:
+        search:
+          index: test_index
+          body:
+            query: { "bool" : { "filter" : [{ "script" : { "script" : {"source": "doc['version'].isValid() == false"}}}] }} 
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._source.version: "a123.2.2-beta" }
+
+  - do:
+      search:
+        index: test_index
+        body:
+          query: { "bool" : { "filter" : [{ "script" : { "script" : {"source": "doc['version'].isValid()"}}}] }} 
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._source.version: "1.1.12" }
+  - match: { hits.hits.1._source.version: "2.0.0-beta" }
+  - match: { hits.hits.2._source.version: "3.1.0" }
+
+---
+"Filter script for pre-release versions":
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "test_index", "_id" : "4" } }'
+          - '{"version": "a123.2.2-beta" }'
+
+  - do:
+      search:
+        index: test_index
+        body:
+          query: { "bool" : { "filter" : [{ "script" : { "script" : {"source": "doc['version'].isRelease()"}}}] }} 
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._source.version: "1.1.12" }
+  - match: { hits.hits.1._source.version: "3.1.0" }
+
+---
+"Aggregate using script on major, minor, patch versions":
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "test_index", "_id" : "4" } }'
+          - '{"version": "3" }'
+          - '{ "index" : { "_index" : "test_index", "_id" : "5" } }'
+          - '{"version": "3.1" }'
+          - '{ "index" : { "_index" : "test_index", "_id" : "6" } }'
+          - '{"version": "illegal3.1" }'
+
+  - do:
+      search:
+        index: test_index
+        body:
+          size: 0
+          aggs: { "majors": { "terms": { "script": { "source": "doc['version'].getMajor()", "lang": "painless"}}}}
+
+  - length: { aggregations.majors.buckets: 3 }
+  - match: { aggregations.majors.buckets.0.key: "3" }
+  - match: { aggregations.majors.buckets.0.doc_count: 3 }
+  - match: { aggregations.majors.buckets.1.key: "1" }
+  - match: { aggregations.majors.buckets.1.doc_count: 1 }
+  - match: { aggregations.majors.buckets.2.key: "2" }
+  - match: { aggregations.majors.buckets.2.doc_count: 1 }
+
+  - do:
+      search:
+        index: test_index
+        body:
+          size: 0
+          aggs: { "majors": { "terms": { "script": { "source": "doc['version'].getMinor()", "lang": "painless"}}}}
+
+  - length: { aggregations.majors.buckets: 2 }
+  - match: { aggregations.majors.buckets.0.key: "1" }
+  - match: { aggregations.majors.buckets.0.doc_count: 3 }
+  - match: { aggregations.majors.buckets.1.key: "0" }
+  - match: { aggregations.majors.buckets.1.doc_count: 1 }
+
+  - do:
+      search:
+        index: test_index
+        body:
+          size: 0
+          aggs: { "majors": { "terms": { "script": { "source": "doc['version'].getPatch()", "lang": "painless"}}}}
+
+  - length: { aggregations.majors.buckets: 2 }
+  - match: { aggregations.majors.buckets.0.key: "0" }
+  - match: { aggregations.majors.buckets.0.doc_count: 2 }
+  - match: { aggregations.majors.buckets.1.key: "12" }
+  - match: { aggregations.majors.buckets.1.doc_count: 1 }


### PR DESCRIPTION
Spin off of https://github.com/elastic/elasticsearch/pull/59773 that factors out adding support to access special information about a version field value via scripts. 
This is only one potential solution, so mainly opening this for discussion.