### PR TITLE
Update logstash_admin role for system indices

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -74,6 +74,7 @@ A successful call returns an object with "cluster" and "index" fields.
     "manage_ilm",
     "manage_index_templates",
     "manage_ingest_pipelines",
+    "manage_logstash"
     "manage_ml",
     "manage_oidc",
     "manage_own_api_key",

--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -74,7 +74,7 @@ A successful call returns an object with "cluster" and "index" fields.
     "manage_ilm",
     "manage_index_templates",
     "manage_ingest_pipelines",
-    "manage_logstash",
+    "manage_logstash_pipelines",
     "manage_ml",
     "manage_oidc",
     "manage_own_api_key",

--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -74,7 +74,7 @@ A successful call returns an object with "cluster" and "index" fields.
     "manage_ilm",
     "manage_index_templates",
     "manage_ingest_pipelines",
-    "manage_logstash"
+    "manage_logstash",
     "manage_ml",
     "manage_oidc",
     "manage_own_api_key",

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -15,7 +15,7 @@ Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
 [[built-in-roles-apm-user]] `apm_user` ::
-Grants the privileges required for APM users (such as `read` and 
+Grants the privileges required for APM users (such as `read` and
 `view_index_metadata` privileges on the `apm-*` and `.ml-anomalies*` indices).
 
 [[built-in-roles-beats-admin]] `beats_admin` ::
@@ -27,7 +27,7 @@ Grants access necessary for the Beats system user to send system-level data
 (such as monitoring) to {es}.
 +
 --
-[NOTE] 
+[NOTE]
 ===============================
 * This role should not be assigned to users as the granted permissions may
 change between releases.
@@ -60,12 +60,12 @@ NOTE: This role does *not* provide the ability to create indices; those privileg
 must be defined in a separate role.
 
 [[built-in-roles-kibana-dashboard]] `kibana_dashboard_only_user` ::
-(This role is deprecated, please use 
+(This role is deprecated, please use
 {kibana-ref}/kibana-privileges.html#kibana-feature-privileges[{kib} feature privileges]
 instead).
-Grants read-only access to the {kib} Dashboard in every 
+Grants read-only access to the {kib} Dashboard in every
 {kibana-ref}/xpack-spaces.html[space in {kib}].
-This role does not have access to editing tools in {kib}. 
+This role does not have access to editing tools in {kib}.
 
 [[built-in-roles-kibana-system]] `kibana_system` ::
 Grants access necessary for the {kib} system user to read from and write to the
@@ -88,7 +88,8 @@ Grants access to all features in {kib}. For more information on {kib} authorizat
 see {kibana-ref}/xpack-security-authorization.html[Kibana authorization].
 
 [[built-in-roles-logstash-admin]] `logstash_admin` ::
-Grants access to the `.logstash*` indices for managing configurations.
+Grants access to the `.logstash*` indices for managing configurations, and grants
+necessary access for logstash-specific APIs exposed by the logstash x-pack plugin.
 
 [[built-in-roles-logstash-system]] `logstash_system` ::
 Grants access necessary for the Logstash system user to send system-level data
@@ -96,7 +97,7 @@ Grants access necessary for the Logstash system user to send system-level data
 {logstash-ref}/ls-security.html[Configuring Security in Logstash].
 +
 --
-[NOTE] 
+[NOTE]
 ===============================
 * This role should not be assigned to users as the granted permissions may
 change between releases.
@@ -131,17 +132,17 @@ with {kibana-ref}/xpack-security-authorization.html[access to the {kib} instance
 
 [[built-in-roles-remote-monitoring-agent]] `remote_monitoring_agent`::
 Grants the minimum privileges required to write data into the monitoring indices
-(`.monitoring-*`). This role also has the privileges necessary to create 
-{metricbeat} indices (`metricbeat-*`) and write data into them. 
+(`.monitoring-*`). This role also has the privileges necessary to create
+{metricbeat} indices (`metricbeat-*`) and write data into them.
 
 [[built-in-roles-remote-monitoring-collector]] `remote_monitoring_collector`::
 Grants the minimum privileges required to collect monitoring data for the {stack}.
 
 [[built-in-roles-reporting-user]] `reporting_user`::
 Grants the specific privileges required for users of {reporting} other than those
-required to use {kib}. This role grants access to the reporting indices; each 
+required to use {kib}. This role grants access to the reporting indices; each
 user has access to only their own reports.
-Reporting users should also be assigned additional roles that grant 
+Reporting users should also be assigned additional roles that grant
 {kibana-ref}/xpack-security-authorization.html[access to {kib}] as well as read
 access to the <<roles-indices-priv,indices>> that will be used to generate reports.
 
@@ -158,13 +159,13 @@ the `superuser` role can also manage users and roles and
 <<run-as-privilege, impersonate>> any other user in the system. Due to the
 permissive nature of this role, take extra care when assigning it to a user.
 
-[[built-in-roles-transform-admin]] `transform_admin`:: 
-Grants `manage_transform` cluster privileges, which enable you to manage 
-{transforms}. This role also includes all 
+[[built-in-roles-transform-admin]] `transform_admin`::
+Grants `manage_transform` cluster privileges, which enable you to manage
+{transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-transform-user]] `transform_user`::
-Grants `monitor_transform` cluster privileges, which enable you to use 
+Grants `monitor_transform` cluster privileges, which enable you to use
 {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -59,6 +59,9 @@ All operations on index templates.
 `manage_ingest_pipelines`::
 All operations on ingest node pipelines.
 
+`manage_logstash_pipelines`::
+All operations on logstash pipelines.
+
 `manage_ml`::
 All {ml} operations, such as creating and deleting {dfeeds}, jobs, and model
 snapshots.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -131,6 +131,9 @@ public class ClusterPrivilegeResolver {
     public static final NamedClusterPrivilege MANAGE_OWN_API_KEY = ManageOwnApiKeyClusterPrivilege.INSTANCE;
     public static final NamedClusterPrivilege MANAGE_ENRICH = new ActionClusterPrivilege("manage_enrich", MANAGE_ENRICH_AUTOMATON);
 
+    public static final NamedClusterPrivilege MANAGE_LOGSTASH_PIPELINES = new ActionClusterPrivilege("manage_logstash_pipelines",
+        Set.of("cluster:admin/logstash/pipeline/*"));
+
     private static final Map<String, NamedClusterPrivilege> VALUES = Stream.of(
         NONE,
         ALL,
@@ -167,7 +170,8 @@ public class ClusterPrivilegeResolver {
         READ_SLM,
         DELEGATE_PKI,
         MANAGE_OWN_API_KEY,
-        MANAGE_ENRICH).collect(Collectors.toUnmodifiableMap(NamedClusterPrivilege::name, Function.identity()));
+        MANAGE_ENRICH,
+        MANAGE_LOGSTASH_PIPELINES).collect(Collectors.toUnmodifiableMap(NamedClusterPrivilege::name, Function.identity()));
 
     /**
      * Resolves a {@link NamedClusterPrivilege} from a given name if it exists.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -273,7 +273,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder().indices(HistoryStoreField.INDEX_PREFIX + "*")
                                         .privileges("read")
                                         .build() }, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
-                .put("logstash_admin", new RoleDescriptor("logstash_admin", null, new RoleDescriptor.IndicesPrivileges[] {
+                .put("logstash_admin", new RoleDescriptor("logstash_admin", new String[] {"manage_logstash_pipelines"},
+                    new RoleDescriptor.IndicesPrivileges[] {
                         RoleDescriptor.IndicesPrivileges.builder().indices(".logstash*")
                                 .privileges("create", "delete", "index", "manage", "read").build() },
                         null, MetadataUtils.DEFAULT_RESERVED_METADATA))

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1656,6 +1656,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(logstashAdminRole.cluster().check(ClusterUpdateSettingsAction.NAME, request, authentication), is(false));
         assertThat(logstashAdminRole.cluster().check(DelegatePkiAuthenticationAction.NAME, request, authentication), is(false));
 
+        assertThat(logstashAdminRole.cluster().check("cluster:admin/logstash/pipeline/delete", request, authentication), is(true));
+        assertThat(logstashAdminRole.cluster().check("cluster:admin/logstash/pipeline/get", request, authentication), is(true));
+        assertThat(logstashAdminRole.cluster().check("cluster:admin/logstash/pipeline/put", request, authentication), is(true));
+
         assertThat(logstashAdminRole.runAs().check(randomAlphaOfLengthBetween(1, 30)), is(false));
 
         assertThat(logstashAdminRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction("foo")), is(false));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -15,5 +15,5 @@ setup:
   # This is fragile - it needs to be updated every time we add a new cluster/index privilege
   # I would much prefer we could just check that specific entries are in the array, but we don't have
   # an assertion for that
-  - length: { "cluster" : 36 }
+  - length: { "cluster" : 37 }
   - length: { "index" : 19 }


### PR DESCRIPTION
We added a Logstash xpack plugin that can access system indices in #53350, but we didn't hook it into security roles. This PR will update the current `logstash_admin` role so that the role allows both the old direct access to `.logstash-*` indexes as well as the use of the new plugin.

Closes #63133