### PR TITLE
[ML] fixing testTwoJobsWithSameRandomizeSeedUseSameTrainingSet tests

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -641,6 +641,8 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig firstJob = buildAnalytics(firstJobId, sourceIndex, firstJobDestIndex, null,
             new Classification(dependentVariable, boostedTreeParams, null, null, 1, 50.0, null, null));
         putAnalytics(firstJob);
+        startAnalytics(firstJobId);
+        waitUntilAnalyticsIsStopped(firstJobId);
 
         String secondJobId = "classification_two_jobs_with_same_randomize_seed_2";
         String secondJobDestIndex = secondJobId + "_dest";
@@ -650,11 +652,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             new Classification(dependentVariable, boostedTreeParams, null, null, 1, 50.0, randomizeSeed, null));
 
         putAnalytics(secondJob);
-
-        // Let's run both jobs in parallel and wait until they are finished
-        startAnalytics(firstJobId);
         startAnalytics(secondJobId);
-        waitUntilAnalyticsIsStopped(firstJobId);
         waitUntilAnalyticsIsStopped(secondJobId);
 
         // Now we compare they both used the same training rows

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -366,6 +366,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig firstJob = buildAnalytics(firstJobId, sourceIndex, firstJobDestIndex, null,
             new Regression(DEPENDENT_VARIABLE_FIELD, boostedTreeParams, null, 50.0, null, null, null, null));
         putAnalytics(firstJob);
+        startAnalytics(firstJobId);
+        waitUntilAnalyticsIsStopped(firstJobId);
 
         String secondJobId = "regression_two_jobs_with_same_randomize_seed_2";
         String secondJobDestIndex = secondJobId + "_dest";
@@ -375,11 +377,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             new Regression(DEPENDENT_VARIABLE_FIELD, boostedTreeParams, null, 50.0, randomizeSeed, null, null, null));
 
         putAnalytics(secondJob);
-
-        // Let's run both jobs in parallel and wait until they are finished
-        startAnalytics(firstJobId);
         startAnalytics(secondJobId);
-        waitUntilAnalyticsIsStopped(firstJobId);
         waitUntilAnalyticsIsStopped(secondJobId);
 
         // Now we compare they both used the same training rows


### PR DESCRIPTION
This fixes the two test failures.

The shard failure seems to be due to the .ml-stats index being in the middle of being created.

See:
https://github.com/elastic/elasticsearch/blob/d1e963e426aaf490d85075df42fa931a615977c2/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java#L391-L405

We fail grabbing the progress on starting the second job.

This commit splits the creating/starting of the two jobs.

We still want to fail on shard failures like this as knowing the previous progress (if it exists) is vitally important.

closes https://github.com/elastic/elasticsearch/issues/62064
closes https://github.com/elastic/elasticsearch/issues/55807