### PR TITLE
Fix enrich policy test bug.

### DIFF
--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/AbstractEnrichTestCase.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/AbstractEnrichTestCase.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -66,7 +67,10 @@ public abstract class AbstractEnrichTestCase extends ESSingleNodeTestCase {
             try {
                 client.admin().indices().create(createIndexRequest).actionGet();
             } catch (ResourceAlreadyExistsException e) {
-                // and that is okay
+                // and that is okay, but update the mapping so that there is always a mapping for match field:
+                PutMappingRequest putMappingRequest = new PutMappingRequest(sourceIndex);
+                putMappingRequest.source(policy.getMatchField(), "type=keyword");
+                client.admin().indices().putMapping(putMappingRequest).actionGet();
             }
         }
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
@@ -175,7 +175,8 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         assertThat(error.get(), nullValue());
 
         // save a second one to verify the count below on GET
-        error = saveEnrichPolicy("something-else", randomEnrichPolicy(XContentType.JSON), clusterService);
+        EnrichPolicy policy2 = randomEnrichPolicy(XContentType.JSON);
+        error = saveEnrichPolicy("something-else", policy2, clusterService);
         assertThat(error.get(), nullValue());
 
         final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
The `randomEnrichPolicy(...)` helper method stores the policy and creates the source indices.
If a source index already exists, because it was creates for a random policy created earlier then
skipping the source index fails, but that is ignored and the test continues. However if the policy
has a match field that doesn't exist in the previous random policy then the mapping is never updated
and the put policy api fails with the fact that the match field can't be found.

This pr fixes that by execute a put mapping call in the event that the source index already exists.

Closes #63126