### PR TITLE
Fix syncing expanded distributions in gradle build (7.x backport)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/DistributionArchive.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/DistributionArchive.java
@@ -21,7 +21,7 @@ package org.elasticsearch.gradle.internal;
 
 import org.gradle.api.Named;
 import org.gradle.api.file.CopySpec;
-import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
@@ -30,10 +30,10 @@ import java.util.function.Supplier;
 public class DistributionArchive implements Named {
 
     private TaskProvider<? extends AbstractArchiveTask> archiveTask;
-    private TaskProvider<Copy> expandedDistTask;
+    private TaskProvider<Sync> expandedDistTask;
     private final String name;
 
-    public DistributionArchive(TaskProvider<? extends AbstractArchiveTask> archiveTask, TaskProvider<Copy> expandedDistTask, String name) {
+    public DistributionArchive(TaskProvider<? extends AbstractArchiveTask> archiveTask, TaskProvider<Sync> expandedDistTask, String name) {
         this.archiveTask = archiveTask;
         this.expandedDistTask = expandedDistTask;
         this.name = name;
@@ -57,7 +57,7 @@ public class DistributionArchive implements Named {
         return archiveTask;
     }
 
-    public TaskProvider<Copy> getExpandedDistTask() {
+    public TaskProvider<Sync> getExpandedDistTask() {
         return expandedDistTask;
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -27,7 +27,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.tasks.AbstractCopyTask;
-import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Compression;
@@ -72,7 +72,7 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
             var subProjectDir = archiveToSubprojectName(name);
             var copyDistributionTaskName = "build" + capitalize(name.substring(0, name.length() - 3));
             TaskContainer tasks = project.getTasks();
-            var explodedDist = tasks.register(copyDistributionTaskName, Copy.class, copy -> copy.into(subProjectDir + "/build/install/"));
+            var explodedDist = tasks.register(copyDistributionTaskName, Sync.class, sync -> sync.into(subProjectDir + "/build/install/"));
             var archiveTaskName = "build" + capitalize(name);
             return name.endsWith("Tar")
                 ? new DistributionArchive(tasks.register(archiveTaskName, SymbolicLinkPreservingTar.class), explodedDist, name)


### PR DESCRIPTION
backports #63285 to 7.x branch