### PR TITLE
Scripting: Augment String with Hash support in Watcher (#63346)

### DIFF
--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -8,7 +8,7 @@ esplugin {
   classname 'org.elasticsearch.xpack.watcher.Watcher'
   hasNativeController false
   requiresKeystore false
-  extendedPlugins = ['x-pack-core']
+  extendedPlugins = ['x-pack-core', 'lang-painless']
 }
 
 archivesBaseName = 'x-pack-watcher'
@@ -24,6 +24,7 @@ tasks.named("dependencyLicenses").configure {
 
 dependencies {
   compileOnly project(':server')
+  compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'), configuration: 'default')
   compileOnly project(path: ':modules:transport-netty4')
   compileOnly project(path: ':plugins:transport-nio')

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/90_painless_sha.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/90_painless_sha.yml
@@ -1,0 +1,47 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test String MessageDigest augmentation":
+  - do:
+      watcher.execute_watch:
+        body: >
+          {
+            "watch" : {
+              "trigger": {
+                "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+              },
+              "input": {
+                "simple": {
+                  "hits": {
+                    "hits": [
+                      { "foo": "bar" }
+                    ]
+                  }
+                }
+              },
+              "condition": {
+                "script": {
+                  "source": "ctx.payload.hits.hits[0].keySet().iterator().next().sha1() == \"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33\""
+                }
+              },
+              "transform" : {
+                "script": "return ctx.payload.hits.hits[0].entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().sha256()))"
+              },
+              "actions": {
+                "logging" : {
+                  "logging" : {
+                    "text" : "Transformed: '{{ctx.payload.foo}}'"
+                  }
+                }
+              }
+            }
+          }
+
+  - match: { watch_record.trigger_event.type: "manual" }
+  - match: { watch_record.state: "executed" }
+  - match: { watch_record.status.execution_state: "executed" }
+  - match: { watch_record.result.actions.0.logging.logged_text: "Transformed: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'" }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherPainlessExtension.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherPainlessExtension.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.watcher;
+
+import org.elasticsearch.painless.spi.PainlessExtension;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.xpack.watcher.condition.WatcherConditionScript;
+import org.elasticsearch.xpack.watcher.transform.script.WatcherTransformScript;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WatcherPainlessExtension implements PainlessExtension {
+
+    private static final Whitelist WHITELIST =
+        WhitelistLoader.loadFromResourceFiles(WatcherPainlessExtension.class, "painless_whitelist.txt");
+
+    @Override
+    public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {
+        Map<ScriptContext<?>, List<Whitelist>> contextWhiltelists = new HashMap<>();
+        contextWhiltelists.put(WatcherConditionScript.CONTEXT, Collections.singletonList(WHITELIST));
+        contextWhiltelists.put(WatcherTransformScript.CONTEXT, Collections.singletonList(WHITELIST));
+        return Collections.unmodifiableMap(contextWhiltelists);
+    }
+}

--- a/x-pack/plugin/watcher/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
+++ b/x-pack/plugin/watcher/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
@@ -1,0 +1,1 @@
+org.elasticsearch.xpack.watcher.WatcherPainlessExtension

--- a/x-pack/plugin/watcher/src/main/resources/org/elasticsearch/xpack/watcher/painless_whitelist.txt
+++ b/x-pack/plugin/watcher/src/main/resources/org/elasticsearch/xpack/watcher/painless_whitelist.txt
@@ -1,0 +1,10 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+class java.lang.String {
+  String org.elasticsearch.painless.api.Augmentation sha1()
+  String org.elasticsearch.painless.api.Augmentation sha256()
+}


### PR DESCRIPTION
Strings in the watcher context may use the `.sha1()` and `.sha256()`
augmentation added for ingest.

Ref: #59633, #59671
Fixes: #61244
Backport of: 380ee6f