### PR TITLE
[DOCS] Updates trained models API docs titles

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
 [[delete-trained-models]]
-= Delete trained model API
+= Delete trained models API
 [subs="attributes"]
 ++++
-<titleabbrev>Delete trained model</titleabbrev>
+<titleabbrev>Delete trained models</titleabbrev>
 ++++
 
 Deletes an existing trained {infer} model that is currently not referenced by an

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-trained-models-stats]]
-= Get trained model statistics API
+= Get trained models statistics API
 [subs="attributes"]
 ++++
-<titleabbrev>Get trained model stats</titleabbrev>
+<titleabbrev>Get trained models stats</titleabbrev>
 ++++
 
 Retrieves usage information for trained models.

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-trained-models]]
-= Get trained model API
+= Get trained models API
 [subs="attributes"]
 ++++
-<titleabbrev>Get trained model</titleabbrev>
+<titleabbrev>Get trained models</titleabbrev>
 ++++
 
 Retrieves configuration information for a trained model.

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-trained-models]]
-= Create trained model API
+= Create trained models API
 [subs="attributes"]
 ++++
-<titleabbrev>Create trained model</titleabbrev>
+<titleabbrev>Create trained models</titleabbrev>
 ++++
 
 Creates a trained model.
@@ -658,7 +658,7 @@ Example of an `exponent` object:
 
 
 [[ml-put-trained-models-json-schema]]
-=== {infer-cap} JSON schema
+=== Trained models JSON schema
 
-For the full JSON schema of model {infer},
+For the full JSON schema of trained models,
 https://github.com/elastic/ml-json-schemas[click here].


### PR DESCRIPTION
## Overview

This PR updates the trained models API docs titles from singular to plural to be aligned with the API endpoints and the URLs.

### Preview

[DELETE](https://elasticsearch_63165.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-trained-models.html)
[GET](https://elasticsearch_63165.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models.html)
[GET stats](https://elasticsearch_63165.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html)
[PUT](https://elasticsearch_63165.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models.html)