### PR TITLE
Fix API key role descriptors rewrite bug for upgraded clusters (#62917)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -136,7 +137,7 @@ public class SecurityContextTests extends ESTestCase {
         assertEquals(original, securityContext.getAuthentication());
     }
 
-    public void testExecuteAfterRewritingAuthenticationShouldRewriteApiKeyMetadataForBwc() throws IOException {
+    public void testExecuteAfterRewritingAuthenticationWillConditionallyRewriteNewApiKeyMetadata() throws IOException {
         User user = new User("test", null, new User("authUser"));
         RealmRef authBy = new RealmRef("_es_api_key", "_es_api_key", "node1");
         final Map<String, Object> metadata = org.elasticsearch.common.collect.Map.of(
@@ -147,6 +148,7 @@ public class SecurityContextTests extends ESTestCase {
             AuthenticationType.API_KEY, metadata);
         original.writeToContext(threadContext);
 
+        // If target is old node, rewrite new style API key metadata to old format
         securityContext.executeAfterRewritingAuthentication(originalCtx -> {
             Authentication authentication = securityContext.getAuthentication();
             assertEquals(org.elasticsearch.common.collect.Map.of("a role",
@@ -156,9 +158,15 @@ public class SecurityContextTests extends ESTestCase {
                 org.elasticsearch.common.collect.Map.of("cluster", org.elasticsearch.common.collect.List.of("all"))),
                 authentication.getMetadata().get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY));
         }, Version.V_7_8_0);
+
+        // If target is new node, no need to rewrite the new style API key metadata
+        securityContext.executeAfterRewritingAuthentication(originalCtx -> {
+            Authentication authentication = securityContext.getAuthentication();
+            assertSame(metadata, authentication.getMetadata());
+        }, VersionUtils.randomVersionBetween(random(), VERSION_API_KEY_ROLES_AS_BYTES, Version.CURRENT));
     }
 
-    public void testExecuteAfterRewritingAuthenticationShouldNotRewriteApiKeyMetadataForOldAuthenticationObject() throws IOException {
+    public void testExecuteAfterRewritingAuthenticationWillConditionallyRewriteOldApiKeyMetadata() throws IOException {
         User user = new User("test", null, new User("authUser"));
         RealmRef authBy = new RealmRef("_es_api_key", "_es_api_key", "node1");
         final Map<String, Object> metadata = org.elasticsearch.common.collect.Map.of(
@@ -170,9 +178,19 @@ public class SecurityContextTests extends ESTestCase {
         final Authentication original = new Authentication(user, authBy, authBy, Version.V_7_8_0, AuthenticationType.API_KEY, metadata);
         original.writeToContext(threadContext);
 
+        // If target is old node, no need to rewrite old style API key metadata
         securityContext.executeAfterRewritingAuthentication(originalCtx -> {
             Authentication authentication = securityContext.getAuthentication();
             assertSame(metadata, authentication.getMetadata());
-        }, randomFrom(VERSION_API_KEY_ROLES_AS_BYTES, Version.V_7_8_0));
+        }, Version.V_7_8_0);
+
+        // If target is new old, ensure old map style API key metadata is rewritten to bytesreference
+        securityContext.executeAfterRewritingAuthentication(originalCtx -> {
+            Authentication authentication = securityContext.getAuthentication();
+            assertEquals("{\"a role\":{\"cluster\":[\"all\"]}}",
+                ((BytesReference)authentication.getMetadata().get(API_KEY_ROLE_DESCRIPTORS_KEY)).utf8ToString());
+            assertEquals("{\"limitedBy role\":{\"cluster\":[\"all\"]}}",
+                ((BytesReference)authentication.getMetadata().get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY)).utf8ToString());
+        }, VersionUtils.randomVersionBetween(random(), VERSION_API_KEY_ROLES_AS_BYTES, Version.CURRENT));
     }
 }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -63,6 +63,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
       setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
+
+      setting 'xpack.security.authc.api_key.enabled', 'true'
     }
   }
 

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -64,7 +64,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
       keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
       setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
 
