### PR TITLE
SnapshotShardSizeInfo should prefer default value when provided (#63390)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -490,9 +490,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return targetShardSize == 0 ? defaultValue : targetShardSize;
         } else {
             if (shard.unassigned() && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
-                final Long shardSize = snapshotShardSizeInfo.getShardSize(shard);
-                assert shardSize != null : "no shard size provided for " + shard;
-                return shardSize;
+                return snapshotShardSizeInfo.getShardSize(shard, defaultValue);
             }
             return clusterInfo.getShardSize(shard, defaultValue);
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardSizeInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardSizeInfo.java
@@ -48,6 +48,9 @@ public class SnapshotShardSizeInfo {
 
     public long getShardSize(ShardRouting shardRouting, long fallback) {
         final Long shardSize = getShardSize(shardRouting);
-        return shardSize == null ? fallback : shardSize;
+        if (shardSize == null || shardSize == ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE) {
+            return fallback;
+        }
+        return shardSize;
     }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -225,7 +225,7 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
         final Predicate<Long> failedSnapshotShardSizeRetrieval = shardSize -> shardSize == Long.MIN_VALUE;
         assertBusy(() -> {
             assertThat(snapshotsInfoService.numberOfKnownSnapshotShardSizes(),
-                equalTo((int) results.values().stream().filter(Predicate.not(failedSnapshotShardSizeRetrieval)).count()));
+                equalTo((int) results.values().stream().filter(size -> failedSnapshotShardSizeRetrieval.test(size) == false).count()));
             assertThat(snapshotsInfoService.numberOfFailedSnapshotShardSizes(),
                 equalTo((int) results.values().stream().filter(failedSnapshotShardSizeRetrieval).count()));
             assertThat(snapshotsInfoService.numberOfUnknownSnapshotShardSizes(), equalTo(0));


### PR DESCRIPTION
In #61906 we agreed on always providing the default value 
ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE 
when the SnasphotInfoService failed to retrieve the exact 
size for a given snapshot shard. The motivation was to 
allow the shard allocation to move forward in case of 
failures (so that the unassigned shard does not get stuck 
in an unassigned state for too long) while relying on the 
fallback values for shard sizes.

Sadly a bug in the 
SnapshotShardSizeInfo#getShardSize(ShardRouting, long) 
makes the default value to be ignored when the snapshot 
shard size retrieval previously failed, returning 
ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE 
instead of the provided default value. With DiskThresholdDecider 
also not relying on the provided default value this triggers 
some assertion like in #63376 which helped us to spot the bug.

Closes ##63376