### PR TITLE
[7.9][DOCS] Adds create index and mapping statements to one of the Painless examples

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -164,6 +164,7 @@ Create the index:
 --------------------------------------------------
 PUT /pivot_logs
 --------------------------------------------------
+// NOTCONSOLE
 
 
 Create the mapping of the index:
@@ -180,6 +181,7 @@ PUT /pivot_logs/_mapping
   }
 }
 --------------------------------------------------
+// NOTCONSOLE
 
 
 Then you can create the {transform}. The example below shows you how to create a 

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -164,7 +164,7 @@ Create the index:
 --------------------------------------------------
 PUT /pivot_logs
 --------------------------------------------------
-// NOTCONSOLE
+// TEST[skip:setup kibana sample data]
 
 
 Create the mapping of the index:
@@ -181,8 +181,7 @@ PUT /pivot_logs/_mapping
   }
 }
 --------------------------------------------------
-// NOTCONSOLE
-
+// TEST[skip:setup kibana sample data]
 
 Then you can create the {transform}. The example below shows you how to create a 
 preview of the {transform}.

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -153,6 +153,38 @@ a script. The following example uses the {kib} sample web logs dataset. The goal
 here is to make the {transform} output easier to understand through normalizing 
 the value of the fields that the data is grouped by.
 
+If you use scripts in `group_by`, the {transform} cannot deduce the mappings of 
+the field. For this reason, you need to create the destination index and its 
+mappings prior to creating the {transform}. Please refer to the example below.
+
+
+Create the index:
+
+[source,console]
+--------------------------------------------------
+PUT /pivot_logs
+--------------------------------------------------
+
+
+Create the mapping of the index:
+
+[source,console]
+--------------------------------------------------
+PUT /pivot_logs/_mapping
+{
+  "properties": {
+    "200": {"type": "long"},
+    "404":  { "type": "long"},
+    "503":  { "type": "long"},
+    "agent":  { "type": "keyword"}
+  }
+}
+--------------------------------------------------
+
+
+Then you can create the {transform}. The example below shows you how to create a 
+preview of the {transform}.
+
 [source,console]
 --------------------------------------------------
 POST _transform/_preview


### PR DESCRIPTION
## Overview

This PR adds the create index and create index mapping statements to the `Painless in group_by` example. It applies to 7.7, 7.8, and 7.9.2.

The additions can be deleted from the 7.9 branch when 7.9.3 is released.

### Preview

[Using Painless in `group_by`](https://elasticsearch_63060.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.9/transform-painless-examples.html#painless-group-by)