### PR TITLE
Speed up interval rounding (backport of #63245)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -915,6 +915,15 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public Prepared prepare(long minUtcMillis, long maxUtcMillis) {
+            /*
+             * 128 is a power of two that isn't huge. We might be able to do
+             * better if the limit was based on the actual type of prepared
+             * rounding but this'll do for now.
+             */
+            return prepareOffsetOrJavaTimeRounding(minUtcMillis, maxUtcMillis).maybeUseArray(minUtcMillis, maxUtcMillis, 128);
+        }
+
+        private TimeIntervalPreparedRounding prepareOffsetOrJavaTimeRounding(long minUtcMillis, long maxUtcMillis) {
             long minLookup = minUtcMillis - interval;
             long maxLookup = maxUtcMillis;
 
@@ -939,7 +948,7 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
-        Prepared prepareJavaTime() {
+        TimeIntervalPreparedRounding prepareJavaTime() {
             return new JavaTimeRounding();
         }
 
@@ -983,7 +992,7 @@ public abstract class Rounding implements Writeable {
             }
         }
 
-        private abstract class TimeIntervalPreparedRounding implements Prepared {
+        private abstract class TimeIntervalPreparedRounding extends PreparedRounding {
             @Override
             public double roundingSize(long utcMillis, DateTimeUnit timeUnit) {
                 if (timeUnit.isMillisBased) {


### PR DESCRIPTION
This speeds up date_histogram by precomputing the rounding points for
date intervals like `10d`. The speedup for the rounding itself is
between 18% (UTC many buckets) and 65% (US Eastern Time few buckets).
43% seems like it'd be pretty common:

```
Benchmark   (count)  (interval)                   (range)           (zone)  Mode  Cnt          Score         Error  Units
before     10000000         10d  2000-10-28 to 2000-10-31              UTC  avgt   10  130822390.700 ±  177466.657  ns/op
before     10000000         10d  2000-10-28 to 2000-10-31 America/New_York  avgt   10  189236837.930 ± 7958933.566  ns/op
after      10000000         10d  2000-10-28 to 2000-10-31              UTC  avgt   10   66413746.325 ± 1578834.032  ns/op
after      10000000         10d  2000-10-28 to 2000-10-31 America/New_York  avgt   10   65656941.375 ±  291608.870  ns/op

before     10000000          2h  2000-10-28 to 2000-10-31              UTC  avgt   10  130854975.013 ±  369133.702  ns/op
before     10000000          2h  2000-10-28 to 2000-10-31 America/New_York  avgt   10  165831615.257 ±  139074.982  ns/op
after      10000000          2h  2000-10-28 to 2000-10-31              UTC  avgt   10  107832636.671 ± 3502704.198  ns/op
after      10000000          2h  2000-10-28 to 2000-10-31 America/New_York  avgt   10  107608802.940 ±  979286.160  ns/op
```

Speedup for the date_histogram is likely to vary based on how much IO
dominates the collection.
