### PR TITLE
[7.x] [DOCS] Move searchable snapshots to beta (#63436)

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -72,11 +72,9 @@ tier should be configured to use one or more replicas.
 The cold tier is made of one or more nodes that have the <<data-cold-node, data_cold>> role.
 Once the data in the <<warm-tier, warm tier>> is not updated anymore it can transition to the
 cold tier. The cold tier is still a responsive query tier but as the data transitions into this
-tier it can be compressed, shrunken, or configured to have zero replicas and be backed by snapshot. The cold tier is usually hosting the data from recent
+tier it can be compressed, shrunken, or configured to have zero replicas and be backed by
+a <<ilm-searchable-snapshot, snapshot>>. The cold tier is usually hosting the data from recent
 months or years.
-ifdef::permanently-unreleased-branch[]
-See <<ilm-searchable-snapshot>>.
-endif::[]
 
 [discrete]
 [[data-tier-allocation]]

--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -6,17 +6,16 @@ Phases allowed: delete.
 
 Permanently removes the index.
 
-ifdef::permanently-unreleased-branch[]
 [[ilm-delete-options]]
 ==== Options
 
 `delete_searchable_snapshot`::
+beta:[]
 (Optional, boolean)
 Deletes the searchable snapshot created in the cold phase. 
 Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot-action,searchable
 snapshot>> action is used in the cold phase.
-endif::[]
 
 [[ilm-delete-action-ex]]
 ==== Example

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -2,6 +2,8 @@
 [[ilm-searchable-snapshot]]
 === Searchable snapshot
 
+beta::[]
+
 Phases allowed: cold.
 
 Takes a snapshot of the managed index in the configured repository

--- a/docs/reference/ilm/actions/ilm-unfollow.asciidoc
+++ b/docs/reference/ilm/actions/ilm-unfollow.asciidoc
@@ -10,20 +10,11 @@ to be be performed safely on follower indices.
 You can also use unfollow directly when moving follower indices through the lifecycle.
 Has no effect on indices that are not followers, phase execution just moves to the next action.
 
-ifdef::permanently-unreleased-branch[]
 [NOTE]
 This action is triggered automatically by the <<ilm-rollover-action, rollover>>,
 <<ilm-shrink-action, shrink>>, and
 <<ilm-searchable-snapshot-action, searchable snapshot>> actions when they are
 applied to follower indices.
-endif::[]
-
-ifndef::permanently-unreleased-branch[]
-[NOTE]
-This action is triggered automatically by the <<ilm-rollover-action, rollover>>
-and <<ilm-shrink-action, shrink>> actions when they are applied to follower
-indices.
-endif::[]
 
 This action waits until is it safe to convert a follower index into a regular index. 
 The following conditions must be met:

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -29,11 +29,10 @@ Block write operations to the index.
 Remove the index as the write index for the rollover alias and 
 start indexing to a new index.
 
-ifdef::permanently-unreleased-branch[]
 [[ilm-searchable-snapshot-action]]<<ilm-searchable-snapshot, Searchable snapshot>>::
+beta:[]
 Take a snapshot of the managed index in the configured repository
 and mount it as a searchable snapshot.
-endif::[]
 
 [[ilm-set-priority-action]]<<ilm-set-priority,Set priority>>::
 Lower the priority of an index as it moves through the lifecycle
@@ -44,12 +43,7 @@ Reduce the number of primary shards by shrinking the index into a new index.
 
 [[ilm-unfollow-action]]<<ilm-unfollow,Unfollow>>::
 Convert a follower index to a regular index.
-ifdef::permanently-unreleased-branch[]
-Performed automatically before a rollover or shrink action.
-endif::[]
-ifndef::permanently-unreleased-branch[]
 Performed automatically before a rollover, shrink, or searchable snapshot action. 
-endif::[]
 
 [[ilm-wait-for-snapshot-action]]<<ilm-wait-for-snapshot,Wait for snapshot>>::
 Ensure that a snapshot exists before deleting the index. 
@@ -61,9 +55,7 @@ include::actions/ilm-freeze.asciidoc[]
 include::actions/ilm-migrate.asciidoc[]
 include::actions/ilm-readonly.asciidoc[]
 include::actions/ilm-rollover.asciidoc[]
-ifdef::permanently-unreleased-branch[]
 include::actions/ilm-searchable-snapshot.asciidoc[]
-endif::[]
 include::actions/ilm-set-priority.asciidoc[]
 include::actions/ilm-shrink.asciidoc[]
 include::actions/ilm-unfollow.asciidoc[]

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -91,9 +91,7 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-unfollow-action,Unfollow>>
   - <<ilm-allocate,Allocate>>
   - <<ilm-freeze,Freeze>>
-ifdef::permanently-unreleased-branch[]
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
-endif::[]
 * Delete
   - <<ilm-wait-for-snapshot-action,Wait For Snapshot>>
   - <<ilm-delete,Delete>>

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1169,9 +1169,7 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
-ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
-endif::[]
 
 [role="exclude",id="searchable-snapshots-api-stats"]
 === Searchable snapshot statistics API
@@ -1180,9 +1178,7 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
-ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
-endif::[]
 
 [role="exclude",id="searchable-snapshots-repository-stats"]
 === Searchable snapshot repository statistics API
@@ -1191,9 +1187,7 @@ We have removed documentation for this API. This a low-level API used to get
 information about snapshot-backed indices. We plan to remove or drastically
 change this API as part of a future release.
 
-ifdef::permanently-unreleased-branch[]
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
-endif::[]
 
 [role="exclude",id="point-in-time"]
 === Point in time API

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -33,9 +33,7 @@ endif::[]
 * <<repositories-metering-apis,Repositories Metering APIs>>
 * <<rollup-apis,Rollup APIs>>
 * <<search, Search APIs>>
-ifdef::permanently-unreleased-branch[]
 * <<searchable-snapshots-apis, Searchable snapshots APIs>>
-endif::[]
 * <<security-api,Security APIs>>
 * <<snapshot-restore-apis,Snapshot and restore APIs>>
 * <<snapshot-lifecycle-management-api,Snapshot lifecycle management APIs>>
@@ -67,9 +65,7 @@ include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::{es-repo-dir}/repositories-metering-api/repositories-metering-apis.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-api.asciidoc[]
 include::{es-repo-dir}/search.asciidoc[]
-ifdef::permanently-unreleased-branch[]
 include::{es-repo-dir}/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc[]
-endif::[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]
 include::{es-repo-dir}/snapshot-restore/apis/snapshot-restore-apis.asciidoc[]
 include::{es-repo-dir}/slm/apis/slm-api.asciidoc[]

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Mount snapshot</titleabbrev>
 ++++
 
-experimental[]
+beta::[]
 
 Mount a snapshot as a snapshot backed index.
 

--- a/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
@@ -3,7 +3,7 @@
 [[searchable-snapshots-apis]]
 == Searchable snapshots APIs
 
-experimental[]
+beta::[]
 
 You can use the following APIs to perform searchable snapshots operations.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Move searchable snapshots to beta (#63436)