### PR TITLE
Use BCFIPS 1.0.2 in our CI

### DIFF
--- a/buildSrc/src/main/resources/fips_java_bcjsse_11.security
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_11.security
@@ -1,6 +1,6 @@
 # Security Properties for JDK 11 and higher, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
 
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN
 security.provider.4=SunJGSS

--- a/buildSrc/src/main/resources/fips_java_bcjsse_8.security
+++ b/buildSrc/src/main/resources/fips_java_bcjsse_8.security
@@ -1,6 +1,6 @@
 # Security Properties for JDK 8, with BouncyCastle FIPS provider and BouncyCastleJsseProvider in FIPS mode
 
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=sun.security.provider.Sun
 security.provider.4=sun.security.jgss.SunProvider

--- a/buildSrc/src/main/resources/fips_java_sunjsse.security
+++ b/buildSrc/src/main/resources/fips_java_sunjsse.security
@@ -1,6 +1,6 @@
 # Security Properties for JDK 8, with BouncyCastle FIPS provider and SunJSSE in FIPS mode
 
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=com.sun.net.ssl.internal.ssl.Provider BCFIPS
 security.provider.3=sun.security.provider.Sun
 security.provider.4=sun.security.jgss.SunProvider

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -25,7 +25,7 @@ if (BuildParams.inFipsJvm) {
       fipsPolicy = new File(fipsResourcesDir, "fips_java_bcjsse_11.policy")
     }
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')
-    def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.1')
+    def bcFips = dependencies.create('org.bouncycastle:bc-fips:1.0.2')
     def bcTlsFips = dependencies.create('org.bouncycastle:bctls-fips:1.0.9')
 
     pluginManager.withPlugin('java') {


### PR DESCRIPTION
Bouncy Castle's BC-FJA-1.0.2 has been certified for a while now
but we had noticed that it seems to be rather entropy hungry and
ES would start very slowly ( and tests would take forever )
because of blocking calls to /dev/random.

We verified that this is resolved when enabling hw RNG or a
software one like haveged. While rng-tools should be suggested for
production uses, our ephemeral workers have haveged installed
which should work just fine for CI.

Backport of #63099