### PR TITLE
[DOCS] Document escaped backticks for identifiers

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -56,7 +56,7 @@ any where network.protocol == "http"
 
 [discrete]
 [[eql-syntax-escape-identifiers]]
-==== Escape an event category or field name
+===== Escape an event category or field name
 
 Event categories or field names that contain a hyphen (`-`), contain a space, or
 start with a numeral must be escaped with enclosing backticks (+++`+++).

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -55,6 +55,30 @@ any where network.protocol == "http"
 ----
 
 [discrete]
+[[eql-syntax-escape-identifiers]]
+==== Escape an event category or field name
+
+Event categories or field names containing non-alphanumeric characters must be
+escaped with enclosing backticks (+++`+++). Non-alphanumeric characters include
+underscores (`_`), dots (`.`), hyphens (`-`), or spaces.
+
+[source,eql]
+----
+`my_field`
+`my.field`
+`my-field`
+`my field`
+----
+
+Any backticks (+++`+++) in an event category or field name must be escaped using
+double backticks (+++``+++).
+
+[source,eql]
+----
+my`field -> `my``field`
+----
+
+[discrete]
 [[eql-syntax-conditions]]
 ==== Conditions
 
@@ -300,8 +324,8 @@ any where true
 ----
 
 [discrete]
-[[eql-syntax-escaped-characters]]
-===== Escaped characters
+[[eql-syntax-escape-characters]]
+===== Escape characters in a string
 
 When used within a string, special characters, such as a carriage return or
 double quote (`"`), must be escaped with a preceding backslash (`\`).
@@ -354,21 +378,6 @@ in the resulting string.
 Raw strings cannot contain only a single backslash or end in an odd number of
 backslashes.
 ====
-
-[discrete]
-[[eql-syntax-non-alpha-field-names]]
-==== Non-alphanumeric field names
-
-Field names containing non-alphanumeric characters, such as underscores (`_`),
-dots (`.`), hyphens (`-`), or spaces, must be escaped using backticks (+++`+++).
-
-[source,eql]
-----
-`my_field`
-`my.field`
-`my-field`
-`my field`
-----
 
 [discrete]
 [[eql-sequences]]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -58,16 +58,14 @@ any where network.protocol == "http"
 [[eql-syntax-escape-identifiers]]
 ==== Escape an event category or field name
 
-Event categories or field names containing non-alphanumeric characters must be
-escaped with enclosing backticks (+++`+++). Non-alphanumeric characters include
-underscores (`_`), dots (`.`), hyphens (`-`), or spaces.
+Event categories or field names that contain a hyphen (`-`), contain a space, or
+start with a numeral must be escaped with enclosing backticks (+++`+++).
 
 [source,eql]
 ----
-`my_field`
-`my.field`
 `my-field`
 `my field`
+`6myfield`
 ----
 
 Any backticks (+++`+++) in an event category or field name must be escaped using


### PR DESCRIPTION
Relates to #62932

### Preview
https://elasticsearch_63079.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-syntax-escape-identifiers