### PR TITLE
[DOCS] Add experimental tag to rollup APIs

### DIFF
--- a/docs/java-rest/high-level/rollup/delete_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/delete_job.asciidoc
@@ -7,6 +7,7 @@
 [id="{upid}-{api}"]
 === Delete Rollup Job API
 
+experimental::[]
 
 [id="{upid}-{api}-request"]
 ==== Request

--- a/docs/java-rest/high-level/rollup/get_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_job.asciidoc
@@ -2,6 +2,8 @@
 [[java-rest-high-x-pack-rollup-get-job]]
 === Get Rollup Job API
 
+experimental::[]
+
 The Get Rollup Job API can be used to get one or all rollup jobs from the
 cluster. It accepts a `GetRollupJobRequest` object as a request and returns
 a `GetRollupJobResponse`.

--- a/docs/java-rest/high-level/rollup/get_rollup_caps.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_rollup_caps.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-x-pack-{api}"]
 === Get Rollup Capabilities API
 
+experimental::[]
+
 The Get Rollup Capabilities API allows the user to query a target index pattern (`logstash-*`, etc)
 and determine if there are any rollup jobs that are/were configured to rollup that pattern.
 The API accepts a `GetRollupCapsRequest` object as a request and returns a `GetRollupCapsResponse`.

--- a/docs/java-rest/high-level/rollup/get_rollup_index_caps.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_rollup_index_caps.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-x-pack-{api}"]
 === Get Rollup Index Capabilities API
 
+experimental::[]
+
 The Get Rollup Index Capabilities API allows the user to determine if a concrete index or index pattern contains
 stored rollup jobs and data.  If it contains data stored from rollup jobs, the capabilities of those jobs
 are returned. The API accepts a `GetRollupIndexCapsRequest` object as a request and returns a `GetRollupIndexCapsResponse`.

--- a/docs/java-rest/high-level/rollup/put_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/put_job.asciidoc
@@ -2,6 +2,8 @@
 [[java-rest-high-x-pack-rollup-put-job]]
 === Put Rollup Job API
 
+experimental::[]
+
 The Put Rollup Job API can be used to create a new Rollup job
 in the cluster. The API accepts a `PutRollupJobRequest` object
 as a request and returns a `PutRollupJobResponse`.

--- a/docs/java-rest/high-level/rollup/search.asciidoc
+++ b/docs/java-rest/high-level/rollup/search.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Rollup Search API
 
+experimental::[]
+
 The Rollup Search endpoint allows searching rolled-up data using the standard
 query DSL. The Rollup Search endpoint is needed because, internally,
 rolled-up documents utilize a different document structure than the original

--- a/docs/java-rest/high-level/rollup/start_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/start_job.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Start Rollup Job API
 
+experimental::[]
+
 [id="{upid}-{api}-request"]
 ==== Request
 

--- a/docs/java-rest/high-level/rollup/stop_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/stop_job.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Stop Rollup Job API
 
+experimental::[]
+
 [id="{upid}-{api}-request"]
 ==== Request
 


### PR DESCRIPTION
This PR adds the missing experimental admonition to the rollup APIs in the [Java high level REST client docs](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_rollup_apis.html) to match the way they're tagged in the [Elasticsearch reference docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-apis.html).

### Preview

https://elasticsearch_63206.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/_rollup_apis.html