### PR TITLE
Correct version field yml test skip version

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/10_basic.yml
@@ -5,8 +5,8 @@ setup:
 
   - skip:
       features: headers
-      version: " - 7.99.99"
-      reason: "version field is added to 8.0 first"
+      version: " - 7.10.00"
+      reason: "version field is added to 7.10"
 
   - do:
         indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/20_scripts.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/versionfield/20_scripts.yml
@@ -5,8 +5,8 @@ setup:
 
   - skip:
       features: headers
-      version: " - 7.99.99"
-      reason: "version field is added to 8.0 first"
+      version: " - 7.10.00"
+      reason: "version field is added to 7.10"
 
   - do:
         indices.create:


### PR DESCRIPTION
The field type was backported to 7.x so we can run the test with 7.10 versions.