### PR TITLE
EQL: Avoid filtering on tiebreakers

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_extra.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_extra.toml
@@ -6,7 +6,7 @@ query = '''
     [ ERROR where true ]
     [ STAT where true ]
 '''
-expected_event_ids  = [1,2,3]
+expected_event_ids  = [1,2,3,1,2,3]
 
 [[queries]]
 name = "basicWithFilter"

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
@@ -7,9 +7,7 @@
 package org.elasticsearch.xpack.eql;
 
 import org.elasticsearch.test.eql.EqlExtraSpecTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 
-@TestLogging(value = "org.elasticsearch.xpack.eql:TRACE", reason = "results logging")
 public class EqlExtraIT extends EqlExtraSpecTestCase {
 
     public EqlExtraIT(String query, String name, long[] eventIds) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -72,7 +72,7 @@ public class ExecutionManager {
             if (query instanceof EsQueryExec) {
                 SearchSourceBuilder source = ((EsQueryExec) query).source(session);
                 QueryRequest original = () -> source;
-                BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName, tiebreakerName);
+                BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName);
                 Criterion<BoxedQueryRequest> criterion =
                         new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i == 0 && descending);
                 criteria.add(criterion);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
@@ -17,7 +17,7 @@ public class Ordinal implements Comparable<Ordinal> {
         this.timestamp = timestamp;
         this.tiebreaker = tiebreaker;
     }
-    
+
     public long timestamp() {
         return timestamp;
     }
@@ -36,11 +36,11 @@ public class Ordinal implements Comparable<Ordinal> {
         if (this == obj) {
             return true;
         }
-        
+
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        
+
         Ordinal other = (Ordinal) obj;
         return Objects.equals(timestamp, other.timestamp)
                 && Objects.equals(tiebreaker, other.tiebreaker);
@@ -79,6 +79,22 @@ public class Ordinal implements Comparable<Ordinal> {
 
     public boolean between(Ordinal left, Ordinal right) {
         return (compareTo(left) <= 0 && compareTo(right) >= 0) || (compareTo(right) <= 0 && compareTo(left) >= 0);
+    }
+
+    public boolean before(Ordinal other) {
+        return compareTo(other) < 0;
+    }
+
+    public boolean beforeOrAt(Ordinal other) {
+        return compareTo(other) <= 0;
+    }
+
+    public boolean after(Ordinal other) {
+        return compareTo(other) > 0;
+    }
+
+    public boolean afterOrAt(Ordinal other) {
+        return compareTo(other) >= 0;
     }
 
     public Object[] toArray() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
@@ -76,6 +76,8 @@ public abstract class SourceGenerator {
             }
         }
 
+        optimize(container, source);
+
         return source;
     }
 
