### PR TITLE
Removes week_year date format

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -148,11 +148,6 @@ public class Joda {
             formatter = ISODateTimeFormat.weekDateTime();
         } else if ("weekDateTimeNoMillis".equals(input) || "week_date_time_no_millis".equals(input)) {
             formatter = ISODateTimeFormat.weekDateTimeNoMillis();
-        } else if ("week_year".equals(input)) {
-            deprecationLogger.getOrCompute()
-                .deprecate("week_year_format_name", "Format name \"week_year\" is deprecated and will be removed in a future version. " +
-                    "Use \"weekyear\" format instead");
-            formatter = ISODateTimeFormat.weekyear();
         } else if ("weekyear".equals(input) ) {
             formatter = ISODateTimeFormat.weekyear();
         } else if ("weekyearWeek".equals(input) || "weekyear_week".equals(input)) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1170,10 +1170,6 @@ public class DateFormatters {
     /*
      * Returns a formatter for a four digit weekyear. (YYYY)
      */
-    private static final DateFormatter WEEK_YEAR = new JavaDateFormatter("week_year",
-        new DateTimeFormatterBuilder().appendValue(WEEK_FIELDS_ROOT.weekBasedYear()).toFormatter(Locale.ROOT)
-                                      .withResolverStyle(ResolverStyle.STRICT));
-
     private static final DateFormatter WEEKYEAR = new JavaDateFormatter("weekyear",
         new DateTimeFormatterBuilder().appendValue(WEEK_FIELDS_ROOT.weekBasedYear()).toFormatter(Locale.ROOT)
             .withResolverStyle(ResolverStyle.STRICT));
@@ -1723,11 +1719,6 @@ public class DateFormatters {
             return WEEK_DATE_TIME;
         } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
             return WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.WEEK_YEAR.matches(input)) {
-            deprecationLogger.getOrCompute()
-                .deprecate("week_year_format_name", "Format name \"week_year\" is deprecated and will be removed in a future version. " +
-                    "Use \"weekyear\" format instead");
-            return WEEK_YEAR;
         } else if (FormatNames.WEEKYEAR.matches(input)) {
             return WEEKYEAR;
         } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {

--- a/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/elasticsearch/common/time/FormatNames.java
@@ -58,7 +58,6 @@ public enum FormatNames {
     WEEK_DATE("week_date"),
     WEEK_DATE_TIME("week_date_time"),
     WEEK_DATE_TIME_NO_MILLIS("week_date_time_no_millis"),
-    WEEK_YEAR("week_year"),
     WEEKYEAR("weekyear"),
     WEEK_YEAR_WEEK("weekyear_week"),
     WEEKYEAR_WEEK_DAY("weekyear_week_day"),

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -128,7 +128,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -871,9 +870,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Generate a random valid date formatter pattern.
      */
     public static String randomDateFormatterPattern() {
-        //WEEKYEAR should be used instead of WEEK_YEAR
-        EnumSet<FormatNames> formatNames = EnumSet.complementOf(EnumSet.of(FormatNames.WEEK_YEAR));
-        return randomFrom(formatNames).getName();
+        return randomFrom(FormatNames.values()).getName();
     }
 
     /**


### PR DESCRIPTION
week_year is replaced by weekyear. This is a single field YYYY date
format.
follow up after a deprecation https://github.com/elastic/elasticsearch/pull/63307
relates #60707

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
