### PR TITLE
[7.x] [ML] Ensure data frame analytics jobs don't run on a node that's too new (#62749)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
@@ -154,6 +154,7 @@ public class StartDataFrameAnalyticsAction extends ActionType<NodeAcknowledgedRe
     public static class TaskParams implements XPackPlugin.XPackPersistentTaskParams {
 
         public static final Version VERSION_INTRODUCED = Version.V_7_3_0;
+        public static final Version VERSION_DESTINATION_INDEX_MAPPINGS_CHANGED = Version.V_7_10_0;
 
         private static final ParseField PROGRESS_ON_START = new ParseField("progress_on_start");
 
@@ -194,19 +195,23 @@ public class StartDataFrameAnalyticsAction extends ActionType<NodeAcknowledgedRe
             this.id = in.readString();
             this.version = Version.readVersion(in);
             if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
-                progressOnStart = in.readList(PhaseProgress::new);
+                this.progressOnStart = in.readList(PhaseProgress::new);
             } else {
-                progressOnStart = Collections.emptyList();
+                this.progressOnStart = Collections.emptyList();
             }
             if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
-                allowLazyStart = in.readBoolean();
+                this.allowLazyStart = in.readBoolean();
             } else {
-                allowLazyStart = false;
+                this.allowLazyStart = false;
             }
         }
 
         public String getId() {
             return id;
+        }
+
+        public Version getVersion() {
+            return version;
         }
 
         public List<PhaseProgress> getProgressOnStart() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsActionTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsActionTaskParamsTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -15,6 +14,8 @@ import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.elasticsearch.test.VersionUtils.randomVersion;
 
 public class StartDataFrameAnalyticsActionTaskParamsTests extends AbstractSerializingTestCase<StartDataFrameAnalyticsAction.TaskParams> {
 
@@ -30,7 +31,11 @@ public class StartDataFrameAnalyticsActionTaskParamsTests extends AbstractSerial
         for (int i = 0; i < phaseCount; i++) {
             progressOnStart.add(new PhaseProgress(randomAlphaOfLength(10), randomIntBetween(0, 100)));
         }
-        return new StartDataFrameAnalyticsAction.TaskParams(randomAlphaOfLength(10), Version.CURRENT, progressOnStart, randomBoolean());
+        return new StartDataFrameAnalyticsAction.TaskParams(
+            randomAlphaOfLength(10),
+            randomVersion(random()),
+            progressOnStart,
+            randomBoolean());
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.TaskParams;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
@@ -165,10 +166,10 @@ public class TransportStartDataFrameAnalyticsAction
         }
 
         // Wait for analytics to be started
