### PR TITLE
Remove unused method from DocumentMapperParser

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -21,13 +21,10 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -79,18 +76,34 @@ public class DocumentMapperParser {
             typeParsers::get, indexVersionCreated, queryShardContextSupplier, dateFormatter, scriptService);
     }
 
+    @SuppressWarnings("unchecked")
     public DocumentMapper parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {
+        String typeName = null;
         Map<String, Object> mapping = null;
         if (source != null) {
             Map<String, Object> root = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
-            Tuple<String, Map<String, Object>> t = extractMapping(type, root);
-            type = t.v1();
-            mapping = t.v2();
+            if (root.isEmpty()) {
+                if (type == null) {
+                    throw new MapperParsingException("malformed mapping, no type name found");
+                } else {
+                    typeName = type;
+                    mapping = root;
+                }
+            } else {
+                String rootName = root.keySet().iterator().next();
+                if (type == null || type.equals(rootName) || mapperService.resolveDocumentType(type).equals(rootName)) {
+                    typeName = rootName;
+                    mapping = (Map<String, Object>) root.get(rootName);
+                } else {
+                    typeName = type;
+                    mapping = root;
+                }
+            }
         }
         if (mapping == null) {
             mapping = new HashMap<>();
         }
-        return parse(type, mapping);
+        return parse(typeName, mapping);
     }
 
     @SuppressWarnings({"unchecked"})
@@ -164,50 +177,6 @@ public class DocumentMapperParser {
             remainingFields.append(" [").append(key).append(" : ").append(map.get(key)).append("]");
         }
         return remainingFields.toString();
-    }
-
-    private Tuple<String, Map<String, Object>> extractMapping(String type, String source) throws MapperParsingException {
-        Map<String, Object> root;
-        try (XContentParser parser = XContentType.JSON.xContent()
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source)) {
-            root = parser.mapOrdered();
-        } catch (Exception e) {
-            throw new MapperParsingException("failed to parse mapping definition", e);
-        }
-        return extractMapping(type, root);
-    }
-
-    /**
-     * Given an optional type name and mapping definition, returns the type and a normalized form of the mappings.
-     *
-     * The provided mapping definition may or may not contain the type name as the root key in the map. This method
-     * attempts to unwrap the mappings, so that they no longer contain a type name at the root. If no type name can
-     * be found, through either the 'type' parameter or by examining the provided mappings, then an exception will be
-     * thrown.
-     *
-     * @param type An optional type name.
-     * @param root The mapping definition.
-     *
-     * @return A tuple of the form (type, normalized mappings).
-     */
-    @SuppressWarnings({"unchecked"})
-    private Tuple<String, Map<String, Object>> extractMapping(String type, Map<String, Object> root) throws MapperParsingException {
-        if (root.size() == 0) {
-            if (type != null) {
-                return new Tuple<>(type, root);
-            } else {
-                throw new MapperParsingException("malformed mapping, no type name found");
-            }
-        }
-
-        String rootName = root.keySet().iterator().next();
-        Tuple<String, Map<String, Object>> mapping;
-        if (type == null || type.equals(rootName) || mapperService.resolveDocumentType(type).equals(rootName)) {
-            mapping = new Tuple<>(rootName, (Map<String, Object>) root.get(rootName));
-        } else {
-            mapping = new Tuple<>(type, root);
-        }
-        return mapping;
     }
 
     NamedXContentRegistry getXContentRegistry() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -78,32 +78,25 @@ public class DocumentMapperParser {
 
     @SuppressWarnings("unchecked")
     public DocumentMapper parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {
-        String typeName = null;
         Map<String, Object> mapping = null;
         if (source != null) {
-            Map<String, Object> root = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
-            if (root.isEmpty()) {
+            mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
+            if (mapping.isEmpty()) {
                 if (type == null) {
                     throw new MapperParsingException("malformed mapping, no type name found");
-                } else {
-                    typeName = type;
-                    mapping = root;
                 }
             } else {
-                String rootName = root.keySet().iterator().next();
+                String rootName = mapping.keySet().iterator().next();
                 if (type == null || type.equals(rootName) || mapperService.resolveDocumentType(type).equals(rootName)) {
-                    typeName = rootName;
-                    mapping = (Map<String, Object>) root.get(rootName);
-                } else {
-                    typeName = type;
-                    mapping = root;
+                    type = rootName;
+                    mapping = (Map<String, Object>) mapping.get(rootName);
                 }
             }
         }
         if (mapping == null) {
             mapping = new HashMap<>();
         }
-        return parse(typeName, mapping);
+        return parse(type, mapping);
     }
 
     @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
`extractMapping` was left unused, and another variant of it was left only used in one place so it can now be folded into its `parse` caller.