### PR TITLE
fix expression type for null safe operator

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -436,15 +436,16 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
             if (irIndexNode != null) {
                 // this load/store requires an index
                 BinaryImplNode binaryImplNode = new BinaryImplNode(location);
-                binaryImplNode.setExpressionType(void.class);
 
                 if (isNullSafe) {
                     // the null-safe structure is slightly different from the standard structure since
                     // both the index and expression are not written to the stack if the prefix is null
+                    binaryImplNode.setExpressionType(irExpressionNode.getExpressionType());
                     binaryImplNode.setLeftNode(irIndexNode);
                     binaryImplNode.setRightNode(irExpressionNode);
                     irExpressionNode = binaryImplNode;
                 } else {
+                    binaryImplNode.setExpressionType(void.class);
                     binaryImplNode.setLeftNode(irPrefixNode);
                     binaryImplNode.setRightNode(irIndexNode);
                     irPrefixNode = binaryImplNode;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ElvisTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ElvisTests.java
@@ -75,6 +75,8 @@ public class ElvisTests extends ScriptTestCase {
     }
 
     public void testWithNullSafeDereferences() {
+        assertEquals(false, exec("Map x = ['0': 0]; x?.0 > 5.0"));
+        assertEquals(false, exec("List x = [0]; x?.0 > 5.0"));
         assertEquals(1, exec("return params.a?.b ?: 1"));
         assertEquals(1, exec("return params.a?.b ?: 2", singletonMap("a", singletonMap("b", 1)), true));
 


### PR DESCRIPTION
An invalid void expression type from a null safe operator caused `ClassFormatError` for the script `Map x= ['0': 0]; x?.0 > 1`. This change sets and propagates the correct expression type for the null safe operator to be written out.