### PR TITLE
Support invalidating API keys with multiple IDs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -2136,7 +2136,8 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
         {
             // tag::invalidate-api-key-id-request
-            InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(createApiKeyResponse1.getId(), false);
+            InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyIds(
+                new String[]{ createApiKeyResponse1.getId() }, false);
             // end::invalidate-api-key-id-request
 
             // tag::invalidate-api-key-execute
@@ -2255,7 +2256,8 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(createApiKeyResponse6.getName(), equalTo("k6"));
             assertNotNull(createApiKeyResponse6.getKey());
 
-            InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(createApiKeyResponse6.getId(), false);
+            InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyIds(
+                new String[]{ createApiKeyResponse6.getId() }, false);
 
             ActionListener<InvalidateApiKeyResponse> listener;
             // tag::invalidate-api-key-execute-listener

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
@@ -31,7 +31,8 @@ import static org.hamcrest.Matchers.is;
 public class InvalidateApiKeyRequestTests extends ESTestCase {
 
     public void testRequestValidation() {
-        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5), randomBoolean());
+        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[]{ randomAlphaOfLength(5) }, randomBoolean());
         Optional<ValidationException> ve = request.validate();
         assertThat(ve.isPresent(), is(false));
         request = InvalidateApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5), randomBoolean());
@@ -61,11 +62,11 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
                 { "realm", randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), "true" },
                 { randomNullOrEmptyString(), "user", randomNullOrEmptyString(), randomNullOrEmptyString(), "true" } };
         String[] expectedErrorMessages = new String[] {
-                "One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false",
-                "username or realm name must not be specified when the api key id or api key name is specified",
-                "username or realm name must not be specified when the api key id or api key name is specified",
-                "username or realm name must not be specified when the api key id or api key name is specified",
-                "only one of [api key id, api key name] can be specified",
+                "One of [api key ids, api key name, username, realm name] must be specified if [owner] flag is false",
+                "username or realm name must not be specified when the api key ids or api key name is specified",
+                "username or realm name must not be specified when the api key ids or api key name is specified",
+                "username or realm name must not be specified when the api key ids or api key name is specified",
+                "only one of [api key ids, api key name] can be specified",
                 "neither username nor realm-name may be specified when invalidating owned API keys",
                 "neither username nor realm-name may be specified when invalidating owned API keys" };
 
@@ -74,6 +75,14 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
             IllegalArgumentException ve = expectThrows(IllegalArgumentException.class,
                     () -> new InvalidateApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], inputs[caseNo][2], inputs[caseNo][3],
                         Boolean.valueOf(inputs[caseNo][4])));
+            assertNotNull(ve);
+            assertThat(ve.getMessage(), equalTo(expectedErrorMessages[caseNo]));
+        }
+        for (int i = 0; i < inputs.length; i++) {
+            final int caseNo = i;
+            IllegalArgumentException ve = expectThrows(IllegalArgumentException.class,
+                () -> new InvalidateApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], null, inputs[caseNo][3],
+                    Boolean.valueOf(inputs[caseNo][4]), new String[] { inputs[caseNo][2] }));
             assertNotNull(ve);
             assertThat(ve.getMessage(), equalTo(expectedErrorMessages[caseNo]));
         }

--- a/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
@@ -13,7 +13,7 @@ API Key(s) can be invalidated using this API.
 ==== Invalidate API Key Request
 The +{request}+ supports invalidating
 
-. A specific API key
+. Specific API keys of specified IDs
 
 . All API keys for a specific realm
 

--- a/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
@@ -31,7 +31,12 @@ The following parameters can be specified in the body of a DELETE request and
 pertain to invalidating api keys:
 
 `id`::
+deprecated:[7.10.0, This parameter is deprecated and will be removed in future version. Use `ids` instead.]
 (Optional, string) An API key id. This parameter cannot be used with any of
+`name`, `realm_name` or `username` are used.
+
+`ids`::
+(Optional, array of strings) An array of API key ids. This parameter cannot be used with any of
 `name`, `realm_name` or `username` are used.
 
 `name`::
