### PR TITLE
Update the cat tasks test skip version after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.tasks/10_basic.yml
@@ -21,8 +21,8 @@
 ---
 "Test cat tasks output with X-Opaque-Id":
   - skip:
-      version: " - 7.99.99"
-      reason: support for opaque_id was added in 8.0.0
+      version: " - 7.9.99"
+      reason: support for opaque_id was added in 7.10.0
       features: headers
 
   - do:


### PR DESCRIPTION
Since #63036 is now backported, we can enable this test for earlier versions.

Relates to #61118
