### PR TITLE
Fix Race in ClusterApplierService Shutdown (#62944)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1766,7 +1766,6 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/62863")
     public void testPeerRecoveryTrimsLocalTranslog() throws Exception {
         internalCluster().startNode();
         List<String> dataNodes = internalCluster().startDataOnlyNodes(2);

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -271,6 +271,10 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
                     final NotifyTimeout notifyTimeout = new NotifyTimeout(listener, timeout);
                     final NotifyTimeout previous = timeoutClusterStateListeners.put(listener, notifyTimeout);
                     assert previous == null : "Added same listener [" + listener + "]";
+                    if (lifecycle.stoppedOrClosed()) {
+                        listener.onClose();
+                        return;
+                    }
                     if (timeout != null) {
                         notifyTimeout.cancellable = threadPool.schedule(notifyTimeout, timeout, ThreadPool.Names.GENERIC);
                     }


### PR DESCRIPTION
The iteration over `timeoutClusterStateListeners` starts when the CS applier
thread is still running. This can lead to entries being added to it that never
get their listener resolved on shutdown and thus leak that listener as observed
in a stuck test in #62863.
Since `listener.onClose()` is idempotent we can just call it if we run into a stopped service
on the CS thread to avoid the race with certainty (because the iteration in `doStop` starts after
the stopped state has been set).

Closes #62863

backport of #62944 