### PR TITLE
Fix querying a data stream name in _index field.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
@@ -74,7 +74,7 @@ public class SearchIndexNameMatcher implements Predicate<String> {
 
     private boolean matchesIndex(String pattern) {
         String[] concreteIndices = expressionResolver.concreteIndexNames(
-            clusterService.state(), IndicesOptions.lenientExpandOpen(), pattern);
+            clusterService.state(), IndicesOptions.lenientExpandOpen(), true, pattern);
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, indexName)) {
                 return true;

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.datastreams;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionRequestBuilder;
@@ -48,6 +49,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -1091,6 +1094,21 @@ public class DataStreamIT extends ESIntegTestCase {
                     + "existing index(s) or alias(s) including '.ds-logs-foobar-000002'"
             )
         );
+    }
+
+    public void testQueryDataStreamNameInIndexField() throws Exception {
+        putComposableIndexTemplate("id1", List.of("metrics-*"));
+        CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request("metrics-foo");
+        client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).get();
+
+        indexDocs("metrics-foo", 1);
+        indexDocs("metrics-bar", 1);
+
+        SearchRequest searchRequest = new SearchRequest("*");
+        searchRequest.source().query(new TermQueryBuilder("_index", "metrics-foo"));
+        SearchResponse searchResponse = client().search(searchRequest).actionGet();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertThat(searchResponse.getHits().getTotalHits().relation, equalTo(TotalHits.Relation.EQUAL_TO));
     }
 
     private static void verifyResolvability(String dataStream, ActionRequestBuilder<?, ?> requestBuilder, boolean fail) {

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -49,7 +49,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;


### PR DESCRIPTION
The _index field is a special field that allows using queries against the name of an index or alias.
Data stream names were not included, this pr fixes that by changing SearchIndexNameMatcher
(which used via IndexFieldMapper) to also include data streams.