@@ -52,7 +57,7 @@ by the currently authenticated user. Defaults to false.
 The 'realm_name' or 'username' parameters cannot be specified when this
 parameter is set to 'true' as they are assumed to be the currently authenticated ones.
 
-NOTE: At least one of "id", "name", "username" and "realm_name" must be specified
+NOTE: At least one of "ids", "name", "username" and "realm_name" must be specified
  if "owner" is "false" (default).
 
 [[security-api-invalidate-api-key-response-body]]
@@ -97,7 +102,7 @@ immediately:
 --------------------------------------------------
 DELETE /_security/api_key
 {
-  "id" : "VuaCfGcBCdbkQm-e5aOx"
+  "ids" : ["VuaCfGcBCdbkQm-e5aOx"]
 }
 --------------------------------------------------
 // TEST[s/VuaCfGcBCdbkQm-e5aOx/$body.id/]
@@ -143,7 +148,7 @@ The following example invalidates the API key identified by the specified `id` i
 --------------------------------------------------
 DELETE /_security/api_key
 {
-  "id" : "VuaCfGcBCdbkQm-e5aOx",
+  "ids" : ["VuaCfGcBCdbkQm-e5aOx"],
   "owner" : "true"
 }
 --------------------------------------------------

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -16,10 +16,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -30,6 +30,7 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
     private final String realmName;
     private final String userName;
+    @Deprecated
     private final String id;
     private final String name;
     private final boolean ownedByAuthenticatedUser;
@@ -101,7 +102,7 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
             apiKeyIds.add(id);
         }
         if (ids != null) {
-            apiKeyIds.addAll(Arrays.asList(ids));
+            apiKeyIds.addAll(Arrays.stream(ids).filter(Strings::hasText).collect(Collectors.toList()));
         }
         return Set.copyOf(apiKeyIds);
     }
@@ -179,7 +180,7 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         if (getAllIds().isEmpty() == false || Strings.hasText(name)) {
             if (Strings.hasText(realmName) || Strings.hasText(userName)) {
                 validationException = addValidationError(
-                    "username or realm name must not be specified when the api key id or api key name is specified",
+                    "username or realm name must not be specified when the api key ids or api key name is specified",
                     validationException);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
@@ -56,9 +56,15 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                     getApiKeyRequest.getRealmName(), getApiKeyRequest.ownedByAuthenticatedUser());
             } else if (request instanceof InvalidateApiKeyRequest) {
                 final InvalidateApiKeyRequest invalidateApiKeyRequest = (InvalidateApiKeyRequest) request;
-                return checkIfUserIsOwnerOfApiKeys(authentication, invalidateApiKeyRequest.getId(),
-                    invalidateApiKeyRequest.getUserName(), invalidateApiKeyRequest.getRealmName(),
-                    invalidateApiKeyRequest.ownedByAuthenticatedUser());
+                if (invalidateApiKeyRequest.getAllIds().isEmpty()) {
+                    return checkIfUserIsOwnerOfApiKeys(authentication, null,
+                        invalidateApiKeyRequest.getUserName(), invalidateApiKeyRequest.getRealmName(),
+                        invalidateApiKeyRequest.ownedByAuthenticatedUser());
+                } else {
+                    return invalidateApiKeyRequest.getAllIds().stream().allMatch(id -> checkIfUserIsOwnerOfApiKeys(authentication, id,
+                        invalidateApiKeyRequest.getUserName(), invalidateApiKeyRequest.getRealmName(),
+                        invalidateApiKeyRequest.ownedByAuthenticatedUser()));
+                }
             }
             throw new IllegalArgumentException(
                 "manage own api key privilege only supports API key requests (not " + request.getClass().getName() + ")");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
@@ -26,7 +26,8 @@ import static org.hamcrest.Matchers.is;
 public class InvalidateApiKeyRequestTests extends ESTestCase {
 
     public void testRequestValidation() {
-        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5), randomBoolean());
+        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { randomAlphaOfLength(5) }, randomBoolean());
         ActionRequestValidationException ve = request.validate();
         assertNull(ve);
         request = InvalidateApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5), randomBoolean());
@@ -118,7 +119,8 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
         final String apiKeyId = randomAlphaOfLength(5);
         final boolean ownedByAuthenticatedUser = true;
