### PR TITLE
Shorten runtime field type class names

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
@@ -32,11 +32,11 @@ import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 /**
  * Abstract base {@linkplain MappedFieldType} for scripted fields.
  */
-abstract class AbstractScriptMappedFieldType<LeafFactory> extends MappedFieldType {
+abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType {
     protected final Script script;
     private final TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory;
 
-    AbstractScriptMappedFieldType(
+    AbstractScriptFieldType(
         String name,
         Script script,
         TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory,

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class BooleanScriptMappedFieldType extends AbstractScriptMappedFieldType<BooleanFieldScript.LeafFactory> {
-    BooleanScriptMappedFieldType(String name, Script script, BooleanFieldScript.Factory scriptFactory, Map<String, String> meta) {
+public class BooleanScriptFieldType extends AbstractScriptFieldType<BooleanFieldScript.LeafFactory> {
+    BooleanScriptFieldType(String name, Script script, BooleanFieldScript.Factory scriptFactory, Map<String, String> meta) {
         super(name, script, scriptFactory::newFactory, meta);
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
@@ -35,10 +35,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class DateScriptMappedFieldType extends AbstractScriptMappedFieldType<DateFieldScript.LeafFactory> {
+public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript.LeafFactory> {
     private final DateFormatter dateTimeFormatter;
 
-    DateScriptMappedFieldType(
+    DateScriptFieldType(
         String name,
         Script script,
         DateFieldScript.Factory scriptFactory,

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
@@ -16,30 +16,30 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.xpack.runtimefields.fielddata.LongScriptFieldData;
-import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldExistsQuery;
-import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldRangeQuery;
-import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermQuery;
-import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
+import org.elasticsearch.xpack.runtimefields.fielddata.DoubleScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermsQuery;
 
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<LongFieldScript.LeafFactory> {
-    LongScriptMappedFieldType(String name, Script script, LongFieldScript.Factory scriptFactory, Map<String, String> meta) {
+public class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
+    DoubleScriptFieldType(String name, Script script, DoubleFieldScript.Factory scriptFactory, Map<String, String> meta) {
         super(name, script, scriptFactory::newFactory, meta);
     }
 
     @Override
     protected String runtimeType() {
-        return NumberType.LONG.typeName();
+        return NumberType.DOUBLE.typeName();
     }
 
     @Override
     public Object valueForDisplay(Object value) {
-        return value; // These should come back as a Long
+        return value; // These should come back as a Double
     }
 
     @Override
@@ -54,14 +54,14 @@ public class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<Lon
     }
 
     @Override
-    public LongScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-        return new LongScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    public DoubleScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new DoubleScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
     }
 
     @Override
     public Query existsQuery(QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new LongScriptFieldExistsQuery(script, leafFactory(context)::newInstance, name());
+        return new DoubleScriptFieldExistsQuery(script, leafFactory(context), name());
     }
 
     @Override
@@ -75,22 +75,19 @@ public class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<Lon
         QueryShardContext context
     ) {
         checkAllowExpensiveQueries(context);
-        return NumberType.longRangeQuery(
+        return NumberType.doubleRangeQuery(
             lowerTerm,
             upperTerm,
             includeLower,
             includeUpper,
-            (l, u) -> new LongScriptFieldRangeQuery(script, leafFactory(context)::newInstance, name(), l, u)
+            (l, u) -> new DoubleScriptFieldRangeQuery(script, leafFactory(context), name(), l, u)
         );
     }
 
     @Override
     public Query termQuery(Object value, QueryShardContext context) {
-        if (NumberType.hasDecimalPart(value)) {
-            return Queries.newMatchNoDocsQuery("Value [" + value + "] has a decimal part");
-        }
         checkAllowExpensiveQueries(context);
-        return new LongScriptFieldTermQuery(script, leafFactory(context)::newInstance, name(), NumberType.objectToLong(value, true));
+        return new DoubleScriptFieldTermQuery(script, leafFactory(context), name(), NumberType.objectToDouble(value));
     }
 
     @Override
@@ -100,15 +97,9 @@ public class LongScriptMappedFieldType extends AbstractScriptMappedFieldType<Lon
         }
         LongSet terms = new LongHashSet(values.size());
         for (Object value : values) {
-            if (NumberType.hasDecimalPart(value)) {
-                continue;
-            }
-            terms.add(NumberType.objectToLong(value, true));
-        }
-        if (terms.isEmpty()) {
-            return Queries.newMatchNoDocsQuery("All values have a decimal part");
+            terms.add(Double.doubleToLongBits(NumberType.objectToDouble(value)));
         }
         checkAllowExpensiveQueries(context);
-        return new LongScriptFieldTermsQuery(script, leafFactory(context)::newInstance, name(), terms);
+        return new DoubleScriptFieldTermsQuery(script, leafFactory(context), name(), terms);
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldType.java
@@ -36,8 +36,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public final class IpScriptMappedFieldType extends AbstractScriptMappedFieldType<IpFieldScript.LeafFactory> {
-    IpScriptMappedFieldType(String name, Script script, IpFieldScript.Factory scriptFactory, Map<String, String> meta) {
+public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScript.LeafFactory> {
+    IpScriptFieldType(String name, Script script, IpFieldScript.Factory scriptFactory, Map<String, String> meta) {
         super(name, script, scriptFactory::newFactory, meta);
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
@@ -35,8 +35,8 @@ import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toSet;
 
-public final class KeywordScriptMappedFieldType extends AbstractScriptMappedFieldType<StringFieldScript.LeafFactory> {
-    KeywordScriptMappedFieldType(String name, Script script, StringFieldScript.Factory scriptFactory, Map<String, String> meta) {
+public final class KeywordScriptFieldType extends AbstractScriptFieldType<StringFieldScript.LeafFactory> {
+    KeywordScriptFieldType(String name, Script script, StringFieldScript.Factory scriptFactory, Map<String, String> meta) {
         super(name, script, scriptFactory::newFactory, meta);
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
@@ -16,30 +16,30 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.xpack.runtimefields.fielddata.DoubleScriptFieldData;
-import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldExistsQuery;
-import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldRangeQuery;
-import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermQuery;
-import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermsQuery;
+import org.elasticsearch.xpack.runtimefields.fielddata.LongScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldExistsQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldRangeQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermQuery;
+import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
 
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<DoubleFieldScript.LeafFactory> {
-    DoubleScriptMappedFieldType(String name, Script script, DoubleFieldScript.Factory scriptFactory, Map<String, String> meta) {
+public class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
+    LongScriptFieldType(String name, Script script, LongFieldScript.Factory scriptFactory, Map<String, String> meta) {
         super(name, script, scriptFactory::newFactory, meta);
     }
 
     @Override
     protected String runtimeType() {
-        return NumberType.DOUBLE.typeName();
+        return NumberType.LONG.typeName();
     }
 
     @Override
     public Object valueForDisplay(Object value) {
-        return value; // These should come back as a Double
+        return value; // These should come back as a Long
     }
 
     @Override
@@ -54,14 +54,14 @@ public class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<D
     }
 
     @Override
-    public DoubleScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
-        return new DoubleScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
+    public LongScriptFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
+        return new LongScriptFieldData.Builder(name(), leafFactory(searchLookup.get()));
     }
 
     @Override
     public Query existsQuery(QueryShardContext context) {
         checkAllowExpensiveQueries(context);
-        return new DoubleScriptFieldExistsQuery(script, leafFactory(context), name());
+        return new LongScriptFieldExistsQuery(script, leafFactory(context)::newInstance, name());
     }
 
     @Override
@@ -75,19 +75,22 @@ public class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<D
         QueryShardContext context
     ) {
         checkAllowExpensiveQueries(context);
-        return NumberType.doubleRangeQuery(
+        return NumberType.longRangeQuery(
             lowerTerm,
             upperTerm,
             includeLower,
             includeUpper,
-            (l, u) -> new DoubleScriptFieldRangeQuery(script, leafFactory(context), name(), l, u)
+            (l, u) -> new LongScriptFieldRangeQuery(script, leafFactory(context)::newInstance, name(), l, u)
         );
     }
 
     @Override
     public Query termQuery(Object value, QueryShardContext context) {
+        if (NumberType.hasDecimalPart(value)) {
+            return Queries.newMatchNoDocsQuery("Value [" + value + "] has a decimal part");
+        }
         checkAllowExpensiveQueries(context);
-        return new DoubleScriptFieldTermQuery(script, leafFactory(context), name(), NumberType.objectToDouble(value));
+        return new LongScriptFieldTermQuery(script, leafFactory(context)::newInstance, name(), NumberType.objectToLong(value, true));
     }
 
     @Override
@@ -97,9 +100,15 @@ public class DoubleScriptMappedFieldType extends AbstractScriptMappedFieldType<D
         }
         LongSet terms = new LongHashSet(values.size());
         for (Object value : values) {
-            terms.add(Double.doubleToLongBits(NumberType.objectToDouble(value)));
+            if (NumberType.hasDecimalPart(value)) {
+                continue;
+            }
+            terms.add(NumberType.objectToLong(value, true));
+        }
+        if (terms.isEmpty()) {
+            return Queries.newMatchNoDocsQuery("All values have a decimal part");
         }
         checkAllowExpensiveQueries(context);
-        return new DoubleScriptFieldTermsQuery(script, leafFactory(context), name(), terms);
+        return new LongScriptFieldTermsQuery(script, leafFactory(context)::newInstance, name(), terms);
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
@@ -129,12 +129,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 IpFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), IpFieldScript.CONTEXT);
-                return new IpScriptFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                return new IpScriptFieldType(builder.buildFullName(context), builder.script.getValue(), factory, builder.meta.getValue());
             },
             KeywordFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
@@ -151,12 +146,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 LongFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), LongFieldScript.CONTEXT);
-                return new LongScriptFieldType(
-                    builder.buildFullName(context),
-                    builder.script.getValue(),
-                    factory,
-                    builder.meta.getValue()
-                );
+                return new LongScriptFieldType(builder.buildFullName(context), builder.script.getValue(), factory, builder.meta.getValue());
             }
         );
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapper.java
@@ -47,7 +47,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
 
     protected RuntimeFieldMapper(
         String simpleName,
-        AbstractScriptMappedFieldType<?> mappedFieldType,
+        AbstractScriptFieldType<?> mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
         String runtimeType,
@@ -58,14 +58,6 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
         this.runtimeType = runtimeType;
         this.script = script;
         this.scriptCompiler = scriptCompiler;
-    }
-
-    String runtimeType() {
-        return runtimeType;
-    }
-
-    Script script() {
-        return script;
     }
 
     @Override
@@ -90,12 +82,12 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
 
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        static final Map<String, BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType<?>>> FIELD_TYPE_RESOLVER = Map.of(
+        static final Map<String, BiFunction<Builder, BuilderContext, AbstractScriptFieldType<?>>> FIELD_TYPE_RESOLVER = Map.of(
             BooleanFieldMapper.CONTENT_TYPE,
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 BooleanFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), BooleanFieldScript.CONTEXT);
-                return new BooleanScriptMappedFieldType(
+                return new BooleanScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -114,7 +106,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
                     locale = Locale.ROOT;
                 }
                 DateFormatter dateTimeFormatter = DateFormatter.forPattern(format).withLocale(locale);
-                return new DateScriptMappedFieldType(
+                return new DateScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -126,7 +118,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 DoubleFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), DoubleFieldScript.CONTEXT);
-                return new DoubleScriptMappedFieldType(
+                return new DoubleScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -137,7 +129,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 IpFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), IpFieldScript.CONTEXT);
-                return new IpScriptMappedFieldType(
+                return new IpScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -148,7 +140,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 StringFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), StringFieldScript.CONTEXT);
-                return new KeywordScriptMappedFieldType(
+                return new KeywordScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -159,7 +151,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             (builder, context) -> {
                 builder.formatAndLocaleNotSupported();
                 LongFieldScript.Factory factory = builder.scriptCompiler.compile(builder.script.getValue(), LongFieldScript.CONTEXT);
-                return new LongScriptMappedFieldType(
+                return new LongScriptFieldType(
                     builder.buildFullName(context),
                     builder.script.getValue(),
                     factory,
@@ -197,7 +189,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<String> format = Parameter.stringParam(
             "format",
             true,
-            mapper -> ((AbstractScriptMappedFieldType<?>) mapper.fieldType()).format(),
+            mapper -> ((AbstractScriptFieldType<?>) mapper.fieldType()).format(),
             null
         ).setSerializer((b, n, v) -> {
             if (v != null && false == v.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern())) {
@@ -209,7 +201,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
             true,
             () -> null,
             (n, c, o) -> o == null ? null : LocaleUtils.parse(o.toString()),
-            mapper -> ((AbstractScriptMappedFieldType<?>) mapper.fieldType()).formatLocale()
+            mapper -> ((AbstractScriptFieldType<?>) mapper.fieldType()).formatLocale()
         ).setSerializer((b, n, v) -> {
             if (v != null && false == v.equals(Locale.ROOT)) {
                 b.field(n, v.toString());
@@ -230,7 +222,7 @@ public final class RuntimeFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public RuntimeFieldMapper build(BuilderContext context) {
-            BiFunction<Builder, BuilderContext, AbstractScriptMappedFieldType<?>> fieldTypeResolver = Builder.FIELD_TYPE_RESOLVER.get(
+            BiFunction<Builder, BuilderContext, AbstractScriptFieldType<?>> fieldTypeResolver = Builder.FIELD_TYPE_RESOLVER.get(
                 runtimeType.getValue()
             );
             if (fieldTypeResolver == null) {

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractNonTextScriptFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractNonTextScriptFieldTypeTestCase.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 
-abstract class AbstractNonTextScriptMappedFieldTypeTestCase extends AbstractScriptMappedFieldTypeTestCase {
+abstract class AbstractNonTextScriptFieldTypeTestCase extends AbstractScriptFieldTypeTestCase {
     public void testFuzzyQueryIsError() throws IOException {
         assertQueryOnlyOnTextAndKeyword(
             "fuzzy",

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
@@ -25,7 +25,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-abstract class AbstractScriptMappedFieldTypeTestCase extends ESTestCase {
+abstract class AbstractScriptFieldTypeTestCase extends ESTestCase {
     protected abstract MappedFieldType simpleMappedFieldType() throws IOException;
 
     protected abstract MappedFieldType loopFieldType() throws IOException;

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTestCase {
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -75,7 +75,7 @@ public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMapp
             List<Long> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                BooleanScriptMappedFieldType ft = simpleMappedFieldType();
+                BooleanScriptFieldType ft = simpleMappedFieldType();
                 BooleanScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 searcher.search(new MatchAllDocsQuery(), new Collector() {
                     @Override
@@ -387,7 +387,7 @@ public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMapp
     }
 
     @Override
-    protected BooleanScriptMappedFieldType simpleMappedFieldType() throws IOException {
+    protected BooleanScriptFieldType simpleMappedFieldType() throws IOException {
         return build("read_foo", Map.of());
     }
 
@@ -401,11 +401,11 @@ public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMapp
         return "boolean";
     }
 
-    private static BooleanScriptMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static BooleanScriptFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, "test", code, params));
     }
 
-    private static BooleanScriptMappedFieldType build(Script script) throws IOException {
+    private static BooleanScriptFieldType build(Script script) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -468,7 +468,7 @@ public class BooleanScriptMappedFieldTypeTests extends AbstractNonTextScriptMapp
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             BooleanFieldScript.Factory factory = scriptService.compile(script, BooleanFieldScript.CONTEXT);
-            return new BooleanScriptMappedFieldType("test", script, factory, emptyMap());
+            return new BooleanScriptFieldType("test", script, factory, emptyMap());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
@@ -25,7 +25,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -36,14 +37,11 @@ import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.xpack.runtimefields.RuntimeFields;
-import org.elasticsearch.xpack.runtimefields.fielddata.BinaryScriptFieldData;
-import org.elasticsearch.xpack.runtimefields.fielddata.IpScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.DoubleScriptFieldData;
 
 import java.io.IOException;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -52,28 +50,27 @@ import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.sameInstance;
 
-public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeTestCase {
+public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTestCase {
     public void testFormat() throws IOException {
-        assertThat(simpleMappedFieldType().docValueFormat(null, null), sameInstance(DocValueFormat.IP));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat("ASDFA", null));
-        assertThat(e.getMessage(), equalTo("Field [test] of type [runtime] with runtime type [ip] does not support custom formats"));
-        e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat(null, ZoneId.of("America/New_York")));
-        assertThat(e.getMessage(), equalTo("Field [test] of type [runtime] with runtime type [ip] does not support custom time zones"));
+        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1), equalTo("1.0"));
+        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1.2), equalTo("1.2"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(11), equalTo("11"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(1123), equalTo("1,123"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123), equalTo("1,123.00"));
+        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123.1), equalTo("1,123.10"));
     }
 
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.2\", \"192.168.1\"]}"))));
-            List<Object> results = new ArrayList<>();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.0]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [3.14, 1.4]}"))));
+            List<Double> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                IpScriptMappedFieldType ft = build("append_param", Map.of("param", ".1"));
-                BinaryScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
-                DocValueFormat format = ft.docValueFormat(null, null);
+                DoubleScriptFieldType ft = build("add_param", Map.of("param", 1));
+                DoubleScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 searcher.search(new MatchAllDocsQuery(), new Collector() {
                     @Override
                     public ScoreMode scoreMode() {
@@ -82,7 +79,7 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
 
                     @Override
                     public LeafCollector getLeafCollector(LeafReaderContext context) {
-                        SortedBinaryDocValues dv = ifd.load(context).getBytesValues();
+                        SortedNumericDoubleValues dv = ifd.load(context).getDoubleValues();
                         return new LeafCollector() {
                             @Override
                             public void setScorer(Scorable scorer) {}
@@ -91,14 +88,14 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
                             public void collect(int doc) throws IOException {
                                 if (dv.advanceExact(doc)) {
                                     for (int i = 0; i < dv.docValueCount(); i++) {
-                                        results.add(format.format(dv.nextValue()));
+                                        results.add(dv.nextValue());
                                     }
                                 }
                             }
                         };
                     }
                 });
-                assertThat(results, equalTo(List.of("192.168.0.1", "192.168.1.1", "192.168.2.1")));
+                assertThat(results, equalTo(List.of(2.0, 2.4, 4.140000000000001)));
             }
         }
     }
@@ -106,26 +103,17 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
     @Override
     public void testSort() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                BinaryScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                DoubleScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
                 TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
-                assertThat(
-                    reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(),
-                    equalTo("{\"foo\": [\"192.168.0.1\"]}")
-                );
-                assertThat(
-                    reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(),
-                    equalTo("{\"foo\": [\"192.168.0.2\"]}")
-                );
-                assertThat(
-                    reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(),
-                    equalTo("{\"foo\": [\"192.168.0.4\"]}")
-                );
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1.1]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2.1]}"));
+                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4.2]}"));
             }
         }
     }
@@ -133,9 +121,9 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
     @Override
     public void testUsedInScript() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
@@ -150,8 +138,8 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
                         return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
-                                IpScriptFieldData.IpScriptDocValues bytes = (IpScriptFieldData.IpScriptDocValues) getDoc().get("test");
-                                return Integer.parseInt(bytes.getValue().substring(bytes.getValue().lastIndexOf(".") + 1));
+                                ScriptDocValues.Doubles doubles = (ScriptDocValues.Doubles) getDoc().get("test");
+                                return doubles.get(0);
                             }
                         };
                     }
@@ -163,7 +151,7 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
     @Override
     public void testExistsQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
@@ -175,76 +163,71 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
     @Override
     public void testRangeQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.5]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(
-                    searcher.count(
-                        simpleMappedFieldType().rangeQuery("192.0.0.0", "200.0.0.0", false, false, null, null, null, mockContext())
-                    ),
-                    equalTo(1)
-                );
+                MappedFieldType ft = simpleMappedFieldType();
+                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(2));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2.5, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2.5, 3, false, true, null, null, null, mockContext())), equalTo(0));
             }
         }
     }
 
     @Override
     protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.rangeQuery("192.0.0.0", "200.0.0.0", randomBoolean(), randomBoolean(), null, null, null, ctx);
