### PR TITLE
Fix test failure for watcher with API key in upgraded cluster

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
@@ -1,0 +1,27 @@
+{
+  "trigger" : {
+    "schedule": {
+      "interval": "1s"
+    }
+  },
+  "input" : {
+    "search" : {
+      "timeout": "100s",
+      "request" : {
+        "indices" : [ ".watches" ],
+        "body" : {
+          "query" : { "match_all" : {}},
+          "size": 1
+        }
+      }
+    }
+  },
+  "throttle_period": "1s",
+  "actions" : {
+    "log" : {
+      "logging" : {
+        "text" : "watcher search result: {{ctx.payload}}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Depending on the execution order of different tests, the watcher service may be stopped when the failed test runs. 
This PR ensure the watcher service is started before test assetions.