-      setting 'xpack.security.authc.api_key.enabled', 'true'
+      if (bwcVersion.onOrAfter('6.7.0')) {
+        setting 'xpack.security.authc.api_key.enabled', 'true'
+      }
     }
   }
 

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -10,6 +10,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -58,6 +59,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
@@ -238,6 +240,45 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     assertThat(states, everyItem(is("stopped")));
                 });
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testWatcherWithApiKey() throws Exception {
+        final Request getWatchStatusRequest = new Request("GET", "/_watcher/watch/watch_with_api_key");
+        getWatchStatusRequest.addParameter("filter_path", "status");
+
+        if (isRunningAgainstOldCluster()) {
+            final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
+            createApiKeyRequest.setJsonEntity("{\"name\":\"key-1\"}");
+            final Response response = client().performRequest(createApiKeyRequest);
+            final Map<String, Object> createApiKeyResponse = entityAsMap(response);
+
+            Request createWatchWithApiKeyRequest = new Request("PUT", "/_watcher/watch/watch_with_api_key");
+            createWatchWithApiKeyRequest.setJsonEntity(loadWatch("simple-watch.json"));
+            final byte[] keyBytes =
+                (createApiKeyResponse.get("id") + ":" + createApiKeyResponse.get("api_key")).getBytes(StandardCharsets.UTF_8);
+            final String authHeader = "ApiKey " + Base64.getEncoder().encodeToString(keyBytes);
+            createWatchWithApiKeyRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", authHeader));
+            client().performRequest(createWatchWithApiKeyRequest);
+
+            assertBusy(() -> {
+                final Map<String, Object> getWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
+                final Map<String, Object> status = (Map<String, Object>) getWatchStatusResponse.get("status");
+                assertEquals("executed", status.get("execution_state"));
+            });
+
+        } else {
+            final Map<String, Object> getWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
+            final Map<String, Object> status = (Map<String, Object>) getWatchStatusResponse.get("status");
+            final int version = (int) status.get("version");
+
+            assertBusy(() -> {
+                final Map<String, Object> newGetWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
+                final Map<String, Object> newStatus = (Map<String, Object>) newGetWatchStatusResponse.get("status");
+                assertThat((int) newStatus.get("version"), greaterThan(version + 2));
+                assertEquals("executed", newStatus.get("execution_state"));
+            });
         }
     }
 

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -230,6 +230,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     @SuppressWarnings("unchecked")
     public void testWatcherWithApiKey() throws Exception {
+        assumeTrue("API key is available since 6.7.0", getOldClusterVersion().onOrAfter(Version.V_6_7_0));
         if (isRunningAgainstOldCluster()) {
             final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
             createApiKeyRequest.setJsonEntity("{\"name\":\"key-1\",\"role_descriptors\":" +

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -213,14 +213,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
 
             // Wait for watcher to actually start....
-            Map<String, Object> startWatchResponse = entityAsMap(client().performRequest(new Request("POST", "_watcher/_start")));
-            assertThat(startWatchResponse.get("acknowledged"), equalTo(Boolean.TRUE));
-            assertBusy(() -> {
-                Map<String, Object> statsWatchResponse = entityAsMap(client().performRequest(new Request("GET", "_watcher/stats")));
-                List<?> states = ((List<?>) statsWatchResponse.get("stats"))
-                    .stream().map(o -> ((Map<?, ?>) o).get("watcher_state")).collect(Collectors.toList());
-                assertThat(states, everyItem(is("started")));
-            });
+            startWatcher();
 
             try {
                 assertOldTemplatesAreDeleted();
@@ -230,15 +223,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 /* Shut down watcher after every test because watcher can be a bit finicky about shutting down when the node shuts
                  * down. This makes super sure it shuts down *and* causes the test to fail in a sensible spot if it doesn't shut down.
                  */
-                Map<String, Object> stopWatchResponse = entityAsMap(client().performRequest(new Request("POST", "_watcher/_stop")));
-                assertThat(stopWatchResponse.get("acknowledged"), equalTo(Boolean.TRUE));
-                assertBusy(() -> {
-                    Map<String, Object> statsStoppedWatchResponse = entityAsMap(client().performRequest(
-                        new Request("GET", "_watcher/stats")));
-                    List<?> states = ((List<?>) statsStoppedWatchResponse.get("stats"))
-                        .stream().map(o -> ((Map<?, ?>) o).get("watcher_state")).collect(Collectors.toList());
-                    assertThat(states, everyItem(is("stopped")));
-                });
+                stopWatcher();
             }
         }
     }
@@ -255,7 +240,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             final Map<String, Object> createApiKeyResponse = entityAsMap(response);
 
             Request createWatchWithApiKeyRequest = new Request("PUT", "/_watcher/watch/watch_with_api_key");
-            createWatchWithApiKeyRequest.setJsonEntity(loadWatch("simple-watch.json"));
+            createWatchWithApiKeyRequest.setJsonEntity(loadWatch("logging-watch.json"));
             final byte[] keyBytes =
                 (createApiKeyResponse.get("id") + ":" + createApiKeyResponse.get("api_key")).getBytes(StandardCharsets.UTF_8);
             final String authHeader = "ApiKey " + Base64.getEncoder().encodeToString(keyBytes);
@@ -269,16 +254,32 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             });
 
         } else {
-            final Map<String, Object> getWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
-            final Map<String, Object> status = (Map<String, Object>) getWatchStatusResponse.get("status");
-            final int version = (int) status.get("version");
+            logger.info("testing against {}", getOldClusterVersion());
+            try {
+                waitForYellow(".watches,.watcher-history*");
+            } catch (ResponseException e) {
+                String rsp = toStr(client().performRequest(new Request("GET", "/_cluster/state")));
+                logger.info("cluster_state_response=\n{}", rsp);
+                throw e;
+            }
 
-            assertBusy(() -> {
-                final Map<String, Object> newGetWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
-                final Map<String, Object> newStatus = (Map<String, Object>) newGetWatchStatusResponse.get("status");
-                assertThat((int) newStatus.get("version"), greaterThan(version + 2));
-                assertEquals("executed", newStatus.get("execution_state"));
-            });
+            // Wait for watcher to actually start....
+            startWatcher();
+
+            try {
+                final Map<String, Object> getWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
+                final Map<String, Object> status = (Map<String, Object>) getWatchStatusResponse.get("status");
+                final int version = (int) status.get("version");
+
+                assertBusy(() -> {
+                    final Map<String, Object> newGetWatchStatusResponse = entityAsMap(client().performRequest(getWatchStatusRequest));
+                    final Map<String, Object> newStatus = (Map<String, Object>) newGetWatchStatusResponse.get("status");
+                    assertThat((int) newStatus.get("version"), greaterThan(version + 2));
+                    assertEquals("executed", newStatus.get("execution_state"));
+                });
+            } finally {
+                stopWatcher();
+            }
         }
     }
 
