### PR TITLE
Increase Timeout in testDynamicRestoreThrottling

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -526,10 +526,8 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         client.admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
                 .putNull(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()).build()).get();
 
-        // check that restore now completes quickly (i.e. within 10 seconds)
-        assertBusy(() -> assertTrue(restoreSnapshotResponse.isDone()));
-
-        assertThat(restoreSnapshotResponse.get().getRestoreInfo().totalShards(), greaterThan(0));
+        // check that restore now completes quickly (i.e. within 20 seconds)
+        assertThat(restoreSnapshotResponse.get(20L, TimeUnit.SECONDS).getRestoreInfo().totalShards(), greaterThan(0));
         assertDocCount("test-idx", 100L);
     }
 


### PR DESCRIPTION
Even if we increase the limit it might not take effect straight away if a thread is
blocked on a long wait in `org.elasticsearch.index.snapshots.blobstore.RateLimitingInputStream#maybePause` (also since we use chunk sizes of `100b` for data files here, tens of data files might have to be read adding further latency for some seeds).
Let's increase the limit a little and see if that deals with the remaining failures for good and stop burning
cycles busy asserting a future completion.

Closes #63246
