### PR TITLE
Handle deprecation warnings in "old cluster" parts of BWC tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/issues/63358"
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -143,7 +143,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                             .field("binary", Base64.getEncoder().encodeToString(randomByteArray))
                             .endObject()
             );
-            refresh();
+            refreshAllIndices();
         } else {
             count = countOfIndexedRandomDocuments();
         }
@@ -708,7 +708,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // Count the documents in the index to make sure we have as many as we put there
         Request countRequest = new Request("GET", "/" + index + "/_search");
         countRequest.addParameter("size", "0");
-        refresh();
+        refreshAllIndices();
         Map<String, Object> countResponse = entityAsMap(client().performRequest(countRequest));
         assertTotalHits(count, countResponse);
 
@@ -795,7 +795,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
 
         // Refresh the index so the count doesn't fail
-        refresh();
+        refreshAllIndices();
 
         // Count the documents in the index to make sure we have as many as we put there
         Request countRequest = new Request("GET", "/" + index + "/_search");
@@ -935,7 +935,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 Request request = new Request("POST", "/" + index + "/_doc/" + i);
                 request.setJsonEntity(doc);
                 client().performRequest(request);
-                refresh();
+                refreshAllIndices();
             }
             client().performRequest(new Request("POST", "/" + index + "/_flush"));
             int liveDocs = numDocs;
@@ -951,7 +951,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     liveDocs--;
                 }
             }
-            refresh();
+            refreshAllIndices();
             assertTotalHits(liveDocs, entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search"))));
             saveInfoDocument(index + "_doc_count", Integer.toString(liveDocs));
         } else {
@@ -979,10 +979,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     request.setJsonEntity(Strings.toString(JsonXContent.contentBuilder().startObject().field("field", "v1").endObject()));
                     assertOK(client().performRequest(request));
                     if (rarely()) {
-                        refresh();
+                        refreshAllIndices();
                     }
                 }
-                refresh();
+                refreshAllIndices();
             }
 
             assertTotalHits(numDocs, entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search"))));
@@ -1163,7 +1163,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             createDocument.setJsonEntity(Strings.toString(docSupplier.apply(i)));
             client().performRequest(createDocument);
             if (rarely()) {
-                refresh();
+                refreshAllIndices();
             }
             if (flushAllowed && rarely()) {
                 logger.debug("Flushing [{}]", index);
@@ -1203,11 +1203,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Matcher m = Pattern.compile("\"value\":\"(.+)\"").matcher(doc);
         assertTrue(doc, m.find());
         return m.group(1);
-    }
-
-    private void refresh() throws IOException {
-        logger.debug("Refreshing [{}]", index);
-        client().performRequest(new Request("POST", "/" + index + "/_refresh"));
     }
 
     private List<String> dataNodes(String index, RestClient client) throws IOException {

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1451,6 +1451,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     "    {\"add\":  {\"index\":  \"test_index_reindex\", \"alias\": \"test-system-alias\"}}\n" +
                     "  ]\n" +
                     "}");
+                putAliasRequest.setOptions(expectVersionSpecificWarnings(v -> {
+                    v.current(systemIndexWarning);
+                    v.compatible(systemIndexWarning);
+                }));
                 assertThat(client().performRequest(putAliasRequest).getStatusLine().getStatusCode(), is(200));
             }
         } else {

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1422,6 +1422,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
             // make sure .tasks index exists
             Request getTasksIndex = new Request("GET", "/.tasks");
+            getTasksIndex.setOptions(expectVersionSpecificWarnings(v -> {
+                v.current(systemIndexWarning);
+                v.compatible(systemIndexWarning);
+            }));
             getTasksIndex.addParameter("allow_no_indices", "false");
 
             getTasksIndex.setOptions(expectVersionSpecificWarnings(v -> {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
@@ -100,6 +100,10 @@ public class SystemIndicesUpgradeIT extends AbstractRollingTestCase {
                     "    {\"add\":  {\"index\":  \"test_index_reindex\", \"alias\": \"test-system-alias\"}}\n" +
                     "  ]\n" +
                     "}");
+                putAliasRequest.setOptions(expectVersionSpecificWarnings(v -> {
+                    v.current(systemIndexWarning);
+                    v.compatible(systemIndexWarning);
+                }));
                 assertThat(client().performRequest(putAliasRequest).getStatusLine().getStatusCode(), is(200));
             }
         } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
@@ -71,6 +71,10 @@ public class SystemIndicesUpgradeIT extends AbstractRollingTestCase {
 
             // make sure .tasks index exists
             Request getTasksIndex = new Request("GET", "/.tasks");
+            getTasksIndex.setOptions(expectVersionSpecificWarnings(v -> {
+                v.current(systemIndexWarning);
+                v.compatible(systemIndexWarning);
+            }));
             getTasksIndex.addParameter("allow_no_indices", "false");
 
             getTasksIndex.setOptions(expectVersionSpecificWarnings(v -> {


### PR DESCRIPTION
This PR adjusts the BWC tests in to handle the deprecation warnings that are now emitted in old clusters due to the backport of #60945.

Fixes https://github.com/elastic/elasticsearch/issues/63358
Reverts https://github.com/elastic/elasticsearch/pull/63360