### PR TITLE
[7.x] Fix incorrect use of Format.equals instead of matches

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -157,7 +157,7 @@ public class Joda {
             formatter = ISODateTimeFormat.weekDateTime();
         } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
             formatter = ISODateTimeFormat.weekDateTimeNoMillis();
-        } else if (FormatNames.WEEKYEAR.equals(input)) {
+        } else if (FormatNames.WEEKYEAR.matches(input)) {
             getDeprecationLogger()
                 .deprecate("week_year_format_name", "Format name \"week_year\" is deprecated and will be removed in a future version. " +
                     "Use \"weekyear\" format instead");

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -251,7 +251,6 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 //        assertSamePrinterOutput("E, d MMM yyyy HH:mm:ss Z", LocaleUtils.parse("de"), javaTimeNow, dateTimeNow);
 //    }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63459")
     public void testDuellingFormatsValidParsing() {
         assertSameDate("1522332219", "epoch_second");
         assertSameDate("0", "epoch_second");
@@ -761,7 +760,6 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2012-W1-1", "strict_weekyear_week_day");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63459")
     public void testSamePrinterOutput() {
         int year = randomIntBetween(1970, 2030);
         int month = randomIntBetween(1, 12);


### PR DESCRIPTION
closes #63459