### PR TITLE
[ML] Validate that AucRoc has the data necessary to be calculated

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/evaluation/classification/AucRocMetric.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/evaluation/classification/AucRocMetric.java
@@ -114,27 +114,23 @@ public class AucRocMetric implements EvaluationMetric {
         }
 
         private static final ParseField SCORE = new ParseField("score");
-        private static final ParseField DOC_COUNT = new ParseField("doc_count");
         private static final ParseField CURVE = new ParseField("curve");
 
         @SuppressWarnings("unchecked")
         private static final ConstructingObjectParser<Result, Void> PARSER =
             new ConstructingObjectParser<>(
-                "auc_roc_result", true, args -> new Result((double) args[0], (long) args[1], (List<AucRocPoint>) args[2]));
+                "auc_roc_result", true, args -> new Result((double) args[0], (List<AucRocPoint>) args[1]));
 
         static {
             PARSER.declareDouble(constructorArg(), SCORE);
-            PARSER.declareLong(constructorArg(), DOC_COUNT);
             PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> AucRocPoint.fromXContent(p), CURVE);
         }
 
         private final double score;
-        private final long docCount;
         private final List<AucRocPoint> curve;
 
-        public Result(double score, long docCount, @Nullable List<AucRocPoint> curve) {
+        public Result(double score, @Nullable List<AucRocPoint> curve) {
             this.score = score;
-            this.docCount = docCount;
             this.curve = curve;
         }
 
@@ -147,10 +143,6 @@ public class AucRocMetric implements EvaluationMetric {
             return score;
         }
 
-        public long getDocCount() {
-            return docCount;
-        }
-
         public List<AucRocPoint> getCurve() {
             return curve == null ? null : Collections.unmodifiableList(curve);
         }
@@ -159,7 +151,6 @@ public class AucRocMetric implements EvaluationMetric {
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
             builder.field(SCORE.getPreferredName(), score);
-            builder.field(DOC_COUNT.getPreferredName(), docCount);
             if (curve != null && curve.isEmpty() == false) {
                 builder.field(CURVE.getPreferredName(), curve);
             }
@@ -173,13 +164,12 @@ public class AucRocMetric implements EvaluationMetric {
             if (o == null || getClass() != o.getClass()) return false;
             Result that = (Result) o;
             return score == that.score
-                && docCount == that.docCount
                 && Objects.equals(curve, that.curve);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(score, docCount, curve);
+            return Objects.hash(score, curve);
         }
 
         @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -200,6 +200,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
@@ -1901,18 +1902,17 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         createIndex(indexName, mappingForClassification());
         BulkRequest regressionBulk = new BulkRequest()
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .add(docForClassification(indexName, "cat", "cat", 0.9, "dog"))
-            .add(docForClassification(indexName, "cat", "cat", 0.85, "dog"))
-            .add(docForClassification(indexName, "cat", "cat", 0.95, "horse"))
-            .add(docForClassification(indexName, "cat", "dog", 0.4, "cat"))
-            .add(docForClassification(indexName, "cat", "fish", 0.35, "cat"))
-            .add(docForClassification(indexName, "dog", "cat", 0.5, "dog"))
-            .add(docForClassification(indexName, "dog", "dog", 0.4, "cat"))
-            .add(docForClassification(indexName, "dog", "dog", 0.35, "cat"))
-            .add(docForClassification(indexName, "dog", "dog", 0.6, "cat"))
-            .add(docForClassification(indexName, "ant", "cat", 0.1, "ant"));
+            .add(docForClassification(indexName, "cat", "cat", "dog", "ant"))
+            .add(docForClassification(indexName, "cat", "cat", "dog", "ant"))
+            .add(docForClassification(indexName, "cat", "cat", "horse", "dog"))
+            .add(docForClassification(indexName, "cat", "dog", "cat", "mule"))
+            .add(docForClassification(indexName, "cat", "fish", "cat", "dog"))
+            .add(docForClassification(indexName, "dog", "cat", "dog", "mule"))
+            .add(docForClassification(indexName, "dog", "dog", "cat", "ant"))
+            .add(docForClassification(indexName, "dog", "dog", "cat", "ant"))
+            .add(docForClassification(indexName, "dog", "dog", "cat", "ant"))
+            .add(docForClassification(indexName, "ant", "cat", "ant", "wasp"));
         highLevelClient().bulk(regressionBulk, RequestOptions.DEFAULT);
-
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
 
         {  // AucRoc
@@ -1927,7 +1927,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
             AucRocMetric.Result aucRocResult = evaluateDataFrameResponse.getMetricByName(AucRocMetric.NAME);
             assertThat(aucRocResult.getMetricName(), equalTo(AucRocMetric.NAME));
-            assertThat(aucRocResult.getScore(), closeTo(0.9299, 1e-9));
+            assertThat(aucRocResult.getScore(), closeTo(0.6425, 1e-9));
             assertNotNull(aucRocResult.getCurve());
         }
         {  // Accuracy
@@ -2144,17 +2144,17 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
     private static IndexRequest docForClassification(String indexName,
                                                      String actualClass,
-                                                     String predictedClass,
-                                                     double p,
-                                                     String otherClass) {
+                                                     String... topPredictedClasses) {
+        assert topPredictedClasses.length > 0;
         return new IndexRequest()
             .index(indexName)
             .source(XContentType.JSON,
                 actualClassField, actualClass,
-                predictedClassField, predictedClass,
-                topClassesField, List.of(
-                    Map.of("class_name", predictedClass, "class_probability", p),
-                    Map.of("class_name", otherClass, "class_probability", 1 - p)));
+                predictedClassField, topPredictedClasses[0],
+                topClassesField, IntStream.range(0, topPredictedClasses.length)
+                    // Consecutive assigned probabilities are: 0.5, 0.25, 0.125, etc.
+                    .mapToObj(i -> Map.of("class_name", topPredictedClasses[i], "class_probability", 1.0 / (2 << i)))
+                    .collect(Collectors.toList()));
     }
 
     private static final String actualRegression = "regression_actual";

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -1927,7 +1927,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
             AucRocMetric.Result aucRocResult = evaluateDataFrameResponse.getMetricByName(AucRocMetric.NAME);
             assertThat(aucRocResult.getMetricName(), equalTo(AucRocMetric.NAME));
-            assertThat(aucRocResult.getScore(), closeTo(0.99995, 1e-9));
+            assertThat(aucRocResult.getScore(), closeTo(0.9299, 1e-9));
             assertNotNull(aucRocResult.getCurve());
         }
         {  // Accuracy

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -3561,7 +3561,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(otherClassesCount, equalTo(0L));
 
             assertThat(aucRocResult.getMetricName(), equalTo(AucRocMetric.NAME));
-            assertThat(aucRocScore, equalTo(0.2625));
+            assertThat(aucRocScore, equalTo(0.7162000000000013));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/evaluation/classification/AucRocMetricResultTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/evaluation/classification/AucRocMetricResultTests.java
@@ -31,7 +31,6 @@ public class AucRocMetricResultTests extends AbstractXContentTestCase<AucRocMetr
     public static AucRocMetric.Result randomResult() {
         return new AucRocMetric.Result(
             randomDouble(),
-            randomLong(),
             Stream
                 .generate(AucRocMetricAucRocPointTests::randomPoint)
                 .limit(randomIntBetween(1, 10))

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -121,7 +121,6 @@ include-tagged::{doc-tests-file}[{api}-results-classification]
 <9> Fetching the number of classes that were not included in the matrix
 <10> Fetching AucRoc metric by name
 <11> Fetching the actual AucRoc score
-<12> Fetching the number of documents that were used in order to calculate AucRoc score
 
 ===== Regression
 

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -194,10 +194,8 @@ belongs.
     `class_name`::::
       (Required, string) Name of the only class that will be treated as
       positive during AUC ROC calculation. Other classes will be treated as
-      negative ("one-vs-all" strategy). Documents which do not have `class_name`
-      in the list of their top classes will not be taken into account for 
-      evaluation. The number of documents taken into account is returned in the 
-      evaluation result (`auc_roc.doc_count` field).
+      negative ("one-vs-all" strategy). All the evaluated documents must have `class_name`
+      in the list of their top classes.
 
     `include_curve`::::
       (Optional, boolean) Whether or not the curve should be returned in

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AbstractAucRoc.java
@@ -230,31 +230,23 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
     public static class Result implements EvaluationMetricResult {
 
         private static final String SCORE = "score";
-        private static final String DOC_COUNT = "doc_count";
         private static final String CURVE = "curve";
 
         private final double score;
-        private final Long docCount;
         private final List<AucRocPoint> curve;
 
-        public Result(double score, Long docCount, List<AucRocPoint> curve) {
+        public Result(double score, List<AucRocPoint> curve) {
             this.score = score;
-            this.docCount = docCount;
             this.curve = Objects.requireNonNull(curve);
         }
 
         public Result(StreamInput in) throws IOException {
             this.score = in.readDouble();
-            this.docCount = in.readOptionalLong();
             this.curve = in.readList(AucRocPoint::new);
         }
 
         public double getScore() {
             return score;
-        }
-
-        public Long getDocCount() {
-            return docCount;
         }
 
         public List<AucRocPoint> getCurve() {
@@ -274,7 +266,6 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeDouble(score);
-            out.writeOptionalLong(docCount);
             out.writeList(curve);
         }
 
@@ -282,9 +273,6 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(SCORE, score);
-            if (docCount != null) {
-                builder.field(DOC_COUNT, docCount);
-            }
             if (curve.isEmpty() == false) {
                 builder.field(CURVE, curve);
             }
@@ -298,13 +286,12 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
             if (o == null || getClass() != o.getClass()) return false;
             Result that = (Result) o;
             return score == that.score
-                && Objects.equals(docCount, that.docCount)
                 && Objects.equals(curve, that.curve);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(score, docCount, curve);
+            return Objects.hash(score, curve);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRoc.java
@@ -182,42 +182,43 @@ public class AucRoc extends AbstractAucRoc {
         Filter classAgg = aggs.get(TRUE_AGG_NAME);
         Nested classNested = classAgg.getAggregations().get(NESTED_AGG_NAME);
         Filter classNestedFilter = classNested.getAggregations().get(NESTED_FILTER_AGG_NAME);
+
+        Filter restAgg = aggs.get(NON_TRUE_AGG_NAME);
+        Nested restNested = restAgg.getAggregations().get(NESTED_AGG_NAME);
+        Filter restNestedFilter = restNested.getAggregations().get(NESTED_FILTER_AGG_NAME);
+
+        long filteredDocCount = classNestedFilter.getDocCount() + restNestedFilter.getDocCount();
+        long totalDocCount = classAgg.getDocCount() + restAgg.getDocCount();
+
         if (classAgg.getDocCount() == 0) {
             throw ExceptionsHelper.badRequestException(
                 "[{}] requires at least one [{}] to have the value [{}]",
                 getName(), fields.get().getActualField(), className);
         }
-        if (classNestedFilter.getDocCount() == 0) {
+        if (classNestedFilter.getDocCount() < classAgg.getDocCount()) {
             throw ExceptionsHelper.badRequestException(
-                "[{}] requires at least one [{}] to have the value [{}]",
-                getName(), fields.get().getPredictedClassField(), className);
+                "[{}] requires that [{}] appears as one of the [{}] for every document (appeared for {} out of {})",
+                getName(), className, fields.get().getPredictedClassField(), filteredDocCount, totalDocCount);
         }
-        Percentiles classPercentiles = classNestedFilter.getAggregations().get(PERCENTILES_AGG_NAME);
-        double[] tpPercentiles = percentilesArray(classPercentiles);
-
-        Filter restAgg = aggs.get(NON_TRUE_AGG_NAME);
-        Nested restNested = restAgg.getAggregations().get(NESTED_AGG_NAME);
-        Filter restNestedFilter = restNested.getAggregations().get(NESTED_FILTER_AGG_NAME);
         if (restAgg.getDocCount() == 0) {
             throw ExceptionsHelper.badRequestException(
                 "[{}] requires at least one [{}] to have a different value than [{}]",
                 getName(), fields.get().getActualField(), className);
         }
-        if (restNestedFilter.getDocCount() == 0) {
+        if (restNestedFilter.getDocCount() < restAgg.getDocCount()) {
             throw ExceptionsHelper.badRequestException(
-                "[{}] requires at least one [{}] to have the value [{}]",
-                getName(), fields.get().getPredictedClassField(), className);
+                "[{}] requires that [{}] appears as one of the [{}] for every document (appeared for {} out of {})",
+                getName(), className, fields.get().getPredictedClassField(), filteredDocCount, totalDocCount);
         }
+
+        Percentiles classPercentiles = classNestedFilter.getAggregations().get(PERCENTILES_AGG_NAME);
+        double[] tpPercentiles = percentilesArray(classPercentiles);
         Percentiles restPercentiles = restNestedFilter.getAggregations().get(PERCENTILES_AGG_NAME);
         double[] fpPercentiles = percentilesArray(restPercentiles);
 
         List<AucRocPoint> aucRocCurve = buildAucRocCurve(tpPercentiles, fpPercentiles);
         double aucRocScore = calculateAucScore(aucRocCurve);
-        result.set(
-            new Result(
-                aucRocScore,
-                classNestedFilter.getDocCount() + restNestedFilter.getDocCount(),
-                includeCurve ? aucRocCurve : Collections.emptyList()));
+        result.set(new Result(aucRocScore, includeCurve ? aucRocCurve : Collections.emptyList()));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/AucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/AucRoc.java
@@ -173,11 +173,7 @@ public class AucRoc extends AbstractAucRoc {
 
         List<AucRocPoint> aucRocCurve = buildAucRocCurve(tpPercentiles, fpPercentiles);
         double aucRocScore = calculateAucScore(aucRocCurve);
-        result.set(
-            new Result(
-                aucRocScore,
-                classAgg.getDocCount() + restAgg.getDocCount(),
-                includeCurve ? aucRocCurve : Collections.emptyList()));
+        result.set(new Result(aucRocScore, includeCurve ? aucRocCurve : Collections.emptyList()));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRocResultTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AucRocResultTests.java
@@ -20,13 +20,12 @@ public class AucRocResultTests extends AbstractWireSerializingTestCase<Result> {
 
     public static Result createRandom() {
         double score = randomDoubleBetween(0.0, 1.0, true);
-        Long docCount = randomBoolean() ? randomLong() : null;
         List<AucRocPoint> curve =
             Stream
                 .generate(() -> new AucRocPoint(randomDouble(), randomDouble(), randomDouble()))
                 .limit(randomIntBetween(0, 20))
                 .collect(Collectors.toList());
-        return new Result(score, docCount, curve);
+        return new Result(score, curve);
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
@@ -166,14 +166,12 @@ public class ClassificationEvaluationIT extends MlNativeDataFrameAnalyticsIntegT
     public void testEvaluate_AucRoc_DoNotIncludeCurve() {
         AucRoc.Result aucrocResult = evaluateAucRoc(false);
         assertThat(aucrocResult.getScore(), is(closeTo(0.5, 0.0001)));
-        assertThat(aucrocResult.getDocCount(), is(equalTo(75L)));
         assertThat(aucrocResult.getCurve(), hasSize(0));
     }
 
     public void testEvaluate_AucRoc_IncludeCurve() {
         AucRoc.Result aucrocResult = evaluateAucRoc(true);
         assertThat(aucrocResult.getScore(), is(closeTo(0.5, 0.0001)));
-        assertThat(aucrocResult.getDocCount(), is(equalTo(75L)));
         assertThat(aucrocResult.getCurve(), hasSize(greaterThan(0)));
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -979,7 +979,6 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             AucRoc.Result aucRocResult = (AucRoc.Result) evaluateDataFrameResponse.getMetrics().get(1);
             assertThat(aucRocResult.getMetricName(), equalTo(AucRoc.NAME.getPreferredName()));
             assertThat(aucRocResult.getScore(), allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            assertThat(aucRocResult.getDocCount(), allOf(greaterThanOrEqualTo(1L), lessThanOrEqualTo(350L)));
             assertThat(aucRocResult.getCurve(), hasSize(greaterThan(0)));
         }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
@@ -207,7 +207,6 @@ setup:
             }
           }
   - match: { outlier_detection.auc_roc.score: 0.9899 }
-  - match: { outlier_detection.auc_roc.doc_count: 8 }
   - is_false: outlier_detection.auc_roc.curve
 
 ---
@@ -228,7 +227,6 @@ setup:
             }
           }
   - match: { outlier_detection.auc_roc.score: 0.9899 }
-  - match: { outlier_detection.auc_roc.doc_count: 8 }
   - is_false: outlier_detection.auc_roc.curve
 
 ---
@@ -249,7 +247,6 @@ setup:
             }
           }
   - match: { outlier_detection.auc_roc.score: 0.9899 }
-  - match: { outlier_detection.auc_roc.doc_count: 8 }
   - is_true: outlier_detection.auc_roc.curve
 
 ---
@@ -415,7 +412,6 @@ setup:
             }
           }
   - is_true: outlier_detection.auc_roc.score
-  - is_true: outlier_detection.auc_roc.doc_count
   - is_true: outlier_detection.precision.0\.25
   - is_true: outlier_detection.precision.0\.5
   - is_true: outlier_detection.precision.0\.75
@@ -689,7 +685,7 @@ setup:
 ---
 "Test classification auc_roc given predicted_class_field is never equal to mouse":
   - do:
-      catch: /\[auc_roc\] requires at least one \[ml.top_classes.class_name\] to have the value \[mouse\]/
+      catch: /\[auc_roc\] requires that \[mouse\] appears as one of the \[ml.top_classes.class_name\] for every document (appeared for 0 out of 8)/
       ml.evaluate_data_frame:
         body:  >
           {
@@ -726,7 +722,6 @@ setup:
             }
           }
   - match: { classification.auc_roc.score: 0.8050111095212122 }
-  - match: { classification.auc_roc.doc_count: 8 }
   - is_false: classification.auc_roc.curve
 ---
 "Test classification auc_roc with default top_classes_field":
@@ -747,7 +742,6 @@ setup:
             }
           }
   - match: { classification.auc_roc.score: 0.8050111095212122 }
