### PR TITLE
[7.x][ML] Remove direct access to system index from filter_crud REST …

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -3,22 +3,6 @@ setup:
   - skip:
       features:
         - headers
-        - allowed_warnings
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-        Content-Type: application/json
-      allowed_warnings:
-        - "index [.ml-meta] matches multiple legacy templates [.ml-meta, global], composable templates will only match a single template"
-      index:
-        index: .ml-meta
-        id: filter_imposter-filter
-        body: >
-          {
-            "filter_id": "imposter",
-            "items": ["a", "b"],
-            "type": "imposter"
-          }
 
   - do:
       headers:
@@ -317,19 +301,3 @@ setup:
   - match: { count: 0 }
   - match: { filters: [] }
 
----
-"Test get all filter given index exists but no mapping for filter_id":
-
-  - do:
-      indices.delete:
-        index: ".ml-meta"
-  - do:
-      allowed_warnings:
-        - "index [.ml-meta] matches multiple legacy templates [.ml-meta, global], composable templates will only match a single template"
-      indices.create:
-        index: ".ml-meta"
-
-  - do:
-      ml.get_filters: {}
-  - match: { count: 0 }
-  - match: { filters: [] }


### PR DESCRIPTION
…test (#63111)

This test accesses system indices for 2 reasons.

First, it creates a filter that has a different type. This was done
to assert that filter is not returned from the APIs. However,
now that access to the `.ml-meta` index is restricted,
it is not really a concern.

Second, it creates a `.ml-meta` index without mappings to test
the get API does not fail due to lack of mappings on a sorted field,
namely the `filter_id`. Once again, this test is less useful once
system indices have restricted access.

Relates #62501

Backport of #63111
