### PR TITLE
Make Rounding.nextRoundingValue consistent

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -1157,7 +1157,7 @@ public abstract class Rounding implements Writeable {
                         }
                         continue;
                     }
-                    assert highEnough && false == tooHigh;
+                    assert highEnough && (false == tooHigh);
                     assert roundedRoundedDown == prevRound;
                     if (iterations > 3 && logger.isDebugEnabled()) {
                         logger.debug("Iterated {} time for {} using {}", iterations, utcMillis, TimeIntervalRounding.this.toString());

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.common;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.LocalTimeOffset.Gap;
@@ -61,6 +63,8 @@ import java.util.concurrent.TimeUnit;
  * a comedy gold mine. If you like time zones. Or hate them.
  */
 public abstract class Rounding implements Writeable {
+    private static final Logger logger = LogManager.getLogger(Rounding.class);
+
     public enum DateTimeUnit {
         WEEK_OF_WEEKYEAR(
             (byte) 1,
@@ -1119,15 +1123,60 @@ public abstract class Rounding implements Writeable {
 
             @Override
             public long nextRoundingValue(long utcMillis) {
-                long from = utcMillis + interval; // TODO this implementation makes me very upset
-                while (from > utcMillis) {
+                /*
+                 * Ok. I'm not proud of this, but it gets the job done. So here is the deal:
+                 * its super important that nextRoundingValue be *exactly* the next rounding
+                 * value. And I can't come up with a nice way to use the java time API to figure
+                 * it out. Thus, we treat "round" like a black box here and run a kind of whacky
+                 * binary search, newton's method hybrid. We don't have a "slope" so we can't do
+                 * a "real" newton's method, so we just sort of cut the diff in half. As janky
+                 * as it looks, it tends to get the job done in under four iterations. Frankly,
+                 * `round(round(utcMillis) + interval)` is usually a good guess so we mostly get
+                 * it in a single iteration. But daylight savings time and other janky stuff can
+                 * make it less likely.
+                 */
+                long prevRound = round(utcMillis);
+                long increment = interval;
+                long from = prevRound;
+                int iterations = 0;
+                while (++iterations < 100) {
+                    from += increment;
                     long rounded = round(from);
-                    if (rounded > utcMillis) {
-                        return rounded;
+                    boolean highEnough = rounded > prevRound;
+                    if (false == highEnough) {
+                        if (increment < 0) {
+                            increment = -increment / 2;
+                        }
+                        continue;
                     }
-                    from += 60000;
+                    long roundedRoundedDown = round(rounded - 1);
+                    boolean tooHigh = roundedRoundedDown > prevRound;
+                    if (tooHigh) {
+                        if (increment > 0) {
+                            increment = -increment / 2;
+                        }
+                        continue;
+                    }
+                    assert highEnough && false == tooHigh;
+                    assert roundedRoundedDown == prevRound;
+                    if (iterations > 3 && logger.isDebugEnabled()) {
+                        logger.debug("Iterated {} time for {} using {}", iterations, utcMillis, TimeIntervalRounding.this.toString());
+                    }
+                    return rounded;
                 }
-                throw new IllegalArgumentException("No rounding available after [" + utcMillis + "] in [" + timeZone + "]");
+                assert false : String.format(
+                    Locale.ROOT,
+                    "Expected to find the rounding in 100 iterations but didn't for [%d] with [%s]",
+                    utcMillis,
+                    TimeIntervalRounding.this.toString()
+                );
+                logger.debug(
+                    "Expected to find the rounding in 100 iterations but didn't for {} using {}",
+                    iterations,
+                    utcMillis,
+                    TimeIntervalRounding.this.toString()
+                );
+                return round(from);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -1172,7 +1172,6 @@ public abstract class Rounding implements Writeable {
                 );
                 logger.debug(
                     "Expected to find the rounding in 100 iterations but didn't for {} using {}",
-                    iterations,
                     utcMillis,
                     TimeIntervalRounding.this.toString()
                 );

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -1164,6 +1164,11 @@ public abstract class Rounding implements Writeable {
                     }
                     return rounded;
                 }
+                /*
+                 * After 100 iterations we still couldn't settle on something! Crazy!
+                 * The most I've seen in tests is 20 and its usually 1 or 2. If we're
+                 * not in a test let's log something and round from our best guess.
+                 */
                 assert false : String.format(
                     Locale.ROOT,
                     "Expected to find the rounding in 100 iterations but didn't for [%d] with [%s]",

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -449,13 +449,13 @@ public class RoundingTests extends ESTestCase {
                     assertThat("Values smaller than rounded value should round further down", prepared.round(roundedDate - 1),
                         lessThan(roundedDate));
                     assertThat("Rounding should be >= previous rounding value", roundedDate, greaterThanOrEqualTo(previousRoundedValue));
+                    assertThat("NextRounding value should be greater than date", nextRoundingValue, greaterThan(roundedDate));
+                    assertThat("NextRounding value rounds to itself", nextRoundingValue,
+                        isDate(rounding.round(nextRoundingValue), tz));
 
                     if (tz.getRules().isFixedOffset()) {
-                        assertThat("NextRounding value should be greater than date", nextRoundingValue, greaterThan(roundedDate));
                         assertThat("NextRounding value should be interval from rounded value", nextRoundingValue - roundedDate,
                             equalTo(interval));
-                        assertThat("NextRounding value should be a rounded date", nextRoundingValue,
-                            equalTo(rounding.round(nextRoundingValue)));
                     }
                     previousRoundedValue = roundedDate;
                 } catch (AssertionError e) {
@@ -467,6 +467,20 @@ public class RoundingTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    public void testFoo() {
+        Rounding rounding = new Rounding.TimeIntervalRounding(960000, ZoneId.of("Europe/Minsk"));
+        long rounded = rounding.prepareForUnknown().round(877824908400L);
+        long next = rounding.prepareForUnknown().nextRoundingValue(rounded);
+        assertThat(next, greaterThan(rounded));
+    }
+
+    public void testBar() {
+        Rounding rounding = new Rounding.TimeIntervalRounding(480000, ZoneId.of("Portugal"));
+        long rounded = rounding.prepareJavaTime().round(972780720000L);
+        long next = rounding.prepareJavaTime().nextRoundingValue(rounded);
+        assertThat(next, greaterThan(rounded));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -469,18 +469,46 @@ public class RoundingTests extends ESTestCase {
         }
     }
 
-    public void testFoo() {
+    /**
+     * Check a {@link Rounding.Prepared#nextRoundingValue} that was difficult
+     * to build well with the java.time APIs.
+     */
+    public void testHardNextRoundingValue() {
         Rounding rounding = new Rounding.TimeIntervalRounding(960000, ZoneId.of("Europe/Minsk"));
         long rounded = rounding.prepareForUnknown().round(877824908400L);
         long next = rounding.prepareForUnknown().nextRoundingValue(rounded);
         assertThat(next, greaterThan(rounded));
     }
 
-    public void testBar() {
+    /**
+     * Check a {@link Rounding.Prepared#nextRoundingValue} that was difficult
+     * to build well with the java.time APIs.
+     */
+    public void testOtherHardNextRoundingValue() {
         Rounding rounding = new Rounding.TimeIntervalRounding(480000, ZoneId.of("Portugal"));
         long rounded = rounding.prepareJavaTime().round(972780720000L);
         long next = rounding.prepareJavaTime().nextRoundingValue(rounded);
         assertThat(next, greaterThan(rounded));
+    }
+
+    /**
+     * Check a {@link Rounding.Prepared#nextRoundingValue} that was difficult
+     * to build well our janky Newton's Method/binary search hybrid.
+     */
+    public void testHardNewtonsMethod() {
+        ZoneId tz = ZoneId.of("Asia/Jerusalem");
+        Rounding rounding = new Rounding.TimeIntervalRounding(19800000, tz);
+        assertThat(rounding.prepareJavaTime().nextRoundingValue(1824929914182L), isDate(time("2027-10-31T01:30:00", tz), tz));
+    }
+
+    /**
+     * Check a {@link Rounding.Prepared#nextRoundingValue} that was difficult
+     * to build well with the java.time APIs.
+     */
+    public void testOtherHardNewtonsMethod() {
+        ZoneId tz = ZoneId.of("America/Glace_Bay");
+        Rounding rounding = new Rounding.TimeIntervalRounding(13800000, tz);
+        assertThat(rounding.prepareJavaTime().nextRoundingValue(1383463147373L), isDate(time("2013-11-03T03:40:00", tz), tz));
     }
 
     /**


### PR DESCRIPTION
"interval" style roundings were implementing `nextRoundingValue` in a
fairly inconsistent way - it'd produce a value, but sometimes that
value would be the same as the previous rounding value. This makes it
consistently the next value that `rounding` would make.
