### PR TITLE
[7.x] [ML] allow datafeeds to run if there are any concrete indices (#62827)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -33,7 +33,6 @@ import org.junit.After;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -80,10 +79,9 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         openJob(job.getId());
         assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
 
-        List<String> t = new ArrayList<>(2);
-        t.add("data-1");
-        t.add("data-2");
-        DatafeedConfig datafeedConfig = createDatafeed(job.getId() + "-datafeed", job.getId(), t);
+        // Having a pattern with missing indices is acceptable
+        List<String> indices = Arrays.asList("data-*", "missing-*");
+        DatafeedConfig datafeedConfig = createDatafeed(job.getId() + "-datafeed", job.getId(), indices);
         registerDatafeed(datafeedConfig);
         putDatafeed(datafeedConfig);
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] allow datafeeds to run if there are any concrete indices (#62827)