+        return ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx);
     }
 
     @Override
     public void testTermQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                IpScriptMappedFieldType fieldType = build("append_param", Map.of("param", ".1"));
-                assertThat(searcher.count(fieldType.termQuery("192.168.0.1", mockContext())), equalTo(1));
-                assertThat(searcher.count(fieldType.termQuery("192.168.0.7", mockContext())), equalTo(0));
-                assertThat(searcher.count(fieldType.termQuery("192.168.0.0/16", mockContext())), equalTo(2));
-                assertThat(searcher.count(fieldType.termQuery("10.168.0.0/16", mockContext())), equalTo(0));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery("1", mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1, mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termQuery(1.1, mockContext())), equalTo(0));
+                assertThat(searcher.count(build("add_param", Map.of("param", 1)).termQuery(2, mockContext())), equalTo(1));
             }
         }
     }
 
     @Override
     protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.termQuery(randomIp(randomBoolean()), ctx);
+        return ft.termQuery(randomLong(), ctx);
     }
 
     @Override
     public void testTermsQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(
-                    searcher.count(simpleMappedFieldType().termsQuery(List.of("192.168.0.1", "1.1.1.1"), mockContext())),
-                    equalTo(2)
-                );
-                assertThat(
-                    searcher.count(simpleMappedFieldType().termsQuery(List.of("192.168.0.0/16", "1.1.1.1"), mockContext())),
-                    equalTo(3)
-                );
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of("1"), mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1), mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1), mockContext())), equalTo(0));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1, 2.1), mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(2.1, 1), mockContext())), equalTo(2));
             }
         }
     }
 
     @Override
     protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.termsQuery(randomList(100, () -> randomIp(randomBoolean())), ctx);
