### PR TITLE
[7.x] [ML] fixing testTwoJobsWithSameRandomizeSeedUseSameTrainingSet tests (#62976)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -643,6 +643,8 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig firstJob = buildAnalytics(firstJobId, sourceIndex, firstJobDestIndex, null,
             new Classification(dependentVariable, boostedTreeParams, null, null, 1, 50.0, null, null));
         putAnalytics(firstJob);
+        startAnalytics(firstJobId);
+        waitUntilAnalyticsIsStopped(firstJobId);
 
         String secondJobId = "classification_two_jobs_with_same_randomize_seed_2";
         String secondJobDestIndex = secondJobId + "_dest";
@@ -652,11 +654,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             new Classification(dependentVariable, boostedTreeParams, null, null, 1, 50.0, randomizeSeed, null));
 
         putAnalytics(secondJob);
-
-        // Let's run both jobs in parallel and wait until they are finished
-        startAnalytics(firstJobId);
         startAnalytics(secondJobId);
-        waitUntilAnalyticsIsStopped(firstJobId);
         waitUntilAnalyticsIsStopped(secondJobId);
 
         // Now we compare they both used the same training rows

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -324,7 +324,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/55807")
     public void testTwoJobsWithSameRandomizeSeedUseSameTrainingSet() throws Exception {
         String sourceIndex = "regression_two_jobs_with_same_randomize_seed_source";
         indexData(sourceIndex, 100, 0);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -343,6 +343,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig firstJob = buildAnalytics(firstJobId, sourceIndex, firstJobDestIndex, null,
             new Regression(DEPENDENT_VARIABLE_FIELD, boostedTreeParams, null, 50.0, null, null, null, null));
         putAnalytics(firstJob);
+        startAnalytics(firstJobId);
+        waitUntilAnalyticsIsStopped(firstJobId);
 
         String secondJobId = "regression_two_jobs_with_same_randomize_seed_2";
         String secondJobDestIndex = secondJobId + "_dest";
@@ -352,11 +354,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             new Regression(DEPENDENT_VARIABLE_FIELD, boostedTreeParams, null, 50.0, randomizeSeed, null, null, null));
 
         putAnalytics(secondJob);
-
-        // Let's run both jobs in parallel and wait until they are finished
-        startAnalytics(firstJobId);
         startAnalytics(secondJobId);
-        waitUntilAnalyticsIsStopped(firstJobId);
         waitUntilAnalyticsIsStopped(secondJobId);
 
         // Now we compare they both used the same training rows


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fixing testTwoJobsWithSameRandomizeSeedUseSameTrainingSet tests (#62976)