### PR TITLE
Update link to Snowball documentation

### DIFF
--- a/docs/reference/analysis/stemming.asciidoc
+++ b/docs/reference/analysis/stemming.asciidoc
@@ -60,7 +60,7 @@ algorithmic stemming with a built-in dictionary.
 * <<analysis-porterstem-tokenfilter,`porter_stem`>>, our recommended algorithmic
 stemmer for English.
 * <<analysis-snowball-tokenfilter,`snowball`>>, which uses
-http://snowball.tartarus.org/[Snowball]-based stemming rules for several
+https://snowballstem.org/[Snowball]-based stemming rules for several
 languages.
 
 [[dictionary-stemmers]]


### PR DESCRIPTION
The current link points to an obsolete site, which is no longer maintained.