### PR TITLE
Openjdk download on mac is fixed

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/JdkDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/JdkDownloadPluginFuncTest.groovy
@@ -89,6 +89,8 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
         "darwin"  | VENDOR_ADOPTOPENJDK | ADOPT_JDK_VERSION   | "Contents/Home/bin/java" | ""
         "darwin"  | VENDOR_OPENJDK      | OPEN_JDK_VERSION    | "Contents/Home/bin/java" | ""
         "darwin"  | VENDOR_OPENJDK      | OPENJDK_VERSION_OLD | "Contents/Home/bin/java" | "(old version)"
+        "mac"     | VENDOR_OPENJDK      | OPEN_JDK_VERSION    | "Contents/Home/bin/java" | ""
+        "mac"     | VENDOR_OPENJDK      | OPENJDK_VERSION_OLD | "Contents/Home/bin/java" | "(old version)"
     }
 
     def "transforms are reused across projects"() {
@@ -200,10 +202,10 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
     private static String urlPath(final String vendor, final String version, final String platform) {
         if (vendor.equals(VENDOR_ADOPTOPENJDK)) {
-            final String module = platform.equals("darwin") ? "mac" : platform;
+            final String module = isMac(platform) ? "mac" : platform;
             return "/jdk-12.0.2+10/" + module + "/x64/jdk/hotspot/normal/adoptopenjdk";
         } else if (vendor.equals(VENDOR_OPENJDK)) {
-            final String effectivePlatform = platform.equals("darwin") ? "osx" : platform;
+            final String effectivePlatform = isMac(platform) ? "osx" : platform;
             final boolean isOld = version.equals(OPENJDK_VERSION_OLD);
             final String versionPath = isOld ? "jdk1/99" : "jdk12.0.1/123456789123456789123456789abcde/99";
             final String filename = "openjdk-" + (isOld ? "1" : "12.0.1") + "_" + effectivePlatform + "-x64_bin." + extension(platform);
@@ -212,12 +214,16 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
     }
 
     private static byte[] filebytes(final String vendor, final String platform) throws IOException {
-        final String effectivePlatform = platform.equals("darwin") ? "osx" : platform;
+        final String effectivePlatform = isMac(platform) ? "osx" : platform;
         if (vendor.equals(VENDOR_ADOPTOPENJDK)) {
             return JdkDownloadPluginFuncTest.class.getResourceAsStream("fake_adoptopenjdk_" + effectivePlatform + "." + extension(platform)).getBytes()
         } else if (vendor.equals(VENDOR_OPENJDK)) {
             JdkDownloadPluginFuncTest.class.getResourceAsStream("fake_openjdk_" + effectivePlatform + "." + extension(platform)).getBytes()
         }
+    }
+
+    private static boolean isMac(String platform) {
+        platform.equals("darwin") || platform.equals("mac")
     }
 
     private static String extension(String platform) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
@@ -153,7 +153,7 @@ public class JdkDownloadPlugin implements Plugin<Project> {
     }
 
     private static String dependencyNotation(Jdk jdk) {
-        String platformDep = jdk.getPlatform().equals("darwin") || jdk.getPlatform().equals("osx")
+        String platformDep = jdk.getPlatform().equals("darwin") || jdk.getPlatform().equals("mac")
             ? (jdk.getVendor().equals(VENDOR_ADOPTOPENJDK) ? "mac" : "osx")
             : jdk.getPlatform();
         String extension = jdk.getPlatform().equals("windows") ? "zip" : "tar.gz";


### PR DESCRIPTION
- the wrong platform classifier (mac) was used when downloading
openjdk on mac. This fixes it to use osx