### PR TITLE
Docs: sync breaking changes from release notes

### DIFF
--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -65,7 +65,7 @@ To support future feature development, the existing
 `Supplier<SearchLookup>` argument.
  
 *Impact* +
-If developing an {es} plugin, update your implementation of the
+If developing or maintaining an {es} plugin, update your implementation of the
 `MappedFieldType#fielddataBuilder` method to accommodate the new signature.
 ====
 
@@ -114,7 +114,7 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 === Search Changes
 
 [[max-doc-value-field-search-limits]]
-.The `index.max_docvalue_fields_search` setting now limits doc values returned by `inner_hits` or the `top_hits` aggregation.
+.The `index.max_docvalue_fields_search` setting now limits doc values fields returned by `inner_hits` or the `top_hits` aggregation.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -65,7 +65,8 @@ To support future feature development, the existing
 `Supplier<SearchLookup>` argument.
  
 *Impact* +
-No action needed.
+If developing an {es} plugin, update your implementation of the
+`MappedFieldType#fielddataBuilder` method to accommodate the new signature.
 ====
 
 [discrete]
@@ -118,10 +119,10 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 ====
 *Details* +
 The `index.max_docvalue_fields_search` setting limits the number of doc value
-fields retrieved by a search. Previously, this setting applied only to doc values
-returned by the `docvalue_fields` parameter in a top-level search. The setting
-now also applies to doc values returned by an `inner_hits` section or
-`top_hits` aggregation.
+fields retrieved by a search. Previously, this setting applied only to doc value
+fields returned by the `docvalue_fields` parameter in a top-level search. The
+setting now also applies to doc value fields returned by an `inner_hits` section
+or `top_hits` aggregation.
 
 *Impact* +
 If you use `inner_hits` or the `top_hits` aggregation, ensure

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -117,9 +117,9 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 ====
 *Details* +
 The `index.max_docvalue_fields_search` setting limits the number of doc value
-fields retrieved a search. Previously, this setting only applied to doc values
-retrieved by the `docvalue_fields` parameter in a top-level search. The setting
-now also applies to doc values retrieved by an `inner_hits` section or
+fields retrieved by a search. Previously, this setting applied only to doc values
+returned by the `docvalue_fields` parameter in a top-level search. The setting
+now also applies to doc values returned by an `inner_hits` section or
 `top_hits` aggregation.
 
 *Impact* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -114,7 +114,7 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 === Search Changes
 
 [[max-doc-value-field-search-limits]]
-.The `index.max_docvalue_fields_search` setting now limits doc values fields returned by `inner_hits` or the `top_hits` aggregation.
+.The `index.max_docvalue_fields_search` setting now limits doc value fields returned by `inner_hits` or the `top_hits` aggregation.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -21,7 +21,6 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [[breaking_710_security_changes]]
 === Authentication changes
 
-[discrete]
 [[api-keys-require-name-property]]
 .API keys now require a `name` property.
 [%collapsible]
@@ -91,7 +90,7 @@ directly on queries instead.
 [[breaking_710_networking_changes]]
 === Networking Changes
 
-[discrete]
+[keep-idle-and-keep-internal-limits]
 .The `*.tcp.keep_idle` and `*.tcp.keep_interval` settings are now limited to `300` seconds.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -92,7 +92,7 @@ directly on queries instead.
 === Networking Changes
 
 [discrete]
-.`*.tcp.keep_idle` and `*.tcp.keep_interval` are now limited to `300` seconds.
+.The `*.tcp.keep_idle` and `*.tcp.keep_interval` settings are now limited to `300` seconds.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -22,43 +22,31 @@ See also <<release-highlights>> and <<es-release-notes>>.
 === Authentication changes
 
 [discrete]
-=== Grant API key always requires the key name
-When using the grant API key action, it was possible to create a key without a
-name. This was because the name field is nested under `api_key` field, i.e.:
-```
+[[api-keys-require-name-property]]
+.API keys now require a `name` property.
+[%collapsible]
+====
+*Details* +
+The `name` property is now required to create or grant an API key.
+
+[source,js]
+----
 {
     "...": "...",
-    "api_key": {"name": "key-1"}
+    "api_key": {
+      "name": "key-1"
+    }
 }
-```
-The `name` is now required when creating or granting API keys.
+----
+// NOTCONSOLE
 
