### PR TITLE
Checkout dir should be available as artifact from bwc projects

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.fixtures
+
+import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleFuncTest {
+
+    @Rule
+    TemporaryFolder remoteRepoDirs = new TemporaryFolder()
+
+    File remoteGitRepo
+
+    def setup() {
+        remoteGitRepo = new File(setupGitRemote(), '.git')
+        "git clone ${remoteGitRepo.absolutePath} cloned".execute(Collections.emptyList(), testProjectDir.root).waitFor()
+        buildFile = new File(testProjectDir.root, 'cloned/build.gradle')
+        settingsFile = new File(testProjectDir.root, 'cloned/settings.gradle')
+    }
+
+    File setupGitRemote() {
+        URL fakeRemote = getClass().getResource("fake_git/remote")
+        File workingRemoteGit = new File(remoteRepoDirs.root, 'remote')
+        FileUtils.copyDirectory(new File(fakeRemote.file), workingRemoteGit)
+        fakeRemote.file + "/.git"
+        gradleRunner(workingRemoteGit, "wrapper").build()
+
+        execute("git init", workingRemoteGit)
+        execute('git config user.email "build-tool@elastic.co"', workingRemoteGit)
+        execute('git config user.name "Build tool"', workingRemoteGit)
+        execute("git add .", workingRemoteGit)
+        execute('git commit -m"Initial"', workingRemoteGit)
+        execute("git checkout -b origin/8.0", workingRemoteGit)
+        return workingRemoteGit;
+    }
+
+    GradleRunner gradleRunner(String... arguments) {
+        gradleRunner(new File(testProjectDir.root, "cloned"), arguments)
+    }
+
+}

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -123,8 +123,8 @@ abstract class AbstractGradleFuncTest extends Specification {
         def proc = command.execute(Collections.emptyList(), workingDir)
         proc.waitFor()
         if(proc.exitValue()) {
-            println "Error running command ${command}:"
-            println "Syserr: " + proc.errorStream.text
+            System.err.println("Error running command ${command}:")
+            System.err.println("Syserr: " + proc.errorStream.text)
         }
     }
 }

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -19,34 +19,21 @@
 
 package org.elasticsearch.gradle.internal
 
