### PR TITLE
Switch bundled jdk back to Oracle JDK

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 8.0.0
 lucene            = 8.7.0-snapshot-77396dbf339
 
-bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 15+36
+bundled_jdk_vendor = openjdk
+bundled_jdk = 15+36@779bf45e88a44cbd9ea6621d33e33db1
 
 checkstyle = 8.20
 


### PR DESCRIPTION
We switched to adoptopenjdk from oracle jdk to rely on the notarization
found in adoptopnejdk on MacOS. However, that notarization still had
issues, and we currently do our own notarization of the entire
distribution, including the jdk. The recent bump to jdk 15 has revealed
adoptopenjdk to be lax in maintaining support for older systems. Since the
notarization is no longer an issue, this PR moves the bundled jdk back
to Oracle, in order to continue supporting those older systems affected
by adoptopenjdk 15.

relates #62709