### PR TITLE
Use default memory settings for Gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
-options.forkOptions.memoryMaximumSize=2g
+org.gradle.jvmargs=-Xms3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xms3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
The current jvm arguments specified in our `gradle.properties` file set a _maximum_ heap size of 3GB. This has served us well, but as we add more projects and more complexity to the build we are starting to his this threshold, especially when switching between disparate branches. There is still likely some improvements we can make to reduce overall heap usage in this scenario but for now we want to give developers some breathing room. This PR changes our JVM args so we set the _initial_ heap at 3GB, effectively specifying a _minimum_ memory availability requirement. Gradle will then determine the optimal maximum heap size given the available memory on the system. Since most folks are probably working on systems with 32GB of RAM or more, makes sense to make use of those available resources.