### PR TITLE
Bulk invalidate API keys using a list of IDs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -28,9 +28,9 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
     private final String realmName;
     private final String userName;
+    private final String[] ids;
     private final String name;
     private final boolean ownedByAuthenticatedUser;
-    private final String[] ids;
 
     public InvalidateApiKeyRequest() {
         this(null, null, null, null, false, null);
@@ -67,13 +67,13 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
         this.realmName = realmName;
         this.userName = userName;
-        this.name = name;
-        this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
         if (id != null) {
             this.ids = new String[] {id};
         } else {
             this.ids = ids;
         }
+        this.name = name;
+        this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
     }
 
     public String getRealmName() {
@@ -194,7 +194,7 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
             }
         }
         if (ids != null && Strings.hasText(name)) {
-            validationException = addValidationError("only one of [api key id, api key name] can be specified", validationException);
+            validationException = addValidationError("only one of [api key id(s), api key name] can be specified", validationException);
         }
         return validationException;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -176,13 +176,13 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         }
         if (Strings.hasText(realmName) == false && Strings.hasText(userName) == false && ids == null
             && Strings.hasText(name) == false && ownedByAuthenticatedUser == false) {
-            validationException = addValidationError("One of [api key id, api key name, username, realm name] must be specified if " +
+            validationException = addValidationError("One of [api key id(s), api key name, username, realm name] must be specified if " +
                 "[owner] flag is false", validationException);
         }
         if (ids != null || Strings.hasText(name)) {
             if (Strings.hasText(realmName) || Strings.hasText(userName)) {
                 validationException = addValidationError(
-                    "username or realm name must not be specified when the api key id or api key name is specified",
+                    "username or realm name must not be specified when the api key id(s) or api key name are specified",
                     validationException);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -15,7 +15,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -26,19 +29,24 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
     private final String realmName;
     private final String userName;
-    private final String id;
     private final String name;
     private final boolean ownedByAuthenticatedUser;
+    private final String[] ids;
 
     public InvalidateApiKeyRequest() {
-        this(null, null, null, null, false);
+        this(null, null, null, null, false, null);
     }
 
     public InvalidateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
         realmName = in.readOptionalString();
         userName = in.readOptionalString();
-        id = in.readOptionalString();
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
+            ids = in.readOptionalStringArray();
+        } else {
+            final String id = in.readOptionalString();
+            ids = Strings.hasText(id) == false ? null : new String[] { id };
+        }
         name = in.readOptionalString();
         if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             ownedByAuthenticatedUser = in.readOptionalBoolean();
@@ -49,11 +57,24 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
     public InvalidateApiKeyRequest(@Nullable String realmName, @Nullable String userName, @Nullable String id,
                                    @Nullable String name, boolean ownedByAuthenticatedUser) {
+        this(realmName, userName, id, name, ownedByAuthenticatedUser, null);
+    }
+
+    public InvalidateApiKeyRequest(@Nullable String realmName, @Nullable String userName, @Nullable String id,
+                                   @Nullable String name, boolean ownedByAuthenticatedUser, @Nullable String[] ids) {
+        if (id != null && ids != null) {
+            throw new IllegalArgumentException("Must use either [id] or [ids], not both at the same time");
+        }
+
         this.realmName = realmName;
         this.userName = userName;
-        this.id = id;
         this.name = name;
         this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
+        if (id != null) {
+            this.ids = new String[] {id};
+        } else {
+            this.ids = ids;
+        }
     }
 
     public String getRealmName() {
@@ -64,8 +85,8 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         return userName;
     }
 
-    public String getId() {
-        return id;
+    public String[] getIds() {
+        return ids;
     }
 
     public String getName() {
@@ -141,12 +162,25 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (Strings.hasText(realmName) == false && Strings.hasText(userName) == false && Strings.hasText(id) == false
+        if (ids != null) {
+            if (ids.length == 0) {
+                validationException = addValidationError("Field [ids] cannot be an empty array", validationException);
+            } else {
+                final int[] idxOfBlankIds = IntStream.range(0, ids.length).filter(i -> Strings.hasText(ids[i]) == false).toArray();
+                if (idxOfBlankIds.length > 0) {
+                    validationException = addValidationError("Field [ids] must not contain blank id, but got blank "
+                        + (idxOfBlankIds.length == 1 ? "id" : "ids") + " at index "
+                        + (idxOfBlankIds.length == 1 ? "position" : "positions") + ": "
+                        + Arrays.toString(idxOfBlankIds), validationException);
+                }
+            }
+        }
+        if (Strings.hasText(realmName) == false && Strings.hasText(userName) == false && ids == null
             && Strings.hasText(name) == false && ownedByAuthenticatedUser == false) {
             validationException = addValidationError("One of [api key id, api key name, username, realm name] must be specified if " +
                 "[owner] flag is false", validationException);
         }
-        if (Strings.hasText(id) || Strings.hasText(name)) {
+        if (ids != null || Strings.hasText(name)) {
             if (Strings.hasText(realmName) || Strings.hasText(userName)) {
                 validationException = addValidationError(
                     "username or realm name must not be specified when the api key id or api key name is specified",
@@ -160,7 +194,7 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
                     validationException);
             }
         }
-        if (Strings.hasText(id) && Strings.hasText(name)) {
+        if (ids != null && Strings.hasText(name)) {
             validationException = addValidationError("only one of [api key id, api key name] can be specified", validationException);
         }
         return validationException;
@@ -171,7 +205,19 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         super.writeTo(out);
         out.writeOptionalString(realmName);
         out.writeOptionalString(userName);
-        out.writeOptionalString(id);
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
+            out.writeOptionalStringArray(ids);
+        } else {
+            if (ids != null) {
+                if (ids.length == 1) {
+                    out.writeOptionalString(ids[0]);
+                } else {
+                    throw new IllegalArgumentException("a request with multi-valued field [ids] cannot be sent to an older version");
+                }
+            } else {
+                out.writeOptionalString(null);
+            }
+        }
         out.writeOptionalString(name);
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalBoolean(ownedByAuthenticatedUser);
@@ -190,12 +236,12 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         return ownedByAuthenticatedUser == that.ownedByAuthenticatedUser &&
             Objects.equals(realmName, that.realmName) &&
             Objects.equals(userName, that.userName) &&
-            Objects.equals(id, that.id) &&
+            Arrays.equals(ids, that.ids) &&
             Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(realmName, userName, id, name, ownedByAuthenticatedUser);
+        return Objects.hash(realmName, userName, ids, name, ownedByAuthenticatedUser);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
@@ -188,11 +188,23 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
         {
             ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
             OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-            out.setVersion(randomVersionBetween(random(), Version.V_7_4_0, Version.CURRENT));
+            out.setVersion(randomVersionBetween(random(), Version.V_7_4_0, Version.V_7_9_0));
             invalidateApiKeyRequest.writeTo(out);
 
             InputStreamStreamInput inputStreamStreamInput = new InputStreamStreamInput(new ByteArrayInputStream(outBuffer.toByteArray()));
-            inputStreamStreamInput.setVersion(randomVersionBetween(random(), Version.V_7_4_0, Version.CURRENT));
+            inputStreamStreamInput.setVersion(randomVersionBetween(random(), Version.V_7_4_0, Version.V_7_9_0));
+            InvalidateApiKeyRequest requestFromInputStream = new InvalidateApiKeyRequest(inputStreamStreamInput);
+
+            assertThat(requestFromInputStream, equalTo(invalidateApiKeyRequest));
+        }
+        {
+            ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+            OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+            out.setVersion(randomVersionBetween(random(), Version.V_7_10_0, Version.CURRENT));
+            invalidateApiKeyRequest.writeTo(out);
+
+            InputStreamStreamInput inputStreamStreamInput = new InputStreamStreamInput(new ByteArrayInputStream(outBuffer.toByteArray()));
+            inputStreamStreamInput.setVersion(randomVersionBetween(random(), Version.V_7_10_0, Version.CURRENT));
             InvalidateApiKeyRequest requestFromInputStream = new InvalidateApiKeyRequest(inputStreamStreamInput);
 
             assertThat(requestFromInputStream, equalTo(invalidateApiKeyRequest));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequestTests.java
@@ -135,13 +135,13 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
             {randomNullOrEmptyString(), "user", randomNullOrEmptyString(), randomNullOrEmptyString(), "true"},
         };
         String[][] expectedErrorMessages = new String[][]{
-            {"One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false"},
-            {"username or realm name must not be specified when the api key id or api key name is specified",
-                "only one of [api key id, api key name] can be specified"},
-            {"username or realm name must not be specified when the api key id or api key name is specified",
-                "only one of [api key id, api key name] can be specified"},
-            {"username or realm name must not be specified when the api key id or api key name is specified"},
-            {"only one of [api key id, api key name] can be specified"},
+            {"One of [api key id(s), api key name, username, realm name] must be specified if [owner] flag is false"},
+            {"username or realm name must not be specified when the api key id(s) or api key name are specified",
+                "only one of [api key id(s), api key name] can be specified"},
+            {"username or realm name must not be specified when the api key id(s) or api key name are specified",
+                "only one of [api key id(s), api key name] can be specified"},
+            {"username or realm name must not be specified when the api key id(s) or api key name are specified"},
+            {"only one of [api key id(s), api key name] can be specified"},
             {"neither username nor realm-name may be specified when invalidating owned API keys"},
             {"neither username nor realm-name may be specified when invalidating owned API keys"}
         };

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportInvalidateApiKeyAction.java
@@ -36,7 +36,7 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
 
     @Override
     protected void doExecute(Task task, InvalidateApiKeyRequest request, ActionListener<InvalidateApiKeyResponse> listener) {
-        String apiKeyId = request.getId();
+        String[] apiKeyIds = request.getIds();
         String apiKeyName = request.getName();
         String username = request.getUserName();
         String realm = request.getRealmName();
@@ -53,7 +53,7 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
             realm = ApiKeyService.getCreatorRealmName(authentication);
         }
 
-        apiKeyService.invalidateApiKeys(realm, username, apiKeyName, apiKeyId, listener);
+        apiKeyService.invalidateApiKeys(realm, username, apiKeyName, apiKeyIds, listener);
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -747,7 +747,7 @@ public class ApiKeyService {
                                   ActionListener<InvalidateApiKeyResponse> invalidateListener) {
         ensureEnabled();
         if (Strings.hasText(realmName) == false && Strings.hasText(username) == false && Strings.hasText(apiKeyName) == false
-            && apiKeyIds.length == 0) {
+            && (apiKeyIds == null || apiKeyIds.length == 0)) {
             logger.trace("none of the parameters [api key id, api key name, username, realm name] were specified for invalidation");
             invalidateListener
                 .onFailure(new IllegalArgumentException("One of [api key id, api key name, username, realm name] must be specified"));
@@ -757,7 +757,7 @@ public class ApiKeyService {
                     if (apiKeys.isEmpty()) {
                         logger.debug(
                             "No active api keys to invalidate for realm [{}], username [{}], api key name [{}] and api key id [{}]",
-                            realmName, username, apiKeyName, apiKeyIds);
+                            realmName, username, apiKeyName, Arrays.toString(apiKeyIds));
                         invalidateListener.onResponse(InvalidateApiKeyResponse.emptyResponse());
                     } else {
                         invalidateAllApiKeys(apiKeys.stream().map(apiKey -> apiKey.getId()).collect(Collectors.toSet()),
@@ -831,7 +831,7 @@ public class ApiKeyService {
                     boolQuery.filter(QueryBuilders.termQuery("name", apiKeyName));
                 }
             }
-            if (apiKeyIds.length > 0) {
+            if (apiKeyIds != null && apiKeyIds.length > 0) {
                 boolQuery.filter(QueryBuilders.idsQuery().addIds(apiKeyIds));
             }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -740,24 +740,24 @@ public class ApiKeyService {
      * @param realmName realm name
      * @param username user name
      * @param apiKeyName API key name
-     * @param apiKeyId API key id
+     * @param apiKeyIds API key id
      * @param invalidateListener listener for {@link InvalidateApiKeyResponse}
      */
-    public void invalidateApiKeys(String realmName, String username, String apiKeyName, String apiKeyId,
+    public void invalidateApiKeys(String realmName, String username, String apiKeyName, String[] apiKeyIds,
                                   ActionListener<InvalidateApiKeyResponse> invalidateListener) {
         ensureEnabled();
         if (Strings.hasText(realmName) == false && Strings.hasText(username) == false && Strings.hasText(apiKeyName) == false
-            && Strings.hasText(apiKeyId) == false) {
+            && apiKeyIds.length == 0) {
             logger.trace("none of the parameters [api key id, api key name, username, realm name] were specified for invalidation");
             invalidateListener
                 .onFailure(new IllegalArgumentException("One of [api key id, api key name, username, realm name] must be specified"));
         } else {
-            findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyId, true, false,
+            findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyIds, true, false,
                 ActionListener.wrap(apiKeys -> {
                     if (apiKeys.isEmpty()) {
                         logger.debug(
                             "No active api keys to invalidate for realm [{}], username [{}], api key name [{}] and api key id [{}]",
-                            realmName, username, apiKeyName, apiKeyId);
+                            realmName, username, apiKeyName, apiKeyIds);
                         invalidateListener.onResponse(InvalidateApiKeyResponse.emptyResponse());
                     } else {
                         invalidateAllApiKeys(apiKeys.stream().map(apiKey -> apiKey.getId()).collect(Collectors.toSet()),
@@ -808,7 +808,7 @@ public class ApiKeyService {
         }
     }
 
-    private void findApiKeysForUserRealmApiKeyIdAndNameCombination(String realmName, String userName, String apiKeyName, String apiKeyId,
+    private void findApiKeysForUserRealmApiKeyIdAndNameCombination(String realmName, String userName, String apiKeyName, String[] apiKeyIds,
                                                                    boolean filterOutInvalidatedKeys, boolean filterOutExpiredKeys,
                                                                    ActionListener<Collection<ApiKey>> listener) {
         final SecurityIndexManager frozenSecurityIndex = securityIndex.freeze();
@@ -831,8 +831,8 @@ public class ApiKeyService {
                     boolQuery.filter(QueryBuilders.termQuery("name", apiKeyName));
                 }
             }
-            if (Strings.hasText(apiKeyId)) {
-                boolQuery.filter(QueryBuilders.termQuery("_id", apiKeyId));
+            if (apiKeyIds.length > 0) {
+                boolQuery.filter(QueryBuilders.idsQuery().addIds(apiKeyIds));
             }
 
             findApiKeys(boolQuery, filterOutInvalidatedKeys, filterOutExpiredKeys, listener);
@@ -972,7 +972,8 @@ public class ApiKeyService {
     public void getApiKeys(String realmName, String username, String apiKeyName, String apiKeyId,
                            ActionListener<GetApiKeyResponse> listener) {
         ensureEnabled();
-        findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyId, false, false,
+        final String[] apiKeyIds = Strings.hasText(apiKeyId) == false ? null : new String[] { apiKeyId };
+        findApiKeysForUserRealmApiKeyIdAndNameCombination(realmName, username, apiKeyName, apiKeyIds, false, false,
             ActionListener.wrap(apiKeyInfos -> {
                 if (apiKeyInfos.isEmpty()) {
                     logger.debug("No active api keys found for realm [{}], user [{}], api key name [{}] and api key id [{}]",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyAction.java
@@ -33,8 +33,9 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 public final class RestInvalidateApiKeyAction extends ApiKeyBaseRestHandler {
     static final ConstructingObjectParser<InvalidateApiKeyRequest, Void> PARSER = new ConstructingObjectParser<>("invalidate_api_key",
             a -> {
-                return new InvalidateApiKeyRequest((String) a[0], (String) a[1], (String) a[2], (String) a[3], (a[4] == null) ? false :
-                    (Boolean) a[4]);
+                return new InvalidateApiKeyRequest((String) a[0], (String) a[1], (String) a[2], (String) a[3],
+                    (a[4] == null) ? false : (Boolean) a[4],
+                    (a[5] == null) ? null : ((List<String>) a[5]).toArray(new String[0]));
             });
 
     static {
@@ -43,6 +44,7 @@ public final class RestInvalidateApiKeyAction extends ApiKeyBaseRestHandler {
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), new ParseField("id"));
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), new ParseField("name"));
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), new ParseField("owner"));
+        PARSER.declareStringArray(ConstructingObjectParser.optionalConstructorArg(), new ParseField("ids"));
     }
 
     public RestInvalidateApiKeyAction(Settings settings, XPackLicenseState licenseState) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyResponse;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -97,7 +98,8 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
                     return;
                 }
                 if (invalidateApiKeyRequest.getName() != null && invalidateApiKeyRequest.getName().equals("api-key-name-1")
-                        || invalidateApiKeyRequest.getId() != null && invalidateApiKeyRequest.getId().equals("api-key-id-1")
+                        || invalidateApiKeyRequest.getIds() != null && Arrays.equals(
+                            invalidateApiKeyRequest.getIds(), new String[] {"api-key-id-1"})
                         || invalidateApiKeyRequest.getRealmName() != null && invalidateApiKeyRequest.getRealmName().equals("realm-1")
                         || invalidateApiKeyRequest.getUserName() != null && invalidateApiKeyRequest.getUserName().equals("user-x")) {
                     listener.onResponse((Response) invalidateApiKeyResponseExpected);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -186,7 +186,7 @@ teardown:
   - is_true: "api_keys.0.creation"
 
 ---
-"Test invalidate api key":
+"Test invalidate api keys":
   - skip:
       features: transform_and_set
 
@@ -205,7 +205,7 @@ teardown:
   - is_true: id
   - is_true: api_key
   - is_true: expiration
-  - set: { id: api_key_id }
+  - set: { id: api_key_id_1 }
   - transform_and_set: { login_creds: "#base64EncodeCredentials(id,api_key)" }
 
   - do:
@@ -214,10 +214,58 @@ teardown:
       security.invalidate_api_key:
         body:  >
             {
-              "id": "${api_key_id}"
+              "id": "${api_key_id_1}"
             }
   - length: { "invalidated_api_keys" : 1 }
-  - match: { "invalidated_api_keys.0" : "${api_key_id}" }
+  - match: { "invalidated_api_keys.0" : "${api_key_id_1}" }
+  - length: { "previously_invalidated_api_keys" : 0 }
+  - match: { "error_count" : 0 }
+
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.create_api_key:
+        body:  >
+          {
+            "name": "my-api-key-2",
+            "expiration": "1d",
+            "role_descriptors": {
+            }
+          }
+  - match: { name: "my-api-key-2" }
+  - is_true: id
+  - is_true: api_key
+  - is_true: expiration
+  - set: { id: api_key_id_2 }
+
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.create_api_key:
+        body:  >
+          {
+            "name": "my-api-key-3",
+            "expiration": "1d",
+            "role_descriptors": {
+            }
+          }
+  - match: { name: "my-api-key-3" }
+  - is_true: id
+  - is_true: api_key
+  - is_true: expiration
+  - set: { id: api_key_id_3 }
+
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.invalidate_api_key:
+        body:  >
+          {
+            "ids": [ "${api_key_id_2}", "${api_key_id_3}" ]
+          }
+  - length: { "invalidated_api_keys" : 2 }
+  - match: { "invalidated_api_keys.0" : "/^(${api_key_id_2}|${api_key_id_3})$/" }
+  - match: { "invalidated_api_keys.1" : "/^(${api_key_id_2}|${api_key_id_3})$/" }
   - length: { "previously_invalidated_api_keys" : 0 }
   - match: { "error_count" : 0 }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -261,7 +261,7 @@ teardown:
       security.invalidate_api_key:
         body:  >
           {
-            "ids": [ "${api_key_id_2}", "${api_key_id_3}" ]
+            "ids": [ "${api_key_id_1}", "${api_key_id_2}", "${api_key_id_3}" ]
           }
   - length: { "invalidated_api_keys" : 2 }
   - match: { "invalidated_api_keys.0" : "/^(${api_key_id_2}|${api_key_id_3})$/" }


### PR DESCRIPTION
Following discussions in #47609, I am reverting back to the approach of adding a new `ids` field to support bulk invalidation by specifying an array of API key ids.
This PR intentionally keeps the existing `id` field as is on the API level. Deprecation may as well be introduced for it in the future. But it is not done in this PR to reduce the scope. 

I would also like to raise the priority of this PR because of #59376, where a new cache is introduced for API key document. The new cache requires a cache clear call to be issued after API key invalidation. It is helpful if the cache clear call is issued for a collection of API key ids instead of one for each of them. Hence being able to specifiying multiple IDs for invalidation improves the efficiency of the cache clearing call.

Resolves: #47609
Supersedes: #63081, #63127