### PR TITLE
Docs: Support """ in console-response (#62876)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -298,7 +298,9 @@ class RestTestsFromSnippetsTask extends SnippetsTask {
             if (null == response.skip) {
                 current.println("  - match: ")
                 current.println("      \$body: ")
-                response.contents.eachLine { current.println("        $it") }
+                replaceBlockQuote(response.contents).eachLine {
+                    current.println("        $it")
+                }
             }
         }
 

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -156,7 +156,7 @@ The API returns the following result:
 {
   "script" : {
     "lang" : "mustache",
-    "source" : "{\"query\":{\"match\":{\"title\":\"{{query_string}}\"}}}",
+    "source" : """{"query":{"match":{"title":"{{query_string}}"}}}""",
     "options": {
       "content_type" : "application/json; charset=UTF-8"
     }


### PR DESCRIPTION
We support `"""` in `console` snippets to emulate kibana's CONSOLE.
CONSOLE also spits out `"""` when a json field contains a new line or a
double quote. This adds support for those sorts of responses to the
handling of `console-response` snippets.
