### PR TITLE
[7.9] [DOCS] Clarify `allow_no_indices` def (#63209)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -48,13 +48,9 @@ end::target-index-aliases[]
 
 tag::allow-no-indices[]
 `allow_no_indices`::
-(Optional, boolean) If `true`,
-the request does *not* return an error
-if a wildcard expression
-or `_all` value retrieves only missing or closed indices.
-+
-This parameter also applies to <<indices-aliases,index aliases>>
-that point to a missing or closed index.
+(Optional, boolean) If `false`, the request returns an error when a
+wildcard expression, <<indices-aliases,index alias>>, or `_all` value targets
+only missing or closed indices.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Clarify `allow_no_indices` def (#63209)