### PR TITLE
[7.10] [ML] fix grabbing the doc value limit setting in _explain (#63402)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsRestIT.java
@@ -117,8 +117,7 @@ public class ExplainDataFrameAnalyticsRestIT extends ESRestTestCase {
             addSecondaryAuthHeader(options, ML_ADMIN);
             explain.setOptions(options);
             // Should throw
-            ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(explain));
-            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            expectThrows(ResponseException.class, () -> client().performRequest(explain));
         }
         { // request with secondary headers with perms
             Request explain = explainRequestViaConfig(config);
@@ -160,8 +159,7 @@ public class ExplainDataFrameAnalyticsRestIT extends ESRestTestCase {
             addSecondaryAuthHeader(options, ML_ADMIN);
             explain.setOptions(options);
             // Should throw
-            ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(explain));
-            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            expectThrows(ResponseException.class, () -> client().performRequest(explain));
         }
         { // request with secondary headers with perms
             Request explain = explainRequestConfigId(configId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -376,8 +376,10 @@ public class ExtractedFieldsDetector {
         if (preferSource) {
             extractedFields = fetchFromSourceIfSupported(extractedFields);
             if (extractedFields.getDocValueFields().size() > docValueFieldsLimit) {
-                throw ExceptionsHelper.badRequestException("[{}] fields must be retrieved from doc_values but the limit is [{}]; " +
-                        "please adjust the index level setting [{}]", extractedFields.getDocValueFields().size(), docValueFieldsLimit,
+                throw ExceptionsHelper.badRequestException(
+                    "[{}] fields must be retrieved from doc_values and this is greater than the configured limit. " +
+                        "Please adjust the index level setting [{}]",
+                    extractedFields.getDocValueFields().size(),
                     IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.getKey());
             }
         }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [ML] fix grabbing the doc value limit setting in _explain (#63402)