### PR TITLE
Use BCFIPS 1.0.2 in our CI

### DIFF
--- a/buildSrc/src/main/resources/fips_java.security
+++ b/buildSrc/src/main/resources/fips_java.security
@@ -1,4 +1,4 @@
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN
 security.provider.4=SunJGSS

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -11,7 +11,7 @@ if (BuildParams.inFipsJvm) {
     File fipsSecurity = new File(fipsResourcesDir, 'fips_java.security')
     File fipsPolicy = new File(fipsResourcesDir, 'fips_java.policy')
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')
-    def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
+    def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.2')
     def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
 
     pluginManager.withPlugin('java') {


### PR DESCRIPTION
Bouncy Castle's BC-FJA-1.0.2 has been certified for a while now
but we had noticed that it seems to be rather entropy hungry and
ES would start very slowly ( and tests would take forever )
because of the blocking calls to /dev/random.

We verified that this is resolved when enabling hw RNG or a
software one like haveged. While rng-tools should be suggested for
production uses, our ephemeral workers have haveged installed
which should work just fine for CI.

Resolves: #47455