### PR TITLE
Improve Snapshot Abort Efficiency (#62173)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -547,7 +547,8 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         // Second delete works out cleanly since the repo is unblocked now
         assertThat(secondDeleteFuture.get().isAcknowledged(), is(true));
         // Snapshot should have been aborted
-        assertThat(snapshotFuture.get().getSnapshotInfo().state(), is(SnapshotState.FAILED));
+        final SnapshotException snapshotException = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
+        assertThat(snapshotException.getMessage(), containsString(SnapshotsInProgress.ABORTED_FAILURE_TEXT));
 
         assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
@@ -573,7 +574,8 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         // Second delete works out cleanly since the repo is unblocked now
         assertThat(secondDeleteFuture.get().isAcknowledged(), is(true));
         // Snapshot should have been aborted
-        assertThat(snapshotFuture.get().getSnapshotInfo().state(), is(SnapshotState.FAILED));
+        final SnapshotException snapshotException = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
+        assertThat(snapshotException.getMessage(), containsString(SnapshotsInProgress.ABORTED_FAILURE_TEXT));
 
         assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
@@ -1221,6 +1223,30 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertAcked(deleteFuture.get());
         final SnapshotException sne = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
         assertThat(sne.getCause().getMessage(), containsString("exception after block"));
+    }
+
+    public void testAbortNotStartedSnapshotWithoutIO() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        createIndexWithContent("test-index");
+
+        final ActionFuture<CreateSnapshotResponse> createSnapshot1Future =
+            startFullSnapshotBlockedOnDataNode("first-snapshot", repoName, dataNode);
+
+        final String snapshotTwo = "second-snapshot";
+        final ActionFuture<CreateSnapshotResponse> createSnapshot2Future = startFullSnapshot(repoName, snapshotTwo);
+
+        awaitNumberOfSnapshotsInProgress(2);
+
+        assertAcked(startDeleteSnapshot(repoName, snapshotTwo).get());
+        final SnapshotException sne = expectThrows(SnapshotException.class, createSnapshot2Future::actionGet);
+
+        assertFalse(createSnapshot1Future.isDone());
+        unblockNode(repoName, dataNode);
+        assertSuccessful(createSnapshot1Future);
+        assertThat(getRepositoryData(repoName).getGenId(), is(0L));
     }
 
     private static String startDataNodeWithLargeSnapshotPool() {

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -66,6 +66,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
     public static final String TYPE = "snapshots";
 
+    public static final String ABORTED_FAILURE_TEXT = "Snapshot was aborted by deletion";
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -291,14 +293,19 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
          * data node or to {@link ShardState#FAILED} if not assigned to any data node.
          * If the instance had no in-progress shard snapshots assigned to data nodes it's moved to state {@link State#SUCCESS}, otherwise
          * it's moved to state {@link State#ABORTED}.
+         * In the special case where this instance has not yet made any progress on any shard this method just returns
+         * {@code null} since no abort is needed and the snapshot can simply be removed from the cluster state outright.
          *
-         * @return aborted snapshot entry
+         * @return aborted snapshot entry or {@code null} if entry can be removed from the cluster state directly
          */
+        @Nullable
         public Entry abort() {
             final ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> shardsBuilder = ImmutableOpenMap.builder();
             boolean completed = true;
+            boolean allQueued = true;
             for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardEntry : shards) {
                 ShardSnapshotStatus status = shardEntry.value;
+                allQueued &= status.state() == ShardState.QUEUED;
                 if (status.state().completed() == false) {
                     final String nodeId = status.nodeId();
                     status = new ShardSnapshotStatus(nodeId, nodeId == null ? ShardState.FAILED : ShardState.ABORTED,
@@ -307,7 +314,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 completed &= status.state().completed();
                 shardsBuilder.put(shardEntry.key, status);
             }
-            return fail(shardsBuilder.build(), completed ? State.SUCCESS : State.ABORTED, "Snapshot was aborted by deletion");
+            if (allQueued) {
+                return null;
+            }
+            return fail(shardsBuilder.build(), completed ? State.SUCCESS : State.ABORTED, ABORTED_FAILURE_TEXT);
         }
 
         public Entry fail(ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, State state, String failure) {


### PR DESCRIPTION
There is no need to let snapshots that haven't yet written anything to the repo
finalize with `FAILED`. When we still had the `INIT` state we would also just remove
these snapshots from the state without any further action.

This is not just a theoretical optimization. Currently, the situation of having a lot of
queued up snapshots is fairly complicated to resolve when all the queued shards move to aborted
since it is now necessary to execute tasks on the `SNAPSHOT` pool (that might be very busy) to
remove the snapshot from the CS (including a number of redundant CS updates and repo writes
for finalizing these snapshots before deleting them right away after).

backport of #62173, #62707