### PR TITLE
[DOCS] Update `ignore_unavailable` default for EQL search API

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -64,7 +64,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+`ignore_unavailable`::
+(Optional, boolean) If `true`, missing or closed indices are not included in the
+response. Defaults to `true`.
 
 `keep_alive`::
 +


### PR DESCRIPTION
Relates to #63192

### Preview
https://elasticsearch_63210.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html#eql-search-api-query-params