-[discrete]
-[[breaking_710_search_changes]]
-=== Search Changes
-
-[discrete]
-==== Missing checks for `index.max_docvalue_fields_search`
-The setting `index.max_docvalue_fields_search` limits the number of fields that
-can be retrieved through `docvalue_fields` in a search. Previously we only
-checked this limit when `docvalue_fields` appeared in the top-level search
-request body. Now we also enforce the limit when loading doc value fields in
-an `inner_hits` section or in a `top_hits` aggregation.
-
-[discrete]
-[[breaking_710_networking_changes]]
-=== Networking Changes
-
-[discrete]
-==== *.tcp.keep_idle and *.tcp.keep_interval now bounded
-The settings `{network,transport,http}.tcp.keep_idle` and
-`{network,transport,http}.tcp.keep_interval` are now limited to a maximum
-value of 300, which amounts to 5 minutes. This helps ensure that, if
-explicitly configured, only reasonable values are set.
+*Impact* +
+To avoid errors, specify the `name` property when creating or granting API keys.
+====
 
 [discrete]
 [[breaking_710_java_changes]]
-==== Breaking Java Changes
+==== Java changes
 
 [discrete]
 ==== Machine Learning: `allow_no_jobs` and `allow_no_datafeeds` deprecated in favor of `allow_no_match`
@@ -68,40 +56,93 @@ deprecation warning is emitted if the old parameter name is used in the request
 body or as a request param.
 High-level REST client classes will now send the new `allow_no_match` parameter.
 
-[discrete]
-==== Mapping: add `Supplier<SearchLookup>` argument to the existing `MappedFieldType#fielddataBuilder` method
-Runtime fields need to have a SearchLookup available, when building their
-fielddata implementations, so that they can look up other fields, runtime or
-not.
-To achieve that, we added a `Supplier<SearchLookup>` argument to the existing
-`MappedFieldType#fielddataBuilder` method.
-
-//end::notable-breaking-changes[]
-
-.Repository Stats API is deprecated
+[[supplier-searchlookup-arg]]
+.The `MappedFieldType#fielddataBuilder` method now accepts a `Supplier<SearchLookup>` argument.
 [%collapsible]
 ====
 *Details* +
-The Repository Stats API has been introduced in 7.8.0 as an experimental API
-and was never released. This API is superseded by the <<repositories-metering-apis,Repositories Metering APIs>>
-added in 7.10.0 which should be used instead. The Repository Stats API is
-deprecated starting 7.10.0 and will be removed in 8.0.0.
-
+For future feature development, we added a `Supplier<SearchLookup>` argument to
+the existing `MappedFieldType#fielddataBuilder` method.
+ 
 *Impact* +
-Use the <<repositories-metering-apis,Repositories Metering APIs>>.
+No action needed.
 ====
+
+[discrete]
+[[breaking_710_mapping_changes]]
+=== Mapping changes
 
 [[mapping-boosts]]
-.The `boost` parameter on field mappings has been deprecated
+.The `boost` parameter on field mappings has been deprecated.
 [%collapsible]
 ====
 *Details* +
-Index-time boosts have been deprecated since the 5x line, but it is still possible
+Index-time boosts have been deprecated since the 5.x line, but it is still possible
 to declare field-specific boosts in the mappings.  This is now deprecated as well,
 and will be removed entirely in 8.0.  Mappings containing field boosts will continue
 to work in 7.x but will emit a deprecation warning.
 
 *Impact* +
-The `boost` setting should be removed from templates and mappings.  Use boosts
+The `boost` setting should be removed from templates and mappings. Use boosts
 directly on queries instead.
 ====
