### PR TITLE
Remove ml cpp notice check from oss distributions

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -73,7 +73,8 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
             task.dependsOn(checkNotice);
         });
 
-        if (project.getName().contains("zip") || project.getName().contains("tar")) {
+        String projectName = project.getName();
+        if (projectName.contains("oss") == false && (projectName.contains("zip") || projectName.contains("tar"))) {
             project.getExtensions().add("licenseName", "Elastic License");
             project.getExtensions().add("licenseUrl", project.getExtensions().getExtraProperties().get("elasticLicenseUrl"));
             TaskProvider<Task> checkMlCppNoticeTask = registerCheckMlCppNoticeTask(


### PR DESCRIPTION
The ML cpp notice only exists with default distributions, but the check
task exists on all archive distributions. This commit avoids creating
the task for distributions that don't have ML.

closes #63128