### PR TITLE
[DOCS] Updating permissions language for RPM install packages

### DIFF
--- a/docs/reference/setup/install/etc-elasticsearch.asciidoc
+++ b/docs/reference/setup/install/etc-elasticsearch.asciidoc
@@ -1,11 +1,13 @@
-Elasticsearch defaults to using `/etc/elasticsearch` for runtime configuration.
-The ownership of this directory and all files in this directory are set to
-`root:elasticsearch` on package installation and the directory has the `setgid`
-flag set so that any files and subdirectories created under `/etc/elasticsearch`
-are created with this ownership as well (e.g., if a keystore is created using
-the <<secure-settings,keystore tool>>). It is expected that this be maintained so
-that the Elasticsearch process can read the files under this directory via the
-group permissions.
+The `/etc/elasticsearch` directory contains the default runtime configuration
+for {es}. The ownership of this directory and all contained files are set to
+`root:elasticsearch` on package installations.
+
+The `setgid` flag applies group permissions on the `/etc/elasticsearch`
+directory to ensure that {es} can ready any contained files and subdirectories.
+All files and subdirectories inherit the `root:elasticsearch` ownership.
+Running commands from this directory or any subdirectories, such as the
+<<secure-settings,elasticsearch-keystore tool>>, requires `root:elasticsearch`
+permissions.
 
 Elasticsearch loads its configuration from the
 `/etc/elasticsearch/elasticsearch.yml` file by default.  The format of this

--- a/docs/reference/setup/install/etc-elasticsearch.asciidoc
+++ b/docs/reference/setup/install/etc-elasticsearch.asciidoc
@@ -3,7 +3,7 @@ for {es}. The ownership of this directory and all contained files are set to
 `root:elasticsearch` on package installations.
 
 The `setgid` flag applies group permissions on the `/etc/elasticsearch`
-directory to ensure that {es} can ready any contained files and subdirectories.
+directory to ensure that {es} can read any contained files and subdirectories.
 All files and subdirectories inherit the `root:elasticsearch` ownership.
 Running commands from this directory or any subdirectories, such as the
 <<secure-settings,elasticsearch-keystore tool>>, requires `root:elasticsearch`


### PR DESCRIPTION
Some users reported that the current documentation is unclear regarding permissions required to run `elasticsearch-keystore`. This PR seeks to clarify permissions for the `/etc/elasticsearch` directory for [Configuring ES on RPM](https://elasticsearch_63277.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rpm.html#rpm-configuring).

**Note**: this same language is included in the page for [Configuring ES on Debian](https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-configuring), so we should ensure that it applies to both RPM and Debian.

cc: @JohannesMahne, who reported the issue.

Backports:
* 7.x #63344
* 7.9 #63345