+
+[discrete]
+[[breaking_710_networking_changes]]
+=== Networking Changes
+
+[discrete]
+.`*.tcp.keep_idle` and `*.tcp.keep_interval` are now limited to `300` seconds.
+[%collapsible]
+====
+*Details* +
+The settings `{network,transport,http}.tcp.keep_idle` and
+`{network,transport,http}.tcp.keep_interval` settings now have a maximum
+value of `300` seconds, equivalent to 5 minutes.
+
+*Impact* +
+If specified, ensure the `{network,transport,http}.tcp.keep_idle` and
+`{network,transport,http}.tcp.keep_interval` settings does not exceed `300`
+seconds. Setting `{network,transport,http}.tcp.keep_idle` or
+`{network,transport,http}.tcp.keep_interval` greater `300` seconds in
+`elasticsearch.yml` will result in an error on startup.
+====
+
+[discrete]
+[[breaking_710_search_changes]]
+=== Search Changes
+
+[discrete]
+[[max-doc-value-field-search-limits]]
+.The `index.max_docvalue_fields_search` setting now limits the number of retrieved through `inner_hits` or a `top_hits` aggregation.
+[%collapsible]
+====
+*Details* +
+The `index.max_docvalue_fields_search` setting limits the number of doc value
+fields retrieved through `docvalue_fields` in a search. Previously, this setting
+only applied to fields in an `inner_hits` section or `top_hits` aggregation.
+
+*Impact* +
+Ensure `index.max_docvalue_fields_search` is configured correctly for your use
+case.
+====
+
+[discrete]
+[[breaking_710_snapshot_restore_changes]]
+=== Snapshot and restore changes
+
+[[respository-stats-api-deprecated]]
+.The repository stats API has been deprecated.
+[%collapsible]
+====
+*Details* +
+The repository stats API was introduced as an experimental API in 7.8.0. The
+<<repositories-metering-apis,repositories metering APIs>> now replace the
+repository stats API. The repository stats API has been deprecated and will be
+removed in 8.0.0.
+
+*Impact* +
+Use the <<repositories-metering-apis,repositories metering APIs>>. Discontinue
+use of the repository stats API.
+====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -113,7 +113,7 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 === Search Changes
 
 [[max-doc-value-field-search-limits]]
-.The `index.max_docvalue_fields_search` setting now limits the number of retrieved through `inner_hits` or a `top_hits` aggregation.
+.The `index.max_docvalue_fields_search` setting now limits doc values returned by `inner_hits` or the `top_hits` aggregation.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -44,6 +44,44 @@ To avoid errors, specify the `name` property when creating or granting API keys.
 ====
 
 [discrete]
+[[breaking_710_indices_changes]]
+==== Indices changes
+
+[[supplier-searchlookup-arg]]
+.REST API access to system indices is now deprecated.
+[%collapsible]
+====
+*Details* +
+We are deprecating REST API access to system indices. Most REST API requests
+that attempt to access system indices will return the following deprecation
+warning:
+
+[source,text]
+----
+this request accesses system indices: [.system_index_name], but in a future
+major version, direct access to system indices will be prevented by default
+----
+
+The following REST API endpoints access system indices as part of their
+implementation and will not return the deprecation warning:
+
+* `GET _cluster/health`
+* `GET {index}/_recovery`
+* `GET _cluster/allocation/explain`
+* `GET _cluster/state`
+* `POST _cluster/reroute`
+* `GET {index}/_stats`
+* `GET {index}/_segments`
+* `GET {index}/_shard_stores`
+* `GET _cat/[indices,aliases,health,recovery,shards,segments]`
+
+*Impact* +
+To avoid deprecation warnings, do not use unsupported REST APIs to access system
+indices.
+====
+
+
+[discrete]
 [[breaking_710_java_changes]]
 ==== Java changes
 

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -18,6 +18,22 @@ See also <<release-highlights>> and <<es-release-notes>>.
 //tag::notable-breaking-changes[]
 
 [discrete]
+[[breaking_710_security_changes]]
+=== Authentication changes
+
+[discrete]
+=== Grant API key always requires the key name
+When using the grant API key action, it was possible to create a key without a
+name. This was because the name field is nested under `api_key` field, i.e.:
+```
+{
+    "...": "...",
+    "api_key": {"name": "key-1"}
+}
+```
+The `name` is now required when creating or granting API keys.
+
+[discrete]
 [[breaking_710_search_changes]]
 === Search Changes
 
@@ -39,6 +55,26 @@ The settings `{network,transport,http}.tcp.keep_idle` and
 `{network,transport,http}.tcp.keep_interval` are now limited to a maximum
 value of 300, which amounts to 5 minutes. This helps ensure that, if
 explicitly configured, only reasonable values are set.
