### PR TITLE
[DOCS] Fix titles for ML APIs

### DIFF
--- a/docs/java-rest/high-level/ml/close-job.asciidoc
+++ b/docs/java-rest/high-level/ml/close-job.asciidoc
@@ -5,12 +5,12 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Close {anomaly-job} API
+=== Close {anomaly-jobs} API
 
 Closes {anomaly-jobs} in the cluster. It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Close {anomaly-job} request
+==== Close {anomaly-jobs} request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -27,7 +27,7 @@ which has not responded to its initial close request.
 execution should wait for the job to be closed.
 
 [id="{upid}-{api}-response"]
-==== Close {anomaly-job} response
+==== Close {anomaly-jobs} response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
@@ -5,13 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete calendar event API
+=== Delete calendar events API
+
 Removes a scheduled event from an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete calendar event request
+==== Delete calendar events request
 
 A +{request}+ is constructed referencing a non-null
 calendar ID, and eventId which to remove from the calendar
@@ -24,7 +25,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <2> The eventId to remove from the calendar
 
 [id="{upid}-{api}-response"]
-====  Delete calendar event response
+====  Delete calendar events response
 
 The returned +{response}+ acknowledges the success of the request:
 

--- a/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
@@ -6,6 +6,7 @@
 [role="xpack"]
 [id="{upid}-{api}"]
 === Delete {anomaly-jobs} from calendar API
+
 Removes {anomaly-jobs} from an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/delete-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar.asciidoc
