### PR TITLE
[DOCS] Add props for searchable snapshots API links

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1186,7 +1186,9 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
+ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
+endif::[]
 
 [role="exclude",id="searchable-snapshots-api-stats"]
 === Searchable snapshot statistics API
@@ -1195,7 +1197,9 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
+ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
+endif::[]
 
 [role="exclude",id="searchable-snapshots-repository-stats"]
 === Searchable snapshot repository statistics API
@@ -1204,7 +1208,9 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
+ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
+endif::[]
 
 [role="exclude",id="avoid-oversharding"]
 === Avoid oversharding

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -33,7 +33,9 @@ endif::[]
 * <<repositories-metering-apis,Repositories Metering APIs>>
 * <<rollup-apis,Rollup APIs>>
 * <<search, Search APIs>>
+ifdef::permanently-unreleased-branch[]
 * <<searchable-snapshots-apis, Searchable snapshots APIs>>
+endif::[]
 * <<security-api,Security APIs>>
 * <<snapshot-restore-apis,Snapshot and restore APIs>>
 * <<snapshot-lifecycle-management-api,Snapshot lifecycle management APIs>>


### PR DESCRIPTION
This PR addresses the following docs build failure in 7.10:

>  WARNING: invalid reference: searchable-snapshots-apis

It adds the ifdef qualifiers around all the links to that API.