### PR TITLE
Wildcard field - add normalisation of ngram tokens to reduce disk space.

### DIFF
--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -116,7 +116,6 @@ public class WildcardFieldMapper extends FieldMapper {
         public TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new NGramTokenizer(NGRAM_SIZE, NGRAM_SIZE);
             TokenStream tok = new LowerCaseFilter(tokenizer);
-//                return new TokenStreamComponents(tokenizer);
             return new TokenStreamComponents(r -> {
                 tokenizer.setReader(r);
             }, tok);            

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -100,7 +100,7 @@ public class WildcardFieldMapper extends FieldMapper {
             Tokenizer tokenizer = new NGramTokenizer(NGRAM_SIZE, NGRAM_SIZE);
             
             TokenStream tok = new LowerCaseFilter(tokenizer);
-            tok = new NormaliseThinningFilter(tok);
+            tok = new PunctuationFoldingFilter(tok);
             
             return new TokenStreamComponents(r -> {
                 tokenizer.setReader(r);
@@ -123,16 +123,16 @@ public class WildcardFieldMapper extends FieldMapper {
         }
     });
     
-    public static class NormaliseThinningFilter extends TokenFilter {
+    public static class PunctuationFoldingFilter extends TokenFilter {
         private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
         
         /**
-         * Create a new NormaliseThinningFilter, that normalizes token text such that even-numbered ascii values
+         * Create a new PunctuationFoldingFilter, that normalizes token text such that even-numbered ascii values
          * are made odd and punctuation is replaced with /
          * 
          * @param in TokenStream to filter
          */
-        public NormaliseThinningFilter(TokenStream in) {
+        public PunctuationFoldingFilter(TokenStream in) {
           super(in);
         }
         
@@ -718,7 +718,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 // fragment must have been less than NGRAM_SIZE - add a placeholder which may be used in a prefix query e.g. ab*
                 fragment = toLowerCase(fragment);
                 if (indexAnalyzer() == WILDCARD_ANALYZER_7_10) {
-                    fragment = NormaliseThinningFilter.normalize(fragment);
+                    fragment = PunctuationFoldingFilter.normalize(fragment);
                 }
                 tokens.add(fragment);
             }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -500,7 +500,6 @@ public class WildcardFieldMapperTests extends ESTestCase {
             String regex = test[0];
             String expectedAccelerationQueryString = test[1].replaceAll("_", ""+WildcardFieldMapper.TOKEN_START_OR_END_CHAR);
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, RegExp.ALL, 0, 20000, null, MOCK_QSC);
-            System.out.println(regex+"\n\t"+wildcardFieldQuery);
             testExpectedAccelerationQuery(regex, wildcardFieldQuery, expectedAccelerationQueryString);
         }
 

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -78,15 +78,17 @@ import static org.mockito.Mockito.when;
 
 public class WildcardFieldMapperTests extends ESTestCase {
 
-    static QueryShardContext createMockQueryShardContext(boolean allowExpensiveQueries) {
+    static QueryShardContext createMockQueryShardContext(boolean allowExpensiveQueries, Version version) {
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
         when(queryShardContext.allowExpensiveQueries()).thenReturn(allowExpensiveQueries);
+        when(queryShardContext.indexVersionCreated()).thenReturn(version);        
         return queryShardContext;
-    }
+    }    
 
     private static final String KEYWORD_FIELD_NAME = "keyword_field";
     private static final String WILDCARD_FIELD_NAME = "wildcard_field";
-    public static final QueryShardContext MOCK_QSC = createMockQueryShardContext(true);
+    public static final QueryShardContext MOCK_QSC = createMockQueryShardContext(true, Version.CURRENT);
+    public static final QueryShardContext MOCK_7_9_QSC = createMockQueryShardContext(true, Version.V_7_9_0);
 
     static final int MAX_FIELD_LENGTH = 30;
     static WildcardFieldMapper wildcardFieldType;
@@ -121,7 +123,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
 
     public void testTooBigKeywordField() throws IOException {
         Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
@@ -144,11 +146,44 @@ public class WildcardFieldMapperTests extends ESTestCase {
         reader.close();
         dir.close();
     }
+    
+    public void testBWCIndexVersion() throws IOException {
+        // Create old format index using wildcard ngram analyzer used in 7.9 launch
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_9);
+        iwc.setMergePolicy(newTieredMergePolicy(random()));
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+
+        Document doc = new Document();
+        ParseContext.Document parseDoc = new ParseContext.Document();
+        addFields(parseDoc, doc, "a b");
+        indexDoc(parseDoc, doc, iw);
+
+        iw.forceMerge(1);
+        DirectoryReader reader = iw.getReader();
+        IndexSearcher searcher = newSearcher(reader);
+        iw.close();
+        
+
+        // Unnatural circumstance - testing we fail if we were to use the new analyzer on old index
+        Query oldWildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery("a b", null, MOCK_QSC);
+        TopDocs oldWildcardFieldTopDocs = searcher.search(oldWildcardFieldQuery, 10, Sort.INDEXORDER);
+        assertThat(oldWildcardFieldTopDocs.totalHits.value, equalTo(0L));
+        
+        
+        // Natural  circumstance test we revert to the old analyzer for old indices
+        Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery("a b", null, MOCK_7_9_QSC);
+        TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, 10, Sort.INDEXORDER);
+        assertThat(wildcardFieldTopDocs.totalHits.value, equalTo(1L));
+
+        reader.close();
+        dir.close();
+    }    
 
     //Test long query strings don't cause exceptions
     public void testTooBigQueryField() throws IOException {
         Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
@@ -183,7 +218,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
     
     public void testTermAndPrefixQueryIgnoreWildcardSyntax() throws IOException {
         Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
@@ -224,7 +259,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
 
     public void testSearchResultsVersusKeywordField() throws IOException {
         Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
@@ -362,7 +397,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
 
     public void testRangeQueryVersusKeywordField() throws IOException {
         Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER);
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
@@ -375,6 +410,10 @@ public class WildcardFieldMapperTests extends ESTestCase {
         indexDoc(iw, "a.txt");
         indexDoc(iw, "n.txt");
         indexDoc(iw, "z.txt");
+        indexDoc(iw, "A.txt");
+        indexDoc(iw, "N.txt");
+        indexDoc(iw, "^.txt");
+        indexDoc(iw, "Z.txt");
 
         iw.forceMerge(1);
         DirectoryReader reader = iw.getReader();
@@ -391,7 +430,8 @@ public class WildcardFieldMapperTests extends ESTestCase {
             {"a.txt", "z.txt"},
             {"a.txt", "n.txt"},
             {null, "z.txt"},
-            {"a.txt", null}
+            {"a.txt", null},
+            {"A.txt", "z.txt"}
         };
 
         for (String[] bounds : rangeTests) {
@@ -437,15 +477,16 @@ public class WildcardFieldMapperTests extends ESTestCase {
 
         // All of these regexes should be accelerated as the equivalent of the given QueryString query
         String acceleratedTests[][] = {
-            {".*foo.*", "foo"},
-            {"..foobar","+foo +oba +ar_ +r__"},
-            {"(maynotexist)?foobar","+foo +oba +ar_ +r__"},
-            {".*/etc/passw.*", "+\\/et +tc\\/ +\\/pa +ass +ssw"},
-            {".*etc/passwd",  "+etc +c\\/p +pas +ssw +wd_ +d__"},
-            {"(http|ftp)://foo.*",  "+((+htt +ttp) ftp) +(+\\:\\/\\/ +\\/fo +foo)"},
-            {"[Pp][Oo][Ww][Ee][Rr][Ss][Hh][Ee][Ll][Ll]\\.[Ee][Xx][Ee]",  "+_po +owe +ers +she +ell +l\\.e +exe +e__"},
-            {"foo<1-100>bar",  "+(+_fo +foo) +(+bar +r__ )"},
-            {"(aaa.+&.+bbb)cat", "+cat +t__"},
+            {".*foo.*", "eoo"},
+            {"..foobar","+eoo +ooa +oaa +aaq +aq_ +q__"},
+            {"(maynotexist)?foobar","+eoo +ooa +oaa +aaq +aq_ +q__"},
+            {".*/etc/passw.*", "+\\/es +esc +sc\\/ +c\\/o +\\/oa +oas +ass +ssw"},
+            {".*etc/passwd",  " +esc +sc\\/ +c\\/o +\\/oa +oas +ass +ssw +swc +wc_ +c__"},
+            {"(http|ftp)://foo.*",  "+((+gss +sso) eso) +(+\\/\\/\\/ +\\/\\/e +\\/eo +eoo)"},
+            {"[Pp][Oo][Ww][Ee][Rr][Ss][Hh][Ee][Ll][Ll]\\.[Ee][Xx][Ee]",
+                "+_oo +oow +owe +weq +eqs +qsg +sge +gek +ekk +kk\\/ +k\\/e +\\/ew +ewe +we_ +e__"},
+            {"foo<1-100>bar",  "+(+_eo +eoo) +(+aaq +aq_ +q__)"},
+            {"(aaa.+&.+bbb)cat", "+cas +as_ +s__"},
             {".a", "a__"}
             };
         for (String[] test : acceleratedTests) {
@@ -470,7 +511,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
         String suboptimalTests[][] = {
             // TODO short wildcards like a* OR b* aren't great so we just drop them.
             // Ideally we would attach to successors to create (acd OR bcd)
-            { "[ab]cd",  "+cd_ +d__"}
+            { "[ab]cd",  "+cc_ +c__"}
             };
         for (String[] test : suboptimalTests) {
             String regex = test[0];
@@ -500,13 +541,13 @@ public class WildcardFieldMapperTests extends ESTestCase {
 
         // All of these patterns should be accelerated.
         String tests[][] = {
-            { "*foobar", "+foo +oba +ar_ +r__" },
-            { "foobar*", "+_fo +oob +bar" },
-            { "foo\\*bar*", "+_fo +oo\\* +\\*ba +bar" },
-            { "foo\\?bar*", "+_fo +oo\\? +\\?ba +bar" },
-            { "foo*bar", "+_fo +foo +bar +r__" },
-            { "foo?bar", "+_fo +foo +bar +r__" },
-            { "?foo*bar?", "+foo +bar" },
+            { "*foobar", "+eoo +ooa +oaa +aaq +aq_ +q__" },
+            { "foobar*", "+_eo +eoo +ooa +oaa +aaq" },
+            { "foo\\*bar*", "+_eo +eoo +oo\\/ +o\\/a +\\/aa +aaq" },
+            { "foo\\?bar*", "+_eo +eoo +oo\\/ +o\\/a +\\/aa +aaq" },
+            { "foo*bar", "+_eo +eoo +aaq +aq_ +q__" },
+            { "foo?bar", "+_eo +eoo +aaq +aq_ +q__" },
+            { "?foo*bar?", "+eoo +aaq" },
             { "*c", "+c__" } };
         for (String[] test : tests) {
             String pattern = test[0];
@@ -602,10 +643,10 @@ public class WildcardFieldMapperTests extends ESTestCase {
     public void testFuzzyAcceleration() throws IOException, ParseException {
 
         FuzzyTest[] tests = {
-            new FuzzyTest("123456", 0, Fuzziness.ONE, null, 1, "123 456"),
-            new FuzzyTest("1234567890", 2, Fuzziness.ONE, "_12", 1, "345 678"),
-            new FuzzyTest("12345678901", 2, Fuzziness.ONE, "_12", 2, "345 678 901"),
-            new FuzzyTest("12345678", 4, Fuzziness.ONE, "_12 234", 0, null)
+            new FuzzyTest("123456", 0, Fuzziness.ONE, null, 1, "113 355"),
+            new FuzzyTest("1234567890", 2, Fuzziness.ONE, "_11", 1, "335 577"),
+            new FuzzyTest("12345678901", 2, Fuzziness.ONE, "_11", 2, "335 577 901"),
+            new FuzzyTest("12345678", 4, Fuzziness.ONE, "_11 113 133", 0, null)
         };
         for (FuzzyTest test : tests) {
             Query wildcardFieldQuery = test.getFuzzyQuery();
@@ -651,8 +692,8 @@ public class WildcardFieldMapperTests extends ESTestCase {
     public void testRangeAcceleration() throws IOException, ParseException {
 
         RangeTest[] tests = {
-            new RangeTest("c:/a.txt", "c:/z.txt", "_c: c:/"),
-            new RangeTest("C:/ProgramFiles/a.txt", "C:/ProgramFiles/z.txt", "_c: :/p pro ogr ram mfi ile es/"),
+            new RangeTest("c:/a.txt", "c:/z.txt", "_c/ c//"),
+            new RangeTest("C:/ProgramFiles/a.txt", "C:/ProgramFiles/z/txt", "_c/ c// //o /oq oqo qog ogq gqa qam ame mei eik ike kes es/"),
         };
         for (RangeTest test : tests) {
             Query wildcardFieldQuery = test.getRangeQuery();

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -100,12 +100,17 @@ public class WildcardFieldMapperTests extends ESTestCase {
     public void setUp() throws Exception {
         Builder builder = new WildcardFieldMapper.Builder(WILDCARD_FIELD_NAME);
         builder.ignoreAbove(MAX_FIELD_LENGTH);
-        wildcardFieldType = builder.build(new Mapper.BuilderContext(createIndexSettings(Version.CURRENT).getSettings(), new ContentPath(0)));
-        wildcardFieldType79 = builder.build(new Mapper.BuilderContext(createIndexSettings(Version.V_7_9_0).getSettings(), new ContentPath(0)));
-
+        wildcardFieldType = builder.build(
+            new Mapper.BuilderContext(createIndexSettings(Version.CURRENT).getSettings(), new ContentPath(0))
+        );
+        wildcardFieldType79 = builder.build(
+            new Mapper.BuilderContext(createIndexSettings(Version.V_7_9_0).getSettings(), new ContentPath(0))
+        );
 
         org.elasticsearch.index.mapper.KeywordFieldMapper.Builder kwBuilder = new KeywordFieldMapper.Builder(KEYWORD_FIELD_NAME);
-        keywordFieldType = kwBuilder.build(new Mapper.BuilderContext(createIndexSettings(Version.CURRENT).getSettings(), new ContentPath(0)));
+        keywordFieldType = kwBuilder.build(
+            new Mapper.BuilderContext(createIndexSettings(Version.CURRENT).getSettings(), new ContentPath(0))
+        );
         super.setUp();
     }
 


### PR DESCRIPTION
All punctuation becomes `/` char and for `A-Z0-9` chars turn even codepoints to prior odd e.g. aab becomes aaa.

Closes #62817