@@ -5,13 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete calendar API
-Delete a {ml} calendar.
+=== Delete calendars API
+
+Deletes a {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete calendar request
+==== Delete calendars request
 
 A `DeleteCalendar` object requires a non-null `calendarId`.
 
@@ -22,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request referencing an existing calendar
 
 [id="{upid}-{api}-response"]
-==== Delete calendar response
+==== Delete calendars response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-datafeed.asciidoc
@@ -5,12 +5,12 @@
 --
 [role="xpack"]
 [id="{upid}-delete-datafeed"]
-=== Delete datafeed API
+=== Delete datafeeds API
 
 Deletes an existing datafeed.
 
 [id="{upid}-{api}-request"]
-==== Delete datafeed request
+==== Delete datafeeds request
 
 A +{request}+ object requires a non-null `datafeedId` and can optionally set `force`.
 
@@ -24,7 +24,7 @@ stopping and deleting the datafeed. Defaults to `false`.
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Delete datafeed response
+==== Delete datafeeds response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
@@ -7,7 +7,8 @@
 [role="xpack"]
 [id="{upid}-{api}"]
 === Delete expired data API
-Delete expired {ml} data.
+
+Deletes expired {ml} data.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 

--- a/docs/java-rest/high-level/ml/delete-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-filter.asciidoc
@@ -5,13 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete filter API
-Delete a {ml} filter.
+=== Delete filters API
+
+Deletes a {ml} filter.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete filter request
+==== Delete filters request
 
 A +{request}+ object requires a non-null `filterId`.
 
@@ -22,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request referencing an existing filter
 
 [id="{upid}-{api}-response"]
-==== Delete filter response
+==== Delete filters response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-forecast.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-forecast.asciidoc
@@ -5,15 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete forecast API
+=== Delete forecasts API
 
-The delete forecast API provides the ability to delete a {ml} job's
-forecast in the cluster.
+Deletes forecasts from an {anomaly-job}.
 It accepts a +{request}+ object and responds
 with an +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete forecast request
+==== Delete forecasts request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -39,7 +38,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 request finds no forecasts. It defaults to `true`
 
 [id="{upid}-{api}-response"]
-==== Delete forecast response
+==== Delete forecasts response
 
 An +{response}+ contains an acknowledgement of the forecast(s) deletion
 

--- a/docs/java-rest/high-level/ml/delete-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-job.asciidoc
@@ -5,12 +5,12 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete {anomaly-job} API
+=== Delete {anomaly-jobs} API
 
 Deletes an {anomaly-job} that exists in the cluster.
 
 [id="{upid}-{api}-request"]
-==== Delete {anomaly-job} request
+==== Delete {anomaly-jobs} request
 
 A +{request}+ object requires a non-null `jobId` and can optionally set `force`.
 
@@ -40,7 +40,7 @@ before returning. Defaults to `true`.
 
 
 [id="{upid}-{api}-response"]
-==== Delete {anomaly-job} response
+==== Delete {anomaly-jobs} response
 
 The returned +{response}+ object indicates the acknowledgement of the job
 deletion or the deletion task depending on whether the request was set to wait

--- a/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
@@ -5,10 +5,12 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete model snapshot API
+=== Delete model snapshots API
+
+Deletes an existing model snapshot.
 
 [id="{upid}-{api}-request"]
-==== Delete model snapshot request
+==== Delete model snapshots request
 
 A +{request}+ object requires both a non-null `jobId` and a non-null `snapshotId`.
 
@@ -21,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Delete model snapshot response
+==== Delete model snapshots response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
@@ -5,7 +5,7 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete trained model API
+=== Delete trained models API
 
 experimental::[]
 
@@ -13,7 +13,7 @@ Deletes a previously saved trained model.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Delete trained model request
+==== Delete trained models request
 
 A +{request}+ requires a valid trained model ID.
 

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -9,7 +9,7 @@
 
 experimental::[]
 
-Evaluates the {ml} algorithm that ran on a {dataframe}.
+Evaluates the {dfanalytics} for an annotated index.
 The API accepts an +{request}+ object and returns an +{response}+.
 
 [id="{upid}-{api}-request"]

--- a/docs/java-rest/high-level/ml/find-file-structure.asciidoc
+++ b/docs/java-rest/high-level/ml/find-file-structure.asciidoc
@@ -9,13 +9,12 @@
 
 experimental::[]
 
-The Find File Structure API can be used to find the structure of a text file
-and other information that will be useful to import its contents to an {es}
-index.  It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Determines the structure of a text file and other information that will be
+useful to import its contents to an {es} index. It accepts a +{request}+ object
+and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Find File Structure Request
+==== Find file structure request
 
 A sample from the beginning of the file (or the entire file contents if
 it's small) must be added to the +{request}+ object using the
@@ -28,7 +27,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Create a new `FindFileStructureRequest` object
 <2> Add the contents of `anInterestingFile` to the request
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -43,7 +42,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Find File Structure Response
+==== Find file structure response
 
 A +{response}+ contains information about the file structure,
 as well as mappings and an ingest pipeline that could be used

--- a/docs/java-rest/high-level/ml/flush-job.asciidoc
+++ b/docs/java-rest/high-level/ml/flush-job.asciidoc
@@ -5,15 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Flush job API
+=== Flush jobs API
 
-The flush job API provides the ability to flush a {ml} job's 
-datafeed in the cluster.
+Flushes an anomaly detection job's datafeed in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Flush job request
+==== Flush jobs request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -41,7 +40,7 @@ to calculate interim results (requires `calc_interim` to be `true`)
 <5> Set the skip time to skip a particular time value
 
 [id="{upid}-{api}-response"]
-==== Flush job response
+==== Flush jobs response
 
 A +{response}+ contains an acknowledgement and an optional end date for the
 last finalized bucket

--- a/docs/java-rest/high-level/ml/forecast-job.asciidoc
+++ b/docs/java-rest/high-level/ml/forecast-job.asciidoc
@@ -5,15 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Forecast job API
+=== Forecast jobs API
 
-The forecast job API provides the ability to forecast a {ml} job's behavior based
-on historical data.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Forecasts a {ml} job's behavior based on historical data. It accepts a
++{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Forecast job request
+==== Forecast jobs request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 All other fields are optional for the request.
@@ -40,7 +38,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
     automatically reduced to below that number.
 
 [id="{upid}-{api}-response"]
-==== Forecast job response
+==== Forecast jobs response
 
 A +{response}+ contains an acknowledgement and the forecast ID
 

--- a/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
@@ -6,12 +6,13 @@
 [role="xpack"]
 [id="{upid}-{api}"]
 === Get calendar events API
+
 Retrieves a calendar's events.
 It accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get calendars request
+==== Get calendar events request
 
 A +{request}+ requires a non-null calendar ID.
 Using the literal `_all` returns the events for all calendars.
@@ -54,7 +55,7 @@ include-tagged::{doc-tests-file}[{api}-jobid]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get calendars response
+==== Get calendar events response
 
 The returned +{response}+ contains the requested events:
 

--- a/docs/java-rest/high-level/ml/get-calendars.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendars.asciidoc
@@ -6,6 +6,7 @@
 [role="xpack"]
 [id="{upid}-{api}"]
 === Get calendars API
+
 Retrieves one or more calendar objects.
 It accepts a +{request}+ and responds
 with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/get-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get datafeed API
+=== Get datafeeds API
 
 Retrieves configuration information about {ml} datafeeds in the cluster.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get datafeed request
+==== Get datafeeds request
 
 A +{request}+ object gets can have any number of `datafeedId` entries. However,
 they all must be non-null. An empty list is the same as requesting for all
@@ -30,7 +30,7 @@ then be put into another cluster. Certain fields that can only be set when
 the datafeed is created are removed.
 
 [id="{upid}-{api}-response"]
-==== Get datafeed response
+==== Get datafeeds response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/get-info.asciidoc
+++ b/docs/java-rest/high-level/ml/get-info.asciidoc
@@ -5,7 +5,7 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== ML get info API
+=== Get {ml} info API
 
 Provides defaults and limits used internally by {ml}.
 These may be useful to a user interface that needs to interpret machine learning
@@ -15,7 +15,7 @@ with the default value.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get info request
+==== Get {ml} info request
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request.
 
 [id="{upid}-{api}-response"]
-==== ML get info response
+==== Get {ml} info response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/get-job-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job-stats.asciidoc
@@ -11,7 +11,7 @@ Retrieves statistics for any number of {anomaly-jobs} in the cluster.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get job stats request
+==== Get {anomaly-job} stats request
 
 A `GetJobsStatsRequest` object can have any number of `jobId`
 entries. However, they all must be non-null. An empty list is the same as
@@ -29,7 +29,7 @@ wildcards.
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get job stats response
+==== Get {anomaly-job} stats response
 The returned +{response}+ contains the requested job statistics:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/open-job.asciidoc
+++ b/docs/java-rest/high-level/ml/open-job.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Open {anomaly-job} API
+=== Open {anomaly-jobs} API
 
 Opens {anomaly-jobs} in the cluster. It accepts a +{request}+ object and
 responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Open {anomaly-job} request
+==== Open {anomaly-jobs} request
 
 An +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -24,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 execution should wait for the job to be opened.
 
 [id="{upid}-{api}-response"]
-==== Open {anomaly-job} response
+==== Open {anomaly-jobs} response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
@@ -5,14 +5,15 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Post calendar event API
+=== Post calendar events API
+
 Adds new ScheduledEvents to an existing {ml} calendar.
 
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Post calendar event request
+==== Post calendar events request
 
 A +{request}+ is constructed with a calendar ID object
 and a non-empty list of scheduled events.
@@ -26,7 +27,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 
 
 [id="{upid}-{api}-response"]
-==== Post calendar event response
+==== Post calendar events response
 
 The returned +{response}+ contains the added `ScheduledEvent` objects:
 

--- a/docs/java-rest/high-level/ml/post-data.asciidoc
+++ b/docs/java-rest/high-level/ml/post-data.asciidoc
@@ -7,8 +7,7 @@
 [id="{upid}-{api}"]
 === Post data API
 
-The post data API provides the ability to post data to an open
- {ml} job in the cluster.
+Posts data to an open {ml} job in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 

--- a/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
@@ -5,14 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Preview datafeed API
+=== Preview datafeeds API
 
-The preview datafeed API provides the ability to preview a {ml} datafeed's data
-in the cluster. It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Previews a {ml} datafeed's data in the cluster. It accepts a +{request}+ object
+and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Preview datafeed request
+==== Preview datafeeds request
 
 A +{request}+ object is created referencing a non-null `datafeedId`.
 
@@ -23,7 +22,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> Constructing a new request referencing an existing `datafeedId`
 
 [id="{upid}-{api}-response"]
-==== Preview datafeed response
+==== Preview datafeeds response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
@@ -6,6 +6,7 @@
 [role="xpack"]
 [id="{upid}-{api}"]
 === Put {anomaly-jobs} in calendar API
+
 Adds {anomaly-jobs} jobs to an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/put-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar.asciidoc
@@ -5,13 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put calendar API
+=== Put calendars API
+
 Creates a new {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Put calendar request
+==== Put calendars request
 
 A +{request}+ is constructed with a calendar object
 
@@ -23,7 +24,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 
 
 [id="{upid}-{api}-response"]
-==== Put Calendar Response
+==== Put calendars response
 
 The returned +{response}+ contains the created calendar:
 

--- a/docs/java-rest/high-level/ml/put-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/put-datafeed.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put datafeed API
+=== Put datafeeds API
 
 Creates a new {ml} datafeed in the cluster. The API accepts a +{request}+ object
 as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put datafeed request
+==== Put datafeeds request
 
 A +{request}+ requires the following argument:
 

--- a/docs/java-rest/high-level/ml/put-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/put-filter.asciidoc
@@ -5,14 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put filter API
+=== Put filters API
 
-The put filter API can be used to create a new {ml} filter
-in the cluster. The API accepts a +{request}+ object
+Creates a new {ml} filter in the cluster. The API accepts a +{request}+ object
 as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put filter request
+==== Put filters request
 
 A +{request}+ requires the following argument:
 

--- a/docs/java-rest/high-level/ml/put-job.asciidoc
+++ b/docs/java-rest/high-level/ml/put-job.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put {anomaly-job} API
+=== Put {anomaly-jobs} API
 
 Creates a new {anomaly-job} in the cluster. The API accepts a +{request}+ object
 as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put {anomaly-job} request
+==== Put {anomaly-jobs} request
 
 A +{request}+ requires the following argument:
 

--- a/docs/java-rest/high-level/ml/put-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model.asciidoc
@@ -5,7 +5,9 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put trained model API
+=== Put trained models API
+
+experimental:[]
 
 experimental::[]
 
@@ -13,7 +15,7 @@ Creates a new trained model for inference.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put trained model request
+==== Put trained models request
 
 A +{request}+ requires the following argument:
 

--- a/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
@@ -6,14 +6,14 @@
 [role="xpack"]
 
 [id="{upid}-{api}"]
-=== Revert model snapshot API
+=== Revert model snapshots API
 
-The revert model snapshot API provides the ability to revert to a previous {ml} model snapshot.
+Reverts to a previous {ml} model snapshot.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Revert model snapshot request
+==== Revert model snapshots request
 
 A +{request}+ requires the following arguments:
 

--- a/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
+++ b/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Set upgrade mode API
 
-The set upgrade mode API temporarily halts all {ml} job and {dfeed} tasks when `enabled=true`. Their
+Temporarily halts all {ml} job and {dfeed} tasks when `enabled=true`. Their
 reported states remain unchanged. Consequently, when exiting upgrade mode the halted {ml} jobs and
 {dfeeds} will return to their previous state.
 

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -13,7 +13,7 @@ Starts an existing {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Start {dfanalytics-job} request
+==== Start {dfanalytics-jobs} request
 
 A +{request}+ object requires a {dfanalytics-job} ID.
 
@@ -26,7 +26,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Start {dfanalytics-job} response
+==== Start {dfanalytics-jobs} response
 
 The returned +{response}+ object acknowledges the {dfanalytics-job} has started.
 

--- a/docs/java-rest/high-level/ml/start-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/start-datafeed.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Start {dfeed} API
+=== Start {dfeeds} API
 
 Starts a {ml} {dfeed} in the cluster. It accepts a +{request}+ object and
 responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Start {dfeed} request
+==== Start {dfeeds} request
 
 A +{request}+ object is created referencing a non-null `datafeedId`.
 All other fields are optional for the request.
@@ -41,7 +41,7 @@ the analysis starts from the earliest time for which data is available.
 <3> Set the timeout for the request
 
 [id="{upid}-{api}-response"]
-==== Start {dfeed} response
+==== Start {dfeeds} response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
@@ -5,14 +5,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Stop datafeed API
+=== Stop datafeeds API
 
-The stop datafeed API provides the ability to stop a {ml} datafeed in the cluster.
+Stops a {ml} datafeed in the cluster.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Stop datafeed request
+==== Stop datafeeds request
 
 A +{request}+ object is created referencing any number of non-null `datafeedId` entries.
 Wildcards and `_all` are also accepted.

--- a/docs/java-rest/high-level/ml/update-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/update-datafeed.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Update datafeed API
+=== Update datafeeds API
 
 Updates a {ml} datafeed in the cluster. The API accepts a +{request}+ object
 as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Update datafeed request
+==== Update datafeeds request
 
 A +{request}+ requires the following argument:
 
@@ -22,7 +22,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <1> The updated configuration of the {ml} datafeed
 
 [id="{upid}-{api}-config"]
-==== Updated datafeed arguments
+==== Updated datafeeds arguments
 
 A `DatafeedUpdate` requires an existing non-null `datafeedId` and
 allows updating various settings.

--- a/docs/java-rest/high-level/ml/update-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/update-filter.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Update filter API
+=== Update filters API
 
 Updates an existing {ml} filter in the cluster. The API accepts a +{request}+
 object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Update filter request
+==== Update filters request
 
 A +{request}+ requires the following argument:
 

--- a/docs/java-rest/high-level/ml/update-job.asciidoc
+++ b/docs/java-rest/high-level/ml/update-job.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Update {anomaly-job} API
+=== Update {anomaly-jobs} API
 
 Provides the ability to update an {anomaly-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Update {anomaly-job} request
+==== Update {anomaly-jobs} request
 
 An +{request}+ object gets created with a `JobUpdate` object.
 
@@ -56,7 +56,7 @@ include-tagged::{doc-tests-file}[{api}-detector-options]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Update {anomaly-job} response
+==== Update {anomaly-jobs} response
 
 A +{response}+ contains the updated `Job` object
 

--- a/docs/java-rest/high-level/ml/update-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/update-model-snapshot.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Update model snapshot API
+=== Update model snapshots API
 
-Provides the ability to update a {ml} model snapshot.
+Updates a {ml} model snapshot.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Update model snapshot request
+==== Update model snapshots request
 
 A +{request}+ requires the following arguments:
 
@@ -42,7 +42,7 @@ include-tagged::{doc-tests-file}[{api}-retain]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Update model snapshot response
+==== Update model snapshots response
 
 A +{response}+ contains an acknowledgement of the update request and the full representation of the updated `ModelSnapshot` object
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-calendar]]
-= Delete calendar API
+= Delete calendars API
 ++++
-<titleabbrev>Delete calendar</titleabbrev>
+<titleabbrev>Delete calendars</titleabbrev>
 ++++
 
 Deletes a calendar.

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-filter]]
-= Delete filter API
+= Delete filters API
 ++++
-<titleabbrev>Delete filter</titleabbrev>
+<titleabbrev>Delete filters</titleabbrev>
 ++++
 
 Deletes a filter.

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-forecast]]
-= Delete forecast API
+= Delete forecasts API
 ++++
