### PR TITLE
Remove unused deprecated serialization code

### DIFF
--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
@@ -35,8 +35,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 
 public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry> {
 
-    public static final int TYPE = 999;
-
     public static final ParseField DUMMY = new ParseField("dummy");
 
     private String dummy;
@@ -60,11 +58,6 @@ public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry>
     @Override
     public String getWriteableName() {
         return CustomSuggestionBuilder.SUGGESTION_NAME;
-    }
-
-    @Override
-    public int getWriteableType() {
-        return TYPE;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -240,17 +240,6 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
             entries.add(entry);
         }
 
-        /**
-         * Returns a integer representing the type of the suggestion. This is used for
-         * internal serialization over the network.
-         *
-         * This class is now serialized as a NamedWriteable and this method only remains for backwards compatibility
-         */
-        @Deprecated
-        public int getWriteableType() {
-            return TYPE;
-        }
-
         @Override
         public Iterator<T> iterator() {
             return entries.iterator();

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
@@ -66,9 +66,6 @@ import static org.elasticsearch.search.suggest.Suggest.COMPARATOR;
  */
 public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSuggestion.Entry> {
 
-    @Deprecated
-    public static final int TYPE = 4;
-
     private boolean skipDuplicates;
 
     /**
@@ -232,11 +229,6 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
                 option.setShardIndex(shardIndex);
             }
         }
-    }
-
-    @Override
-    public int getWriteableType() {
-        return TYPE;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -40,9 +40,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
  */
 public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry> {
 
-    @Deprecated
-    public static final int TYPE = 3;
-
     public PhraseSuggestion(String name, int size) {
         super(name, size);
     }
@@ -54,11 +51,6 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
     @Override
     public String getWriteableName() {
         return PhraseSuggestionBuilder.SUGGESTION_NAME;
-    }
-
-    @Override
-    public int getWriteableType() {
-        return TYPE;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -43,9 +43,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
  */
 public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
 
-    @Deprecated
-    public static final int TYPE = 1;
-
     public static final Comparator<Suggestion.Entry.Option> SCORE = new Score();
     public static final Comparator<Suggestion.Entry.Option> FREQUENCY = new Frequency();
 
@@ -98,11 +95,6 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
             // third criteria: term text
             return first.getText().compareTo(second.getText());
         }
-    }
-
-    @Override
-    public int getWriteableType() {
-        return TYPE;
     }
 
     public void setSort(SortBy sort) {


### PR DESCRIPTION
The integer values seem to have been used by internal serialization back in v6 but have been removed in #30284 almost two years ago.
In 7 this was still used to write to pre 7.0 nodes (https://github.com/elastic/elasticsearch/blob/7.0/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java#L161) but I think its safe to delete them on master now.