### PR TITLE
Add tier preference when mounting

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -34,6 +34,8 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
+import org.elasticsearch.xpack.core.DataTier;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotAllocator;
@@ -184,6 +186,11 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                             Settings.builder()
                                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0) // can be overridden
                                 .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false) // can be overridden
+                                // prefer to allocate to the cold tier, then the warm tier, then the hot tier
+                                .put(
+                                    DataTierAllocationDecider.INDEX_ROUTING_PREFER,
+                                    String.join(",", DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT)
+                                )
                                 .put(request.indexSettings())
                                 .put(buildIndexSettings(request.repositoryName(), snapshotId, indexId))
                                 .build()


### PR DESCRIPTION
This commit adds a tier preference when mounting a searchable snapshot. This sets a preference that a searchable snapshot is mounted to a node with the cold role if one exists, then the warm role, then the hot role, assuming that no other allocation rules are in place. This means that by default, searchable snapshots are mounted to a node with the cold role.

Note that depending on how we implement frozen functionality of searchable snapshots (not pre-cached/not fully-cached), we might need to adjust this to prefer frozen if mounting a not pre-cached/fully-cached searchable snapshot versus mounting a pre-cached/fully-cached searchable snapshot. This is a later concern since neither this nor the frozen role are implemented currently.