@@ -690,6 +691,29 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 throw ioe;
             }
         }, 30, TimeUnit.SECONDS);
+    }
+
+    private void startWatcher() throws Exception {
+        Map<String, Object> startWatchResponse = entityAsMap(client().performRequest(new Request("POST", "_watcher/_start")));
+        assertThat(startWatchResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        assertBusy(() -> {
+            Map<String, Object> statsWatchResponse = entityAsMap(client().performRequest(new Request("GET", "_watcher/stats")));
+            List<?> states = ((List<?>) statsWatchResponse.get("stats"))
+                .stream().map(o -> ((Map<?, ?>) o).get("watcher_state")).collect(Collectors.toList());
+            assertThat(states, everyItem(is("started")));
+        });
+    }
+
+    private void stopWatcher() throws Exception {
+        Map<String, Object> stopWatchResponse = entityAsMap(client().performRequest(new Request("POST", "_watcher/_stop")));
+        assertThat(stopWatchResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        assertBusy(() -> {
+            Map<String, Object> statsStoppedWatchResponse = entityAsMap(client().performRequest(
+                new Request("GET", "_watcher/stats")));
+            List<?> states = ((List<?>) statsStoppedWatchResponse.get("stats"))
+                .stream().map(o -> ((Map<?, ?>) o).get("watcher_state")).collect(Collectors.toList());
+            assertThat(states, everyItem(is("stopped")));
+        });
     }
 
     static String toStr(Response response) throws IOException {

--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
@@ -16,7 +16,7 @@
       }
     }
   },
-  "throttle_period": "1s",
+  "throttle_period_in_millis": 500,
   "actions" : {
     "log" : {
       "logging" : {

--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
@@ -1,0 +1,27 @@
+{
+  "trigger" : {
+    "schedule": {
+      "interval": "1s"
+    }
+  },
+  "input" : {
+    "search" : {
+      "timeout": "100s",
+      "request" : {
+        "indices" : [ ".watches" ],
+        "body" : {
+          "query" : { "match_all" : {}},
+          "size": 1
+        }
+      }
+    }
+  },
+  "throttle_period": "1s",
+  "actions" : {
+    "log" : {
+      "logging" : {
+        "text" : "watcher search result: {{ctx.payload}}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR ensures that API key role descriptors are always rewritten to a target node
compatible format before a request is sent.