+
+[discrete]
+[[breaking_710_java_changes]]
+==== Breaking Java Changes
+
+[discrete]
+==== Machine Learning: `allow_no_jobs` and `allow_no_datafeeds` deprecated in favor of `allow_no_match`
+`allow_no_jobs` and `allow_no_datafeeds` API parameters are deprecated in favor
+of `allow_no_match`. The old parameters are still accepted by the APIs but the
+deprecation warning is emitted if the old parameter name is used in the request
+body or as a request param.
+High-level REST client classes will now send the new `allow_no_match` parameter.
+
+[discrete]
+==== Mapping: add `Supplier<SearchLookup>` argument to the existing `MappedFieldType#fielddataBuilder` method
+Runtime fields need to have a SearchLookup available, when building their
+fielddata implementations, so that they can look up other fields, runtime or
+not.
+To achieve that, we added a `Supplier<SearchLookup>` argument to the existing
+`MappedFieldType#fielddataBuilder` method.
 
 //end::notable-breaking-changes[]
 

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -96,7 +96,7 @@ directly on queries instead.
 [%collapsible]
 ====
 *Details* +
-The settings `{network,transport,http}.tcp.keep_idle` and
+The `{network,transport,http}.tcp.keep_idle` and
 `{network,transport,http}.tcp.keep_interval` settings now have a maximum
 value of `300` seconds, equivalent to 5 minutes.
 

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -65,7 +65,7 @@ To support future feature development, the existing
 `Supplier<SearchLookup>` argument.
  
 *Impact* +
-If developing or maintaining an {es} plugin, update your implementation of the
+If you develop or maintain a mapper plugin, update your implementation of the
 `MappedFieldType#fielddataBuilder` method to accommodate the new signature.
 ====
 

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -48,7 +48,7 @@ To avoid errors, specify the `name` property when creating or granting API keys.
 ==== Indices changes
 
 [[bc-deprecate-rest-api-access-to-system-indices]]
-.REST API access to system indices is now deprecated.
+.REST API access to system indices is deprecated.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -47,7 +47,7 @@ To avoid errors, specify the `name` property when creating or granting API keys.
 [[breaking_710_indices_changes]]
 ==== Indices changes
 
-[[supplier-searchlookup-arg]]
+[[bc-deprecate-rest-api-access-to-system-indices]]
 .REST API access to system indices is now deprecated.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -45,7 +45,7 @@ To avoid errors, specify the `name` property when creating or granting API keys.
 
 [discrete]
 [[breaking_710_indices_changes]]
-==== Indices changes
+=== Indices changes
 
 [[bc-deprecate-rest-api-access-to-system-indices]]
 .REST API access to system indices is deprecated.
@@ -83,7 +83,7 @@ indices.
 
 [discrete]
 [[breaking_710_java_changes]]
-==== Java changes
+=== Java changes
 
 [[supplier-searchlookup-arg]]
 .The `MappedFieldType#fielddataBuilder` method now accepts a `Supplier<SearchLookup>` argument.

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -78,7 +78,7 @@ No action needed.
 *Details* +
 Index-time boosts have been deprecated since the 5.x line, but it is still possible
 to declare field-specific boosts in the mappings.  This is now deprecated as well,
-and will be removed entirely in 8.0.  Mappings containing field boosts will continue
+and will be removed entirely in 8.0.0.  Mappings containing field boosts will continue
 to work in 7.x but will emit a deprecation warning.
 
 *Impact* +
@@ -101,10 +101,10 @@ value of `300` seconds, equivalent to 5 minutes.
 
 *Impact* +
 If specified, ensure the `{network,transport,http}.tcp.keep_idle` and
-`{network,transport,http}.tcp.keep_interval` settings does not exceed `300`
+`{network,transport,http}.tcp.keep_interval` settings do not exceed `300`
 seconds. Setting `{network,transport,http}.tcp.keep_idle` or
-`{network,transport,http}.tcp.keep_interval` greater `300` seconds in
-`elasticsearch.yml` will result in an error on startup.
+`{network,transport,http}.tcp.keep_interval` to a value greater than `300`
+seconds in `elasticsearch.yml` will result in an error on startup.
 ====
 
 [discrete]
@@ -117,14 +117,14 @@ seconds. Setting `{network,transport,http}.tcp.keep_idle` or
 ====
 *Details* +
 The `index.max_docvalue_fields_search` setting limits the number of doc value
-fields retrieved a search. by the `docvalue_fields` parameter in a search.
-Previously, this setting only applied to doc values retrieved by the
-`docvalue_fields` parameter in a top-level search. The setting now also applies
-to doc values retrieved by an `inner_hits` section or `top_hits` aggregation.
+fields retrieved a search. Previously, this setting only applied to doc values
+retrieved by the `docvalue_fields` parameter in a top-level search. The setting
+now also applies to doc values retrieved by an `inner_hits` section or
+`top_hits` aggregation.
 
 *Impact* +