-  - match: { classification.auc_roc.doc_count: 8 }
   - is_false: classification.auc_roc.curve
 ---
 "Test classification accuracy with missing predicted_field":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
@@ -685,7 +685,7 @@ setup:
 ---
 "Test classification auc_roc given predicted_class_field is never equal to mouse":
   - do:
-      catch: /\[auc_roc\] requires that \[mouse\] appears as one of the \[ml.top_classes.class_name\] for every document \(appeared for 0 out of 8\)/
+      catch: /\[auc_roc\] requires that \[mouse\] appears as one of the \[ml.top_classes.class_name\] for every document \(appeared in 0 out of 8\)./
       ml.evaluate_data_frame:
         body:  >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
@@ -685,7 +685,7 @@ setup:
 ---
 "Test classification auc_roc given predicted_class_field is never equal to mouse":
   - do:
-      catch: /\[auc_roc\] requires that \[mouse\] appears as one of the \[ml.top_classes.class_name\] for every document (appeared for 0 out of 8)/
+      catch: /\[auc_roc\] requires that \[mouse\] appears as one of the \[ml.top_classes.class_name\] for every document \(appeared for 0 out of 8\)/
       ml.evaluate_data_frame:
         body:  >
           {


### PR DESCRIPTION
When `AucRoc` is evaluated in the context of multiclass classification evaluation, it must require that the probability of the class in question (`class_name`) is known for every document. Otherwise, the results will not be correct.

This PR tightens the validation so that when the probability of the class in question is not known for at least one document, the evaluation request fails rather than returning erroneous results.

Consequently, `AbstractAucRoc.Result.doc_count` field is no longer needed so it is removed in this PR as well.

Marking this PR `>non-issue` as the `AucRoc` metric is not released yet.

Relates https://github.com/elastic/elasticsearch/issues/63306