+        return ft.termsQuery(List.of(randomLong()), ctx);
     }
 
     @Override
-    protected IpScriptMappedFieldType simpleMappedFieldType() throws IOException {
+    protected DoubleScriptFieldType simpleMappedFieldType() throws IOException {
         return build("read_foo", Map.of());
     }
 
@@ -255,14 +238,14 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
 
     @Override
     protected String runtimeType() {
-        return "ip";
+        return "double";
     }
 
-    private static IpScriptMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static DoubleScriptFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, "test", code, params));
     }
 
-    private static IpScriptMappedFieldType build(Script script) throws IOException {
+    private static DoubleScriptFieldType build(Script script) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -274,7 +257,7 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
 
                     @Override
                     public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(StringFieldScript.CONTEXT);
+                        return Set.of(DoubleFieldScript.CONTEXT);
                     }
 
                     @Override
@@ -289,23 +272,23 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
                         return factory;
                     }
 
-                    private IpFieldScript.Factory factory(String code) {
+                    private DoubleFieldScript.Factory factory(String code) {
                         switch (code) {
                             case "read_foo":
-                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
+                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(foo.toString());
+                                            emit(((Number) foo).doubleValue());
                                         }
                                     }
                                 };
-                            case "append_param":
-                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
+                            case "add_param":
+                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(foo.toString() + getParams().get("param"));
+                                            emit(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
                                         }
                                     }
                                 };
