### PR TITLE
Ensure consistent ordering of hits in test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
@@ -78,6 +78,7 @@ setup:
                script:
                  script:
                    source: "doc['ul'].value.doubleValue() > 10E18"
+          sort: [ { ul: asc } ]
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "4" }
   - match: { hits.hits.1._id: "5" }


### PR DESCRIPTION
50_script_values/Script query fails sometimes
as resulting hits can be ordered differently from expected.
This patch ensures consistent ordering of hits.

Closes #62975