### PR TITLE
[7.x] [DOCS] EQL: date_nanos timestamp is not supported (#63101)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -260,8 +260,8 @@ Events in the API response are sorted by this field's value, converted to
 milliseconds since the {wikipedia}/Unix_time[Unix epoch], in
 ascending order.
 
-The timestamp field is typically mapped as a <<date,`date`>> or
-<<date_nanos,`date_nanos`>> field.
+The timestamp field should be mapped as a <<date,`date`>>. The
+<<date_nanos,`date_nanos`>> field type is not supported.
 --
 
 [[eql-search-api-wait-for-completion-timeout]]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -405,8 +405,9 @@ in the search request using the `timestamp_field` or `event_category_field`
 parameters.
 
 The event category field is typically mapped as a field type in the
-<<keyword,`keyword`>> family. The timestamp field is typically mapped as a
-<<date,`date`>> or <<date_nanos,`date_nanos`>> field.
+<<keyword,`keyword`>> family. The timestamp field should be mapped as a
+<<date,`date`>> field type. <<date_nanos,`date_nanos`>> timestamp fields are not
+supported.
 
 NOTE: You cannot use a <<nested,`nested`>> field or the sub-fields of a `nested`
 field as the timestamp or event category field. See <<eql-nested-fields>>.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: date_nanos timestamp is not supported (#63101)