-        InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(apiKeyId, ownedByAuthenticatedUser);
+        InvalidateApiKeyRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { apiKeyId }, ownedByAuthenticatedUser);
         {
             ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
             OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilegeTests.java
@@ -32,7 +32,8 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final Authentication authentication = createMockAuthentication("joe","_es_api_key",
             AuthenticationType.API_KEY, Map.of("_security_api_key_id", apiKeyId));
         final TransportRequest getApiKeyRequest = GetApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
-        final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
+        final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { apiKeyId }, randomBoolean());
 
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/invalidate", invalidateApiKeyRequest, authentication));
@@ -47,7 +48,8 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final Authentication authentication = createMockAuthentication("joe","_es_api_key",
             AuthenticationType.API_KEY, Map.of("_security_api_key_id", randomAlphaOfLength(7)));
         final TransportRequest getApiKeyRequest = GetApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
-        final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
+        final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { apiKeyId }, randomBoolean());
 
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/invalidate", invalidateApiKeyRequest, authentication));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -271,7 +271,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         Client client = client().filterWithHeader(Collections.singletonMap("Authorization", UsernamePasswordToken
                 .basicAuthHeaderValue(SecuritySettingsSource.TEST_SUPERUSER, SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)));
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(0).getId(), false), listener);
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { responses.get(0).getId() }, false), listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
         verifyInvalidateResponse(1, responses, invalidateResponse);
     }
@@ -304,7 +305,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         List<CreateApiKeyResponse> createdApiKeys = createApiKeys(2, null);
 
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(createdApiKeys.get(0).getId(), false),
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { createdApiKeys.get(0).getId() }, false),
                        listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
         assertThat(invalidateResponse.getInvalidatedApiKeys().size(), equalTo(1));
@@ -338,7 +340,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         // invalidate API key to trigger remover
         listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(createdApiKeys.get(1).getId(), false),
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { createdApiKeys.get(1).getId() }, false),
                        listener);
         assertThat(listener.get().getInvalidatedApiKeys().size(), is(1));
 
@@ -419,7 +422,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         // Invalidate to trigger the remover
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(createdApiKeys.get(2).getId(), false),
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { createdApiKeys.get(2).getId() }, false),
                        listener);
         assertThat(listener.get().getInvalidatedApiKeys().size(), is(1));
 
@@ -471,7 +475,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 .basicAuthHeaderValue(SecuritySettingsSource.TEST_SUPERUSER, SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)));
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
         // trigger expired keys remover
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(1).getId(), false), listener);
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { responses.get(1).getId() }, false), listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
         assertThat(invalidateResponse.getInvalidatedApiKeys().size(), equalTo(1));
         assertThat(invalidateResponse.getPreviouslyInvalidatedApiKeys().size(), equalTo(0));
@@ -494,7 +499,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         Set<String> expectedValidKeyIds = null;
         if (invalidate) {
             PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-            client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(0).getId(), false),
+            client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+                new String[] { responses.get(0).getId() }, false),
                            listener);
             InvalidateApiKeyResponse invalidateResponse = listener.get();
             invalidatedApiKeyIds = invalidateResponse.getInvalidatedApiKeys();