@@ -324,8 +307,8 @@ public class IpScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeT
         };
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            IpFieldScript.Factory factory = scriptService.compile(script, IpFieldScript.CONTEXT);
-            return new IpScriptMappedFieldType("test", script, factory, emptyMap());
+            DoubleFieldScript.Factory factory = scriptService.compile(script, DoubleFieldScript.CONTEXT);
+            return new DoubleScriptFieldType("test", script, factory, emptyMap());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
@@ -10,9 +10,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
-import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -27,7 +25,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -38,11 +36,14 @@ import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.xpack.runtimefields.RuntimeFields;
-import org.elasticsearch.xpack.runtimefields.fielddata.LongScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.BinaryScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.IpScriptFieldData;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -51,25 +52,28 @@ import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     public void testFormat() throws IOException {
-        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1), equalTo("1.0"));
-        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(11), equalTo("11"));
-        assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(1123), equalTo("1,123"));
+        assertThat(simpleMappedFieldType().docValueFormat(null, null), sameInstance(DocValueFormat.IP));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat("ASDFA", null));
+        assertThat(e.getMessage(), equalTo("Field [test] of type [runtime] with runtime type [ip] does not support custom formats"));
+        e = expectThrows(IllegalArgumentException.class, () -> simpleMappedFieldType().docValueFormat(null, ZoneId.of("America/New_York")));
+        assertThat(e.getMessage(), equalTo("Field [test] of type [runtime] with runtime type [ip] does not support custom time zones"));
     }
 
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2, 1]}"))));
-            List<Long> results = new ArrayList<>();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.2\", \"192.168.1\"]}"))));
+            List<Object> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                LongScriptMappedFieldType ft = build("add_param", Map.of("param", 1));
-                LongScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                IpScriptFieldType ft = build("append_param", Map.of("param", ".1"));
+                BinaryScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                DocValueFormat format = ft.docValueFormat(null, null);
                 searcher.search(new MatchAllDocsQuery(), new Collector() {
                     @Override
                     public ScoreMode scoreMode() {
@@ -78,7 +82,7 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
 
                     @Override
                     public LeafCollector getLeafCollector(LeafReaderContext context) {
-                        SortedNumericDocValues dv = ifd.load(context).getLongValues();
+                        SortedBinaryDocValues dv = ifd.load(context).getBytesValues();
                         return new LeafCollector() {
                             @Override
                             public void setScorer(Scorable scorer) {}
@@ -87,14 +91,14 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                             public void collect(int doc) throws IOException {
                                 if (dv.advanceExact(doc)) {
                                     for (int i = 0; i < dv.docValueCount(); i++) {
-                                        results.add(dv.nextValue());
+                                        results.add(format.format(dv.nextValue()));
                                     }
                                 }
                             }
                         };
                     }
                 });
-                assertThat(results, equalTo(List.of(2L, 2L, 3L)));
+                assertThat(results, equalTo(List.of("192.168.0.1", "192.168.1.1", "192.168.2.1")));
             }
         }
     }
