### PR TITLE
[ML] Adjust wire serialization code after backport to 7.x

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -246,11 +245,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
 
         public Result(StreamInput in) throws IOException {
             this.score = in.readDouble();
-            if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-                this.docCount = in.readOptionalLong();
-            }  else {
-                this.docCount = null;
-            }
+            this.docCount = in.readOptionalLong();
             this.curve = in.readList(AucRocPoint::new);
         }
 
@@ -279,9 +274,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeDouble(score);
-            if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-                out.writeOptionalLong(docCount);
-            }
+            out.writeOptionalLong(docCount);
             out.writeList(curve);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
@@ -246,7 +246,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
 
         public Result(StreamInput in) throws IOException {
             this.score = in.readDouble();
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
                 this.docCount = in.readOptionalLong();
             }  else {
                 this.docCount = null;
@@ -279,7 +279,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeDouble(score);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
                 out.writeOptionalLong(docCount);
             }
             out.writeList(curve);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -97,18 +96,14 @@ public class Classification implements Evaluation {
     }
 
     public Classification(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-            this.fields =
-                new EvaluationFields(
-                    in.readString(),
-                    in.readOptionalString(),
-                    in.readOptionalString(),
-                    in.readOptionalString(),
-                    in.readOptionalString(),
-                    true);
-        } else {
-            this.fields = new EvaluationFields(in.readString(), in.readString(), null, null, null, true);
-        }
+        this.fields =
+            new EvaluationFields(
+                in.readString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                true);
         this.metrics = in.readNamedWriteableList(EvaluationMetric.class);
     }
 
@@ -135,14 +130,10 @@ public class Classification implements Evaluation {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fields.getActualField());
-        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-            out.writeOptionalString(fields.getPredictedField());
-            out.writeOptionalString(fields.getTopClassesField());
-            out.writeOptionalString(fields.getPredictedClassField());
-            out.writeOptionalString(fields.getPredictedProbabilityField());
-        } else {
-            out.writeString(fields.getPredictedField());
-        }
+        out.writeOptionalString(fields.getPredictedField());
+        out.writeOptionalString(fields.getTopClassesField());
+        out.writeOptionalString(fields.getPredictedClassField());
+        out.writeOptionalString(fields.getPredictedProbabilityField());
         out.writeNamedWriteableList(metrics);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -97,7 +97,7 @@ public class Classification implements Evaluation {
     }
 
     public Classification(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             this.fields =
                 new EvaluationFields(
                     in.readString(),
@@ -135,7 +135,7 @@ public class Classification implements Evaluation {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fields.getActualField());
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
             out.writeOptionalString(fields.getPredictedField());
             out.writeOptionalString(fields.getTopClassesField());
             out.writeOptionalString(fields.getPredictedClassField());


### PR DESCRIPTION
This PR adjusts wire serialization code for `Classification` and `AbstractAucRoc` classes after backport to 7.x

Relates #62160