### PR TITLE
Fix possible test failure for API key BWC with earlier versions

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -216,7 +216,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
         if (isRunningAgainstOldCluster()) {
             final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
-            createApiKeyRequest.setJsonEntity("{\"name\":\"key-1\"}");
+            createApiKeyRequest.setJsonEntity("{\"name\":\"key-1\",\"role_descriptors\":" +
+                "{\"r\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"*\"],\"privileges\":[\"all\"]}]}}}");
             final Response response = client().performRequest(createApiKeyRequest);
             final Map<String, Object> createApiKeyResponse = entityAsMap(response);
 

--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/logging-watch.json
@@ -16,7 +16,7 @@
       }
     }
   },
-  "throttle_period": "1s",
+  "throttle_period_in_millis": 500,
   "actions" : {
     "log" : {
       "logging" : {


### PR DESCRIPTION
In earlier versions, e.g. 7.0, creation of API keys mandate the role_descriptors field. 
This PR ensure role_descriptors field is always specified. 
Also the watcher created with the API key has interval of 1s and throttle of 1s as well.
In rare cases, the watcher state may happen to be throttled instead of executed during
the assertion period. This PR reduces the throttle to 500ms.