### PR TITLE
SQL: Allow skip of bwc tests on `check` task (#62936)

### DIFF
--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -138,3 +138,9 @@ task regen {
     }
   }
 }
+
+allprojects {
+  task checkNoBwc {
+    dependsOn tasks.withType(Test).matching { it.name.contains('bwc') == false }
+  }
+}


### PR DESCRIPTION
Bwc tests can consume much time to build and to run so it's nice to be
able to skip them when running the `check` task on the SQL module.

Introduce a new task `checkNoBwc` so one can use:
```
./gradlew -p x-pack/plugin/sql checkNoBwc
```
to skip them.

(cherry picked from commit a52e1846f338f6869273181c6f248579581fa68c)