-<titleabbrev>Delete forecast</titleabbrev>
+<titleabbrev>Delete forecasts</titleabbrev>
 ++++
 
 Deletes forecasts from a {ml} job.

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-calendar]]
-= Create calendar API
+= Create calendars API
 ++++
-<titleabbrev>Create calendar</titleabbrev>
+<titleabbrev>Create calendars</titleabbrev>
 ++++
 
 Instantiates a calendar.

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-filter]]
-= Create filter API
+= Create filters API
 ++++
-<titleabbrev>Create filter</titleabbrev>
+<titleabbrev>Create filters</titleabbrev>
 ++++
 
 Instantiates a filter.

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-update-filter]]
-= Update filter API
+= Update filters API
 ++++
-<titleabbrev>Update filter</titleabbrev>
+<titleabbrev>Update filters</titleabbrev>
 ++++
 
 Updates the description of a filter, adds items, or removes items. 

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Explain {dfanalytics} API</titleabbrev>
+<titleabbrev>Explain {dfanalytics}</titleabbrev>
 ++++
 
 Explains a {dataframe-analytics-config}.


### PR DESCRIPTION
This PR fixes the plural terms in the machine learning API titles across the HLRC and Elasticsearch docs.

### Preview

https://elasticsearch_63152.docs-preview.app.elstc.co/diff