### PR TITLE
[DOCS] Fix elasticsearch-croneval chunking

### DIFF
--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -318,6 +318,7 @@ as such may be:
 Like most design decisions, this is the basis of a trade-off in which we have chosen to provide fast performance at the cost of some (typically small) inaccuracies.
 However, the `size` and `shard size` settings covered in the next section provide tools to help control the accuracy levels.
 
+[[significantterms-aggregation-parameters]]
 ==== Parameters
 
 ===== JLH score

--- a/docs/reference/aggregations/bucket/significanttext-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significanttext-aggregation.asciidoc
@@ -345,6 +345,7 @@ as such may be:
 Like most design decisions, this is the basis of a trade-off in which we have chosen to provide fast performance at the cost of some (typically small) inaccuracies.
 However, the `size` and `shard size` settings covered in the next section provide tools to help control the accuracy levels.
 
+[[significanttext-aggregation-parameters]]
 ==== Parameters
 
 ===== Significance heuristics

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -450,6 +450,7 @@ Returns:
 By default `flat_settings` is set to `false`.
 
 [discrete]
+[[api-conventions-parameters]]
 ==== Parameters
 
 Rest parameters (when using HTTP, map to HTTP URL parameters) follow the

--- a/docs/reference/commands/certgen.asciidoc
+++ b/docs/reference/commands/certgen.asciidoc
@@ -55,6 +55,7 @@ signed certificates must be in PEM format to work with the {stack}
 {security-features}.
 
 [discrete]
+[[certgen-parameters]]
 === Parameters
 
 `--cert <cert_file>`:: Specifies to generate new instance certificates and keys

--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -124,6 +124,7 @@ for use in {es} and {kib}. Each folder in the zip file contains a readme that
 explains how to use the files.
 
 [discrete]
+[[certutil-parameters]]
 === Parameters
 
 `ca`:: Specifies to generate a new local certificate authority (CA). This

--- a/docs/reference/commands/croneval.asciidoc
+++ b/docs/reference/commands/croneval.asciidoc
@@ -24,6 +24,8 @@ cron expressions are valid for use with
 
 This command is provided in the `$ES_HOME/bin` directory.
 
+[discrete]
+[[elasticsearch-croneval-parameters]]
 === Parameters
 
 `-c, --count` <Integer>::

--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -322,6 +322,7 @@ its job.
 
 
 [discrete]
+[[node-tool-parameters]]
 === Parameters
 
 `repurpose`:: Delete excess data when a node's roles are changed.

--- a/docs/reference/commands/saml-metadata.asciidoc
+++ b/docs/reference/commands/saml-metadata.asciidoc
@@ -45,6 +45,7 @@ are prompted to enter the password when you run the
 `elasticsearch-saml-metadata` command.
 
 [discrete]
+[[saml-metadata-parameters]]
 === Parameters
 
 `--attribute <name>`:: Specifies a SAML attribute that should be

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -41,6 +41,7 @@ option. For more information about debugging connection failures, see
 <<trb-security-setup>>.
 
 [discrete]
+[[setup-passwords-parameters]]
 === Parameters
 
 `auto`::  Outputs randomly-generated passwords to the console.

--- a/docs/reference/commands/syskeygen.asciidoc
+++ b/docs/reference/commands/syskeygen.asciidoc
@@ -28,6 +28,7 @@ IMPORTANT: The system key is a symmetric key, so the same key must be used on
 every node in the cluster.
 
 [discrete]
+[[syskeygen-parameters]]
 === Parameters
 
 `-E <KeyValuePair>`:: Configures a setting. For example, if you have a custom

--- a/docs/reference/commands/users-command.asciidoc
+++ b/docs/reference/commands/users-command.asciidoc
@@ -41,6 +41,7 @@ command as root or some other user updates the permissions for the `users` and
 `users_roles` files and prevents {es} from accessing them.
 
 [discrete]
+[[users-command-parameters]]
 === Parameters
 
 `-a <roles>`:: If used with the `roles` parameter, adds a comma-separated list

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1190,3 +1190,8 @@ For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
 === Avoid oversharding
 
 See <<size-your-shards>>.
+
+[role="exclude",id="_parameters_8"]
+=== elasticsearch-croneval parameters
+
+See <<elasticsearch-croneval-parameters>>.


### PR DESCRIPTION
Previously, the `elasticsearch-croneval` tool's parameters were on a separate page.

This fixes the chunking and fixes several auto-generated anchors.