### PR TITLE
[7.9] [DOCS] Updated target_field description of the json ingest processor (#61968)

### DIFF
--- a/docs/reference/ingest/processors/json.asciidoc
+++ b/docs/reference/ingest/processors/json.asciidoc
@@ -11,8 +11,8 @@ Converts a JSON string into a structured JSON object.
 [options="header"]
 |======
 | Name           | Required  | Default  | Description
-| `field`        | yes       | -        | The field to be parsed
-| `target_field` | no        | `field`  | The field to insert the converted structured object into
+| `field`        | yes       | -        | The field to be parsed.
+| `target_field` | no        | `field`  | The field that the converted structured object will be written into. Any existing content in this field will be overwritten.
 | `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
 include::common-options.asciidoc[]
 |======


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Updated target_field description of the json ingest processor (#61968)