### PR TITLE
Backport 7.10 API Key id part of transport request body (#63221)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -31,12 +32,16 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public final class CreateApiKeyRequest extends ActionRequest {
     public static final WriteRequest.RefreshPolicy DEFAULT_REFRESH_POLICY = WriteRequest.RefreshPolicy.WAIT_UNTIL;
 
+    private final String id;
     private String name;
     private TimeValue expiration;
     private List<RoleDescriptor> roleDescriptors = Collections.emptyList();
     private WriteRequest.RefreshPolicy refreshPolicy = DEFAULT_REFRESH_POLICY;
 
-    public CreateApiKeyRequest() {}
+    public CreateApiKeyRequest() {
+        this.id = UUIDs.base64UUID(); // because auditing can currently only catch requests but not responses,
+        // we generate the API key id soonest so it's part of the request body so it is audited
+    }
 
     /**
      * Create API Key request constructor
@@ -45,6 +50,7 @@ public final class CreateApiKeyRequest extends ActionRequest {
      * @param expiration to specify expiration for the API key
      */
     public CreateApiKeyRequest(String name, @Nullable List<RoleDescriptor> roleDescriptors, @Nullable TimeValue expiration) {
+        this();
         this.name = name;
         this.roleDescriptors = (roleDescriptors == null) ? Collections.emptyList() : Collections.unmodifiableList(roleDescriptors);
         this.expiration = expiration;
@@ -52,6 +58,11 @@ public final class CreateApiKeyRequest extends ActionRequest {
 
     public CreateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
+        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
+            this.id = in.readString();
+        } else {
+            this.id = UUIDs.base64UUID();
+        }
         if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
             this.name = in.readOptionalString();
         } else {
@@ -60,6 +71,14 @@ public final class CreateApiKeyRequest extends ActionRequest {
         this.expiration = in.readOptionalTimeValue();
         this.roleDescriptors = Collections.unmodifiableList(in.readList(RoleDescriptor::new));
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId() {
+        throw new UnsupportedOperationException("The API Key Id cannot be set, it must be generated randomly");
     }
 
     public String getName() {
@@ -116,6 +135,9 @@ public final class CreateApiKeyRequest extends ActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
+            out.writeString(id);
+        }
         if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
             out.writeOptionalString(name);
         } else {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequestTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.security.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -97,11 +98,22 @@ public class CreateApiKeyRequestTests extends ESTestCase {
         }
         request.setRoleDescriptors(descriptorList);
 
+        boolean testV710Bwc = randomBoolean();
+
         try (BytesStreamOutput out = new BytesStreamOutput()) {
+            if (testV710Bwc) {
+                out.setVersion(Version.V_7_9_0); // a version before 7.10
+            }
             request.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
+                if (testV710Bwc) {
+                    in.setVersion(Version.V_7_9_0);
+                }
                 final CreateApiKeyRequest serialized = new CreateApiKeyRequest(in);
                 assertEquals(name, serialized.getName());
+                if (false == testV710Bwc) {
+                    assertEquals(request.getId(), serialized.getId()); // API key id is only preserved after v 7.10
+                }
                 assertEquals(expiration, serialized.getExpiration());
                 assertEquals(refreshPolicy, serialized.getRefreshPolicy());
                 if (nullOrEmptyRoleDescriptors) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -239,6 +239,7 @@ public class ApiKeyService {
             final IndexRequest indexRequest =
                 client.prepareIndex(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME)
                     .setSource(builder)
+                    .setId(request.getId())
                     .setRefreshPolicy(request.getRefreshPolicy())
                     .request();
             final BulkRequest bulkRequest = toSingleItemBulkRequest(indexRequest);
@@ -246,8 +247,11 @@ public class ApiKeyService {
             securityIndex.prepareIndexIfNeededThenExecute(listener::onFailure, () ->
                 executeAsyncWithOrigin(client, SECURITY_ORIGIN, BulkAction.INSTANCE, bulkRequest,
                     TransportSingleItemBulkWriteAction.<IndexResponse>wrapBulkResponse(ActionListener.wrap(
-                        indexResponse -> listener.onResponse(
-                            new CreateApiKeyResponse(request.getName(), indexResponse.getId(), apiKey, expiration)),
+                        indexResponse -> {
+                            assert request.getId().equals(indexResponse.getId());
+                            listener.onResponse(
+                                    new CreateApiKeyResponse(request.getName(), request.getId(), apiKey, expiration));
+                        },
                         listener::onFailure))));
         } catch (IOException e) {
             listener.onFailure(e);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -158,7 +158,6 @@ public class ApiKeyServiceTests extends ESTestCase {
             return null;
         }).when(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());
         service.createApiKey(authentication, createApiKeyRequest, org.elasticsearch.common.collect.Set.of(), new PlainActionFuture<>());
-        verify(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());
     }
 
     public void testGetCredentialsFromThreadContext() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
@@ -104,7 +105,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ApiKeyServiceTests extends ESTestCase {
@@ -138,7 +138,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         this.securityIndex = SecurityMocks.mockSecurityIndexManager();
     }
 
-    public void testCreateApiKeyWillUseBulkAction() {
+    public void testCreateApiKeyUsesBulkIndexAction() {
         final Settings settings = Settings.builder().put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true).build();
         final ApiKeyService service = createApiKeyService(settings);
         final Authentication authentication = new Authentication(
@@ -148,6 +148,15 @@ public class ApiKeyServiceTests extends ESTestCase {
         final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest("key-1", null, null);
         when(client.prepareIndex(anyString(), anyString())).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
         when(client.threadPool()).thenReturn(threadPool);
+        doAnswer(inv -> {
+            final Object[] args = inv.getArguments();
+            BulkRequest bulkRequest = (BulkRequest) args[1];
+            assertThat(bulkRequest.numberOfActions(), is(1));
+            assertThat(bulkRequest.requests().get(0), instanceOf(IndexRequest.class));
+            IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
+            assertThat(indexRequest.id(), is(createApiKeyRequest.getId()));
+            return null;
+        }).when(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());
         service.createApiKey(authentication, createApiKeyRequest, org.elasticsearch.common.collect.Set.of(), new PlainActionFuture<>());
         verify(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());
     }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/63221

When auditing API key creation, it is useful to show the id of the key together
with its other parameters (such as name and expiration, etc). Because auditing
prints request bodies of security transport actions (see #62916), the `id` must
be part of the request body for it to be audited.