### PR TITLE
 Enable support for compressed response within RestHighLevelClient

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.entity.GzipDecompressingEntity;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
@@ -2037,11 +2038,18 @@ public class RestHighLevelClient implements Closeable {
         return elasticsearchException;
     }
 
-    protected final <Resp> Resp parseEntity(final HttpEntity entity,
+    protected final <Resp> Resp parseEntity(final HttpEntity httpEntity,
                                       final CheckedFunction<XContentParser, Resp, IOException> entityParser) throws IOException {
-        if (entity == null) {
+        if (httpEntity == null) {
             throw new IllegalStateException("Response body expected but not returned");
         }
+
+        final HttpEntity entity = Optional.ofNullable(httpEntity.getContentEncoding())
+            .map(Header::getValue)
+            .filter("gzip"::equalsIgnoreCase)
+            .map(gzipHeaderValue -> (HttpEntity) new GzipDecompressingEntity(httpEntity))
+            .orElse(httpEntity);
+
         if (entity.getContentType() == null) {
             throw new IllegalStateException("Elasticsearch didn't return the [Content-Type] header, unable to parse response body");
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/HighLevelRestClientCompressionIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/HighLevelRestClientCompressionIT.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HighLevelRestClientCompressionIT extends ESRestHighLevelClientTestCase {
+
+    private static final String GZIP_ENCODING = "gzip";
+    private static final String SAMPLE_DOCUMENT = "{\"name\":{\"first name\":\"Steve\",\"last name\":\"Jobs\"}}";
+
+    public void testCompressesResponseIfRequested() throws IOException {
+        Request doc = new Request(HttpPut.METHOD_NAME, "/company/_doc/1");
+        doc.setJsonEntity(SAMPLE_DOCUMENT);
+        client().performRequest(doc);
+        client().performRequest(new Request(HttpPost.METHOD_NAME, "/_refresh"));
+
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .addHeader(HttpHeaders.ACCEPT_ENCODING, GZIP_ENCODING)
+            .build();
+
+        SearchRequest searchRequest = new SearchRequest("company");
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync, requestOptions);
+
+        assertThat(searchResponse.status().getStatus(), equalTo(200));
+        assertEquals(1L, searchResponse.getHits().getTotalHits().value);
+        assertEquals(SAMPLE_DOCUMENT, searchResponse.getHits().getHits()[0].getSourceAsString());
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/HighLevelRestClientCompressionIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/HighLevelRestClientCompressionIT.java
@@ -39,15 +39,15 @@ public class HighLevelRestClientCompressionIT extends ESRestHighLevelClientTestC
         client().performRequest(doc);
         client().performRequest(new Request(HttpPost.METHOD_NAME, "/_refresh"));
 
-        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
-            .addHeader(HttpHeaders.ACCEPT_ENCODING, GZIP_ENCODING)
-            .build();
+        RequestOptions.Builder requestOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+        requestOptionsBuilder.addHeader(HttpHeaders.ACCEPT_ENCODING, GZIP_ENCODING);
+        RequestOptions requestOptions = requestOptionsBuilder.build();
 
         SearchRequest searchRequest = new SearchRequest("company");
         SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync, requestOptions);
 
         assertThat(searchResponse.status().getStatus(), equalTo(200));
-        assertEquals(1L, searchResponse.getHits().getTotalHits().value);
+        assertEquals(1L, searchResponse.getHits().getTotalHits());
         assertEquals(SAMPLE_DOCUMENT, searchResponse.getHits().getHits()[0].getSourceAsString());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -34,6 +34,7 @@ import org.apache.http.message.BasicRequestLine;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NByteArrayEntity;
 import org.apache.http.nio.entity.NStringEntity;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;


### PR DESCRIPTION
Backport of #53533

This pull request is to enable the RestHighLevelClient to handle an Elasticsearch response which has compressed content. It was already possible to do this with the low level client, see here [AsyncElasticsearchCompressedRequest](https://gist.github.com/Hakky54/e818a2d8d7d8153cd0ef89ca4143d805)
Compression can enabled within a node configuration with the following property: `http.compression: true` Compression can be triggered by a request from a client. Therefor you also need to provide additional information within the header of the request to Elasticsearch if a client really wants to enable it. That is possible with the following RequestOptions:
```
RequestOptions.Builder requestOptions = RequestOptions.DEFAULT.toBuilder()
    .addHeader("Accept-Encoding", "gzip")
```

With these two properties Elasticsearch will return a gzip compressed response body. The RestHighLevelClient can send a request with the above request options but it couldn't handle the response yet. This feature request contains the option to handle a compressed response if it is compressed with gzip.