### PR TITLE
EQL: [Test] Add a test for `identifier` as eventType

### DIFF
--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
@@ -263,6 +263,12 @@ public class ExpressionTests extends ESTestCase {
         assertEquals("line 1:19: token recognition error at: '` == true'", e.getMessage());
     }
 
+    public void testIdentifierForEventTypeDisallowed() {
+        ParsingException e = expectThrows(ParsingException.class, "Expected syntax error",
+                () -> parser.createStatement("`identifier` where foo == true"));
+        assertEquals("line 1:1: no viable alternative at input '`identifier`'", e.getMessage());
+    }
+
     public void testFunctions() {
         List<Expression> arguments = Arrays.asList(
             new UnresolvedAttribute(null, "some.field"),


### PR DESCRIPTION
Add a unit test to verify that an identifier surrounded with backquotes
is not a valid syntax for eventType value, as eventType is
schematically a string literal and not a field identifier.

Follows: #63169
