### PR TITLE
[7.x] [ML] adding new flag exclude_generated that removes generated fields in GET config APIs (#63899)(#63092)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -123,8 +123,8 @@ final class MLRequestConverters {
         if (getJobRequest.getAllowNoMatch() != null) {
             params.putParam(GetJobRequest.ALLOW_NO_MATCH.getPreferredName(), Boolean.toString(getJobRequest.getAllowNoMatch()));
         }
-        if (getJobRequest.getForExport() != null) {
-            params.putParam(GetJobRequest.FOR_EXPORT, Boolean.toString(getJobRequest.getForExport()));
+        if (getJobRequest.getExcludeGenerated() != null) {
+            params.putParam(GetJobRequest.EXCLUDE_GENERATED, Boolean.toString(getJobRequest.getExcludeGenerated()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -273,8 +273,8 @@ final class MLRequestConverters {
             params.putParam(GetDatafeedRequest.ALLOW_NO_MATCH.getPreferredName(),
                     Boolean.toString(getDatafeedRequest.getAllowNoMatch()));
         }
-        if (getDatafeedRequest.getForExport() != null) {
-            params.putParam(GetDatafeedRequest.FOR_EXPORT, Boolean.toString(getDatafeedRequest.getForExport()));
+        if (getDatafeedRequest.getExcludeGenerated() != null) {
+            params.putParam(GetDatafeedRequest.EXCLUDE_GENERATED, Boolean.toString(getDatafeedRequest.getExcludeGenerated()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -653,8 +653,8 @@ final class MLRequestConverters {
         if (getRequest.getAllowNoMatch() != null) {
             params.putParam(GetDataFrameAnalyticsRequest.ALLOW_NO_MATCH, Boolean.toString(getRequest.getAllowNoMatch()));
         }
-        if (getRequest.getForExport() != null) {
-            params.putParam(GetDataFrameAnalyticsRequest.FOR_EXPORT, Boolean.toString(getRequest.getForExport()));
+        if (getRequest.getExcludeGenerated() != null) {
+            params.putParam(GetDataFrameAnalyticsRequest.EXCLUDE_GENERATED, Boolean.toString(getRequest.getExcludeGenerated()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -795,8 +795,8 @@ final class MLRequestConverters {
         if (getTrainedModelsRequest.getTags() != null) {
             params.putParam(GetTrainedModelsRequest.TAGS, Strings.collectionToCommaDelimitedString(getTrainedModelsRequest.getTags()));
         }
-        if (getTrainedModelsRequest.getForExport() != null) {
-            params.putParam(GetTrainedModelsRequest.FOR_EXPORT, Boolean.toString(getTrainedModelsRequest.getForExport()));
+        if (getTrainedModelsRequest.getExcludeGenerated() != null) {
+            params.putParam(GetTrainedModelsRequest.EXCLUDE_GENERATED, Boolean.toString(getTrainedModelsRequest.getExcludeGenerated()));
         }
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         request.addParameters(params.asMap());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -121,7 +121,10 @@ final class MLRequestConverters {
 
         RequestConverters.Params params = new RequestConverters.Params();
         if (getJobRequest.getAllowNoMatch() != null) {
-            params.putParam("allow_no_match", Boolean.toString(getJobRequest.getAllowNoMatch()));
+            params.putParam(GetJobRequest.ALLOW_NO_MATCH.getPreferredName(), Boolean.toString(getJobRequest.getAllowNoMatch()));
+        }
+        if (getJobRequest.getForExport() != null) {
+            params.putParam(GetJobRequest.FOR_EXPORT, Boolean.toString(getJobRequest.getForExport()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -269,6 +272,9 @@ final class MLRequestConverters {
         if (getDatafeedRequest.getAllowNoMatch() != null) {
             params.putParam(GetDatafeedRequest.ALLOW_NO_MATCH.getPreferredName(),
                     Boolean.toString(getDatafeedRequest.getAllowNoMatch()));
+        }
+        if (getDatafeedRequest.getForExport() != null) {
+            params.putParam(GetDatafeedRequest.FOR_EXPORT, Boolean.toString(getDatafeedRequest.getForExport()));
         }
         request.addParameters(params.asMap());
         return request;
@@ -645,7 +651,10 @@ final class MLRequestConverters {
             }
         }
         if (getRequest.getAllowNoMatch() != null) {
-            params.putParam(GetDataFrameAnalyticsRequest.ALLOW_NO_MATCH.getPreferredName(), Boolean.toString(getRequest.getAllowNoMatch()));
+            params.putParam(GetDataFrameAnalyticsRequest.ALLOW_NO_MATCH, Boolean.toString(getRequest.getAllowNoMatch()));
+        }
+        if (getRequest.getForExport() != null) {
+            params.putParam(GetDataFrameAnalyticsRequest.FOR_EXPORT, Boolean.toString(getRequest.getForExport()));
         }
         request.addParameters(params.asMap());
         return request;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDataFrameAnalyticsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDataFrameAnalyticsRequest.java
@@ -23,7 +23,6 @@ import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
 import org.elasticsearch.client.core.PageParams;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,11 +31,13 @@ import java.util.Optional;
 
 public class GetDataFrameAnalyticsRequest implements Validatable {
 
-    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
+    public static final String ALLOW_NO_MATCH = "allow_no_match";
+    public static final String FOR_EXPORT = "for_export";
 
     private final List<String> ids;
     private Boolean allowNoMatch;
     private PageParams pageParams;
+    private Boolean forExport;
 
     /**
      * Helper method to create a request that will get ALL Data Frame Analytics
@@ -56,6 +57,22 @@ public class GetDataFrameAnalyticsRequest implements Validatable {
 
     public Boolean getAllowNoMatch() {
         return allowNoMatch;
+    }
+
+    /**
+     * Setting this flag to `true` removes certain fields from the configuration on retrieval.
+     *
+     * This is useful when getting the configuration and wanting to put it in another cluster.
+     *
+     * Default value is false.
+     * @param forExport Boolean value indicating if certain fields should be removed
+     */
+    public void setForExport(boolean forExport) {
+        this.forExport = forExport;
+    }
+
+    public Boolean getForExport() {
+        return forExport;
     }
 
     /**
@@ -94,11 +111,12 @@ public class GetDataFrameAnalyticsRequest implements Validatable {
         GetDataFrameAnalyticsRequest other = (GetDataFrameAnalyticsRequest) o;
         return Objects.equals(ids, other.ids)
             && Objects.equals(allowNoMatch, other.allowNoMatch)
+            && Objects.equals(forExport, other.forExport)
             && Objects.equals(pageParams, other.pageParams);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ids, allowNoMatch, pageParams);
+        return Objects.hash(ids, allowNoMatch, forExport, pageParams);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDataFrameAnalyticsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDataFrameAnalyticsRequest.java
@@ -32,12 +32,12 @@ import java.util.Optional;
 public class GetDataFrameAnalyticsRequest implements Validatable {
 
     public static final String ALLOW_NO_MATCH = "allow_no_match";
-    public static final String FOR_EXPORT = "for_export";
+    public static final String EXCLUDE_GENERATED = "exclude_generated";
 
     private final List<String> ids;
     private Boolean allowNoMatch;
     private PageParams pageParams;
-    private Boolean forExport;
+    private Boolean excludeGenerated;
 
     /**
      * Helper method to create a request that will get ALL Data Frame Analytics
@@ -65,14 +65,14 @@ public class GetDataFrameAnalyticsRequest implements Validatable {
      * This is useful when getting the configuration and wanting to put it in another cluster.
      *
      * Default value is false.
-     * @param forExport Boolean value indicating if certain fields should be removed
+     * @param excludeGenerated Boolean value indicating if certain fields should be removed
      */
-    public void setForExport(boolean forExport) {
-        this.forExport = forExport;
+    public void setExcludeGenerated(boolean excludeGenerated) {
+        this.excludeGenerated = excludeGenerated;
     }
 
-    public Boolean getForExport() {
-        return forExport;
+    public Boolean getExcludeGenerated() {
+        return excludeGenerated;
     }
 
     /**
@@ -111,12 +111,12 @@ public class GetDataFrameAnalyticsRequest implements Validatable {
         GetDataFrameAnalyticsRequest other = (GetDataFrameAnalyticsRequest) o;
         return Objects.equals(ids, other.ids)
             && Objects.equals(allowNoMatch, other.allowNoMatch)
-            && Objects.equals(forExport, other.forExport)
+            && Objects.equals(excludeGenerated, other.excludeGenerated)
             && Objects.equals(pageParams, other.pageParams);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ids, allowNoMatch, forExport, pageParams);
+        return Objects.hash(ids, allowNoMatch, excludeGenerated, pageParams);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
@@ -42,12 +42,12 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
 
     public static final ParseField DATAFEED_IDS = new ParseField("datafeed_ids");
     public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
-    public static final String FOR_EXPORT = "for_export";
+    public static final String EXCLUDE_GENERATED = "exclude_generated";
 
     private static final String ALL_DATAFEEDS = "_all";
     private final List<String> datafeedIds;
     private Boolean allowNoMatch;
-    private Boolean forExport;
+    private Boolean excludeGenerated;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetDatafeedRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -109,14 +109,14 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
      * This is useful when getting the configuration and wanting to put it in another cluster.
      *
      * Default value is false.
-     * @param forExport Boolean value indicating if certain fields should be removed
+     * @param excludeGenerated Boolean value indicating if certain fields should be removed
      */
-    public void setForExport(boolean forExport) {
-        this.forExport = forExport;
+    public void setExcludeGenerated(boolean excludeGenerated) {
+        this.excludeGenerated = excludeGenerated;
     }
 
-    public Boolean getForExport() {
-        return forExport;
+    public Boolean getExcludeGenerated() {
+        return excludeGenerated;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedIds, forExport, allowNoMatch);
+        return Objects.hash(datafeedIds, excludeGenerated, allowNoMatch);
     }
 
     @Override
@@ -142,7 +142,7 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
         GetDatafeedRequest that = (GetDatafeedRequest) other;
         return Objects.equals(datafeedIds, that.datafeedIds) &&
             Objects.equals(allowNoMatch, that.allowNoMatch) &&
-            Objects.equals(forExport, that.forExport);
+            Objects.equals(excludeGenerated, that.excludeGenerated);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
@@ -42,10 +42,12 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
 
     public static final ParseField DATAFEED_IDS = new ParseField("datafeed_ids");
     public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
+    public static final String FOR_EXPORT = "for_export";
 
     private static final String ALL_DATAFEEDS = "_all";
     private final List<String> datafeedIds;
     private Boolean allowNoMatch;
+    private Boolean forExport;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetDatafeedRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -101,6 +103,22 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
         return allowNoMatch;
     }
 
+    /**
+     * Setting this flag to `true` removes certain fields from the configuration on retrieval.
+     *
+     * This is useful when getting the configuration and wanting to put it in another cluster.
+     *
+     * Default value is false.
+     * @param forExport Boolean value indicating if certain fields should be removed
+     */
+    public void setForExport(boolean forExport) {
+        this.forExport = forExport;
+    }
+
+    public Boolean getForExport() {
+        return forExport;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;
@@ -108,7 +126,7 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedIds, allowNoMatch);
+        return Objects.hash(datafeedIds, forExport, allowNoMatch);
     }
 
     @Override
@@ -123,7 +141,8 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
 
         GetDatafeedRequest that = (GetDatafeedRequest) other;
         return Objects.equals(datafeedIds, that.datafeedIds) &&
-            Objects.equals(allowNoMatch, that.allowNoMatch);
+            Objects.equals(allowNoMatch, that.allowNoMatch) &&
+            Objects.equals(forExport, that.forExport);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
@@ -43,10 +43,12 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
     public static final ParseField JOB_IDS = new ParseField("job_ids");
     public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
+    public static final String FOR_EXPORT = "for_export";
 
     private static final String ALL_JOBS = "_all";
     private final List<String> jobIds;
     private Boolean allowNoMatch;
+    private Boolean forExport;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetJobRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -101,6 +103,22 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
         return allowNoMatch;
     }
 
+    /**
+     * Setting this flag to `true` removes certain fields from the configuration on retrieval.
+     *
+     * This is useful when getting the configuration and wanting to put it in another cluster.
+     *
+     * Default value is false.
+     * @param forExport Boolean value indicating if certain fields should be removed
+     */
+    public void setForExport(boolean forExport) {
+        this.forExport = forExport;
+    }
+
+    public Boolean getForExport() {
+        return forExport;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;
@@ -108,7 +126,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, allowNoMatch);
+        return Objects.hash(jobIds, forExport, allowNoMatch);
     }
 
     @Override
@@ -123,6 +141,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
         GetJobRequest that = (GetJobRequest) other;
         return Objects.equals(jobIds, that.jobIds) &&
+            Objects.equals(forExport, that.forExport) &&
             Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
@@ -43,12 +43,12 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
     public static final ParseField JOB_IDS = new ParseField("job_ids");
     public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
-    public static final String FOR_EXPORT = "for_export";
+    public static final String EXCLUDE_GENERATED = "exclude_generated";
 
     private static final String ALL_JOBS = "_all";
     private final List<String> jobIds;
     private Boolean allowNoMatch;
-    private Boolean forExport;
+    private Boolean excludeGenerated;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<GetJobRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -109,14 +109,14 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
      * This is useful when getting the configuration and wanting to put it in another cluster.
      *
      * Default value is false.
-     * @param forExport Boolean value indicating if certain fields should be removed
+     * @param excludeGenerated Boolean value indicating if certain fields should be removed
      */
-    public void setForExport(boolean forExport) {
-        this.forExport = forExport;
+    public void setExcludeGenerated(boolean excludeGenerated) {
+        this.excludeGenerated = excludeGenerated;
     }
 
-    public Boolean getForExport() {
-        return forExport;
+    public Boolean getExcludeGenerated() {
+        return excludeGenerated;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, forExport, allowNoMatch);
+        return Objects.hash(jobIds, excludeGenerated, allowNoMatch);
     }
 
     @Override
@@ -141,7 +141,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
 
         GetJobRequest that = (GetJobRequest) other;
         return Objects.equals(jobIds, that.jobIds) &&
-            Objects.equals(forExport, that.forExport) &&
+            Objects.equals(excludeGenerated, that.excludeGenerated) &&
             Objects.equals(allowNoMatch, that.allowNoMatch);
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetTrainedModelsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetTrainedModelsRequest.java
@@ -39,7 +39,7 @@ public class GetTrainedModelsRequest implements Validatable {
     private static final String TOTAL_FEATURE_IMPORTANCE = "total_feature_importance";
     private static final String FEATURE_IMPORTANCE_BASELINE = "feature_importance_baseline";
     public static final String ALLOW_NO_MATCH = "allow_no_match";
-    public static final String FOR_EXPORT = "for_export";
+    public static final String EXCLUDE_GENERATED = "exclude_generated";
     public static final String DECOMPRESS_DEFINITION = "decompress_definition";
     public static final String TAGS = "tags";
     public static final String INCLUDE = "include";
@@ -48,7 +48,7 @@ public class GetTrainedModelsRequest implements Validatable {
     private Boolean allowNoMatch;
     private Set<String> includes = new HashSet<>();
     private Boolean decompressDefinition;
-    private Boolean forExport;
+    private Boolean excludeGenerated;
     private PageParams pageParams;
     private List<String> tags;
 
@@ -163,8 +163,8 @@ public class GetTrainedModelsRequest implements Validatable {
         return setTags(Arrays.asList(tags));
     }
 
-    public Boolean getForExport() {
-        return forExport;
+    public Boolean getExcludeGenerated() {
+        return excludeGenerated;
     }
 
     /**
@@ -173,10 +173,10 @@ public class GetTrainedModelsRequest implements Validatable {
      * This is useful when getting the model and wanting to put it in another cluster.
      *
      * Default value is false.
-     * @param forExport Boolean value indicating if certain fields should be removed from the mode on GET
+     * @param excludeGenerated Boolean value indicating if certain fields should be removed from the mode on GET
      */
-    public GetTrainedModelsRequest setForExport(Boolean forExport) {
-        this.forExport = forExport;
+    public GetTrainedModelsRequest setExcludeGenerated(Boolean excludeGenerated) {
+        this.excludeGenerated = excludeGenerated;
         return this;
     }
 
@@ -198,12 +198,12 @@ public class GetTrainedModelsRequest implements Validatable {
             && Objects.equals(allowNoMatch, other.allowNoMatch)
             && Objects.equals(decompressDefinition, other.decompressDefinition)
             && Objects.equals(includes, other.includes)
-            && Objects.equals(forExport, other.forExport)
+            && Objects.equals(excludeGenerated, other.excludeGenerated)
             && Objects.equals(pageParams, other.pageParams);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ids, allowNoMatch, pageParams, decompressDefinition, includes, forExport);
+        return Objects.hash(ids, allowNoMatch, pageParams, decompressDefinition, includes, excludeGenerated);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -343,6 +343,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::get-job-request
             GetJobRequest request = new GetJobRequest("get-machine-learning-job1", "get-machine-learning-job*"); // <1>
             request.setAllowNoMatch(true); // <2>
+            request.setForExport(false); // <3>
             // end::get-job-request
 
             // tag::get-job-execute
@@ -839,6 +840,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::get-datafeed-request
             GetDatafeedRequest request = new GetDatafeedRequest(datafeedId); // <1>
             request.setAllowNoMatch(true); // <2>
+            request.setForExport(false); // <3>
             // end::get-datafeed-request
 
             // tag::get-datafeed-execute
@@ -2864,6 +2866,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-data-frame-analytics-request
             GetDataFrameAnalyticsRequest request = new GetDataFrameAnalyticsRequest("my-analytics-config"); // <1>
+            request.setForExport(false); // <2>
             // end::get-data-frame-analytics-request
 
             // tag::get-data-frame-analytics-execute

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -343,7 +343,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::get-job-request
             GetJobRequest request = new GetJobRequest("get-machine-learning-job1", "get-machine-learning-job*"); // <1>
             request.setAllowNoMatch(true); // <2>
-            request.setForExport(false); // <3>
+            request.setExcludeGenerated(false); // <3>
             // end::get-job-request
 
             // tag::get-job-execute
@@ -840,7 +840,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::get-datafeed-request
             GetDatafeedRequest request = new GetDatafeedRequest(datafeedId); // <1>
             request.setAllowNoMatch(true); // <2>
-            request.setForExport(false); // <3>
+            request.setExcludeGenerated(false); // <3>
             // end::get-datafeed-request
 
             // tag::get-datafeed-execute
@@ -2866,7 +2866,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-data-frame-analytics-request
             GetDataFrameAnalyticsRequest request = new GetDataFrameAnalyticsRequest("my-analytics-config"); // <1>
-            request.setForExport(false); // <2>
+            request.setExcludeGenerated(false); // <2>
             // end::get-data-frame-analytics-request
 
             // tag::get-data-frame-analytics-execute
@@ -3731,7 +3731,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
                 .setDecompressDefinition(false) // <6>
                 .setAllowNoMatch(true) // <7>
                 .setTags("regression") // <8>
-                .setForExport(false); // <9>
+                .setExcludeGenerated(false); // <9>
             // end::get-trained-models-request
             request.setTags((List<String>)null);
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -23,6 +23,9 @@ IDs, or the special wildcard `_all` to get all {dfanalytics-jobs}.
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new GET request referencing an existing {dfanalytics-job}
+<2> Optional boolean value for requesting the {dfanalytics-job} in a format that can
+then be put into another cluster. Certain fields that can only be set when
+the {dfanalytics-job} is created are removed.
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/ml/get-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed.asciidoc
@@ -25,6 +25,9 @@ include-tagged::{doc-tests-file}[{api}-request]
 contain wildcards.
 <2> Whether to ignore if a wildcard expression matches no datafeeds.
  (This includes `_all` string or when no datafeeds have been specified).
+<3> Optional boolean value for requesting the datafeed in a format that can
+then be put into another cluster. Certain fields that can only be set when
+the datafeed is created are removed.
 
 [id="{upid}-{api}-response"]
 ==== Get datafeeds response

--- a/docs/java-rest/high-level/ml/get-job.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job.asciidoc
@@ -25,6 +25,9 @@ include-tagged::{doc-tests-file}[{api}-request]
 wildcards.
 <2> Whether to ignore if a wildcard expression matches no {anomaly-jobs}.
  (This includes `_all` string or when no jobs have been specified).
+<3> Optional boolean value for requesting the job in a format that can
+then be put into another cluster. Certain fields that can only be set when
+the job is created are removed.
 
 [id="{upid}-{api}-response"]
 ==== Get {anomaly-jobs} response

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -57,6 +57,10 @@ all {dfeeds}.
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
+`for_export`::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+
 [[ml-get-datafeed-results]]
 == {api-response-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -19,7 +19,7 @@ Retrieves configuration information for {dfeeds}.
 
 `GET _ml/datafeeds/` +
 
-`GET _ml/datafeeds/_all` 
+`GET _ml/datafeeds/_all`
 
 [[ml-get-datafeed-prereqs]]
 == {api-prereq-title}
@@ -36,7 +36,7 @@ comma-separated list of {dfeeds} or a wildcard expression. You can get
 information for all {dfeeds} by using `_all`, by specifying `*` as the
 `<feed_id>`, or by omitting the `<feed_id>`.
 
-IMPORTANT: This API returns a maximum of 10,000 {dfeeds}. 
+IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 
 [[ml-get-datafeed-path-parms]]
 == {api-path-parms-title}
@@ -57,9 +57,9 @@ all {dfeeds}.
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
-`for_export`::
+`exclude_generated`::
 (Optional, boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-generated]
 
 [[ml-get-datafeed-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -34,7 +34,7 @@ using a group name, a comma-separated list of jobs, or a wildcard expression.
 You can get information for all {anomaly-jobs} by using `_all`, by specifying
 `*` as the `<job_id>`, or by omitting the `<job_id>`.
 
-IMPORTANT: This API returns a maximum of 10,000 jobs. 
+IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 [[ml-get-job-path-parms]]
 == {api-path-parms-title}
@@ -50,9 +50,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
-`for_export`::
+`exclude_generated`::
 (Optional, boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-generated]
 
 [[ml-get-job-results]]
 == {api-response-body-title}
@@ -63,7 +63,7 @@ properties, see <<ml-put-job-request-body,create {anomaly-jobs} API>>.
 `create_time`::
 (string) The time the job was created. For example, `1491007356077`. This
 property is informational; you cannot change its value.
-  
+
 `finished_time`::
 (string) If the job closed or failed, this is the time the job finished.
 Otherwise, it is `null`. This property is informational; you cannot change its
@@ -83,7 +83,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 == {api-response-codes-title}
 
 `404` (Missing resources)::
-  If `allow_no_match` is `false`, this code indicates that there are no 
+  If `allow_no_match` is `false`, this code indicates that there are no
   resources that match the request or only partial matches for the request.
 
 [[ml-get-job-example]]

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -50,6 +50,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-defaul
 (Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
+`for_export`::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+
 [[ml-get-job-results]]
 == {api-response-body-title}
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -30,14 +30,14 @@ experimental[]
 If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
-  
+
 For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 
 [[ml-get-dfanalytics-desc]]
 == {api-description-title}
 
-You can get information for multiple {dfanalytics-jobs} in a single API request 
+You can get information for multiple {dfanalytics-jobs} in a single API request
 by using a comma-separated list of {dfanalytics-jobs} or a wildcard expression.
 
 
@@ -45,12 +45,12 @@ by using a comma-separated list of {dfanalytics-jobs} or a wildcard expression.
 == {api-path-parms-title}
 
 `<data_frame_analytics_id>`::
-(Optional, string) 
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
 +
 --
-You can get information for all {dfanalytics-jobs} by using _all, by specifying 
-`*` as the `<data_frame_analytics_id>`, or by omitting the 
+You can get information for all {dfanalytics-jobs} by using _all, by specifying
+`*` as the `<data_frame_analytics_id>`, or by omitting the
 `<data_frame_analytics_id>`.
 --
 
@@ -59,20 +59,20 @@ You can get information for all {dfanalytics-jobs} by using _all, by specifying
 == {api-query-parms-title}
 
 `allow_no_match`::
-(Optional, boolean) 
+(Optional, boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 `from`::
-(Optional, integer) 
+(Optional, integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `size`::
-(Optional, integer) 
+(Optional, integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
-`for_export`::
+`exclude_generated`::
 (Optional, boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-generated]
 
 [role="child_attributes"]
 [[ml-get-dfanalytics-results]]
@@ -80,7 +80,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
 
 `data_frame_analytics`::
 (array)
-An array of {dfanalytics-job} resources, which are sorted by the `id` value in 
+An array of {dfanalytics-job} resources, which are sorted by the `id` value in
 ascending order.
 +
 .Properties of {dfanalytics-job} resources
@@ -91,18 +91,18 @@ ascending order.
 
 //Begin analyzed_fields
 `analyzed_fields`:::
-(object) Contains `includes` and/or `excludes` patterns that select which fields 
+(object) Contains `includes` and/or `excludes` patterns that select which fields
 are included in the analysis.
 +
 .Properties of `analyzed_fields`
 [%collapsible%open]
 =====
 `excludes`:::
-(Optional, array) An array of strings that defines the fields that are excluded 
+(Optional, array) An array of strings that defines the fields that are excluded
 from the analysis.
-    
+
 `includes`:::
-(Optional, array) An array of strings that defines the fields that are included 
+(Optional, array) An array of strings that defines the fields that are included
 in the analysis.
 =====
 //End analyzed_fields
@@ -114,11 +114,11 @@ in the analysis.
 [%collapsible%open]
 =====
 `index`:::
-(string) The _destination index_ that stores the results of the 
+(string) The _destination index_ that stores the results of the
 {dfanalytics-job}.
 
 `results_field`:::
-(string) The name of the field that stores the results of the analysis. Defaults 
+(string) The name of the field that stores the results of the analysis. Defaults
 to `ml`.
 =====
 //End dest
@@ -130,36 +130,36 @@ to `ml`.
 (string) The `model_memory_limit` that has been set to the {dfanalytics-job}.
 
 `source`:::
-(object) The configuration of how the analysis data is sourced. It has an 
+(object) The configuration of how the analysis data is sourced. It has an
 `index` parameter and optionally a `query` and a `_source`.
 +
 .Properties of `source`
 [%collapsible%open]
 =====
 `index`:::
-(array) Index or indices on which to perform the analysis. It can be a single 
+(array) Index or indices on which to perform the analysis. It can be a single
 index or index pattern as well as an array of indices or patterns.
-    
+
 `query`:::
-(object) The query that has been specified for the {dfanalytics-job}. The {es} 
-query domain-specific language (<<query-dsl,DSL>>). This value corresponds to 
-the query object in an {es} search POST body. By default, this property has the 
+(object) The query that has been specified for the {dfanalytics-job}. The {es}
+query domain-specific language (<<query-dsl,DSL>>). This value corresponds to
+the query object in an {es} search POST body. By default, this property has the
 following value: `{"match_all": {}}`.
 
 `_source`:::
-(object) Contains the specified `includes` and/or `excludes` patterns that 
-select which fields are present in the destination. Fields that are excluded 
+(object) Contains the specified `includes` and/or `excludes` patterns that
+select which fields are present in the destination. Fields that are excluded
 cannot be included in the analysis.
 +
 .Properties of `_source`
 [%collapsible%open]
 ======
 `excludes`:::
-(array) An array of strings that defines the fields that are excluded from the 
+(array) An array of strings that defines the fields that are excluded from the
 destination.
-        
+
 `includes`:::
-(array) An array of strings that defines the fields that are included in the 
+(array) An array of strings that defines the fields that are included in the
 destination.
 ======
 //End of _source
@@ -179,7 +179,7 @@ destination.
 [[ml-get-dfanalytics-example]]
 == {api-examples-title}
 
-The following example gets configuration information for the `loganalytics` 
+The following example gets configuration information for the `loganalytics`
 {dfanalytics-job}:
 
 [source,console]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -70,6 +70,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 (Optional, integer) 
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
+`for_export`::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+
 [role="child_attributes"]
 [[ml-get-dfanalytics-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -67,9 +67,7 @@ Specifies whether the included model definition should be returned as a JSON map
 
 `for_export`::
 (Optional, boolean)
-Indicates if certain fields should be removed from the model configuration on
-retrieval. This allows the model to be in an acceptable format to be retrieved
-and then added to another cluster. Default is false.
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
 
 `from`::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -65,9 +65,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-models]
 Specifies whether the included model definition should be returned as a JSON map
 (`true`) or in a custom compressed format (`false`). Defaults to `true`.
 
-`for_export`::
+`exclude_generated`::
 (Optional, boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=for-export]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-generated]
 
 `from`::
 (Optional, integer)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -673,6 +673,12 @@ The number of individual forecasts currently available for the job. A value of
 `1` or more indicates that forecasts exist.
 end::forecast-total[]
 
+tag::for-export[]
+Indicates if certain fields should be removed from the configuration on
+retrieval. This allows the configuration to be in an acceptable format to be retrieved
+and then added to another cluster. Default is false.
+end::for-export[]
+
 tag::frequency[]
 The interval at which scheduled queries are made while the {dfeed} runs in real
 time. The default value is either the bucket span for short bucket spans, or,

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -673,11 +673,11 @@ The number of individual forecasts currently available for the job. A value of
 `1` or more indicates that forecasts exist.
 end::forecast-total[]
 
-tag::for-export[]
+tag::exclude-generated[]
 Indicates if certain fields should be removed from the configuration on
 retrieval. This allows the configuration to be in an acceptable format to be retrieved
 and then added to another cluster. Default is false.
-end::for-export[]
+end::exclude-generated[]
 
 tag::frequency[]
 The interval at which scheduled queries are made while the {dfeed} runs in real

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,6 +51,8 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+
 /**
  * Datafeed configuration options. Describes where to proactively pull input
  * data from.
@@ -66,6 +69,9 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     private static final int TWO_MINS_SECONDS = 2 * SECONDS_IN_MINUTE;
     private static final int TWENTY_MINS_SECONDS = 20 * SECONDS_IN_MINUTE;
     private static final int HALF_DAY_SECONDS = 12 * 60 * SECONDS_IN_MINUTE;
+    public static final int DEFAULT_AGGREGATION_CHUNKING_BUCKETS = 1000;
+    private static final TimeValue MIN_DEFAULT_QUERY_DELAY = TimeValue.timeValueMinutes(1);
+    private static final TimeValue MAX_DEFAULT_QUERY_DELAY = TimeValue.timeValueMinutes(2);
 
     private static final Logger logger = LogManager.getLogger(DatafeedConfig.class);
 
@@ -480,17 +486,43 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(ID.getPreferredName(), id);
-        builder.field(Job.ID.getPreferredName(), jobId);
-        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
-            builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
+        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
+            builder.field(ID.getPreferredName(), id);
+            // We don't include the job_id in export as we assume the PUT will be referring to a new job as well
+            builder.field(Job.ID.getPreferredName(), jobId);
+            if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+                builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
+            }
+            if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+                builder.field(HEADERS.getPreferredName(), headers);
+            }
+            builder.field(QUERY_DELAY.getPreferredName(), queryDelay.getStringRep());
+            if (chunkingConfig != null) {
+                builder.field(CHUNKING_CONFIG.getPreferredName(), chunkingConfig);
+            }
+            builder.startObject(INDICES_OPTIONS.getPreferredName());
+            indicesOptions.toXContent(builder, params);
+            builder.endObject();
+        } else { // Don't include random defaults or unnecessary defaults in export
+            if (queryDelay.equals(defaultRandomQueryDelay(jobId)) == false) {
+                builder.field(QUERY_DELAY.getPreferredName(), queryDelay.getStringRep());
+            }
+            // Indices options are a pretty advanced feature, better to not include them if they are just the default ones
+            if (indicesOptions.equals(SearchRequest.DEFAULT_INDICES_OPTIONS) == false) {
+                builder.startObject(INDICES_OPTIONS.getPreferredName());
+                indicesOptions.toXContent(builder, params);
+                builder.endObject();
+            }
+            // Removing the default chunking config as it is determined by OTHER fields
+            if (chunkingConfig != null && chunkingConfig.equals(defaultChunkingConfig(aggProvider)) == false) {
+                builder.field(CHUNKING_CONFIG.getPreferredName(), chunkingConfig);
+            }
         }
-        builder.field(QUERY_DELAY.getPreferredName(), queryDelay.getStringRep());
+        builder.field(QUERY.getPreferredName(), queryProvider.getQuery());
         if (frequency != null) {
             builder.field(FREQUENCY.getPreferredName(), frequency.getStringRep());
         }
         builder.field(INDICES.getPreferredName(), indices);
-        builder.field(QUERY.getPreferredName(), queryProvider.getQuery());
         if (aggProvider != null) {
             builder.field(AGGREGATIONS.getPreferredName(), aggProvider.getAggs());
         }
@@ -502,24 +534,32 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             builder.endObject();
         }
         builder.field(SCROLL_SIZE.getPreferredName(), scrollSize);
-        if (chunkingConfig != null) {
-            builder.field(CHUNKING_CONFIG.getPreferredName(), chunkingConfig);
-        }
-        if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
-            builder.field(HEADERS.getPreferredName(), headers);
-        }
         if (delayedDataCheckConfig != null) {
             builder.field(DELAYED_DATA_CHECK_CONFIG.getPreferredName(), delayedDataCheckConfig);
         }
         if (maxEmptySearches != null) {
             builder.field(MAX_EMPTY_SEARCHES.getPreferredName(), maxEmptySearches);
         }
-        builder.startObject(INDICES_OPTIONS.getPreferredName());
-        indicesOptions.toXContent(builder, params);
-        builder.endObject();
-
         builder.endObject();
         return builder;
+    }
+
+    private static TimeValue defaultRandomQueryDelay(String jobId) {
+        Random random = new Random(jobId.hashCode());
+        long delayMillis = random.longs(MIN_DEFAULT_QUERY_DELAY.millis(), MAX_DEFAULT_QUERY_DELAY.millis()).findFirst().getAsLong();
+        return TimeValue.timeValueMillis(delayMillis);
+    }
+
+    private static ChunkingConfig defaultChunkingConfig(@Nullable AggProvider aggProvider) {
+        if (aggProvider == null || aggProvider.getParsedAggs() == null) {
+            return ChunkingConfig.newAuto();
+        } else {
+            long histogramIntervalMillis = ExtractorUtils.getHistogramIntervalMillis(aggProvider.getParsedAggs());
+            if (histogramIntervalMillis <= 0) {
+                throw ExceptionsHelper.badRequestException(Messages.DATAFEED_AGGREGATIONS_INTERVAL_MUST_BE_GREATER_THAN_ZERO);
+            }
+            return ChunkingConfig.newManual(TimeValue.timeValueMillis(DEFAULT_AGGREGATION_CHUNKING_BUCKETS * histogramIntervalMillis));
+        }
     }
 
     /**
@@ -614,10 +654,6 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     }
 
     public static class Builder {
-
-        public static final int DEFAULT_AGGREGATION_CHUNKING_BUCKETS = 1000;
-        private static final TimeValue MIN_DEFAULT_QUERY_DELAY = TimeValue.timeValueMinutes(1);
-        private static final TimeValue MAX_DEFAULT_QUERY_DELAY = TimeValue.timeValueMinutes(2);
 
         private String id;
         private String jobId;
@@ -855,25 +891,13 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
 
         private void setDefaultChunkingConfig() {
             if (chunkingConfig == null) {
-                if (aggProvider == null || aggProvider.getParsedAggs() == null) {
-                    chunkingConfig = ChunkingConfig.newAuto();
-                } else {
-                    long histogramIntervalMillis = ExtractorUtils.getHistogramIntervalMillis(aggProvider.getParsedAggs());
-                    if (histogramIntervalMillis <= 0) {
-                        throw ExceptionsHelper.badRequestException(Messages.DATAFEED_AGGREGATIONS_INTERVAL_MUST_BE_GREATER_THAN_ZERO);
-                    }
-                    chunkingConfig = ChunkingConfig.newManual(TimeValue.timeValueMillis(
-                            DEFAULT_AGGREGATION_CHUNKING_BUCKETS * histogramIntervalMillis));
-                }
+                chunkingConfig = defaultChunkingConfig(aggProvider);
             }
         }
 
         private void setDefaultQueryDelay() {
             if (queryDelay == null) {
-                Random random = new Random(jobId.hashCode());
-                long delayMillis = random.longs(MIN_DEFAULT_QUERY_DELAY.millis(), MAX_DEFAULT_QUERY_DELAY.millis())
-                        .findFirst().getAsLong();
-                queryDelay = TimeValue.timeValueMillis(delayMillis);
+                queryDelay = defaultRandomQueryDelay(jobId);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -51,7 +51,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 /**
  * Datafeed configuration options. Describes where to proactively pull input
@@ -486,10 +486,9 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
-            builder.field(ID.getPreferredName(), id);
-            // We don't include the job_id in export as we assume the PUT will be referring to a new job as well
-            builder.field(Job.ID.getPreferredName(), jobId);
+        builder.field(ID.getPreferredName(), id);
+        builder.field(Job.ID.getPreferredName(), jobId);
+        if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
                 builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ObjectParser.ValueType.OBJECT_ARRAY_BOOLEAN_OR_STRING;
 import static org.elasticsearch.common.xcontent.ObjectParser.ValueType.VALUE;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
 
@@ -231,8 +231,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
-            builder.field(ID.getPreferredName(), id);
+        builder.field(ID.getPreferredName(), id);
+        if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             if (createTime != null) {
                 builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ObjectParser.ValueType.OBJECT_ARRAY_BOOLEAN_OR_STRING;
 import static org.elasticsearch.common.xcontent.ObjectParser.ValueType.VALUE;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
 
@@ -230,34 +231,34 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(ID.getPreferredName(), id);
+        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
+            builder.field(ID.getPreferredName(), id);
+            if (createTime != null) {
+                builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
+            }
+            if (version != null) {
+                builder.field(VERSION.getPreferredName(), version);
+            }
+            if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+                builder.field(HEADERS.getPreferredName(), headers);
+            }
+            if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+                builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
+            }
+        }
         if (description != null) {
             builder.field(DESCRIPTION.getPreferredName(), description);
         }
         builder.field(SOURCE.getPreferredName(), source);
         builder.field(DEST.getPreferredName(), dest);
-
         builder.startObject(ANALYSIS.getPreferredName());
         builder.field(analysis.getWriteableName(), analysis,
             new MapParams(Collections.singletonMap(VERSION.getPreferredName(), version == null ? null : version.toString())));
         builder.endObject();
-
-        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
-            builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
-        }
         if (analyzedFields != null) {
             builder.field(ANALYZED_FIELDS.getPreferredName(), analyzedFields);
         }
         builder.field(MODEL_MEMORY_LIMIT.getPreferredName(), getModelMemoryLimit().getStringRep());
-        if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
-            builder.field(HEADERS.getPreferredName(), headers);
-        }
-        if (createTime != null) {
-            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
-        }
-        if (version != null) {
-            builder.field(VERSION.getPreferredName(), version);
-        }
         builder.field(ALLOW_LAZY_START.getPreferredName(), allowLazyStart);
         builder.field(MAX_NUM_THREADS.getPreferredName(), maxNumThreads);
         builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper.writeNamedObject;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 
 public class TrainedModelConfig implements ToXContentObject, Writeable {
@@ -315,9 +315,9 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        builder.field(MODEL_ID.getPreferredName(), modelId);
         // If the model is to be exported for future import to another cluster, these fields are irrelevant.
-        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
-            builder.field(MODEL_ID.getPreferredName(), modelId);
+        if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             builder.field(CREATED_BY.getPreferredName(), createdBy);
             builder.field(VERSION.getPreferredName(), version.toString());
             builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper.writeNamedObject;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 
 public class TrainedModelConfig implements ToXContentObject, Writeable {
@@ -54,7 +55,6 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
     public static final String NAME = "trained_model_config";
     public static final int CURRENT_DEFINITION_COMPRESSION_VERSION = 1;
     public static final String DECOMPRESS_DEFINITION = "decompress_definition";
-    public static final String FOR_EXPORT = "for_export";
     public static final String TOTAL_FEATURE_IMPORTANCE = "total_feature_importance";
     public static final String FEATURE_IMPORTANCE_BASELINE = "feature_importance_baseline";
     private static final Set<String> RESERVED_METADATA_FIELDS = new HashSet<>(Arrays.asList(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 /**
  * This class represents a configured and created Job. The creation time is set
@@ -553,8 +553,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
 
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         final String humanReadableSuffix = "_string";
-        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
-            builder.field(ID.getPreferredName(), jobId);
+        builder.field(ID.getPreferredName(), jobId);
+        if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             builder.field(JOB_TYPE.getPreferredName(), jobType);
             if (jobVersion != null) {
                 builder.field(JOB_VERSION.getPreferredName(), jobVersion);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,6 +41,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 /**
  * This class represents a configured and created Job. The creation time is set
@@ -550,22 +553,41 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
 
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         final String humanReadableSuffix = "_string";
-
-        builder.field(ID.getPreferredName(), jobId);
-        builder.field(JOB_TYPE.getPreferredName(), jobType);
-        if (jobVersion != null) {
-            builder.field(JOB_VERSION.getPreferredName(), jobVersion);
+        if (params.paramAsBoolean(FOR_EXPORT, false) == false) {
+            builder.field(ID.getPreferredName(), jobId);
+            builder.field(JOB_TYPE.getPreferredName(), jobType);
+            if (jobVersion != null) {
+                builder.field(JOB_VERSION.getPreferredName(), jobVersion);
+            }
+            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + humanReadableSuffix, createTime.getTime());
+            if (finishedTime != null) {
+                builder.timeField(FINISHED_TIME.getPreferredName(), FINISHED_TIME.getPreferredName() + humanReadableSuffix,
+                    finishedTime.getTime());
+            }
+            if (modelSnapshotId != null) {
+                builder.field(MODEL_SNAPSHOT_ID.getPreferredName(), modelSnapshotId);
+            }
+            if (deleting) {
+                builder.field(DELETING.getPreferredName(), deleting);
+            }
+            if (modelSnapshotMinVersion != null) {
+                builder.field(MODEL_SNAPSHOT_MIN_VERSION.getPreferredName(), modelSnapshotMinVersion);
+            }
+            if (customSettings != null) {
+                builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
+            }
+        } else {
+            if (customSettings != null) {
+                HashMap<String, Object> newCustomSettings = new HashMap<>(customSettings);
+                newCustomSettings.remove("created_by");
+                builder.field(CUSTOM_SETTINGS.getPreferredName(), newCustomSettings);
+            }
         }
         if (groups.isEmpty() == false) {
             builder.field(GROUPS.getPreferredName(), groups);
         }
         if (description != null) {
             builder.field(DESCRIPTION.getPreferredName(), description);
-        }
-        builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + humanReadableSuffix, createTime.getTime());
-        if (finishedTime != null) {
-            builder.timeField(FINISHED_TIME.getPreferredName(), FINISHED_TIME.getPreferredName() + humanReadableSuffix,
-                    finishedTime.getTime());
         }
         builder.field(ANALYSIS_CONFIG.getPreferredName(), analysisConfig, params);
         if (analysisLimits != null) {
@@ -592,19 +614,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
-        if (customSettings != null) {
-            builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
-        }
-        if (modelSnapshotId != null) {
-            builder.field(MODEL_SNAPSHOT_ID.getPreferredName(), modelSnapshotId);
-        }
-        if (modelSnapshotMinVersion != null) {
-            builder.field(MODEL_SNAPSHOT_MIN_VERSION.getPreferredName(), modelSnapshotMinVersion);
-        }
         builder.field(RESULTS_INDEX_NAME.getPreferredName(), resultsIndexName);
-        if (deleting) {
-            builder.field(DELETING.getPreferredName(), deleting);
-        }
         builder.field(ALLOW_LAZY_OPEN.getPreferredName(), allowLazyOpen);
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ToXContentParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ToXContentParams.java
@@ -24,7 +24,7 @@ public final class ToXContentParams {
      *
      * This helps to GET a configuration, copy it, and then PUT it directly without removing or changing any fields in between
      */
-    public static final String FOR_EXPORT = "for_export";
+    public static final String EXCLUDE_GENERATED = "exclude_generated";
 
     /**
      * When serialising POJOs to X Content this indicates whether the calculated (i.e. not stored) fields

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ToXContentParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ToXContentParams.java
@@ -19,6 +19,14 @@ public final class ToXContentParams {
     public static final String FOR_INTERNAL_STORAGE = "for_internal_storage";
 
     /**
+     * Parameter to indicate if this XContent serialization should only include fields that are allowed to be used
+     * on PUT
+     *
+     * This helps to GET a configuration, copy it, and then PUT it directly without removing or changing any fields in between
+     */
+    public static final String FOR_EXPORT = "for_export";
+
+    /**
      * When serialising POJOs to X Content this indicates whether the calculated (i.e. not stored) fields
      * should be included or not
      */

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.yaml.snakeyaml.util.UriEncoder;
 
+import javax.print.attribute.standard.JobStateReason;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
@@ -247,8 +248,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         String jobId = "test-export-import-job";
         createFarequoteJob(jobId);
         Response jobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "anomaly_detectors/" + jobId + "?for_export=true"));
+            new Request("GET", BASE_PATH + "anomaly_detectors/" + jobId + "?exclude_generated=true"));
         Map<String, Object> originalJobBody = (Map<String, Object>)((List<?>) entityAsMap(jobResponse).get("jobs")).get(0);
+        originalJobBody.remove("job_id");
 
         XContentBuilder xContentBuilder = jsonBuilder().map(originalJobBody);
         Request request = new Request("PUT", BASE_PATH + "anomaly_detectors/" + jobId + "-import");
@@ -256,8 +258,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response importedJobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "anomaly_detectors/" + jobId + "-import" + "?for_export=true"));
+            new Request("GET", BASE_PATH + "anomaly_detectors/" + jobId + "-import" + "?exclude_generated=true"));
         Map<String, Object> importedJobBody = (Map<String, Object>)((List<?>) entityAsMap(importedJobResponse).get("jobs")).get(0);
+        importedJobBody.remove("job_id");
         assertThat(originalJobBody, equalTo(importedJobBody));
     }
 
@@ -270,8 +273,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         createDatafeed(datafeedId, jobId);
 
         Response dfResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "datafeeds/" + datafeedId + "?for_export=true"));
+            new Request("GET", BASE_PATH + "datafeeds/" + datafeedId + "?exclude_generated=true"));
         Map<String, Object> originalDfBody = (Map<String, Object>)((List<?>) entityAsMap(dfResponse).get("datafeeds")).get(0);
+        originalDfBody.remove("datafeed_id");
 
         //Delete this so we can PUT another datafeed for the same job
         client().performRequest(new Request("DELETE", BASE_PATH + "datafeeds/" + datafeedId));
@@ -284,8 +288,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response importedDfResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "datafeeds/" + datafeedId + "-import" + "?for_export=true"));
+            new Request("GET", BASE_PATH + "datafeeds/" + datafeedId + "-import" + "?exclude_generated=true"));
         Map<String, Object> importedDfBody = (Map<String, Object>)((List<?>) entityAsMap(importedDfResponse).get("datafeeds")).get(0);
+        importedDfBody.remove("datafeed_id");
         assertThat(originalDfBody, equalTo(importedDfBody));
     }
 
@@ -325,8 +330,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response jobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?exclude_generated=true"));
         Map<String, Object> originalJobBody = (Map<String, Object>)((List<?>) entityAsMap(jobResponse).get("data_frame_analytics")).get(0);
+        originalJobBody.remove("id");
 
         XContentBuilder newBuilder = jsonBuilder().map(originalJobBody);
         request = new Request("PUT", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import");
@@ -334,10 +340,11 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response importedJobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?exclude_generated=true"));
         Map<String, Object> importedJobBody = (Map<String, Object>)((List<?>) entityAsMap(importedJobResponse)
             .get("data_frame_analytics"))
             .get(0);
+        importedJobBody.remove("id");
         assertThat(originalJobBody, equalTo(importedJobBody));
     }
 
@@ -378,8 +385,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response jobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?exclude_generated=true"));
         Map<String, Object> originalJobBody = (Map<String, Object>)((List<?>) entityAsMap(jobResponse).get("data_frame_analytics")).get(0);
+        originalJobBody.remove("id");
 
         XContentBuilder newBuilder = jsonBuilder().map(originalJobBody);
         request = new Request("PUT", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import");
@@ -387,10 +395,11 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response importedJobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?exclude_generated=true"));
         Map<String, Object> importedJobBody = (Map<String, Object>)((List<?>) entityAsMap(importedJobResponse)
             .get("data_frame_analytics"))
             .get(0);
+        importedJobBody.remove("id");
         assertThat(originalJobBody, equalTo(importedJobBody));
     }
 
@@ -431,8 +440,9 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response jobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "?exclude_generated=true"));
         Map<String, Object> originalJobBody = (Map<String, Object>)((List<?>) entityAsMap(jobResponse).get("data_frame_analytics")).get(0);
+        originalJobBody.remove("id");
 
         XContentBuilder newBuilder = jsonBuilder().map(originalJobBody);
         request = new Request("PUT", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import");
@@ -440,10 +450,11 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         client().performRequest(request);
 
         Response importedJobResponse = client().performRequest(
-            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?for_export=true"));
+            new Request("GET", BASE_PATH + "data_frame/analytics/" + analyticsId + "-import" + "?exclude_generated=true"));
         Map<String, Object> importedJobBody = (Map<String, Object>)((List<?>) entityAsMap(importedJobResponse)
             .get("data_frame_analytics"))
             .get(0);
+        importedJobBody.remove("id");
         assertThat(originalJobBody, equalTo(importedJobBody));
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelIT.java
@@ -204,11 +204,12 @@ public class TrainedModelIT extends ESRestTestCase {
         getModel = client().performRequest(new Request("GET",
             MachineLearning.BASE_PATH +
                 "trained_models/" + modelId +
-                "?include=definition&decompress_definition=false&for_export=true"));
+                "?include=definition&decompress_definition=false&exclude_generated=true"));
         assertThat(getModel.getStatusLine().getStatusCode(), equalTo(200));
 
         Map<String, Object> exportedModel = entityAsMap(getModel);
         Map<String, Object> modelDefinition = ((List<Map<String, Object>>)exportedModel.get("trained_model_configs")).get(0);
+        modelDefinition.remove("model_id");
 
         String importedModelId = "regression_model_to_import";
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -320,11 +320,11 @@ public class ChunkedDataExtractor implements DataExtractor {
         }
 
         /**
-         * This heuristic is a direct copy of the manual chunking config auto-creation done in {@link DatafeedConfig.Builder}
+         * This heuristic is a direct copy of the manual chunking config auto-creation done in {@link DatafeedConfig}
          */
         @Override
         public long estimateChunk() {
-            return DatafeedConfig.Builder.DEFAULT_AGGREGATION_CHUNKING_BUCKETS * histogramIntervalMillis;
+            return DatafeedConfig.DEFAULT_AGGREGATION_CHUNKING_BUCKETS * histogramIntervalMillis;
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
@@ -19,8 +19,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 public class RestGetDatafeedsAction extends BaseRestHandler {
 
@@ -60,5 +62,10 @@ public class RestGetDatafeedsAction extends BaseRestHandler {
                 Request.ALLOW_NO_MATCH,
                 restRequest.paramAsBoolean(Request.ALLOW_NO_DATAFEEDS, request.allowNoMatch())));
         return channel -> client.execute(GetDatafeedsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Collections.singleton(FOR_EXPORT);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestGetDatafeedsAction.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class RestGetDatafeedsAction extends BaseRestHandler {
 
@@ -66,6 +66,6 @@ public class RestGetDatafeedsAction extends BaseRestHandler {
 
     @Override
     protected Set<String> responseParams() {
-        return Collections.singleton(FOR_EXPORT);
+        return Collections.singleton(EXCLUDE_GENERATED);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
@@ -16,11 +16,14 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 public class RestGetDataFrameAnalyticsAction extends BaseRestHandler {
 
@@ -50,5 +53,10 @@ public class RestGetDataFrameAnalyticsAction extends BaseRestHandler {
         request.setAllowNoResources(restRequest.paramAsBoolean(GetDataFrameAnalyticsAction.Request.ALLOW_NO_MATCH.getPreferredName(),
                 request.isAllowNoResources()));
         return channel -> client.execute(GetDataFrameAnalyticsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Collections.singleton(FOR_EXPORT);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class RestGetDataFrameAnalyticsAction extends BaseRestHandler {
 
@@ -57,6 +57,6 @@ public class RestGetDataFrameAnalyticsAction extends BaseRestHandler {
 
     @Override
     protected Set<String> responseParams() {
-        return Collections.singleton(FOR_EXPORT);
+        return Collections.singleton(EXCLUDE_GENERATED);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
@@ -35,7 +35,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Request.ALLOW_NO_MATCH;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class RestGetTrainedModelsAction extends BaseRestHandler {
 
@@ -100,7 +100,7 @@ public class RestGetTrainedModelsAction extends BaseRestHandler {
 
     @Override
     protected Set<String> responseParams() {
-        return org.elasticsearch.common.collect.Set.of(TrainedModelConfig.DECOMPRESS_DEFINITION, FOR_EXPORT);
+        return org.elasticsearch.common.collect.Set.of(TrainedModelConfig.DECOMPRESS_DEFINITION, EXCLUDE_GENERATED);
     }
 
     private static class RestToXContentListenerWithDefaultValues<T extends ToXContentObject> extends RestToXContentListener<T> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
@@ -35,6 +35,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Request.ALLOW_NO_MATCH;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 public class RestGetTrainedModelsAction extends BaseRestHandler {
 
@@ -99,7 +100,7 @@ public class RestGetTrainedModelsAction extends BaseRestHandler {
 
     @Override
     protected Set<String> responseParams() {
-        return org.elasticsearch.common.collect.Set.of(TrainedModelConfig.DECOMPRESS_DEFINITION, TrainedModelConfig.FOR_EXPORT);
+        return org.elasticsearch.common.collect.Set.of(TrainedModelConfig.DECOMPRESS_DEFINITION, FOR_EXPORT);
     }
 
     private static class RestToXContentListenerWithDefaultValues<T extends ToXContentObject> extends RestToXContentListener<T> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
 
 public class RestGetJobsAction extends BaseRestHandler {
 
@@ -62,5 +64,10 @@ public class RestGetJobsAction extends BaseRestHandler {
                 Request.ALLOW_NO_MATCH,
                 restRequest.paramAsBoolean(Request.ALLOW_NO_JOBS, request.allowNoMatch())));
         return channel -> client.execute(GetJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Collections.singleton(FOR_EXPORT);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestGetJobsAction.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_EXPORT;
+import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 public class RestGetJobsAction extends BaseRestHandler {
 
@@ -68,6 +68,6 @@ public class RestGetJobsAction extends BaseRestHandler {
 
     @Override
     protected Set<String> responseParams() {
-        return Collections.singleton(FOR_EXPORT);
+        return Collections.singleton(EXCLUDE_GENERATED);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
@@ -44,7 +44,7 @@
         "description":"specifies a max number of analytics to get",
         "default":100
       },
-      "for_export": {
+      "exclude_generated": {
         "required": false,
         "type": "boolean",
         "default": false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
@@ -43,6 +43,12 @@
         "type":"int",
         "description":"specifies a max number of analytics to get",
         "default":100
+      },
+      "for_export": {
+        "required": false,
+        "type": "boolean",
+        "default": false,
+        "description": "Omits fields that are illegal to set on data frame analytics PUT"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -39,7 +39,7 @@
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
         "deprecated":true
       },
-      "for_export": {
+      "exclude_generated": {
         "required": false,
         "type": "boolean",
         "default": false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -38,6 +38,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
         "deprecated":true
+      },
+      "for_export": {
+        "required": false,
+        "type": "boolean",
+        "default": false,
+        "description": "Omits fields that are illegal to set on datafeed PUT"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -39,7 +39,7 @@
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
         "deprecated":true
       },
-      "for_export": {
+      "exclude_generated": {
         "required": false,
         "type": "boolean",
         "default": false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -38,6 +38,12 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
         "deprecated":true
+      },
+      "for_export": {
+        "required": false,
+        "type": "boolean",
+        "default": false,
+        "description": "Omits fields that are illegal to set on job PUT"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -69,7 +69,7 @@
         "type":"list",
         "description":"A comma-separated list of tags that the model must have."
       },
-      "for_export": {
+      "exclude_generated": {
         "required": false,
         "type": "boolean",
         "default": false,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -2188,7 +2188,7 @@ setup:
   - do:
       ml.get_data_frame_analytics:
         id: "simple-outlier-detection"
-        for_export: true
+        exclude_generated: true
   - match: { data_frame_analytics.0.source.index.0: "index-source" }
   - match: { data_frame_analytics.0.source.query: {"match_all" : {} } }
   - match: { data_frame_analytics.0.dest.index: "index-dest" }
@@ -2201,4 +2201,3 @@ setup:
   }}
   - is_false: data_frame_analytics.0.create_time
   - is_false: data_frame_analytics.0.version
-  - is_false: data_frame_analytics.0.id

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -2168,3 +2168,37 @@ setup:
           {
             "description": "blah"
           }
+
+---
+"Test GET config for export":
+
+  - do:
+      ml.put_data_frame_analytics:
+        id: "simple-outlier-detection"
+        body: >
+          {
+            "source": {
+              "index": "index-source"
+            },
+            "dest": {
+              "index": "index-dest"
+            },
+            "analysis": {"outlier_detection":{}}
+          }
+  - do:
+      ml.get_data_frame_analytics:
+        id: "simple-outlier-detection"
+        for_export: true
+  - match: { data_frame_analytics.0.source.index.0: "index-source" }
+  - match: { data_frame_analytics.0.source.query: {"match_all" : {} } }
+  - match: { data_frame_analytics.0.dest.index: "index-dest" }
+  - match: { data_frame_analytics.0.analysis: {
+    "outlier_detection":{
+      "compute_feature_influence": true,
+      "outlier_fraction": 0.05,
+      "standardization_enabled": true
+    }
+  }}
+  - is_false: data_frame_analytics.0.create_time
+  - is_false: data_frame_analytics.0.version
+  - is_false: data_frame_analytics.0.id

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -513,3 +513,23 @@ setup:
 
   - match: { datafeeds.0.indices_options.ignore_throttled: false }
   - match: { datafeeds.0.indices_options.allow_no_indices: false }
+---
+"Test get datafeed for export":
+  - do:
+      ml.put_datafeed:
+        datafeed_id: test-for-export
+        body:  >
+          {
+            "job_id":"datafeeds-crud-1",
+            "indexes":["index-foo"]
+          }
+  - do:
+      ml.get_datafeeds:
+        datafeed_id: test-for-export
+        for_export: true
+  - match: { datafeeds.0.indices.0: "index-foo"}
+  - is_false: datafeeds.0.datafeed_id
+  - is_false: datafeeds.0.job_id
+  - is_false: datafeeds.0.create_time
+  - is_false: datafeeds.0.query_delay
+  - is_false: datafeeds.0.chunking_config

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -526,10 +526,8 @@ setup:
   - do:
       ml.get_datafeeds:
         datafeed_id: test-for-export
-        for_export: true
+        exclude_generated: true
   - match: { datafeeds.0.indices.0: "index-foo"}
-  - is_false: datafeeds.0.datafeed_id
-  - is_false: datafeeds.0.job_id
   - is_false: datafeeds.0.create_time
   - is_false: datafeeds.0.query_delay
   - is_false: datafeeds.0.chunking_config

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -854,20 +854,20 @@ setup:
             }
           }
 ---
-"Test for_export flag":
+"Test exclude_generated flag":
   - do:
       ml.get_trained_models:
         model_id: "a-regression-model-1"
-        for_export: true
+        exclude_generated: true
         include: "definition"
         decompress_definition: false
 
   - match: { trained_model_configs.0.description: "empty model for tests" }
+  - match: { trained_model_configs.0.model_id: "a-regression-model-1" }
   - is_true:  trained_model_configs.0.compressed_definition
   - is_true:  trained_model_configs.0.input
   - is_true:  trained_model_configs.0.inference_config
   - is_true:  trained_model_configs.0.tags
-  - is_false: trained_model_configs.0.model_id
   - is_false: trained_model_configs.0.created_by
   - is_false: trained_model_configs.0.version
   - is_false: trained_model_configs.0.create_time

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get.yml
@@ -92,9 +92,8 @@ setup:
   - do:
       ml.get_jobs:
         job_id: jobs-get-1
-        for_export: true
+        exclude_generated: true
   - match: { jobs.0.description: "Job 1"}
-  - is_false: job_id
   - is_false: job_type
   - is_false: job_version
   - is_false: create_time

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get.yml
@@ -86,3 +86,19 @@ setup:
   - match: { jobs.0.description: "Job 1"}
   - match: { jobs.1.job_id: "jobs-get-2"}
   - match: { jobs.1.description: "Job 2"}
+---
+"Test get job for export":
+
+  - do:
+      ml.get_jobs:
+        job_id: jobs-get-1
+        for_export: true
+  - match: { jobs.0.description: "Job 1"}
+  - is_false: job_id
+  - is_false: job_type
+  - is_false: job_version
+  - is_false: create_time
+  - is_false: finished_time
+  - is_false: model_snapshot_id
+  - is_false: model_snapshot_min_version
+  - is_false: deleting


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] adding for_export flag for ml plugin GET resource APIs (#63092)
 - [ML] adding new flag exclude_generated that removes generated fields in GET config APIs #63899