@@ -102,41 +106,26 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     @Override
     public void testSort() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                LongScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                BinaryScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
                 TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
-                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1]}"));
-                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2]}"));
-                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4]}"));
-            }
-        }
-    }
-
-    public void testNow() throws IOException {
-        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}"))));
-            try (DirectoryReader reader = iw.getReader()) {
-                IndexSearcher searcher = newSearcher(reader);
-                LongScriptFieldData ifd = build("millis_ago", Map.of()).fielddataBuilder("test", mockContext()::lookup)
-                    .build(null, null, null);
-                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
-                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
-                assertThat(readSource(reader, docs.scoreDocs[0].doc), equalTo("{\"timestamp\": [1595432181356]}"));
-                assertThat(readSource(reader, docs.scoreDocs[1].doc), equalTo("{\"timestamp\": [1595432181354]}"));
-                assertThat(readSource(reader, docs.scoreDocs[2].doc), equalTo("{\"timestamp\": [1595432181351]}"));
-                long t1 = (Long) (((FieldDoc) docs.scoreDocs[0]).fields[0]);
-                assertThat(t1, greaterThan(3638011399L));
-                long t2 = (Long) (((FieldDoc) docs.scoreDocs[1]).fields[0]);
-                long t3 = (Long) (((FieldDoc) docs.scoreDocs[2]).fields[0]);
-                assertThat(t2, equalTo(t1 + 2));
-                assertThat(t3, equalTo(t1 + 5));
+                assertThat(
+                    reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.1\"]}")
+                );
+                assertThat(
+                    reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.2\"]}")
+                );
+                assertThat(
+                    reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(),
+                    equalTo("{\"foo\": [\"192.168.0.4\"]}")
+                );
             }
         }
     }
@@ -144,9 +133,9 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     @Override
     public void testUsedInScript() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.4\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
