### PR TITLE
[7.9][DOCS] Adds delta and offset parameters to Evaluate DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -22,11 +22,13 @@ experimental[]
 [[ml-evaluate-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following privileges:
+If the {es} {security-features} are enabled, you must have the following 
+privileges:
 
 * cluster: `monitor_ml`
   
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+For more information, see <<security-privileges>> and 
+{ml-docs-setup-privileges}.
 
 
 [[ml-evaluate-dfanalytics-desc]]
@@ -122,24 +124,40 @@ which outputs a prediction of values.
   in other words the results of the {regression} analysis.
   
 `metrics`::
-  (Optional, object) Specifies the metrics that are used for the evaluation.
+  (Optional, object) Specifies the metrics that are used for the evaluation. For 
+  more information on `mse`, `msle`, and `huber`, consult 
+  https://github.com/elastic/examples/tree/master/Machine%20Learning/Regression%20Loss%20Functions[the Jupyter notebook on regression loss functions].
   Available metrics:
 
   `mse`:::
-    (Optional, object) Average squared difference between the predicted values and the actual (`ground truth`) value.
-    For more information, read {wikipedia}/Mean_squared_error[this wiki article].
+    (Optional, object) Average squared difference between the predicted values 
+    and the actual (`ground truth`) value. For more information, read 
+    {wikipedia}/Mean_squared_error[this wiki article].
 
   `msle`:::
-    (Optional, object) Average squared difference between the logarithm of the predicted values and the logarithm of the actual
-    (`ground truth`) value.
+    (Optional, object) Average squared difference between the logarithm of the 
+    predicted values and the logarithm of the actual (`ground truth`) value.
+    
+    `offset`::::
+      (Optional, double) Defines the transition point at which you switch from 
+      minimizing quadratic error to minimizing quadratic log error. Defaults to 
+      `1`.
 
   `huber`:::
     (Optional, object) Pseudo Huber loss function.
-    For more information, read {wikipedia}/Huber_loss#Pseudo-Huber_loss_function[this wiki article].
+    For more information, read 
+    {wikipedia}/Huber_loss#Pseudo-Huber_loss_function[this wiki article].
+    
+    `delta`::::
+      (Optional, double) Approximates 1/2 (prediction - actual)^2^ for values 
+      much less than delta and approximates a straight line with slope delta for 
+      values much larger than delta. Defaults to `1`. Delta needs to be greater 
+      than `0`.
 
   `r_squared`:::
-    (Optional, object) Proportion of the variance in the dependent variable that is predictable from the independent variables.
-    For more information, read {wikipedia}/Coefficient_of_determination[this wiki article].
+    (Optional, object) Proportion of the variance in the dependent variable that 
+    is predictable from the independent variables. For more information, read 
+    {wikipedia}/Coefficient_of_determination[this wiki article].
 
 
   


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Adds delta and offset parameters to Evaluate DFA API docs (#63317)