### PR TITLE
[ML] Delete dest index and reindex if incompatible

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -98,7 +98,7 @@ public class DataFrameAnalyticsManager {
                 if (destIndex != null) {
                     MappingMetadata destIndexMapping = clusterState.getMetadata().index(config.getDest().getIndex()).mapping();
                     DestinationIndex.Metadata metadata = DestinationIndex.readMetadata(config.getId(), destIndexMapping);
-                    if (metadata.hasMetadata() && metadata.isCompatible() == false) {
+                    if (metadata.hasMetadata() && (metadata.isCompatible() == false)) {
                         LOGGER.info("[{}] Destination index was created in version [{}] but minimum supported version is [{}]. " +
                             "Deleting index and starting from scratch.", config.getId(), metadata.getVersion(),
                             DestinationIndex.MIN_COMPATIBLE_VERSION);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -97,12 +97,11 @@ public class DataFrameAnalyticsManager {
                 IndexMetadata destIndex = clusterState.getMetadata().index(config.getDest().getIndex());
                 if (destIndex != null) {
                     MappingMetadata destIndexMapping = clusterState.getMetadata().index(config.getDest().getIndex()).mapping();
-                    DestinationIndex.CompatibilityCheckResult compatibilityCheckResult =
-                        DestinationIndex.checkCompatible(config.getId(), destIndexMapping);
-                    if (compatibilityCheckResult.isCompatible() == false) {
+                    DestinationIndex.Metadata metadata = DestinationIndex.readMetadata(config.getId(), destIndexMapping);
+                    if (metadata.hasMetadata() && metadata.isCompatible() == false) {
                         LOGGER.info("[{}] Destination index was created in version [{}] but minimum supported version is [{}]. " +
-                            "Deleting index and starting from scratch.", config.getId(), compatibilityCheckResult.getDestIndexVersion(),
-                            compatibilityCheckResult.getMinCompatibleVersion());
+                            "Deleting index and starting from scratch.", config.getId(), metadata.getVersion(),
+                            DestinationIndex.MIN_COMPATIBLE_VERSION);
                         task.getStatsHolder().resetProgressTracker(config.getAnalysis().getProgressPhases(),
                             config.getAnalysis().supportsInference());
                         DataFrameAnalyticsTaskState reindexingState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.REINDEXING,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -234,14 +234,12 @@ public final class DestinationIndex {
         }
     }
 
-    public static boolean isCompatible(String jobId, MappingMetadata mappingMetadata) {
+    public static CompatibilityCheckResult checkCompatible(String jobId, MappingMetadata mappingMetadata) {
         try {
-            Version destIndexVersion = getVersion(mappingMetadata);
-            logger.debug("[{}] Destination index version [{}]", jobId, destIndexVersion);
-            return destIndexVersion.onOrAfter(MIN_COMPATIBLE_VERSION);
+            return new CompatibilityCheckResult(getVersion(mappingMetadata));
         } catch (Exception e) {
             logger.error(new ParameterizedMessage("[{}] Could not retrieve destination index version", jobId), e);
-            return false;
+            return new CompatibilityCheckResult(null);
         }
     }
 
@@ -252,5 +250,26 @@ public final class DestinationIndex {
         Map<String, Object> version = (Map<String, Object>) meta.get(VERSION);
         String createdVersionString = (String) version.get(CREATED);
         return Version.fromString(createdVersionString);
+    }
+
+    public static class CompatibilityCheckResult {
+
+        private final Version destIndexVersion;
+
+        private CompatibilityCheckResult(Version destIndexVersion) {
+            this.destIndexVersion = destIndexVersion;
+        }
+
+        public boolean isCompatible() {
+            return destIndexVersion == null ? false : destIndexVersion.onOrAfter(MIN_COMPATIBLE_VERSION);
+        }
+
+        public String getDestIndexVersion() {
+            return destIndexVersion == null ? "unknown" : destIndexVersion.toString();
+        }
+
+        public String getMinCompatibleVersion() {
+            return MIN_COMPATIBLE_VERSION.toString();
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -240,7 +240,7 @@ public final class DestinationIndex {
     public static Metadata readMetadata(String jobId, MappingMetadata mappingMetadata) {
         Map<String, Object> mappings = mappingMetadata.getSourceAsMap();
         Map<String, Object> meta = (Map<String, Object>) mappings.get(META);
-        if (meta == null || DFA_CREATOR.equals(meta.get(CREATED_BY)) == false) {
+        if ((meta == null) || (DFA_CREATOR.equals(meta.get(CREATED_BY)) == false)) {
             return new NoMetadata();
         }
         return new DestMetadata(getVersion(jobId, meta));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
@@ -40,6 +40,11 @@ public class StatsHolder {
         progressTracker.updateReindexingProgress(reindexingProgressPercent < 100 ? 1 : reindexingProgressPercent);
     }
 
+    public void resetProgressTracker(List<String> analysisPhases, boolean hasInferencePhase) {
+        progressTracker = ProgressTracker.fromZeroes(analysisPhases, hasInferencePhase);
+        progressTracker.updateReindexingProgress(1);
+    }
+
     public ProgressTracker getProgressTracker() {
         return progressTracker;
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -337,31 +337,43 @@ public class DestinationIndexTests extends ESTestCase {
         verifyZeroInteractions(client);
     }
 
-    public void testIsCompatible_GivenCurrentVersion() {
+    public void testCheckCompatible_GivenCurrentVersion() {
         Map<String, Object> mappings = new HashMap<>();
         mappings.put("_meta", DestinationIndex.createMetadata("test_id", Clock.systemUTC(), Version.CURRENT));
         MappingMetadata mappingMetadata = mock(MappingMetadata.class);
         when(mappingMetadata.getSourceAsMap()).thenReturn(mappings);
 
-        assertThat(DestinationIndex.isCompatible("test_id", mappingMetadata), is(true));
+        DestinationIndex.CompatibilityCheckResult compatibilityCheckResult = DestinationIndex.checkCompatible("test_id", mappingMetadata);
+
+        assertThat(compatibilityCheckResult.isCompatible(), is(true));
+        assertThat(compatibilityCheckResult.getDestIndexVersion(), equalTo(Version.CURRENT.toString()));
+        assertThat(compatibilityCheckResult.getMinCompatibleVersion(), equalTo("7.10.0"));
     }
 
-    public void testIsCompatible_GivenMinCompatibleVersion() {
+    public void testCheckCompatible_GivenMinCompatibleVersion() {
         Map<String, Object> mappings = new HashMap<>();
         mappings.put("_meta", DestinationIndex.createMetadata("test_id", Clock.systemUTC(), Version.V_7_10_0));
         MappingMetadata mappingMetadata = mock(MappingMetadata.class);
         when(mappingMetadata.getSourceAsMap()).thenReturn(mappings);
 
-        assertThat(DestinationIndex.isCompatible("test_id", mappingMetadata), is(true));
+        DestinationIndex.CompatibilityCheckResult compatibilityCheckResult = DestinationIndex.checkCompatible("test_id", mappingMetadata);
+
+        assertThat(compatibilityCheckResult.isCompatible(), is(true));
+        assertThat(compatibilityCheckResult.getDestIndexVersion(), equalTo("7.10.0"));
+        assertThat(compatibilityCheckResult.getMinCompatibleVersion(), equalTo("7.10.0"));
     }
 
-    public void testIsCompatible_GivenNonCompatibleVersion() {
+    public void testCheckCompatible_GivenNonCompatibleVersion() {
         Map<String, Object> mappings = new HashMap<>();
         mappings.put("_meta", DestinationIndex.createMetadata("test_id", Clock.systemUTC(), Version.V_7_9_3));
         MappingMetadata mappingMetadata = mock(MappingMetadata.class);
         when(mappingMetadata.getSourceAsMap()).thenReturn(mappings);
 
-        assertThat(DestinationIndex.isCompatible("test_id", mappingMetadata), is(false));
+        DestinationIndex.CompatibilityCheckResult compatibilityCheckResult = DestinationIndex.checkCompatible("test_id", mappingMetadata);
+
+        assertThat(compatibilityCheckResult.isCompatible(), is(false));
+        assertThat(compatibilityCheckResult.getDestIndexVersion(), equalTo("7.9.3"));
+        assertThat(compatibilityCheckResult.getMinCompatibleVersion(), equalTo("7.10.0"));
     }
 
     private static <Response> Answer<Response> callListenerOnResponse(Response response) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
@@ -96,4 +96,30 @@ public class StatsHolderTests extends ESTestCase {
         assertThat(phaseProgresses.get(3).getProgressPercent(), equalTo(0));
         assertThat(phaseProgresses.get(4).getProgressPercent(), equalTo(0));
     }
+
+    public void testResetProgressTracker() {
+        List<PhaseProgress> phases = Collections.unmodifiableList(
+            Arrays.asList(
+                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("reindexing", 100),
+                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("loading_data", 20),
+                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("a", 30),
+                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("b", 40),
+                new PhaseProgress("writing_results", 50)
+            )
+        );
+        StatsHolder statsHolder = new StatsHolder(phases);
+
+        statsHolder.resetProgressTracker(Arrays.asList("a", "b"), false);
+
+        List<PhaseProgress> phaseProgresses = statsHolder.getProgressTracker().report();
+
+        assertThat(phaseProgresses.size(), equalTo(5));
+        assertThat(phaseProgresses.stream().map(PhaseProgress::getPhase).collect(Collectors.toList()),
+            contains("reindexing", "loading_data", "a", "b", "writing_results"));
+        assertThat(phaseProgresses.get(0).getProgressPercent(), equalTo(1));
+        assertThat(phaseProgresses.get(1).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(2).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(3).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(4).getProgressPercent(), equalTo(0));
+    }
 }


### PR DESCRIPTION
Data frame analytics results format changed in version `7.10.0`.
If existing jobs that were not completed are restarted, it is
possible the destination index had already been created. That index's
mappings are not suitable for the new results format.

This commit checks the version of the destination index and deletes
it when the version is outdated. The job will then continue by
recreating the destination index and reindexing.

Relates https://github.com/elastic/elasticsearch/issues/61325