### PR TITLE
Add support for x_opaque_id to _cat/tasks

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
@@ -17,3 +17,18 @@
       $body: |
                / # action  task_id      parent_task_id      type    start_time   timestamp            running_time  ip                                  node   description
                ^(  \S+\s+  \S+\:\d+\s+  (?:\-|\S+\:\d+)\s+  \S+\s+  \d+\s+       \d\d\:\d\d\:\d\d\s+  \S+\s+        \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\s+  \S+\s+ .*\n)+$/
+
+---
+"Test cat tasks output with X-Opaque-Id":
+  - skip:
+      features: headers
+
+  - do:
+      headers: { "X-Opaque-Id": "TestID" }
+      cat.tasks:
+        h: ["action", "x_opaque_id"]
+
+  - match:
+      $body: |
+        / # action                        x_opaque_id
+        ^.*cluster\:monitor/tasks/lists\s+TestID\n.*$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
@@ -21,6 +21,8 @@
 ---
 "Test cat tasks output with X-Opaque-Id":
   - skip:
+      version: " - 7.99.99"
+      reason: support for opaque_id was added in 8.0.0
       features: headers
 
   - do:
@@ -29,6 +31,4 @@
         h: ["action", "x_opaque_id"]
 
   - match:
-      $body: |
-        / # action                        x_opaque_id
-        ^.*cluster\:monitor/tasks/lists\s+TestID\n.*$/
+      $body: / ^.*TestID\n.*$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
@@ -31,4 +31,4 @@
         h: ["action", "x_opaque_id"]
 
   - match:
-      $body: / ^.*TestID\n.*$/
+      $body: /TestID/

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestResponseListener;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskInfo;
 
 import java.time.Instant;
@@ -116,6 +117,7 @@ public class RestTasksAction extends AbstractCatAction {
         table.addCell("port", "default:false;alias:po;desc:bound transport port");
         table.addCell("node", "default:true;alias:n;desc:node name");
         table.addCell("version", "default:false;alias:v;desc:es version");
+        table.addCell("x_opaque_id", "default:false;alias:x;desc:X-Opaque-ID header");
 
         // Task detailed info
         if (detailed) {
@@ -152,6 +154,7 @@ public class RestTasksAction extends AbstractCatAction {
         table.addCell(node.getAddress().address().getPort());
         table.addCell(node == null ? "-" : node.getName());
         table.addCell(node == null ? "-" : node.getVersion().toString());
+        table.addCell(taskInfo.getHeaders().getOrDefault(Task.X_OPAQUE_ID, "-"));
 
         if (detailed) {
             table.addCell(taskInfo.getDescription());


### PR DESCRIPTION
Adds an optional column with support for x_opaque_id to _cat/tasks API.

Closes #61118
