### PR TITLE
[7.8] [DOCS] Add release highlight for composable index templates

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,12 +30,10 @@ templates often meant copying similar configurations across templates.
 In 7.8, we added a more modular version of index templates called composable
 index templates. You can still define configurations directly in these
 templates. However, composable index templates can also contain component
-templates.
-
-Also added in 7.8, component templates are reusable configurations for mappings,
-index settings, and aliases. With a component template, you can define a
-configuration once and reuse it across multiple index templates. If you later
-need to change the configuration, you only need to change its component
+templates. Also added in 7.8, component templates are reusable configurations
+for mappings, index settings, and aliases. With a component template, you can
+define a configuration once and reuse it across multiple index templates. If you
+later need to change the configuration, you only need to change its component
 template.
 
 Composable index templates replace the previous version of index templates,

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -17,6 +17,33 @@ Other versions:
 | {ref-bare}/7.1/release-highlights-7.1.0.html[7.1]
 | {ref-bare}/7.0/release-highlights-7.0.0.html[7.0]
 
+// tag::notable-highlights[]
+[discrete]
+[[add-composable-index-templates]]
+=== Add composable index templates
+
+Index templates are an easy, repeatable way to configure mappings, index
+settings, and aliases for new indices. However, in previous versions, you had to
+define these configurations directly in the template. Managing multiple
+templates often meant copying similar configurations across templates.
+
+In 7.8, we added a more modular version of index templates called composable
+index templates. You can still define configurations directly in these
+templates. However, composable index templates can also contain component
+templates.
+
+Also added in 7.8, component templates are reusable configurations for mappings,
+index settings, and aliases. With a component template, you can define a
+configuration once and reuse it across multiple index templates. If you later
+need to change the configuration, you only need to change its component
+template.
+
+Composable index templates replace the previous version of index templates,
+which are now deprecated.
+
+To get started with composable index templates, see
+{ref}/index-templates.html[Index templates].
+// end::notable-highlights[]
 
 // tag::notable-highlights[]
 [discrete]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -37,7 +37,8 @@ later need to change the configuration, you only need to change its component
 template.
 
 Composable index templates replace the previous version of index templates,
-which are now deprecated.
+which are now deprecated. If an index matches both a composable template and a
+legacy index template, {es} uses the composable template.
 
 To get started with composable index templates, see
 {ref}/index-templates.html[Index templates].


### PR DESCRIPTION
Adds a 7.8 release highlight for composable index templates.

### Preview
https://elasticsearch_62969.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.8/release-highlights.html#add-composable-index-templates