@@ -793,7 +799,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         final PlainActionFuture<InvalidateApiKeyResponse> failureListener = new PlainActionFuture<>();
         // for any other API key id, it must deny access
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(1).getId(), randomBoolean()),
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { responses.get(1).getId() }, randomBoolean()),
             failureListener);
         ElasticsearchSecurityException ese = expectThrows(ElasticsearchSecurityException.class, () -> failureListener.actionGet());
         assertErrorMessage(ese, "cluster:admin/xpack/security/api_key/invalidate", SecuritySettingsSource.TEST_SUPERUSER,
@@ -806,7 +813,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             responses.get(0).getId());
 
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
-        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyId(responses.get(0).getId(), randomBoolean()),
+        client.execute(InvalidateApiKeyAction.INSTANCE, InvalidateApiKeyRequest.usingApiKeyIds(
+            new String[] { responses.get(0).getId() }, randomBoolean()),
             listener);
         InvalidateApiKeyResponse invalidateResponse = listener.get();
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
@@ -21,8 +20,6 @@ import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 public final class TransportInvalidateApiKeyAction extends HandledTransportAction<InvalidateApiKeyRequest, InvalidateApiKeyResponse> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
@@ -19,6 +20,10 @@ import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class TransportInvalidateApiKeyAction extends HandledTransportAction<InvalidateApiKeyRequest, InvalidateApiKeyResponse> {
 
@@ -36,7 +41,7 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
 
     @Override
     protected void doExecute(Task task, InvalidateApiKeyRequest request, ActionListener<InvalidateApiKeyResponse> listener) {
-        String apiKeyId = request.getId();
+        Set<String> apiKeyIds = request.getAllIds();
         String apiKeyName = request.getName();
         String username = request.getUserName();
         String realm = request.getRealmName();
@@ -53,7 +58,7 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
             realm = ApiKeyService.getCreatorRealmName(authentication);
         }
 
-        apiKeyService.invalidateApiKeys(realm, username, apiKeyName, apiKeyId, listener);
+        apiKeyService.invalidateApiKeys(realm, username, apiKeyName, apiKeyIds, listener);
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -740,24 +740,24 @@ public class ApiKeyService {
      * @param realmName realm name
      * @param username user name
      * @param apiKeyName API key name
-     * @param apiKeyId API key id
+     * @param apiKeyIds API key id
      * @param invalidateListener listener for {@link InvalidateApiKeyResponse}
      */
-    public void invalidateApiKeys(String realmName, String username, String apiKeyName, String apiKeyId,
+    public void invalidateApiKeys(String realmName, String username, String apiKeyName, Set<String> apiKeyIds,
                                   ActionListener<InvalidateApiKeyResponse> invalidateListener) {
         ensureEnabled();
         if (Strings.hasText(realmName) == false && Strings.hasText(username) == false && Strings.hasText(apiKeyName) == false
-            && Strings.hasText(apiKeyId) == false) {
-            logger.trace("none of the parameters [api key id, api key name, username, realm name] were specified for invalidation");
+            && apiKeyIds.isEmpty()) {
+            logger.trace("none of the parameters [api key ids, api key name, username, realm name] were specified for invalidation");
             invalidateListener
-                .onFailure(new IllegalArgumentException("One of [api key id, api key name, username, realm name] must be specified"));
+                .onFailure(new IllegalArgumentException("One of [api key ids, api key name, username, realm name] must be specified"));
         } else {
-            findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyId, true, false,
+            findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyIds, true, false,
                 ActionListener.wrap(apiKeys -> {
                     if (apiKeys.isEmpty()) {
                         logger.debug(
-                            "No active api keys to invalidate for realm [{}], username [{}], api key name [{}] and api key id [{}]",
-                            realmName, username, apiKeyName, apiKeyId);
+                            "No active api keys to invalidate for realm [{}], username [{}], api key name [{}] and api key ids [{}]",
+                            realmName, username, apiKeyName, apiKeyIds);
                         invalidateListener.onResponse(InvalidateApiKeyResponse.emptyResponse());
                     } else {
                         invalidateAllApiKeys(apiKeys.stream().map(apiKey -> apiKey.getId()).collect(Collectors.toSet()),
@@ -808,7 +808,8 @@ public class ApiKeyService {
         }
     }
 
-    private void findApiKeysForUserRealmApiKeyIdAndNameCombination(String realmName, String userName, String apiKeyName, String apiKeyId,
+    private void findApiKeysForUserRealmApiKeyIdAndNameCombination(String realmName, String userName, String apiKeyName,
+                                                                   Set<String> apiKeyIds,
                                                                    boolean filterOutInvalidatedKeys, boolean filterOutExpiredKeys,
                                                                    ActionListener<Collection<ApiKey>> listener) {
         final SecurityIndexManager frozenSecurityIndex = securityIndex.freeze();
@@ -831,10 +832,9 @@ public class ApiKeyService {
                     boolQuery.filter(QueryBuilders.termQuery("name", apiKeyName));
                 }
             }
-            if (Strings.hasText(apiKeyId)) {
-                boolQuery.filter(QueryBuilders.termQuery("_id", apiKeyId));
+            if (apiKeyIds.isEmpty() == false) {
+                boolQuery.filter(QueryBuilders.idsQuery().addIds(apiKeyIds.toArray(String[]::new)));
             }
-
             findApiKeys(boolQuery, filterOutInvalidatedKeys, filterOutExpiredKeys, listener);
         }
     }
@@ -972,7 +972,8 @@ public class ApiKeyService {
     public void getApiKeys(String realmName, String username, String apiKeyName, String apiKeyId,
                            ActionListener<GetApiKeyResponse> listener) {
         ensureEnabled();
-        findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyId, false, false,
+        Set<String> apiKeyIds = Strings.hasText(apiKeyId) ? Set.of(apiKeyId) : Set.of();
+        findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyIds, false, false,
             ActionListener.wrap(apiKeyInfos -> {
                 if (apiKeyInfos.isEmpty()) {
                     logger.debug("No active api keys found for realm [{}], user [{}], api key name [{}] and api key id [{}]",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -186,9 +186,11 @@ teardown:
   - is_true: "api_keys.0.creation"
 
 ---
-"Test invalidate api key":
+"Test invalidate api keys":
   - skip:
-      features: transform_and_set
+      features:
+        - transform_and_set
+        - warnings
 
   - do:
       headers:
@@ -205,19 +207,58 @@ teardown:
   - is_true: id
   - is_true: api_key
   - is_true: expiration
-  - set: { id: api_key_id }
+  - set: { id: api_key_id_1 }
   - transform_and_set: { login_creds: "#base64EncodeCredentials(id,api_key)" }
 
   - do:
       headers:
         Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.create_api_key:
+        body:  >
+          {
+            "name": "my-api-key-2",
+            "expiration": "1d",
+            "role_descriptors": {
+            }
+          }
+  - match: { name: "my-api-key-2" }
+  - is_true: id
+  - is_true: api_key
+  - is_true: expiration
+  - set: { id: api_key_id_2 }
+
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.create_api_key:
+        body:  >
+          {
+            "name": "my-api-key-3",
+            "expiration": "1d",
+            "role_descriptors": {
+            }
+          }
+  - match: { name: "my-api-key-3" }
+  - is_true: id
+  - is_true: api_key
+  - is_true: expiration
+  - set: { id: api_key_id_3 }
+
+  - do:
+      warnings:
+        - "The id parameter is deprecated, use ids instead"
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
       security.invalidate_api_key:
         body:  >
             {
-              "id": "${api_key_id}"
+              "id": "${api_key_id_1}",
+              "ids": [ "${api_key_id_2}", "${api_key_id_3}" ]
             }
-  - length: { "invalidated_api_keys" : 1 }
-  - match: { "invalidated_api_keys.0" : "${api_key_id}" }
+  - length: { "invalidated_api_keys" : 3 }
+  - match: { "invalidated_api_keys.0" : "/^(${api_key_id_1}|${api_key_id_2}|${api_key_id_3})$/" }
+  - match: { "invalidated_api_keys.1" : "/^(${api_key_id_1}|${api_key_id_2}|${api_key_id_3})$/" }
+  - match: { "invalidated_api_keys.2" : "/^(${api_key_id_1}|${api_key_id_2}|${api_key_id_3})$/" }
   - length: { "previously_invalidated_api_keys" : 0 }
   - match: { "error_count" : 0 }
 


### PR DESCRIPTION
The existing `id` field of API invalidation request only takes a single
API key ID. This PR adds a new `ids` field that takes an array of API 
key IDs for bulk invalidation.

Due to the user facing nature of this change, we need:
* Deprecation handling for the existing `id` field
* Unit and Integ tests for both id and ids
* YAML tests for both id and ids
* Doc update and tests for both id and ids
* Client code, doc and tests for both id and ids

I am not labeling it as `v7.10.0` because I am not 100% sure this could make it. The changes are wider than I expected. In addition to the above list, we also have:
* Any tests using API key invalidation (with ID) as a helper needs to handle deprecation warning
* Manage own API key needs to adjust for testing multiple IDs

Resolves: #47609