### PR TITLE
[7.x] [DOCS] Make EQL case-sensitive by default (#63270)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -131,11 +131,6 @@ used.
 [[eql-search-api-request-body]]
 ==== {api-request-body-title}
 
-`case_sensitive`::
-(Optional, boolean)
-If `true`, matching for the <<eql-search-api-request-query-param,EQL query>> is
-case sensitive. Defaults to `false`.
-
 `event_category_field`::
 (Required*, string)
 Field containing the event classification, such as `process`, `file`, or

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -8,7 +8,8 @@
 
 experimental::[]
 
-{es} supports the following <<eql-functions,EQL functions>>.
+{es} supports the following <<eql-functions,EQL functions>>. Most EQL functions
+are case-sensitive by default.
 
 [discrete]
 [[eql-fn-add]]
@@ -62,7 +63,7 @@ If using a field as the argument, this parameter supports only
 === `between`
 
 Extracts a substring that's between a provided `left` and `right` text in a
-source string.
+source string. Matching is case-sensitive.
 
 *Example*
 [source,eql]
@@ -77,12 +78,6 @@ between(file.path, "\\\\", "\\\\", false)                 // returns "Windows"
 // Sets greedy matching to true
 between(file.path, "\\\\", "\\\\", true)                  // returns "Windows\\System32"
 
-// Case sensitivity defaults to false.
-between(file.path, "system32\\\\", ".exe", false, false)  // returns "cmd"
-// Sets case sensitivity to true
-between(file.path, "system32\\\\", ".exe", false, true)   // returns ""
-between(file.path, "System32\\\\", ".exe", false, true)   // returns "cmd"
-
 // empty source string
 between("", "system32\\\\", ".exe")                       // returns ""
 between("", "", "")                                       // returns ""
@@ -94,7 +89,7 @@ between(null, "system32\\\\", ".exe")                     // returns null
 *Syntax*
 [source,txt]
 ----
-between(<source>, <left>, <right>[, <greedy_matching>, <case_sensitive>])
+between(<source>, <left>, <right>[, <greedy_matching>])
 ----
 
 *Parameters*
@@ -146,10 +141,6 @@ field data types:
 If `true`, match the longest possible substring, similar to `.*` in regular
 expressions. If `false`, match the shortest possible substring, similar to `.*?`
 in regular expressions. Defaults to `false`.
-
-`<case_sensitive>`::
-(Optional, boolean)
-If `true`, matching is case-sensitive. Defaults to `false`.
 
 *Returns:* string or `null`
 
@@ -352,7 +343,8 @@ If using a field as the argument, this parameter supports only
 [[eql-fn-endswith]]
 === `endsWith`
 
-Returns `true` if a source string ends with a provided substring.
+Returns `true` if a source string ends with a provided substring. Matching is
+case-sensitive.
 
 *Example*
 [source,eql]
@@ -416,7 +408,8 @@ field data types:
 [[eql-fn-indexof]]
 === `indexOf`
 
-Returns the first position of a provided substring in a source string.
+Returns the first position of a provided substring in a source string. Matching
+is case-sensitive.
 
 If an optional start position is provided, this function returns the first
 occurrence of the substring at or after the start position.
@@ -561,7 +554,7 @@ field data types:
 === `match`
 
 Returns `true` if a source string matches one or more provided regular
-expressions.
+expressions. Matching is case-sensitive.
 
 *Example*
 [source,eql]
@@ -818,7 +811,8 @@ Fields are not supported as arguments.
 [[eql-fn-startswith]]
 === `startsWith`
 
-Returns `true` if a source string begins with a provided substring.
+Returns `true` if a source string begins with a provided substring. Matching is
+case-sensitive.
 
 *Example*
 [source,eql]
@@ -917,7 +911,8 @@ If using a field as the argument, this parameter does not support the
 [[eql-fn-stringcontains]]
 === `stringContains`
 
-Returns `true` if a source string contains a provided substring.
+Returns `true` if a source string contains a provided substring. Matching is
+case-sensitive.
 
 *Example*
 [source,eql]
@@ -1077,7 +1072,7 @@ If using a field as the argument, this parameter supports only
 === `wildcard`
 
 Returns `true` if a source string matches one or more provided wildcard
-expressions.
+expressions. Matching is case-sensitive.
 
 *Example*
 [source,eql]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -108,7 +108,8 @@ my`field -> `my``field`
 ==== Conditions
 
 A condition consists of one or more criteria an event must match.
-You can specify and combine these criteria using the following operators:
+You can specify and combine these criteria using the following operators. Most
+EQL operators are case-sensitive by default.
 
 [discrete]
 [[eql-syntax-comparison-operators]]
@@ -217,11 +218,13 @@ user.name in ("Administrator", "SYSTEM", "NETWORK SERVICE")
 user.name not in ("Administrator", "SYSTEM", "NETWORK SERVICE")
 ----
 
-`in`::
-Returns `true` if the value is contained in the provided list.
+`in` (case-sensitive)::
+Returns `true` if the value is contained in the provided list. For strings,
+matching is case-sensitive.
 
-`not in`::
-Returns `true` if the value is not contained in the provided list.
+`not in` (case-sensitive)::
+Returns `true` if the value is not contained in the provided list. For strings,
+matching is case-sensitive.
 
 [discrete]
 [[eql-syntax-math-operators]]
@@ -597,7 +600,8 @@ until [ process where event.type == "stop" ]
 === Functions
 
 {es} supports several of EQL's built-in functions. You can use these functions
-to convert data types, perform math, manipulate strings, and more.
+to convert data types, perform math, manipulate strings, and more. Most
+functions are case-sensitive by default.
 
 For a list of supported functions, see <<eql-function-ref>>.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Make EQL case-sensitive by default (#63270)