### PR TITLE
[DOCS] Add experimental tag to data frame analytics APIs

### DIFF
--- a/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Delete {dfanalytics-jobs} API
 
+experimental::[]
+
 Delete an existing {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 

--- a/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Delete trained model API
 
-experimental[]
+experimental::[]
 
 Deletes a previously saved trained model.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Evaluate {dfanalytics} API
 
+experimental::[]
+
 Evaluates the {ml} algorithm that ran on a {dataframe}.
 The API accepts an +{request}+ object and returns an +{response}+.
 

--- a/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Explain {dfanalytics} API
 
+experimental::[]
+
 Explains the following about a {dataframe-analytics-config}:
 
 * field selection: which fields are included or not in the analysis

--- a/docs/java-rest/high-level/ml/find-file-structure.asciidoc
+++ b/docs/java-rest/high-level/ml/find-file-structure.asciidoc
@@ -5,7 +5,9 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Find File Structure API
+=== Find file structure API
+
+experimental::[]
 
 The Find File Structure API can be used to find the structure of a text file
 and other information that will be useful to import its contents to an {es}

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} stats API
 
+experimental::[]
+
 Retrieves the operational statistics of one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} API
 
+experimental::[]
+
 Retrieves one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.
 

--- a/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get trained models stats API
 
-experimental[]
+experimental::[]
 
 Retrieves one or more trained model statistics.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get trained models API
 
-experimental[]
+experimental::[]
 
 Retrieves one or more trained models.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Put {dfanalytics-jobs} API
 
+experimental::[]
+
 Creates a new {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 

--- a/docs/java-rest/high-level/ml/put-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Put trained model API
 
+experimental::[]
+
 Creates a new trained model for inference.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Start {dfanalytics-jobs} API
 
+experimental::[]
+
 Starts an existing {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 

--- a/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Stop {dfanalytics-jobs} API
 
+experimental::[]
+
 Stops a running {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 

--- a/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Update {dfanalytics-jobs} API
 
+experimental::[]
+
 Updates an existing {dfanalytics-job}.
 The API accepts an +{request}+ object as a request and returns an +{response}+.
 

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -49,8 +49,9 @@ Defaults to `open`.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `verbose`::
+experimental:[]
 (Optional, boolean)
-experimental:[] If `true`, the response includes detailed information
+If `true`, the response includes detailed information
 about Lucene's memory usage.
 Defaults to `false`.
 

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -49,9 +49,8 @@ Defaults to `open`.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `verbose`::
-experimental:[]
 (Optional, boolean)
-If `true`, the response includes detailed information
+experimental:[] If `true`, the response includes detailed information
 about Lucene's memory usage.
 Defaults to `false`.
 


### PR DESCRIPTION
This PR adds the "experimental" tag to the data frame analytics APIs in the HLRC docs.

### Preview

https://elasticsearch_63153.docs-preview.app.elstc.co/diff