-import org.apache.commons.io.FileUtils
-import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGitAwareGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
-class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest {
-
-    @Rule
-    TemporaryFolder remoteRepoDirs = new TemporaryFolder()
-
-    File remoteGitRepo
+class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {
-        remoteGitRepo = new File(setupGitRemote(), '.git')
-
-        execute("git clone ${remoteGitRepo.absolutePath}", testProjectDir.root)
-        File buildScript = new File(testProjectDir.root, 'remote/build.gradle')
-        internalBuild(buildScript)
-        buildScript << """
+        internalBuild()
+        buildFile << """
             apply plugin: 'elasticsearch.internal-distribution-bwc-setup'
         """
     }
 
     def "builds distribution from branches via archives assemble"() {
         when:
-        def result = gradleRunner(new File(testProjectDir.root, "remote"),
-                ":distribution:bwc:bugfix:buildBwcDarwinTar",
+        def result = gradleRunner(":distribution:bwc:bugfix:buildBwcDarwinTar",
                 ":distribution:bwc:bugfix:buildBwcOssDarwinTar",
                 "-DtestRemoteRepo=" + remoteGitRepo,
                 "-Dbwc.remote=origin")
@@ -62,7 +49,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
 
     def "bwc distribution archives can be resolved as bwc project artifact"() {
         setup:
-        new File(testProjectDir.root, 'remote/build.gradle') << """
+        buildFile << """
         
         configurations {
             dists
@@ -82,8 +69,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
         }
         """
         when:
-        def result = gradleRunner(new File(testProjectDir.root, "remote"),
-                ":resolveDistributionArchive",
+        def result = gradleRunner(":resolveDistributionArchive",
                 "-DtestRemoteRepo=" + remoteGitRepo,
                 "-Dbwc.remote=origin")
                 .build()
@@ -100,7 +86,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
 
     def "bwc expanded distribution folder can be resolved as bwc project artifact"() {
         setup:
-        new File(testProjectDir.root, 'remote/build.gradle') << """
+        buildFile << """
         
         configurations {
             expandedDist
@@ -120,8 +106,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
         }
         """
         when:
-        def result = gradleRunner(new File(testProjectDir.root, "remote"),
-                ":resolveExpandedDistribution",
+        def result = gradleRunner(":resolveExpandedDistribution",
                 "-DtestRemoteRepo=" + remoteGitRepo,
                 "-Dbwc.remote=origin")
                 .build()

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.gradle.internal
 
+import org.apache.commons.io.FileUtils
 import org.elasticsearch.gradle.fixtures.AbstractGitAwareGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
 

--- a/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/settings.gradle
+++ b/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/settings.gradle
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+rootProject.name = "root"
+
 include ":distribution:bwc:bugfix"
 include ":distribution:bwc:minor"
 include ":distribution:archives:darwin-tar"

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcGitExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcGitExtension.java
@@ -20,15 +20,23 @@
 package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.Version;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 
+import javax.inject.Inject;
 import java.io.File;
 
 public class BwcGitExtension {
 
     private Provider<Version> bwcVersion;
     private Provider<String> bwcBranch;
-    private Provider<File> checkoutDir;
+    private Property<File> checkoutDir;
+
+    @Inject
+    public BwcGitExtension(ObjectFactory objectFactory) {
+        this.checkoutDir = objectFactory.property(File.class);
+    }
 
     public Provider<Version> getBwcVersion() {
         return bwcVersion;
@@ -46,11 +54,7 @@ public class BwcGitExtension {
         this.bwcBranch = bwcBranch;
     }
 
-    public Provider<File> getCheckoutDir() {
+    public Property<File> getCheckoutDir() {
         return checkoutDir;
-    }
-
-    public void setCheckoutDir(Provider<File> checkoutDir) {
-        this.checkoutDir = checkoutDir;
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -74,6 +74,8 @@ public class BwcSetupExtension {
             loggedExec.setWorkingDir(checkoutDir.get());
             loggedExec.doFirst(t -> {
                 // Execution time so that the checkouts are available
+                File file = new File(checkoutDir.get(), ".ci/java-versions.properties");
+                System.out.println("g = " + file.getAbsolutePath());
                 String javaVersionsString = readFromFile(new File(checkoutDir.get(), ".ci/java-versions.properties"));
                 loggedExec.environment(
                     "JAVA_HOME",

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -78,7 +78,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         Provider<Version> bwcVersion = versionInfoProvider.map(info -> info.version);
         gitExtension.setBwcVersion(versionInfoProvider.map(info -> info.version));
         gitExtension.setBwcBranch(versionInfoProvider.map(info -> info.branch));
-        gitExtension.setCheckoutDir(checkoutDir);
+        gitExtension.getCheckoutDir().set(checkoutDir);
 
         // we want basic lifecycle tasks like `clean` here.
         project.getPlugins().apply(LifecycleBasePlugin.class);
@@ -97,7 +97,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 buildBwcTaskProvider
             );
 
-            registerBwcArtifacts(project, distributionProject);
+            registerBwcDistributionArtifacts(project, distributionProject);
         }
 
         // Create build tasks for the JDBC driver used for compatibility testing
@@ -111,7 +111,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         createBuildBwcTask(bwcSetupExtension, project, bwcVersion, "jdbc", jdbcProjectDir, jdbcProjectArtifact, buildBwcTaskProvider);
     }
 
-    private void registerBwcArtifacts(Project bwcProject, DistributionProject distributionProject) {
+    private void registerBwcDistributionArtifacts(Project bwcProject, DistributionProject distributionProject) {
         String projectName = distributionProject.name;
         String buildBwcTask = buildBwcTaskName(projectName);
 
@@ -225,12 +225,14 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
      */
     private static class DistributionProject {
         private final String name;
+        private File checkoutDir;
         private String projectPath;
         private File distFile;
         private File expandedDistDir;
 
         DistributionProject(String name, String baseDir, Version version, String classifier, String extension, File checkoutDir) {
             this.name = name;
+            this.checkoutDir = checkoutDir;
             this.projectPath = baseDir + "/" + name;
             this.distFile = new File(
                 checkoutDir,
@@ -261,6 +263,10 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
         public File getExpandedDistDirectory() {
             return expandedDistDir;
+        }
+
+        public File getCheckoutDir() {
+            return checkoutDir;
         }
     }
 }


### PR DESCRIPTION
Related to #62985 as a step forward on improving resolving test resources
from older elasticsearch branches / versions