@@ -161,8 +150,8 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                         return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
-                                ScriptDocValues.Longs longs = (ScriptDocValues.Longs) getDoc().get("test");
-                                return longs.get(0);
+                                IpScriptFieldData.IpScriptDocValues bytes = (IpScriptFieldData.IpScriptDocValues) getDoc().get("test");
+                                return Integer.parseInt(bytes.getValue().substring(bytes.getValue().lastIndexOf(".") + 1));
                             }
                         };
                     }
@@ -174,7 +163,7 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     @Override
     public void testExistsQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": []}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
@@ -186,86 +175,94 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
     @Override
     public void testRangeQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                MappedFieldType ft = simpleMappedFieldType();
-                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(0));
+                assertThat(
+                    searcher.count(
+                        simpleMappedFieldType().rangeQuery("192.0.0.0", "200.0.0.0", false, false, null, null, null, mockContext())
+                    ),
+                    equalTo(1)
+                );
             }
         }
     }
 
     @Override
     protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx);
+        return ft.rangeQuery("192.0.0.0", "200.0.0.0", randomBoolean(), randomBoolean(), null, null, null, ctx);
     }
 
     @Override
     public void testTermQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(searcher.count(simpleMappedFieldType().termQuery("1", mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termQuery(1, mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termQuery(1.1, mockContext())), equalTo(0));
-                assertThat(searcher.count(build("add_param", Map.of("param", 1)).termQuery(2, mockContext())), equalTo(1));
+                IpScriptFieldType fieldType = build("append_param", Map.of("param", ".1"));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.1", mockContext())), equalTo(1));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.7", mockContext())), equalTo(0));
+                assertThat(searcher.count(fieldType.termQuery("192.168.0.0/16", mockContext())), equalTo(2));
+                assertThat(searcher.count(fieldType.termQuery("10.168.0.0/16", mockContext())), equalTo(0));
             }
         }
     }
 
     @Override
     protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.termQuery(randomLong(), ctx);
+        return ft.termQuery(randomIp(randomBoolean()), ctx);
     }
 
     @Override
     public void testTermsQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.1.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"200.0.0.1\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"1.1.1.1\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of("1"), mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1), mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1), mockContext())), equalTo(0));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1, 2), mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(2, 1), mockContext())), equalTo(2));
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(List.of("192.168.0.1", "1.1.1.1"), mockContext())),
+                    equalTo(2)
+                );
+                assertThat(
+                    searcher.count(simpleMappedFieldType().termsQuery(List.of("192.168.0.0/16", "1.1.1.1"), mockContext())),
+                    equalTo(3)
+                );
             }
         }
     }
 
     @Override
     protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
-        return ft.termsQuery(List.of(randomLong()), ctx);
+        return ft.termsQuery(randomList(100, () -> randomIp(randomBoolean())), ctx);
     }
 
     @Override
-    protected LongScriptMappedFieldType simpleMappedFieldType() throws IOException {
+    protected IpScriptFieldType simpleMappedFieldType() throws IOException {
         return build("read_foo", Map.of());
     }
 
     @Override
-    protected LongScriptMappedFieldType loopFieldType() throws IOException {
+    protected MappedFieldType loopFieldType() throws IOException {
         return build("loop", Map.of());
     }
 
     @Override
     protected String runtimeType() {
-        return "long";
+        return "ip";
     }
 
-    private static LongScriptMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static IpScriptFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, "test", code, params));
     }
 
-    private static LongScriptMappedFieldType build(Script script) throws IOException {
+    private static IpScriptFieldType build(Script script) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -277,7 +274,7 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
 
                     @Override
                     public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(LongFieldScript.CONTEXT);
+                        return Set.of(StringFieldScript.CONTEXT);
                     }
 
                     @Override
@@ -292,34 +289,23 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
                         return factory;
                     }
 
-                    private LongFieldScript.Factory factory(String code) {
+                    private IpFieldScript.Factory factory(String code) {
                         switch (code) {
                             case "read_foo":
-                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
+                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).longValue());
+                                            emit(foo.toString());
                                         }
                                     }
                                 };
-                            case "add_param":
-                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
+                            case "append_param":
+                                return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).longValue() + ((Number) getParams().get("param")).longValue());
-                                        }
-                                    }
-                                };
-                            case "millis_ago":
-                                // Painless actually call System.currentTimeMillis. We could mock the time but this works fine too.
-                                long now = System.currentTimeMillis();
-                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
-                                            emit(now - ((Number) timestamp).longValue());
+                                            emit(foo.toString() + getParams().get("param"));
                                         }
                                     }
                                 };
@@ -338,8 +324,8 @@ public class LongScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedF
         };
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            LongFieldScript.Factory factory = scriptService.compile(script, LongFieldScript.CONTEXT);
-            return new LongScriptMappedFieldType("test", script, factory, emptyMap());
+            IpFieldScript.Factory factory = scriptService.compile(script, IpFieldScript.CONTEXT);
+            return new IpScriptFieldType("test", script, factory, emptyMap());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
@@ -55,7 +55,7 @@ import java.util.Set;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 
-public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedFieldTypeTestCase {
+public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -64,7 +64,7 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
             List<String> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                KeywordScriptMappedFieldType ft = build("append_param", Map.of("param", "-suffix"));
+                KeywordScriptFieldType ft = build("append_param", Map.of("param", "-suffix"));
                 StringScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 searcher.search(new MatchAllDocsQuery(), new Collector() {
                     @Override
@@ -277,7 +277,7 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                KeywordScriptMappedFieldType fieldType = build("append_param", Map.of("param", "-suffix"));
+                KeywordScriptFieldType fieldType = build("append_param", Map.of("param", "-suffix"));
                 assertThat(searcher.count(fieldType.termQuery("1-suffix", mockContext())), equalTo(1));
             }
         }
@@ -336,7 +336,7 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                KeywordScriptMappedFieldType fieldType = build("append_param", Map.of("param", "-Suffix"));
+                KeywordScriptFieldType fieldType = build("append_param", Map.of("param", "-Suffix"));
                 QueryShardContext queryShardContext = mockContext(true, fieldType);
                 Query query = new MatchQueryBuilder("test", "1-Suffix").toQuery(queryShardContext);
                 assertThat(searcher.count(query), equalTo(1));
@@ -345,12 +345,12 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
     }
 
     @Override
