### PR TITLE
Add searchAnalyzer method to QueryShardContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -971,7 +971,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         // set analyzer
         Analyzer analyzerObj = context.getIndexAnalyzers().get(analyzer);
         if (analyzerObj == null) {
-            analyzerObj = context.searchAnalyzer();
+            analyzerObj = context.getSearchAnalyzer();
         }
         mltQuery.setAnalyzer(analyzerObj);
 

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -971,7 +971,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         // set analyzer
         Analyzer analyzerObj = context.getIndexAnalyzers().get(analyzer);
         if (analyzerObj == null) {
-            analyzerObj = context.getMapperService().searchAnalyzer();
+            analyzerObj = context.searchAnalyzer();
         }
         mltQuery.setAnalyzer(analyzerObj);
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -258,6 +258,10 @@ public class QueryShardContext extends QueryRewriteContext {
         return mapperService.searchAnalyzer();
     }
 
+    public Analyzer searchAnalyzer() {
+        return this.mapperService.searchAnalyzer();
+    }
+
     /**
      * Gets the search quote analyzer for the given field, or the default if there is none present for the field
      * TODO: remove this by moving defaults into mappers themselves

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -258,7 +258,10 @@ public class QueryShardContext extends QueryRewriteContext {
         return mapperService.searchAnalyzer();
     }
 
-    public Analyzer searchAnalyzer() {
+    /**
+     * Returns the default search analyzer
+     */
+    public Analyzer getSearchAnalyzer() {
         return this.mapperService.searchAnalyzer();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -105,7 +105,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param defaultField The default field for query terms.
      */
     public QueryStringQueryParser(QueryShardContext context, String defaultField) {
-        this(context, defaultField, Collections.emptyMap(), false, context.getMapperService().searchAnalyzer());
+        this(context, defaultField, Collections.emptyMap(), false, context.searchAnalyzer());
     }
 
     /**
@@ -114,7 +114,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
     public QueryStringQueryParser(QueryShardContext context, String defaultField, boolean lenient) {
-        this(context, defaultField, Collections.emptyMap(), lenient, context.getMapperService().searchAnalyzer());
+        this(context, defaultField, Collections.emptyMap(), lenient, context.searchAnalyzer());
     }
 
     /**
@@ -122,7 +122,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param fieldsAndWeights The default fields and weights expansion for query terms
      */
     public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights) {
-        this(context, null, fieldsAndWeights, false, context.getMapperService().searchAnalyzer());
+        this(context, null, fieldsAndWeights, false, context.searchAnalyzer());
     }
 
     /**
@@ -131,7 +131,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
     public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights, boolean lenient) {
-        this(context, null, fieldsAndWeights, lenient, context.getMapperService().searchAnalyzer());
+        this(context, null, fieldsAndWeights, lenient, context.searchAnalyzer());
     }
 
     /**
@@ -142,7 +142,7 @@ public class QueryStringQueryParser extends XQueryParser {
     public QueryStringQueryParser(QueryShardContext context, boolean lenient) {
         this(context, "*",
             resolveMappingField(context, "*", 1.0f, false, false, null),
-            lenient, context.getMapperService().searchAnalyzer());
+            lenient, context.searchAnalyzer());
     }
 
     private QueryStringQueryParser(QueryShardContext context, String defaultField,

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -105,7 +105,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param defaultField The default field for query terms.
      */
     public QueryStringQueryParser(QueryShardContext context, String defaultField) {
-        this(context, defaultField, Collections.emptyMap(), false, context.searchAnalyzer());
+        this(context, defaultField, Collections.emptyMap(), false, context.getSearchAnalyzer());
     }
 
     /**
@@ -114,7 +114,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
     public QueryStringQueryParser(QueryShardContext context, String defaultField, boolean lenient) {
-        this(context, defaultField, Collections.emptyMap(), lenient, context.searchAnalyzer());
+        this(context, defaultField, Collections.emptyMap(), lenient, context.getSearchAnalyzer());
     }
 
     /**
@@ -122,7 +122,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param fieldsAndWeights The default fields and weights expansion for query terms
      */
     public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights) {
-        this(context, null, fieldsAndWeights, false, context.searchAnalyzer());
+        this(context, null, fieldsAndWeights, false, context.getSearchAnalyzer());
     }
 
     /**
@@ -131,7 +131,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
     public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights, boolean lenient) {
-        this(context, null, fieldsAndWeights, lenient, context.searchAnalyzer());
+        this(context, null, fieldsAndWeights, lenient, context.getSearchAnalyzer());
     }
 
     /**
@@ -142,7 +142,7 @@ public class QueryStringQueryParser extends XQueryParser {
     public QueryStringQueryParser(QueryShardContext context, boolean lenient) {
         this(context, "*",
             resolveMappingField(context, "*", 1.0f, false, false, null),
-            lenient, context.searchAnalyzer());
+            lenient, context.getSearchAnalyzer());
     }
 
     private QueryStringQueryParser(QueryShardContext context, String defaultField,


### PR DESCRIPTION
Some callers of `QueryShardContext#getMapperService` only need to retrieve the search analyzer from the `MapperService`. With this commit we add a `getSearchAnalyzer` method to `QueryShardContext` which can be called directly without having direct access to `MapperService`
