### PR TITLE
Deprecate week_year in favour of weekyear date format backport(63307)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -157,6 +157,11 @@ public class Joda {
             formatter = ISODateTimeFormat.weekDateTime();
         } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
             formatter = ISODateTimeFormat.weekDateTimeNoMillis();
+        } else if (FormatNames.WEEKYEAR.equals(input)) {
+            getDeprecationLogger()
+                .deprecate("week_year_format_name", "Format name \"week_year\" is deprecated and will be removed in a future version. " +
+                    "Use \"weekyear\" format instead");
+            formatter = ISODateTimeFormat.weekyear();
         } else if (FormatNames.WEEK_YEAR.matches(input)) {
             formatter = ISODateTimeFormat.weekyear();
         } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1175,6 +1175,9 @@ public class DateFormatters {
         new DateTimeFormatterBuilder().appendValue(WEEK_FIELDS_ROOT.weekBasedYear()).toFormatter(Locale.ROOT)
                                       .withResolverStyle(ResolverStyle.STRICT));
 
+    private static final DateFormatter WEEKYEAR = new JavaDateFormatter("weekyear",
+        new DateTimeFormatterBuilder().appendValue(WEEK_FIELDS_ROOT.weekBasedYear()).toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
     /*
      * Returns a formatter for a four digit year. (uuuu)
      */
@@ -1728,7 +1731,12 @@ public class DateFormatters {
         } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
             return WEEK_DATE_TIME_NO_MILLIS;
         } else if (FormatNames.WEEK_YEAR.matches(input)) {
+            deprecationLogger.getOrCompute()
+                .deprecate("week_year_format_name", "Format name \"week_year\" is deprecated and will be removed in a future version. " +
+                    "Use \"weekyear\" format instead");
             return WEEK_YEAR;
+        } else if (FormatNames.WEEKYEAR.matches(input)) {
+            return WEEKYEAR;
         } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {
             return WEEKYEAR_WEEK;
         } else if (FormatNames.WEEKYEAR_WEEK_DAY.matches(input)) {

--- a/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
@@ -64,6 +64,7 @@ public enum FormatNames {
     WEEK_DATE_TIME("weekDateTime", "week_date_time"),
     WEEK_DATE_TIME_NO_MILLIS("weekDateTimeNoMillis", "week_date_time_no_millis"),
     WEEK_YEAR("weekyear", "week_year"),
+    WEEKYEAR(null, "weekyear"),
     WEEK_YEAR_WEEK("weekyearWeek", "weekyear_week"),
     WEEKYEAR_WEEK_DAY("weekyearWeekDay", "weekyear_week_day"),
     YEAR(null, "year"),

--- a/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
@@ -63,7 +63,7 @@ public enum FormatNames {
     WEEK_DATE("weekDate", "week_date"),
     WEEK_DATE_TIME("weekDateTime", "week_date_time"),
     WEEK_DATE_TIME_NO_MILLIS("weekDateTimeNoMillis", "week_date_time_no_millis"),
-    WEEK_YEAR("weekyear", "week_year"),
+    WEEK_YEAR(null, "week_year"),
     WEEKYEAR(null, "weekyear"),
     WEEK_YEAR_WEEK("weekyearWeek", "weekyear_week"),
     WEEKYEAR_WEEK_DAY("weekyearWeekDay", "weekyear_week_day"),

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -532,9 +532,9 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2012-1-31", "yearMonthDay");
         assertSameDate("2012-12-1", "yearMonthDay");
 
-        assertSameDate("2018", "week_year");
-        assertSameDate("1", "week_year");
-        assertSameDate("2017", "week_year");
+        assertSameDate("2018", "weekyear");
+        assertSameDate("1", "weekyear");
+        assertSameDate("2017", "weekyear");
 
         assertSameDate("2018-W29", "weekyear_week");
         assertSameDate("2018-W1", "weekyear_week");

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -383,6 +383,12 @@ public class DateFormattersTests extends ESTestCase {
         }
     }
 
+    public void testWeek_yearDeprecation() {
+        DateFormatter.forPattern("week_year");
+        assertWarnings("Format name \"week_year\" is deprecated and will be removed in a future version. " +
+                "Use \"weekyear\" format instead");
+    }
+
     public void testCamelCaseDeprecation() {
         String[] deprecatedNames = new String[]{
             "basicDate", "basicDateTime", "basicDateTimeNoMillis", "basicOrdinalDate", "basicOrdinalDateTime",
@@ -391,7 +397,8 @@ public class DateFormattersTests extends ESTestCase {
             "dateHourMinuteSecond", "dateHourMinuteSecondFraction", "dateHourMinuteSecondMillis", "dateOptionalTime",
             "dateTime", "dateTimeNoMillis", "hourMinute", "hourMinuteSecond", "hourMinuteSecondFraction", "hourMinuteSecondMillis",
             "ordinalDate", "ordinalDateTime", "ordinalDateTimeNoMillis", "timeNoMillis",
-            "tTime", "tTimeNoMillis", "weekDate", "weekDateTime", "weekDateTimeNoMillis", "weekyear", "weekyearWeek", "weekyearWeekDay",
+            "tTime", "tTimeNoMillis", "weekDate", "weekDateTime", "weekDateTimeNoMillis",
+            "weekyearWeek", "weekyearWeekDay",
             "yearMonth", "yearMonthDay", "strictBasicWeekDate", "strictBasicWeekDateTime",
             "strictBasicWeekDateTimeNoMillis", "strictDate", "strictDateHour", "strictDateHourMinute", "strictDateHourMinuteSecond",
             "strictDateHourMinuteSecondFraction", "strictDateHourMinuteSecondMillis", "strictDateOptionalTime",
@@ -408,7 +415,7 @@ public class DateFormattersTests extends ESTestCase {
             DateFormatter dateFormatter = DateFormatter.forPattern(name);
             assertThat(dateFormatter.pattern(), equalTo(name));
             assertWarnings("Camel case format name " + name + " is deprecated and will be removed in a future version. " +
-                "Use snake case name " + snakeCaseName + " instead.");
+                    "Use snake case name " + snakeCaseName + " instead.");
 
             dateFormatter = DateFormatter.forPattern(snakeCaseName);
             assertThat(dateFormatter.pattern(), equalTo(snakeCaseName));

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -130,6 +130,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -924,7 +925,9 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Generate a random valid date formatter pattern.
      */
     public static String randomDateFormatterPattern() {
-        return randomFrom(FormatNames.values()).getSnakeCaseName();
+        //WEEKYEAR should be used instead of WEEK_YEAR
+        EnumSet<FormatNames> formatNames = EnumSet.complementOf(EnumSet.of(FormatNames.WEEK_YEAR));
+        return randomFrom(formatNames).getSnakeCaseName();
     }
 
     /**


### PR DESCRIPTION
week_year is misleading as the formatter only has a weekyear. A field
corresponding to 'Y'. 'weekyear' should be used instead

relates #60707
backports https://github.com/elastic/elasticsearch/pull/63307

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
