### PR TITLE
[DOCS] Adds huber and msle metrics to Evaluate API example calls

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -318,7 +318,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.price_prediction", <4>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }
@@ -355,7 +357,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }
@@ -394,7 +398,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -319,8 +319,8 @@ POST _ml/data_frame/_evaluate
       "metrics": {  
         "r_squared": {},
         "mse": {},
-        "msle": {},
-        "huber": {}
+        "msle": {"offset": 10},
+        "huber": {"delta": 1.5}
       }
     }
   }


### PR DESCRIPTION
## Overview

This PR adds `msle` and `huber` metrics to the example API calls in the Evaluate regression docs.

### Preview

[Evaluate regression](https://elasticsearch_63414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html#ml-evaluate-regression-example)