-    protected KeywordScriptMappedFieldType simpleMappedFieldType() throws IOException {
+    protected KeywordScriptFieldType simpleMappedFieldType() throws IOException {
         return build("read_foo", Map.of());
     }
 
     @Override
-    protected KeywordScriptMappedFieldType loopFieldType() throws IOException {
+    protected KeywordScriptFieldType loopFieldType() throws IOException {
         return build("loop", Map.of());
     }
 
@@ -359,11 +359,11 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
         return "keyword";
     }
 
-    private static KeywordScriptMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static KeywordScriptFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, "test", code, params));
     }
 
-    private static KeywordScriptMappedFieldType build(Script script) throws IOException {
+    private static KeywordScriptFieldType build(Script script) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -426,7 +426,7 @@ public class KeywordScriptMappedFieldTypeTests extends AbstractScriptMappedField
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             StringFieldScript.Factory factory = scriptService.compile(script, StringFieldScript.CONTEXT);
-            return new KeywordScriptMappedFieldType("test", script, factory, emptyMap());
+            return new KeywordScriptFieldType("test", script, factory, emptyMap());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
@@ -10,7 +10,9 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -26,7 +28,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -39,7 +40,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.xpack.runtimefields.RuntimeFields;
-import org.elasticsearch.xpack.runtimefields.fielddata.DoubleScriptFieldData;
+import org.elasticsearch.xpack.runtimefields.fielddata.LongScriptFieldData;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,27 +51,25 @@ import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
-public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappedFieldTypeTestCase {
+public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTestCase {
     public void testFormat() throws IOException {
         assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1), equalTo("1.0"));
-        assertThat(simpleMappedFieldType().docValueFormat("#.0", null).format(1.2), equalTo("1.2"));
         assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(11), equalTo("11"));
         assertThat(simpleMappedFieldType().docValueFormat("#,##0.##", null).format(1123), equalTo("1,123"));
-        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123), equalTo("1,123.00"));
-        assertThat(simpleMappedFieldType().docValueFormat("#,##0.00", null).format(1123.1), equalTo("1,123.10"));
     }
 
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.0]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [3.14, 1.4]}"))));
-            List<Double> results = new ArrayList<>();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2, 1]}"))));
+            List<Long> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                DoubleScriptMappedFieldType ft = build("add_param", Map.of("param", 1));
-                DoubleScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                LongScriptFieldType ft = build("add_param", Map.of("param", 1));
+                LongScriptFieldData ifd = ft.fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 searcher.search(new MatchAllDocsQuery(), new Collector() {
                     @Override
                     public ScoreMode scoreMode() {
@@ -79,7 +78,7 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
 
                     @Override
                     public LeafCollector getLeafCollector(LeafReaderContext context) {
-                        SortedNumericDoubleValues dv = ifd.load(context).getDoubleValues();
+                        SortedNumericDocValues dv = ifd.load(context).getLongValues();
                         return new LeafCollector() {
                             @Override
                             public void setScorer(Scorable scorer) {}
@@ -95,7 +94,7 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
                         };
                     }
                 });
-                assertThat(results, equalTo(List.of(2.0, 2.4, 4.140000000000001)));
+                assertThat(results, equalTo(List.of(2L, 2L, 3L)));
             }
         }
     }
@@ -103,17 +102,41 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
     @Override
     public void testSort() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                DoubleScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
+                LongScriptFieldData ifd = simpleMappedFieldType().fielddataBuilder("test", mockContext()::lookup).build(null, null, null);
                 SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
                 TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
-                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1.1]}"));
-                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2.1]}"));
-                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4.2]}"));
+                assertThat(reader.document(docs.scoreDocs[0].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [1]}"));
+                assertThat(reader.document(docs.scoreDocs[1].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [2]}"));
+                assertThat(reader.document(docs.scoreDocs[2].doc).getBinaryValue("_source").utf8ToString(), equalTo("{\"foo\": [4]}"));
+            }
+        }
+    }
+
+    public void testNow() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181354]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                LongScriptFieldData ifd = build("millis_ago", Map.of()).fielddataBuilder("test", mockContext()::lookup)
+                    .build(null, null, null);
+                SortField sf = ifd.sortField(null, MultiValueMode.MIN, null, false);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 3, new Sort(sf));
+                assertThat(readSource(reader, docs.scoreDocs[0].doc), equalTo("{\"timestamp\": [1595432181356]}"));
+                assertThat(readSource(reader, docs.scoreDocs[1].doc), equalTo("{\"timestamp\": [1595432181354]}"));
+                assertThat(readSource(reader, docs.scoreDocs[2].doc), equalTo("{\"timestamp\": [1595432181351]}"));
+                long t1 = (Long) (((FieldDoc) docs.scoreDocs[0]).fields[0]);
+                assertThat(t1, greaterThan(3638011399L));
+                long t2 = (Long) (((FieldDoc) docs.scoreDocs[1]).fields[0]);
+                long t3 = (Long) (((FieldDoc) docs.scoreDocs[2]).fields[0]);
+                assertThat(t2, equalTo(t1 + 2));
+                assertThat(t3, equalTo(t1 + 5));
             }
         }
     }
