### PR TITLE
Fix DataTiersMigrationsTests.testIndexDataTierMigration

### DIFF
--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
@@ -120,7 +120,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -133,7 +132,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         logger.info("starting a warm data node");
         internalCluster().startNode(warmNode(Settings.EMPTY));
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -148,7 +146,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
 
         // wait for lifecycle to complete in the cold phase after the index has been migrated to the cold node
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -184,7 +181,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -208,7 +204,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         //  1. start another cold node so both the primary and replica can relocate to the cold nodes
         //  2. remove the tier routing setting from the index again (we're doing this below)
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -223,7 +218,6 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
 
         // wait for lifecycle to complete in the cold phase
         assertBusy(() -> {
-            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
@@ -120,6 +120,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -132,6 +133,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         logger.info("starting a warm data node");
         internalCluster().startNode(warmNode(Settings.EMPTY));
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -146,6 +148,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
 
         // wait for lifecycle to complete in the cold phase after the index has been migrated to the cold node
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -181,6 +184,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -204,6 +208,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
         //  1. start another cold node so both the primary and replica can relocate to the cold nodes
         //  2. remove the tier routing setting from the index again (we're doing this below)
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();
@@ -218,6 +223,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
 
         // wait for lifecycle to complete in the cold phase
         assertBusy(() -> {
+            client().admin().cluster().prepareReroute().get();
             ExplainLifecycleRequest explainRequest = new ExplainLifecycleRequest().indices(managedIndex);
             ExplainLifecycleResponse explainResponse = client().execute(ExplainLifecycleAction.INSTANCE,
                 explainRequest).get();

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
@@ -128,7 +128,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             IndexLifecycleExplainResponse indexLifecycleExplainResponse = explainResponse.getIndexResponses().get(managedIndex);
             assertThat(indexLifecycleExplainResponse.getPhase(), is("warm"));
             assertThat(indexLifecycleExplainResponse.getStep(), is(DataTierMigrationRoutedStep.NAME));
-        });
+        }, 30, TimeUnit.SECONDS);
 
         logger.info("starting a warm data node");
         internalCluster().startNode(warmNode(Settings.EMPTY));
@@ -141,7 +141,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             IndexLifecycleExplainResponse indexLifecycleExplainResponse = explainResponse.getIndexResponses().get(managedIndex);
             assertThat(indexLifecycleExplainResponse.getPhase(), is("cold"));
             assertThat(indexLifecycleExplainResponse.getStep(), is(DataTierMigrationRoutedStep.NAME));
-        });
+        }, 30, TimeUnit.SECONDS);
 
         logger.info("starting a cold data node");
         internalCluster().startNode(coldNode(Settings.EMPTY));
@@ -156,7 +156,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             IndexLifecycleExplainResponse indexLifecycleExplainResponse = explainResponse.getIndexResponses().get(managedIndex);
             assertThat(indexLifecycleExplainResponse.getPhase(), is("cold"));
             assertThat(indexLifecycleExplainResponse.getStep(), is("complete"));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testUserOptsOutOfTierMigration() throws Exception {


### PR DESCRIPTION
This commit adds a reroute prior to checking the migration status. In some cases ILM steps can
advance quickly enough that we won't check whether we can advance due to the cluster state not being
updated (because some types of steps are only checks on new cluster states). Even with the test
setting a poll interval of 1 second, certain steps are not checked because they are waiting for a
new cluster state.

Resolves #63350
