### PR TITLE
[7.10] [DOCS] Add xref to data tiers content (#63426)

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -68,10 +68,10 @@ kept in heap memory.
 [[shard-auto-balance]]
 ==== {es} automatically balances shards within a data tier
 
-A cluster's nodes are grouped into data tiers. Within each tier, {es}
-attempts to spread an index's shards across as many nodes as possible. When you
-add a new node or a node fails, {es} automatically rebalances the index's shards
-across the tier's remaining nodes.
+A cluster's nodes are grouped into <<data-tiers,data tiers>>. Within each tier,
+{es} attempts to spread an index's shards across as many nodes as possible. When
+you add a new node or a node fails, {es} automatically rebalances the index's
+shards across the tier's remaining nodes.
 
 [discrete]
 [[shard-size-best-practices]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add xref to data tiers content (#63426)