@@ -121,9 +144,9 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
     @Override
     public void testUsedInScript() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1.1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4.2]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [4]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
@@ -138,8 +161,8 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
                         return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
-                                ScriptDocValues.Doubles doubles = (ScriptDocValues.Doubles) getDoc().get("test");
-                                return doubles.get(0);
+                                ScriptDocValues.Longs longs = (ScriptDocValues.Longs) getDoc().get("test");
+                                return longs.get(0);
                             }
                         };
                     }
@@ -165,17 +188,14 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.5]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 MappedFieldType ft = simpleMappedFieldType();
-                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(2));
-                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(2));
-                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(2));
-                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(2));
-                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(2.5, 3, true, true, null, null, null, mockContext())), equalTo(1));
-                assertThat(searcher.count(ft.rangeQuery(2.5, 3, false, true, null, null, null, mockContext())), equalTo(0));
+                assertThat(searcher.count(ft.rangeQuery("2", "3", true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, true, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(1.1, 3, false, true, null, null, null, mockContext())), equalTo(1));
+                assertThat(searcher.count(ft.rangeQuery(2, 3, false, true, null, null, null, mockContext())), equalTo(0));
             }
         }
     }
@@ -209,14 +229,14 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
     public void testTermsQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [1]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of("1"), mockContext())), equalTo(1));
                 assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1), mockContext())), equalTo(1));
                 assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1), mockContext())), equalTo(0));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1, 2.1), mockContext())), equalTo(1));
-                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(2.1, 1), mockContext())), equalTo(2));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(1.1, 2), mockContext())), equalTo(1));
+                assertThat(searcher.count(simpleMappedFieldType().termsQuery(List.of(2, 1), mockContext())), equalTo(2));
             }
         }
     }
@@ -227,25 +247,25 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
     }
 
     @Override
-    protected DoubleScriptMappedFieldType simpleMappedFieldType() throws IOException {
+    protected LongScriptFieldType simpleMappedFieldType() throws IOException {
         return build("read_foo", Map.of());
     }
 
     @Override
-    protected MappedFieldType loopFieldType() throws IOException {
+    protected LongScriptFieldType loopFieldType() throws IOException {
         return build("loop", Map.of());
     }
 
     @Override
     protected String runtimeType() {
-        return "double";
+        return "long";
     }
 
-    private static DoubleScriptMappedFieldType build(String code, Map<String, Object> params) throws IOException {
+    private static LongScriptFieldType build(String code, Map<String, Object> params) throws IOException {
         return build(new Script(ScriptType.INLINE, "test", code, params));
     }
 
-    private static DoubleScriptMappedFieldType build(Script script) throws IOException {
+    private static LongScriptFieldType build(Script script) throws IOException {
         ScriptPlugin scriptPlugin = new ScriptPlugin() {
             @Override
             public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
@@ -257,7 +277,7 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
 
                     @Override
                     public Set<ScriptContext<?>> getSupportedContexts() {
-                        return Set.of(DoubleFieldScript.CONTEXT);
+                        return Set.of(LongFieldScript.CONTEXT);
                     }
 
                     @Override
@@ -272,23 +292,34 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
                         return factory;
                     }
 
-                    private DoubleFieldScript.Factory factory(String code) {
+                    private LongFieldScript.Factory factory(String code) {
                         switch (code) {
                             case "read_foo":
-                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
+                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).doubleValue());
+                                            emit(((Number) foo).longValue());
                                         }
                                     }
                                 };
                             case "add_param":
-                                return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
+                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
+                                            emit(((Number) foo).longValue() + ((Number) getParams().get("param")).longValue());
+                                        }
+                                    }
+                                };
+                            case "millis_ago":
+                                // Painless actually call System.currentTimeMillis. We could mock the time but this works fine too.
+                                long now = System.currentTimeMillis();
+                                return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
+                                    @Override
+                                    public void execute() {
+                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                            emit(now - ((Number) timestamp).longValue());
                                         }
                                     }
                                 };
@@ -307,8 +338,8 @@ public class DoubleScriptMappedFieldTypeTests extends AbstractNonTextScriptMappe
         };
         ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, List.of(scriptPlugin, new RuntimeFields()));
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
-            DoubleFieldScript.Factory factory = scriptService.compile(script, DoubleFieldScript.CONTEXT);
-            return new DoubleScriptMappedFieldType("test", script, factory, emptyMap());
+            LongFieldScript.Factory factory = scriptService.compile(script, LongFieldScript.CONTEXT);
+            return new LongScriptFieldType("test", script, factory, emptyMap());
         }
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
@@ -323,12 +323,7 @@ public class RuntimeFieldMapperTests extends MapperTestCase {
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
             () -> config.buildIndexSort(
-                field -> new KeywordScriptFieldType(
-                    field,
-                    new Script(""),
-                    mock(StringFieldScript.Factory.class),
-                    Collections.emptyMap()
-                ),
+                field -> new KeywordScriptFieldType(field, new Script(""), mock(StringFieldScript.Factory.class), Collections.emptyMap()),
                 (fieldType, searchLookupSupplier) -> indexFieldDataService.getForField(fieldType, "index", searchLookupSupplier)
             )
         );

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
@@ -323,7 +323,7 @@ public class RuntimeFieldMapperTests extends MapperTestCase {
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
             () -> config.buildIndexSort(
-                field -> new KeywordScriptMappedFieldType(
+                field -> new KeywordScriptFieldType(
                     field,
                     new Script(""),
                     mock(StringFieldScript.Factory.class),


### PR DESCRIPTION
In the codebase there is the non-written convention that classes that extend `MappedFieldType` are generally called `*FieldType`. With this commit we adopt the same convention for runtime field types which allows us to shorten their names by removing the `Mapped` portion which is implicit.