### PR TITLE
[7.9][DOCS] Adds a note on renaming mean_sqared_error to mse

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -132,7 +132,8 @@ which outputs a prediction of values.
   `mse`:::
     (Optional, object) Average squared difference between the predicted values 
     and the actual (`ground truth`) value. For more information, read 
-    {wikipedia}/Mean_squared_error[this wiki article].
+    {wikipedia}/Mean_squared_error[this wiki article]. (This metric was called 
+    `mean_squared_error` prior to 7.9).
 
   `msle`:::
     (Optional, object) Average squared difference between the logarithm of the 


### PR DESCRIPTION
## Overview

This PR adds a note to the `mse` regression evaluation metrics on it has been called `mean_squared_error` prior to 7.9.

### Preview

[Regression evaluation objects](https://elasticsearch_63417.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.9/evaluate-dfanalytics.html#regression-evaluation-resources)