### PR TITLE
[7.9][DOCS] Expands footnote about dest index

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -220,7 +220,10 @@ contains "Firefox". Finally, in every other case, the value of the field is
 returned.
 <3> The aggregations object contains filters that narrow down the results to 
 documents that contains `200`, `404`, or `503` values in the `response` field.
-<4> Specifies the destination index of the {transform}.
+<4> Specifies the destination index of the {transform}. As the mappings of 
+fields created by scrips cannot be deduced, please define the mappings of the 
+destination index prior to creating the {transform}.
+
 
 The API returns the following result:
 


### PR DESCRIPTION
## Overview

This PR expands the footnote of a Painless snippet with further info on destination index mapping.

### Preview

[Using Painless in `group_by`](https://elasticsearch_62994.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/transform-painless-examples.html#painless-group-by)