### PR TITLE
Fix querying a data stream name in _index field.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
@@ -74,7 +74,7 @@ public class SearchIndexNameMatcher implements Predicate<String> {
 
     private boolean matchesIndex(String pattern) {
         String[] concreteIndices = expressionResolver.concreteIndexNames(
-            clusterService.state(), IndicesOptions.lenientExpandOpen(), pattern);
+            clusterService.state(), IndicesOptions.lenientExpandOpen(), true, pattern);
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, indexName)) {
                 return true;


### PR DESCRIPTION
Backport #63170 to 7.9 branch.

The _index field is a special field that allows using queries against the name of an index or alias.
Data stream names were not included, this pr fixes that by changing SearchIndexNameMatcher
(which used via IndexFieldMapper) to also include data streams.