-Ensure `index.max_docvalue_fields_search` is configured correctly for your use
-case.
+If you use `inner_hits` or the `top_hits` aggregation, ensure
+`index.max_docvalue_fields_search` is configured correctly for your use case.
 ====
 
 [discrete]

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -85,14 +85,6 @@ indices.
 [[breaking_710_java_changes]]
 ==== Java changes
 
-[discrete]
-==== Machine Learning: `allow_no_jobs` and `allow_no_datafeeds` deprecated in favor of `allow_no_match`
-`allow_no_jobs` and `allow_no_datafeeds` API parameters are deprecated in favor
-of `allow_no_match`. The old parameters are still accepted by the APIs but the
-deprecation warning is emitted if the old parameter name is used in the request
-body or as a request param.
-High-level REST client classes will now send the new `allow_no_match` parameter.
-
 [[supplier-searchlookup-arg]]
 .The `MappedFieldType#fielddataBuilder` method now accepts a `Supplier<SearchLookup>` argument.
 [%collapsible]
@@ -105,6 +97,25 @@ To support future feature development, the existing
 *Impact* +
 If you develop or maintain a mapper plugin, update your implementation of the
 `MappedFieldType#fielddataBuilder` method to accommodate the new signature.
+====
+
+[discrete]
+[[breaking_710_ml_changes]]
+=== Machine learning changes
+
+[[ml-allow-no-deprecations]]
+.The `allow_no_jobs` and `allow_no_datafeeds` API parameters are deprecated.
+[%collapsible]
+====
+*Details* +
+The `allow_no_jobs` and `allow_no_datafeeds` parameters in {ml} APIs are
+deprecated in favor of `allow_no_match`. The old parameters are still accepted
+by the APIs but a deprecation warning is emitted when the old parameter name is
+used in the request body or as a request parameter. High-level REST client
+classes now send the new `allow_no_match` parameter.
+
+*Impact* +
+To avoid deprecation warnings, use the `allow_no_match` parameter.
 ====
 
 [discrete]
@@ -128,7 +139,7 @@ directly on queries instead.
 
 [discrete]
 [[breaking_710_networking_changes]]
-=== Networking Changes
+=== Networking changes
 
 [keep-idle-and-keep-internal-limits]
 .The `*.tcp.keep_idle` and `*.tcp.keep_interval` settings are now limited to `300` seconds.
@@ -149,7 +160,7 @@ seconds in `elasticsearch.yml` will result in an error on startup.
 
 [discrete]
 [[breaking_710_search_changes]]
-=== Search Changes
+=== Search changes
 
 [[max-doc-value-field-search-limits]]
 .The `index.max_docvalue_fields_search` setting now limits doc value fields returned by `inner_hits` or the `top_hits` aggregation.

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -111,15 +111,16 @@ seconds. Setting `{network,transport,http}.tcp.keep_idle` or
 [[breaking_710_search_changes]]
 === Search Changes
 
-[discrete]
 [[max-doc-value-field-search-limits]]
 .The `index.max_docvalue_fields_search` setting now limits the number of retrieved through `inner_hits` or a `top_hits` aggregation.
 [%collapsible]
 ====
 *Details* +
 The `index.max_docvalue_fields_search` setting limits the number of doc value
-fields retrieved through `docvalue_fields` in a search. Previously, this setting
-only applied to fields in an `inner_hits` section or `top_hits` aggregation.
+fields retrieved a search. by the `docvalue_fields` parameter in a search.
+Previously, this setting only applied to doc values retrieved by the
+`docvalue_fields` parameter in a top-level search. The setting now also applies
+to doc values retrieved by an `inner_hits` section or `top_hits` aggregation.
 
 *Impact* +
 Ensure `index.max_docvalue_fields_search` is configured correctly for your use

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -60,8 +60,9 @@ High-level REST client classes will now send the new `allow_no_match` parameter.
 [%collapsible]
 ====
 *Details* +
-For future feature development, we added a `Supplier<SearchLookup>` argument to
-the existing `MappedFieldType#fielddataBuilder` method.
+To support future feature development, the existing
+`MappedFieldType#fielddataBuilder` method now accepts a new
+`Supplier<SearchLookup>` argument.
  
 *Impact* +
 No action needed.


### PR DESCRIPTION
Add those breaking changes present into the release notes but missing
from the migration notes.

### Preview
https://elasticsearch_63479.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.10/breaking-changes-7.10.html