-        ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams>> waitForAnalyticsToStart =
-            new ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams>>() {
+        ActionListener<PersistentTasksCustomMetadata.PersistentTask<TaskParams>> waitForAnalyticsToStart =
+            new ActionListener<PersistentTasksCustomMetadata.PersistentTask<TaskParams>>() {
                 @Override
-                public void onResponse(PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> task) {
+                public void onResponse(PersistentTasksCustomMetadata.PersistentTask<TaskParams> task) {
                     waitForAnalyticsStarted(task, request.getTimeout(), listener);
                 }
 
@@ -185,11 +186,17 @@ public class TransportStartDataFrameAnalyticsAction
         // Start persistent task
         ActionListener<StartContext> memoryUsageHandledListener = ActionListener.wrap(
             startContext -> {
-                StartDataFrameAnalyticsAction.TaskParams taskParams = new StartDataFrameAnalyticsAction.TaskParams(
-                    request.getId(), startContext.config.getVersion(), startContext.progressOnStart,
-                    startContext.config.isAllowLazyStart());
-                persistentTasksService.sendStartRequest(MlTasks.dataFrameAnalyticsTaskId(request.getId()),
-                    MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, taskParams, waitForAnalyticsToStart);
+                TaskParams taskParams =
+                    new TaskParams(
+                        request.getId(),
+                        startContext.config.getVersion(),
+                        startContext.progressOnStart,
+                        startContext.config.isAllowLazyStart());
+                persistentTasksService.sendStartRequest(
+                    MlTasks.dataFrameAnalyticsTaskId(request.getId()),
+                    MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+                    taskParams,
+                    waitForAnalyticsToStart);
             },
             listener::onFailure
         );
@@ -425,7 +432,7 @@ public class TransportStartDataFrameAnalyticsAction
         );
     }
 
-    private void waitForAnalyticsStarted(PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> task,
+    private void waitForAnalyticsStarted(PersistentTasksCustomMetadata.PersistentTask<TaskParams> task,
                                          TimeValue timeout, ActionListener<NodeAcknowledgedResponse> listener) {
         AnalyticsPredicate predicate = new AnalyticsPredicate();
         persistentTasksService.waitForPersistentTaskCondition(task.getId(), predicate, timeout,
@@ -552,7 +559,7 @@ public class TransportStartDataFrameAnalyticsAction
     }
 
     private void cancelAnalyticsStart(
-        PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> persistentTask, Exception exception,
+        PersistentTasksCustomMetadata.PersistentTask<TaskParams> persistentTask, Exception exception,
         ActionListener<NodeAcknowledgedResponse> listener) {
         persistentTasksService.sendRemoveRequest(persistentTask.getId(),
             new ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>>() {
@@ -591,7 +598,7 @@ public class TransportStartDataFrameAnalyticsAction
         return unavailableIndices;
     }
 
-    public static class TaskExecutor extends PersistentTasksExecutor<StartDataFrameAnalyticsAction.TaskParams> {
+    public static class TaskExecutor extends PersistentTasksExecutor<TaskParams> {
 
         private final Client client;
         private final ClusterService clusterService;
@@ -630,15 +637,14 @@ public class TransportStartDataFrameAnalyticsAction
         @Override
         protected AllocatedPersistentTask createTask(
             long id, String type, String action, TaskId parentTaskId,
-            PersistentTasksCustomMetadata.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> persistentTask,
+            PersistentTasksCustomMetadata.PersistentTask<TaskParams> persistentTask,
             Map<String, String> headers) {
             return new DataFrameAnalyticsTask(
                 id, type, action, parentTaskId, headers, client, clusterService, manager, auditor, persistentTask.getParams());
         }
 
         @Override
-        public PersistentTasksCustomMetadata.Assignment getAssignment(StartDataFrameAnalyticsAction.TaskParams params,
-                                                                      ClusterState clusterState) {
+        public PersistentTasksCustomMetadata.Assignment getAssignment(TaskParams params, ClusterState clusterState) {
 
             // If we are waiting for an upgrade to complete, we should not assign to a node
             if (MlMetadata.getMlMetadata(clusterState).isUpgradeMode()) {
@@ -675,17 +681,21 @@ public class TransportStartDataFrameAnalyticsAction
                 }
             }
 
-            JobNodeSelector jobNodeSelector = new JobNodeSelector(clusterState, id, MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, memoryTracker,
-                params.isAllowLazyStart() ? Integer.MAX_VALUE : maxLazyMLNodes, node -> nodeFilter(node, id));
+            JobNodeSelector jobNodeSelector =
+                new JobNodeSelector(
+                    clusterState,
+                    id,
+                    MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+                    memoryTracker,
+                    params.isAllowLazyStart() ? Integer.MAX_VALUE : maxLazyMLNodes,
+                    node -> nodeFilter(node, params));
             // Pass an effectively infinite value for max concurrent opening jobs, because data frame analytics jobs do
             // not have an "opening" state so would never be rejected for causing too many jobs in the "opening" state
-            return jobNodeSelector.selectNode(
-                maxOpenJobs, Integer.MAX_VALUE, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
+            return jobNodeSelector.selectNode(maxOpenJobs, Integer.MAX_VALUE, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
         }
 
         @Override
-        protected void nodeOperation(AllocatedPersistentTask task, StartDataFrameAnalyticsAction.TaskParams params,
-                                     PersistentTaskState state) {
+        protected void nodeOperation(AllocatedPersistentTask task, TaskParams params, PersistentTaskState state) {
             DataFrameAnalyticsTaskState analyticsTaskState = (DataFrameAnalyticsTaskState) state;
             DataFrameAnalyticsState analyticsState = analyticsTaskState == null ? null : analyticsTaskState.getState();
             logger.info("[{}] Starting data frame analytics from state [{}]", params.getId(), analyticsState);
@@ -726,12 +736,19 @@ public class TransportStartDataFrameAnalyticsAction
             }
         }
 
-        public static String nodeFilter(DiscoveryNode node, String id) {
+        public static String nodeFilter(DiscoveryNode node, TaskParams params) {
+            String id = params.getId();
 
-            if (node.getVersion().before(StartDataFrameAnalyticsAction.TaskParams.VERSION_INTRODUCED)) {
+            if (node.getVersion().before(TaskParams.VERSION_INTRODUCED)) {
                 return "Not opening job [" + id + "] on node [" + JobNodeSelector.nodeNameAndVersion(node)
                     + "], because the data frame analytics requires a node of version ["
-                    + StartDataFrameAnalyticsAction.TaskParams.VERSION_INTRODUCED + "] or higher";
+                    + TaskParams.VERSION_INTRODUCED + "] or higher";
+            }
+            if (node.getVersion().before(TaskParams.VERSION_DESTINATION_INDEX_MAPPINGS_CHANGED)
+                && params.getVersion().onOrAfter(TaskParams.VERSION_DESTINATION_INDEX_MAPPINGS_CHANGED)) {
+                return "Not opening job [" + id + "] on node [" + JobNodeSelector.nodeNameAndVersion(node)
+                    + "], because the data frame analytics created for version [" + params.getVersion() + "] requires a node of version "
+                    + "[" + TaskParams.VERSION_DESTINATION_INDEX_MAPPINGS_CHANGED + "] or higher";
             }
 
             return null;
@@ -749,6 +766,4 @@ public class TransportStartDataFrameAnalyticsAction
             this.maxOpenJobs = maxOpenJobs;
         }
     }
-
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -81,7 +82,8 @@ public final class DestinationIndex {
      * If the results mappings change in a way existing destination indices will fail to index
      * the results, this should be bumped accordingly.
      */
-    public static final Version MIN_COMPATIBLE_VERSION = Version.V_7_10_0;
+    public static final Version MIN_COMPATIBLE_VERSION =
+        StartDataFrameAnalyticsAction.TaskParams.VERSION_DESTINATION_INDEX_MAPPINGS_CHANGED;
 
     private DestinationIndex() {}
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -95,7 +95,6 @@ public class JobNodeSelector {
         long maxAvailableMemory = Long.MIN_VALUE;
         DiscoveryNode minLoadedNodeByCount = null;
         DiscoveryNode minLoadedNodeByMemory = null;
-        PersistentTasksCustomMetadata persistentTasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         for (DiscoveryNode node : clusterState.getNodes()) {
 
             // First check conditions that would rule out the node regardless of what other tasks are assigned to it

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -6,29 +6,58 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.TaskParams;
+import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.action.TransportStartDataFrameAnalyticsAction.TaskExecutor;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
+import java.net.InetAddress;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
+
+    private static final String JOB_ID = "data_frame_id";
 
     public void testVerifyIndicesPrimaryShardsAreActive() {
 
@@ -82,5 +111,135 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
         List<String> result = TransportStartDataFrameAnalyticsAction.verifyIndicesPrimaryShardsAreActive(csBuilder.build(),
             new IndexNameExpressionResolver(), indexName);
         assertThat(result, contains(indexName));
+    }
+
+    // Cannot assign the node because upgrade mode is enabled
+    public void testGetAssignment_UpgradeModeIsEnabled() {
+        TaskExecutor executor = createTaskExecutor();
+        TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, Collections.emptyList(), false);
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().isUpgradeMode(true).build()))
+                .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState);
+        assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(assignment.getExplanation(), is(equalTo("persistent task cannot be assigned while upgrade mode is enabled.")));
+    }
+
+    // Cannot assign the node because there are no existing nodes in the cluster state
+    public void testGetAssignment_NoNodes() {
+        TaskExecutor executor = createTaskExecutor();
+        TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, Collections.emptyList(), false);
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
+                .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState);
+        assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(assignment.getExplanation(), is(emptyString()));
+    }
+
+    // Cannot assign the node because none of the existing nodes is an ML node
+    public void testGetAssignment_NoMlNodes() {
+        TaskExecutor executor = createTaskExecutor();
+        TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, Collections.emptyList(), false);
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
+                .nodes(DiscoveryNodes.builder()
+                    .add(createNode(0, false, Version.CURRENT))
+                    .add(createNode(1, false, Version.CURRENT))
+                    .add(createNode(2, false, Version.CURRENT)))
+                .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState);
+        assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(
+            assignment.getExplanation(),
+            allOf(
+                containsString("Not opening job [data_frame_id] on node [_node_name0], because this node isn't a ml node."),
+                containsString("Not opening job [data_frame_id] on node [_node_name1], because this node isn't a ml node."),
+                containsString("Not opening job [data_frame_id] on node [_node_name2], because this node isn't a ml node.")));
+    }
+
+    // Cannot assign the node because none of the existing nodes is appropriate:
+    //  - _node_name0 is too old (version 7.2.0)
+    //  - _node_name1 is too old (version 7.9.1)
+    //  - _node_name2 is too old (version 7.9.2)
+    public void testGetAssignment_MlNodesAreTooOld() {
+        TaskExecutor executor = createTaskExecutor();
+        TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, Collections.emptyList(), false);
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
+                .nodes(DiscoveryNodes.builder()
+                    .add(createNode(0, true, Version.V_7_2_0))
+                    .add(createNode(1, true, Version.V_7_9_1))
+                    .add(createNode(2, true, Version.V_7_9_2)))
+                .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState);
+        assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(
+            assignment.getExplanation(),
+            allOf(
+                containsString("Not opening job [data_frame_id] on node [{_node_name0}{version=7.2.0}], "
+                    + "because the data frame analytics requires a node of version [7.3.0] or higher"),
+                containsString("Not opening job [data_frame_id] on node [{_node_name1}{version=7.9.1}], "
+                    + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher"),
+                containsString("Not opening job [data_frame_id] on node [{_node_name2}{version=7.9.2}], "
+                    + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher")));
+    }
+
+    // The node can be assigned despite being newer than the job.
+    // In such a case destination index will be created from scratch so that its mappings are up-to-date.
+    public void testGetAssignment_MlNodeIsNewerThanTheMlJobButTheAssignmentSuceeds() {
+        TaskExecutor executor = createTaskExecutor();
+        TaskParams params = new TaskParams(JOB_ID, Version.V_7_9_0, Collections.emptyList(), false);
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
+                .nodes(DiscoveryNodes.builder()
+                    .add(createNode(0, true, Version.V_7_10_0)))
+                .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState);
+        assertThat(assignment.getExecutorNode(), is(equalTo("_node_id0")));
+        assertThat(assignment.getExplanation(), is(emptyString()));
+    }
+
+    private static TaskExecutor createTaskExecutor() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings =
+            new ClusterSettings(
+                Settings.EMPTY,
+                Sets.newHashSet(
+                    MachineLearning.CONCURRENT_JOB_ALLOCATIONS,
+                    MachineLearning.MAX_MACHINE_MEMORY_PERCENT,
+                    MachineLearning.MAX_LAZY_ML_NODES,
+                    MachineLearning.MAX_OPEN_JOBS_PER_NODE));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        return new TaskExecutor(
+            Settings.EMPTY,
+            mock(Client.class),
+            clusterService,
+            mock(DataFrameAnalyticsManager.class),
+            mock(DataFrameAnalyticsAuditor.class),
+            mock(MlMemoryTracker.class),
+            new IndexNameExpressionResolver(),
+            mock(IndexTemplateConfig.class));
+    }
+
+    private static DiscoveryNode createNode(int i, boolean isMlNode, Version nodeVersion) {
+        return new DiscoveryNode(
+            "_node_name" + i,
+            "_node_id" + i,
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300 + i),
+            Map.of("ml.max_open_jobs", isMlNode ? "10" : "0", "ml.machine_memory", "-1"),
+            Collections.emptySet(),
+            nodeVersion);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -171,7 +171,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
     //  - _node_name2 is too old (version 7.9.2)
     public void testGetAssignment_MlNodesAreTooOld() {
         TaskExecutor executor = createTaskExecutor();
-        TaskParams params = new TaskParams(JOB_ID, Version.CURRENT, Collections.emptyList(), false);
+        TaskParams params = new TaskParams(JOB_ID, Version.V_7_10_0, Collections.emptyList(), false);
         ClusterState clusterState =
             ClusterState.builder(new ClusterName("_name"))
                 .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
@@ -189,9 +189,9 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
                 containsString("Not opening job [data_frame_id] on node [{_node_name0}{version=7.2.0}], "
                     + "because the data frame analytics requires a node of version [7.3.0] or higher"),
                 containsString("Not opening job [data_frame_id] on node [{_node_name1}{version=7.9.1}], "
-                    + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher"),
+                    + "because the data frame analytics created for version [7.10.0] requires a node of version [7.10.0] or higher"),
                 containsString("Not opening job [data_frame_id] on node [{_node_name2}{version=7.9.2}], "
-                    + "because the data frame analytics created for version [8.0.0] requires a node of version [7.10.0] or higher")));
+                    + "because the data frame analytics created for version [7.10.0] requires a node of version [7.10.0] or higher")));
     }
 
     // The node can be assigned despite being newer than the job.

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
 import java.net.InetAddress;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -234,11 +235,15 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
     }
 
     private static DiscoveryNode createNode(int i, boolean isMlNode, Version nodeVersion) {
+        Map<String, String> attributes = new HashMap<String, String>() {{
+            put("ml.max_open_jobs", isMlNode ? "10" : "0");
+            put("ml.machine_memory", "-1");
+        }};
         return new DiscoveryNode(
             "_node_name" + i,
             "_node_id" + i,
             new TransportAddress(InetAddress.getLoopbackAddress(), 9300 + i),
-            Map.of("ml.max_open_jobs", isMlNode ? "10" : "0", "ml.machine_memory", "-1"),
+            attributes,
             Collections.emptySet(),
             nodeVersion);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.TaskParams;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -162,7 +163,7 @@ public class JobNodeSelectorTests extends ESTestCase {
 
         JobNodeSelector jobNodeSelector = new JobNodeSelector(cs.build(), dataFrameAnalyticsId,
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, memoryTracker, 0,
-            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, dataFrameAnalyticsId));
+            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, createTaskParams(dataFrameAnalyticsId)));
         PersistentTasksCustomMetadata.Assignment result =
             jobNodeSelector.selectNode(maxRunningJobsPerNode, 2, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
         assertNull(result.getExecutorNode());
@@ -215,7 +216,7 @@ public class JobNodeSelectorTests extends ESTestCase {
 
         JobNodeSelector jobNodeSelector = new JobNodeSelector(cs.build(), dataFrameAnalyticsId,
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, memoryTracker, 0,
-            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, dataFrameAnalyticsId));
+            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, createTaskParams(dataFrameAnalyticsId)));
         PersistentTasksCustomMetadata.Assignment result =
             jobNodeSelector.selectNode(maxRunningJobsPerNode, 2, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
         assertNotNull(result.getExecutorNode());
@@ -268,7 +269,7 @@ public class JobNodeSelectorTests extends ESTestCase {
 
         JobNodeSelector jobNodeSelector = new JobNodeSelector(cs.build(), dataFrameAnalyticsId,
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, memoryTracker, 0,
-            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, dataFrameAnalyticsId));
+            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, createTaskParams(dataFrameAnalyticsId)));
         PersistentTasksCustomMetadata.Assignment result =
             jobNodeSelector.selectNode(maxRunningJobsPerNode, 2, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
         assertNull(result.getExecutorNode());
@@ -294,7 +295,7 @@ public class JobNodeSelectorTests extends ESTestCase {
 
         JobNodeSelector jobNodeSelector = new JobNodeSelector(cs.build(), dataFrameAnalyticsId,
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, memoryTracker, 0,
-            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, dataFrameAnalyticsId));
+            node -> TransportStartDataFrameAnalyticsAction.TaskExecutor.nodeFilter(node, createTaskParams(dataFrameAnalyticsId)));
         PersistentTasksCustomMetadata.Assignment result =
             jobNodeSelector.selectNode(maxRunningJobsPerNode, 2, maxMachineMemoryPercent, isMemoryTrackerRecentlyRefreshed);
         assertNull(result.getExecutorNode());
@@ -650,5 +651,9 @@ public class JobNodeSelectorTests extends ESTestCase {
             builder.updateTaskState(MlTasks.dataFrameAnalyticsTaskId(id),
                 new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null));
         }
+    }
+
+    private static TaskParams createTaskParams(String id) {
+        return new TaskParams(id, Version.CURRENT, Collections.emptyList(), false);
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Ensure data frame analytics jobs don't run on a node that's too new  (#62749)