### PR TITLE
[7.x] [DOCS] Fix painless-datetime example script error (#62811)

### DIFF
--- a/docs/painless/painless-guide/painless-datetime.asciidoc
+++ b/docs/painless/painless-guide/painless-datetime.asciidoc
@@ -710,7 +710,7 @@ long elapsedTime = now - millisDateTime;
 [source,Painless]
 ----
 String nowString = params['now'];
-ZonedDateTime nowZdt = ZonedDateTime.parse(datetime); <1>
+ZonedDateTime nowZdt = ZonedDateTime.parse(nowString); <1>
 long now = ZonedDateTime.toInstant().toEpochMilli();
 ZonedDateTime inputDateTime = doc['input_datetime'];
 long millisDateTime = zdt.toInstant().toEpochMilli();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix plainess-datetime example script error (#62811)