### PR TITLE
Wait for license to be active in PingAndInfoIT before checking in test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -56,7 +56,8 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertEquals(versionMap.get("lucene_version"), info.getVersion().getLuceneVersion());
     }
 
-    public void testXPackInfo() throws IOException {
+    public void testXPackInfo() throws Exception {
+        waitForActiveLicense(client());
         XPackInfoRequest request = new XPackInfoRequest();
         request.setCategories(EnumSet.allOf(XPackInfoRequest.Category.class));
         request.setVerbose(true);


### PR DESCRIPTION
We check the license level with a

```
assertEquals("trial", info.getLicenseInfo().getType());
```

However, the license may not yet be active. This commit adds a `waitForActiveLicense` check to the
beginning of the test.

Resolves #62035
