### PR TITLE
EQL: Change default indices options

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class EqlSearchRequest implements Validatable, ToXContentObject {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, false, true, false);
 
     private QueryBuilder filter = null;
     private String timestampField = "@timestamp";

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -84,6 +84,20 @@ setup:
   - match: {hits.sequences.1.events.1._id: "3"}
 
 ---
+"Execute EQL sequence by default ignores unavailable indices"
+  - do:
+      eql.search:
+        index: eql_test,non_existing
+        body:
+          query: 'sequence by valid [process where user == "SYSTEM"] [process where true]'
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.sequences.0.join_keys.0: true}
+  - match: {hits.sequences.0.events.0._id: "2"}
+  - match: {hits.sequences.0.events.1._id: "3"}
+
+---
 "Execute EQL sequence with boolean key.":
   - do:
       eql.search:
@@ -96,7 +110,6 @@ setup:
   - match: {hits.sequences.0.join_keys.0: true}
   - match: {hits.sequences.0.events.0._id: "2"}
   - match: {hits.sequences.0.events.1._id: "3"}
-
 ---
 "Execute some EQL in async mode":
   - do:

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -84,7 +84,7 @@ setup:
   - match: {hits.sequences.1.events.1._id: "3"}
 
 ---
-"Execute EQL sequence by default ignores unavailable indices"
+"Execute EQL sequence by default ignores unavailable indices.":
   - do:
       eql.search:
         index: eql_test,non_existing
@@ -111,7 +111,7 @@ setup:
   - match: {hits.sequences.0.events.0._id: "2"}
   - match: {hits.sequences.0.events.1._id: "3"}
 ---
-"Execute some EQL in async mode":
+"Execute some EQL in async mode.":
   - do:
       eql.search:
         index: eql_test

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -84,10 +84,24 @@ setup:
   - match: {hits.sequences.1.events.1._id: "3"}
 
 ---
-"Execute EQL sequence by default ignores unavailable indices.":
+"Execute EQL sequence by default ignores unavailable index.":
   - do:
       eql.search:
         index: eql_test,non_existing
+        body:
+          query: 'sequence by valid [process where user == "SYSTEM"] [process where true]'
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.sequences.0.join_keys.0: true}
+  - match: {hits.sequences.0.events.0._id: "2"}
+  - match: {hits.sequences.0.events.1._id: "3"}
+
+---
+"Execute EQL sequence by default ignores unavailable index pattern.":
+  - do:
+      eql.search:
+        index: eql_test,non_existing*
         body:
           query: 'sequence by valid [process where user == "SYSTEM"] [process where true]'
   - match: {timed_out: false}

--- a/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/AsyncEqlSecurityIT.java
+++ b/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/AsyncEqlSecurityIT.java
@@ -90,7 +90,6 @@ public class AsyncEqlSecurityIT extends ESRestTestCase {
         ResponseException exc = expectThrows(ResponseException.class,
             () -> submitAsyncEqlSearch("index-" + other, "*", TimeValue.timeValueSeconds(10), user));
         assertThat(exc.getResponse().getStatusLine().getStatusCode(), equalTo(404));
-        //assertThat(exc.getMessage(), containsString("unauthorized"));
     }
 
     static String extractResponseId(Response response) throws IOException {

--- a/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/AsyncEqlSecurityIT.java
+++ b/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/AsyncEqlSecurityIT.java
@@ -89,8 +89,8 @@ public class AsyncEqlSecurityIT extends ESRestTestCase {
         }
         ResponseException exc = expectThrows(ResponseException.class,
             () -> submitAsyncEqlSearch("index-" + other, "*", TimeValue.timeValueSeconds(10), user));
-        assertThat(exc.getResponse().getStatusLine().getStatusCode(), equalTo(403));
-        assertThat(exc.getMessage(), containsString("unauthorized"));
+        assertThat(exc.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+        //assertThat(exc.getMessage(), containsString("unauthorized"));
     }
 
     static String extractResponseId(Response response) throws IOException {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -40,7 +40,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     public static TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueDays(5);
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false,
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true,
         false, true, false);
 
     private QueryBuilder filter = null;
@@ -123,7 +123,12 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
 
         if (indicesOptions == null) {
             validationException = addValidationError("indicesOptions is null", validationException);
+        } else {
+            if (indicesOptions.allowNoIndices()) {
+                validationException = addValidationError("allowNoIndices must be false", validationException);
+            }
         }
+
 
         if (query == null || query.isEmpty()) {
             validationException = addValidationError("query is null or empty", validationException);


### PR DESCRIPTION
Ignore by default unavailable indices (same as ES) and verify that
allowNoIndices is set to false since at least one index is required
for validating the query.

Fix #62986