@@ -94,7 +96,7 @@ public abstract class SourceGenerator {
                     sortBuilder = fieldSort(fa.name())
                             .missing(as.missing().position())
                             .unmappedType(fa.dataType().esType());
-                    
+
                     if (fa.isNested()) {
                         FieldSortBuilder fieldSort = fieldSort(fa.name())
                                 .missing(as.missing().position())
@@ -134,8 +136,6 @@ public abstract class SourceGenerator {
     }
 
     private static void optimize(QueryContainer query, SearchSourceBuilder builder) {
-        if (query.shouldTrackHits()) {
-            builder.trackTotalHits(true);
-        }
+        builder.trackTotalHits(query.shouldTrackHits());
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -217,8 +217,9 @@ public class TumblingWindow implements Executable {
 
         client.query(request, wrap(r -> {
             Ordinal boundary = reversed ? window.begin : window.end;
+            List<SearchHit> hits = searchHits(r);
             // filter hits that are escaping the window (same timestamp but different tiebreaker)
-            List<SearchHit> hits = trim(searchHits(r), criterion, boundary, reversed);
+            hits = trim(hits, criterion, boundary, reversed);
 
             log.trace("Found [{}] hits", hits.size());
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -264,7 +264,7 @@ public class TumblingWindow implements Executable {
             }
 
             // keep running the query runs out of the results (essentially returns less than what we want)
-            // however check if the window has been fully consumed consumed
+            // however check if the window has been fully consumed
             if (hits.size() == windowSize && request.after().before(boundary)) {
                 secondaryCriterion(window, currentStage, listener);
             }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -56,10 +56,12 @@ public class TumblingWindow implements Executable {
 
     private static class WindowInfo {
         private final int baseStage;
+        private final Ordinal begin;
         private final Ordinal end;
 
-        WindowInfo(int baseStage, Ordinal end) {
+        WindowInfo(int baseStage, Ordinal begin, Ordinal end) {
             this.baseStage = baseStage;
+            this.begin = begin;
             this.end = end;
         }
     }
@@ -104,12 +106,20 @@ public class TumblingWindow implements Executable {
 
         log.trace("Found [{}] hits", hits.size());
 
+        Ordinal begin = null, end = null;
         if (hits.isEmpty() == false) {
             if (matcher.match(baseStage, wrapValues(base, hits)) == false) {
                 payload(listener);
                 return;
             }
+
+            // get borders for the rest of the queries - but only when at least one result is found
+            begin = base.ordinal(hits.get(0));
+            end = base.ordinal(hits.get(hits.size() - 1));
+
+            log.trace("Found base [{}] window {}->{}", base.stage(), begin, end);
         }
+
 
         // only one result means there aren't going to be any matches
         // so move the window boxing to the next stage
@@ -121,7 +131,7 @@ public class TumblingWindow implements Executable {
                 if (until != null && hits.size() == 1) {
                     // find "until" ordinals - early on to discard data in-flight to avoid matching
                     // hits that can occur in other documents
-                    untilCriterion(new WindowInfo(baseStage, base.ordinal(hits.get(0))), listener, next);
+                    untilCriterion(new WindowInfo(baseStage, begin, end), listener, next);
                 } else {
                     next.run();
                 }
@@ -133,16 +143,10 @@ public class TumblingWindow implements Executable {
             return;
         }
 
-        // get borders for the rest of the queries
-        Ordinal begin = base.ordinal(hits.get(0));
-        Ordinal end = base.ordinal(hits.get(hits.size() - 1));
-
         // update current query for the next request
         base.queryRequest().nextAfter(end);
 
-        log.trace("Found base [{}] window {}->{}", base.stage(), begin, end);
-
-        WindowInfo info = new WindowInfo(baseStage, end);
+        WindowInfo info = new WindowInfo(baseStage, begin, end);
 
         // no more queries to run
         if (baseStage + 1 < maxStages) {
@@ -212,7 +216,9 @@ public class TumblingWindow implements Executable {
         log.trace("Querying (secondary) stage [{}] {}", criterion.stage(), request);
 
         client.query(request, wrap(r -> {
-            List<SearchHit> hits = searchHits(r);
+            Ordinal boundary = reversed ? window.begin : window.end;
+            // filter hits that are escaping the window (same timestamp but different tiebreaker)
+            List<SearchHit> hits = trim(searchHits(r), criterion, boundary, reversed);
 
             log.trace("Found [{}] hits", hits.size());
 
@@ -220,9 +226,9 @@ public class TumblingWindow implements Executable {
             if (hits.isEmpty()) {
                 // put the markers in place before the next call
                 if (reversed) {
-                    request.to(window.end);
-                } else {
                     request.from(window.end);
+                } else {
+                    request.to(window.end);
                 }
 
                 // if there are no candidates, advance the window
@@ -235,7 +241,19 @@ public class TumblingWindow implements Executable {
             }
             else {
                 // prepare the query for the next search
-                request.nextAfter(criterion.ordinal(hits.get(hits.size() - 1)));
+                // however when dealing with tiebreakers the same timestamp can contain different values that might
+                // be within or outside the window
+                // to make sure one is not lost, check the minimum ordinal between the one found (which might just outside
+                // the window - same timestamp but a higher tiebreaker) and the actual window end
+                Ordinal next = criterion.ordinal(hits.get(hits.size() - 1));
+
+                log.trace("Found range [{}] -> [{}]", criterion.ordinal(hits.get(0)), next);
+
+                // if the searchAfter is outside the window, trim it down
+                if (next.after(boundary)) {
+                    next = boundary;
+                }
+                request.nextAfter(next);
 
                 // if the limit has been reached, return what's available
                 if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
@@ -245,7 +263,8 @@ public class TumblingWindow implements Executable {
             }
 
             // keep running the query runs out of the results (essentially returns less than what we want)
-            if (hits.size() == windowSize) {
+            // however check if the window has been fully consumed consumed
+            if (hits.size() == windowSize && request.after().before(boundary)) {
                 secondaryCriterion(window, currentStage, listener);
             }
             // looks like this stage is done, move on
@@ -259,8 +278,25 @@ public class TumblingWindow implements Executable {
                     advance(window.baseStage, listener);
                 }
             }
-
         }, listener::onFailure));
+    }
+
+    /**
+     * Trim hits outside the (upper) limit.
+     */
+    private List<SearchHit> trim(List<SearchHit> searchHits, Criterion<BoxedQueryRequest> criterion, Ordinal boundary, boolean reversed) {
+        int offset = 0;
+
+        for (int i = searchHits.size() - 1; i >=0 ; i--) {
+            Ordinal ordinal = criterion.ordinal(searchHits.get(i));
+            boolean withinBoundaries = reversed ? ordinal.afterOrAt(boundary) : ordinal.beforeOrAt(boundary);
+            if (withinBoundaries == false) {
+                offset++;
+            } else {
+                break;
+            }
+        }
+        return offset == 0 ? searchHits : searchHits.subList(0, searchHits.size() - offset);
     }
 
     /**
@@ -285,6 +321,10 @@ public class TumblingWindow implements Executable {
         } else {
             // otherwise just the upper limit
             request.to(window.end);
+            // and the lower limit if it hasn't been set
+            if (request.after() == null) {
+                request.nextAfter(window.begin);
+            }
         }
 
         return reverse;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 
 import static org.elasticsearch.action.ActionListener.wrap;
+import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 
 public class EqlSession {
 
@@ -65,8 +66,7 @@ public class EqlSession {
     }
 
     public void eql(String eql, ParserParams params, ActionListener<Results> listener) {
-        eqlExecutable(eql, params, wrap(e -> e.execute(this, wrap(p -> listener.onResponse(Results.fromPayload(p)), listener::onFailure)),
-                listener::onFailure));
+        eqlExecutable(eql, params, wrap(e -> e.execute(this, map(listener, Results::fromPayload)), listener::onFailure));
     }
 
     public void eqlExecutable(String eql, ParserParams params, ActionListener<PhysicalPlan> listener) {
@@ -78,11 +78,11 @@ public class EqlSession {
     }
 
     public void physicalPlan(LogicalPlan optimized, ActionListener<PhysicalPlan> listener) {
-        optimizedPlan(optimized, wrap(o -> listener.onResponse(planner.plan(o)), listener::onFailure));
+        optimizedPlan(optimized, map(listener, planner::plan));
     }
 
     public void optimizedPlan(LogicalPlan verified, ActionListener<LogicalPlan> listener) {
-        analyzedPlan(verified, wrap(v -> listener.onResponse(optimizer.optimize(v)), listener::onFailure));
+        analyzedPlan(verified, map(listener, optimizer::optimize));
     }
 
     public void analyzedPlan(LogicalPlan parsed, ActionListener<LogicalPlan> listener) {
@@ -91,18 +91,18 @@ public class EqlSession {
             return;
         }
 
-        preAnalyze(parsed, wrap(p -> listener.onResponse(postAnalyze(analyzer.analyze(p))), listener::onFailure));
+        preAnalyze(parsed, map(listener, p -> postAnalyze(analyzer.analyze(p))));
     }
 
     private <T> void preAnalyze(LogicalPlan parsed, ActionListener<LogicalPlan> listener) {
         String indexWildcard = configuration.indexAsWildcard();
         if(configuration.isCancelled()){
-            throw new TaskCancelledException("cancelled");
+            listener.onFailure(new TaskCancelledException("cancelled"));
+            return;
         }
         indexResolver.resolveAsMergedMapping(indexWildcard, null, configuration.includeFrozen(), configuration.filter(),
-            wrap(r -> {
-                listener.onResponse(preAnalyzer.preAnalyze(parsed, r));
-            }, listener::onFailure));
+            map(listener, r -> preAnalyzer.preAnalyze(parsed, r))
+        );
     }
 
     private LogicalPlan postAnalyze(LogicalPlan verified) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -95,7 +95,7 @@ public class SequenceSpecTests extends ESTestCase {
 
         TestCriterion(final int ordinal) {
             super(ordinal,
-                  new BoxedQueryRequest(() -> SearchSourceBuilder.searchSource().query(matchAllQuery()).size(ordinal), "timestamp", null),
+                  new BoxedQueryRequest(() -> SearchSourceBuilder.searchSource().query(matchAllQuery()).size(ordinal), "timestamp"),
                   keyExtractors,
                   tsExtractor, tbExtractor, false);
             this.ordinal = ordinal;

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.eql.execution.assembler;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
 import org.elasticsearch.ExceptionsHelper;

--- a/x-pack/plugin/eql/src/test/resources/sequences.series-spec
+++ b/x-pack/plugin/eql/src/test/resources/sequences.series-spec
@@ -4,12 +4,27 @@
 //
 // A spec is defined by its name, followed by lines describing the events for each criteria
 // followed by the expected result.
-// 
+//
 
 // events describe in one line per join/seq rule
 // the number following the string is used as a timestamp/order
-// while the optional prefix followed by | indicates the key 
+// while the optional prefix followed by | indicates the key
 
+// since the spec checks the way matching is done
+// which is based on the runtime component that can make multiple requests
+// use X99 as an token to force results from other lines to be read in
+
+// For example
+// A1 A2
+//       B3
+// fails because B3 should not be read in its first call as it goes beyond A1/A2 window.
+// however the testing infrastructure doesn't know this so it returns the item
+// which is then discarded.
+// To avoid the runtime filtering leaking in, adding an extra token at the end forces
+// the runtime window to be expanded and thus for all results to be properly read:
+//
+// A1 A2      X99 (event occurring last in the base query)
+//       B3
 
 // spec name
 trivialSequence
@@ -54,7 +69,7 @@ A3 B4
 ;
 
 basicSequenceMergingPreviousStage
-A1 A2
+A1 A2    X99
       B3
 ;
 A2 B3
@@ -68,7 +83,7 @@ A1 B2
 ;
 
 basicSequenceWithDualMergingPreviousStage
-A1 A2   A4 A5 A6    A8 A9 
+A1 A2   A4 A5 A6    A8 A9
       B3         B7
 ;
 A2 B3
@@ -91,15 +106,15 @@ A3 B4
 
 
 basicSequenceMergingCurrentStage
-A1 A2    
-      B3 B4 
+A1 A2       X99
+      B3 B4
 ;
 A2 B3
 ;
 
 basicSequenceWithMergingCurrentStageAndLeftOverInPreviousStage
 A1 A2       A5
-      B3 B4 
+      B3 B4
 ;
 A2 B3
 ;
@@ -120,47 +135,47 @@ A4 B5
 threeStageBasicSequence
 A1     A4
   B2      B5
-    C3      C6 
+    C3      C6
 ;
 A1 B2 C3
 A4 B5 C6
 ;
 
 threeStageWithOverridingSequence
-A1  A3
+A1  A3      X99
   B2  B4
          C5
-;         
-A3 B4 C5 
+;
+A3 B4 C5
 ;
 
 threeStageWithOverridingSequenceOnSecondStage
-A1  
+A1
   B2  B4
     C3
-;         
-A1 B2 C3 
+;
+A1 B2 C3
 ;
 
 threeStageWithNoise
-      A4   A6
-  B2    B5   
+      A4   A6       X99
+  B2    B5
 C1  C3        C7
 ;
 
 A4 B5 C7
 ;
 
-threeStageWithIntermitentUpdates
-A1      A4
+threeStageWithIntermittentUpdates
+A1      A4          X99
      B3    B5
   C2          C6
 ;
 A4 B5 C6
 ;
 
-threeStageWithMoreIntermitentUpdates
-A1      A4    A6   
+threeStageWithMoreIntermittentUpdates
+A1      A4    A6            X99
      B3    B5   B7 B8
   C2                  C9
 ;
@@ -168,15 +183,15 @@ A6 B7 C9
 ;
 
 threeStageWithReverseMatch
-    A3  A5    A8
-  B2        B7  
+    A3  A5    A8        X99
+  B2        B7
 C1    C4  C6    C9
 ;
 A5 B7 C9
 ;
 
 threeStageWithLeftoversOnTheLastStage
-A1  A3  A5
+A1  A3  A5                  X99
   B2  B4  B6
             C7 C8 C9 C10
 ;
@@ -184,7 +199,7 @@ A5 B6 C7
 ;
 
 threeStageWithOverlap
-A1   A3
+A1   A3             X99
   B2       B5
         C4    B6
 ;
@@ -207,7 +222,7 @@ A5 B6 C7 D8
 ;
 
 fourStageIncomplete
-A1      A5
+A1      A5          X99
   B2       B6
     C3       C7
                D8
@@ -216,7 +231,7 @@ A5 B6 C7 D8
 ;
 
 fourStageOverlapping
-A1      A4
+A1      A4              X99
   B2       B5
      C3          C7
              D6     D8
@@ -233,10 +248,10 @@ A4 B5 C7 D8
 
 exampleWithTwoStagesAndKeyFromTheDocs
 
-r|W1 r|W2                u|W6 r|W7 
+r|W1 r|W2                u|W6 r|W7                          x|X99
           u|H3 r|H4 r|H5           u|H8
                                         r|I9 u|I10 r|I11
 ;
 r|W2 H4 I9
 u|W6 H8 I10
-;                
+;

--- a/x-pack/plugin/eql/src/test/resources/sequences.series-spec
+++ b/x-pack/plugin/eql/src/test/resources/sequences.series-spec
@@ -10,17 +10,19 @@
 // the number following the string is used as a timestamp/order
 // while the optional prefix followed by | indicates the key
 
-// since the spec checks the way matching is done
-// which is based on the runtime component that can make multiple requests
-// use X99 as an token to force results from other lines to be read in
+// since the spec checks only the way matching is done it returns
+// all the results in the first call and then an empty list.
+// Since the runtime component can make multiple requests and thus discard
+// returned data, use X99 as an token to force results from other lines
+// to be read in (as it makes a larger window for the runtime)
 
 // For example
 // A1 A2
 //       B3
 // fails because B3 should not be read in its first call as it goes beyond A1/A2 window.
 // however the testing infrastructure doesn't know this so it returns the item
-// which is then discarded.
-// To avoid the runtime filtering leaking in, adding an extra token at the end forces
+// which is then discarded. On the next call, empty results are returned.
+// To avoid the runtime behavior leaking in, adding an extra token at the end forces
 // the runtime window to be expanded and thus for all results to be properly read:
 //
 // A1 A2      X99 (event occurring last in the base query)
@@ -69,7 +71,7 @@ A3 B4
 ;
 
 basicSequenceMergingPreviousStage
-A1 A2    X99
+A1 A2       X99
       B3
 ;
 A2 B3


### PR DESCRIPTION
Do not filter by tiebreaker while searching sequence matches as
it's not monotonic and thus can filter out valid data.
Add handling for data 'near' the boundary that has the same timestamp
but different tie-breaker and thus can be just outside the window.

Fix #62781
Relates #63215