### PR TITLE
Fix Broken Exception Handling in Snapshot Cleanup Tool

### DIFF
--- a/x-pack/snapshot-tool/src/main/java/org/elasticsearch/snapshots/AbstractRepository.java
+++ b/x-pack/snapshot-tool/src/main/java/org/elasticsearch/snapshots/AbstractRepository.java
@@ -94,9 +94,6 @@ public abstract class AbstractRepository {
                     LoggingDeprecationHandler.INSTANCE, out.bytes(), XContentType.JSON)) {
                 return incompatibleSnapshotsFromXContent(parser);
             }
-        } catch (IOException e) {
-            terminal.println("Failed to read [incompatible-snapshots] blob");
-            throw e;
         } catch (Exception e) {
             if (isBlobNotFoundException(e)) {
                 return Collections.emptyList();


### PR DESCRIPTION
In the latest version of the GCS SDK the `404` exception is wrapped
in an `IOException` making it not pass to the unwrapping added in
the previous fix #63168.
We can't be handling `IOException` differently here now that GCS uses it
for `404`s so I adjusted the exception unwrapping accordingly.

Closes #63091
