### PR TITLE
CleanUp/SpeedUp some Spots in DiscoveryNode

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -195,16 +194,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             this.version = version;
         }
         this.attributes = Collections.unmodifiableMap(attributes);
-        //verify that no node roles are being provided as attributes
-        Predicate<Map<String, String>> predicate =  (attrs) -> {
-            boolean success = true;
-            for (final DiscoveryNodeRole role : DiscoveryNode.roleMap.values()) {
-                success &= attrs.containsKey(role.roleName()) == false;
-                assert success : role.roleName();
-            }
-            return success;
-        };
-        assert predicate.test(attributes) : attributes;
+        assert DiscoveryNode.roleMap.values().stream().noneMatch(role -> attributes.containsKey(role.roleName())) :
+                "Node roles must not be provided as attributes but saw attributes " + attributes;
         this.roles = roles.stream().collect(Sets.toUnmodifiableSortedSet());
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -27,18 +27,18 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.node.Node;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -196,7 +196,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         this.attributes = Collections.unmodifiableMap(attributes);
         assert DiscoveryNode.roleMap.values().stream().noneMatch(role -> attributes.containsKey(role.roleName())) :
                 "Node roles must not be provided as attributes but saw attributes " + attributes;
-        this.roles = roles.stream().collect(Sets.toUnmodifiableSortedSet());
+        this.roles = Collections.unmodifiableSortedSet(new TreeSet<>(roles));
     }
 
     /** Creates a DiscoveryNode representing the local node. */
@@ -247,7 +247,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         this.address = new TransportAddress(in);
         this.attributes = in.readMap(StreamInput::readString, StreamInput::readString);
         int rolesSize = in.readVInt();
-        final Set<DiscoveryNodeRole> roles = new HashSet<>(rolesSize);
+        final SortedSet<DiscoveryNodeRole> roles = new TreeSet<>();
         for (int i = 0; i < rolesSize; i++) {
             final String roleName = in.readString();
             final String roleNameAbbreviation = in.readString();
@@ -261,7 +261,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                 roles.add(role);
             }
         }
-        this.roles = roles.stream().collect(Sets.toUnmodifiableSortedSet());
+        this.roles = Collections.unmodifiableSortedSet(roles);
         this.version = Version.readVersion(in);
     }
 
@@ -447,8 +447,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return roleMap.get(roleName);
     }
 
-    public static Set<DiscoveryNodeRole> getPossibleRoles() {
-        return Set.copyOf(roleMap.values());
+    public static Collection<DiscoveryNodeRole> getPossibleRoles() {
+        return roleMap.values();
     }
 
     public static void setAdditionalRoles(final Set<DiscoveryNodeRole> additionalRoles) {


### PR DESCRIPTION
Random things found while looking for a fix for 62840 ...

* Build sorted sets directly
* Don't instantiate `Predicate` needlessly with assertions off
