### PR TITLE
Replace some usages of QueryShardContext#getMapperService (#63239)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -63,7 +63,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParseContext.Document;

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -63,6 +63,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParseContext.Document;
@@ -1654,7 +1655,7 @@ public abstract class Engine implements Closeable {
             this.ifPrimaryTerm = primaryTerm;
             return this;
         }
-        
+
         public long getIfPrimaryTerm() {
             return ifPrimaryTerm;
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -38,9 +38,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -52,7 +50,6 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 /**
  * A {@link Translog.Snapshot} from changes in a Lucene index

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -38,7 +38,9 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -50,6 +52,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 /**
  * A {@link Translog.Snapshot} from changes in a Lucene index
@@ -238,7 +241,7 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
         leaf.reader().document(segmentDocID, fields);
-        fields.postProcess(mapperService);
+        fields.postProcess(mapperService::fieldType, mapperService.documentMapper());
 
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -21,13 +21,13 @@ package org.elasticsearch.index.fieldvisitor;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableSet;
@@ -88,13 +89,12 @@ public class FieldsVisitor extends StoredFieldVisitor {
                 : Status.NO;
     }
 
-    public void postProcess(MapperService mapperService) {
-        final DocumentMapper mapper = mapperService.documentMapper();
+    public final void postProcess(Function<String, MappedFieldType> fieldTypeLookup, @Nullable DocumentMapper mapper) {
         if (mapper != null) {
             type = mapper.type();
         }
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            MappedFieldType fieldType = mapperService.fieldType(entry.getKey());
+            MappedFieldType fieldType = fieldTypeLookup.apply(entry.getKey());
             if (fieldType == null) {
                 throw new IllegalStateException("Field [" + entry.getKey()
                     + "] exists in the index but not in mappings");

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -281,7 +281,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
             // put stored fields into result objects
             if (!fieldVisitor.fields().isEmpty()) {
-                fieldVisitor.postProcess(mapperService);
+                fieldVisitor.postProcess(mapperService::fieldType, mapperService.documentMapper());
                 documentFields = new HashMap<>();
                 metadataFields = new HashMap<>();
                 for (Map.Entry<String, List<Object>> entry : fieldVisitor.fields().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -194,7 +194,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     private static Query newFieldExistsQuery(QueryShardContext context, String field) {
-        MappedFieldType fieldType = context.getMapperService().fieldType(field);
+        MappedFieldType fieldType = context.fieldMapper(field);
         if (fieldType == null) {
             // The field does not exist as a leaf but could be an object so
             // check for an object mapper
@@ -211,7 +211,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         Collection<String> fields = context.simpleMatchToIndexNames(objField + ".*");
         for (String field : fields) {
-            Query existsQuery = context.getMapperService().fieldType(field).existsQuery(context);
+            Query existsQuery = context.fieldMapper(field).existsQuery(context);
             booleanQuery.add(existsQuery, Occur.SHOULD);
         }
         return new ConstantScoreQuery(booleanQuery.build());
@@ -223,7 +223,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
      */
     private static Collection<String> getMappedField(QueryShardContext context, String fieldPattern) {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-            .getMapperService().fieldType(FieldNamesFieldMapper.NAME);
+            .fieldMapper(FieldNamesFieldMapper.NAME);
 
         if (fieldNamesFieldType == null) {
             // can only happen when no types exist, so no docs exist either
@@ -241,7 +241,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
         if (fields.size() == 1) {
             String field = fields.iterator().next();
-            MappedFieldType fieldType = context.getMapperService().fieldType(field);
+            MappedFieldType fieldType = context.fieldMapper(field);
             if (fieldType == null) {
                 // The field does not exist as a leaf but could be an object so
                 // check for an object mapper

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -89,12 +89,11 @@ public abstract class InnerHitContextBuilder {
             innerHitsContext.storedFieldsContext(innerHitBuilder.getStoredFieldsContext());
         }
         if (innerHitBuilder.getDocValueFields() != null) {
-            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(
-                queryShardContext.getMapperService(), innerHitBuilder.getDocValueFields());
+            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(queryShardContext::simpleMatchToIndexNames,
+                queryShardContext.getIndexSettings().getMaxDocvalueFields(), innerHitBuilder.getDocValueFields());
             innerHitsContext.docValuesContext(docValuesContext);
         }
         if (innerHitBuilder.getFetchFields() != null) {
-            String indexName = queryShardContext.index().getName();
             FetchFieldsContext fieldsContext = new FetchFieldsContext(innerHitBuilder.getFetchFields());
             innerHitsContext.fetchFieldsContext(fieldsContext);
         }

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -302,7 +302,8 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
 
         // ToParentBlockJoinQuery requires that the inner query only matches documents
         // in its child space
-        if (new NestedHelper(context.getMapperService()).mightMatchNonNestedDocs(innerQuery, path)) {
+        NestedHelper nestedHelper = new NestedHelper(context.getMapperService()::getObjectMapper, context.getMapperService()::fieldType);
+        if (nestedHelper.mightMatchNonNestedDocs(innerQuery, path)) {
             innerQuery = Queries.filtered(innerQuery, nestedObjectMapper.nestedTypeFilter());
         }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -266,7 +266,7 @@ public class QueryShardContext extends QueryRewriteContext {
         if (fieldType.getTextSearchInfo().getSearchAnalyzer() != null) {
             return fieldType.getTextSearchInfo().getSearchAnalyzer();
         }
-        return getMapperService().searchAnalyzer();
+        return mapperService.searchAnalyzer();
     }
 
     /**
@@ -277,7 +277,7 @@ public class QueryShardContext extends QueryRewriteContext {
         if (fieldType.getTextSearchInfo().getSearchQuoteAnalyzer() != null) {
             return fieldType.getTextSearchInfo().getSearchQuoteAnalyzer();
         }
-        return getMapperService().searchQuoteAnalyzer();
+        return mapperService.searchQuoteAnalyzer();
     }
 
     public ValuesSourceRegistry getValuesSourceRegistry() {
@@ -324,7 +324,7 @@ public class QueryShardContext extends QueryRewriteContext {
     public SearchLookup lookup() {
         if (this.lookup == null) {
             this.lookup = new SearchLookup(
-                getMapperService(),
+                mapperService,
                 (fieldType, searchLookup) -> indexFieldDataService.apply(fieldType, fullyQualifiedIndex.getName(), searchLookup),
                 types
             );
@@ -341,7 +341,7 @@ public class QueryShardContext extends QueryRewriteContext {
          * Real customization coming soon, I promise!
          */
         return new SearchLookup(
-            getMapperService(),
+            mapperService,
             (fieldType, searchLookup) -> indexFieldDataService.apply(fieldType, fullyQualifiedIndex.getName(), searchLookup),
             types
         );

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -480,7 +480,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
              * if the {@link FieldNamesFieldMapper} is enabled.
              */
             final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-                (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fieldType(FieldNamesFieldMapper.NAME);
+                (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
             if (fieldNamesFieldType == null) {
                 return new MatchNoDocsQuery("No mappings yet");
             }

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
@@ -144,7 +144,7 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldV
 
     @Override
     protected ScoreFunction doToFunction(QueryShardContext context) {
-        MappedFieldType fieldType = context.getMapperService().fieldType(field);
+        MappedFieldType fieldType = context.fieldMapper(field);
         IndexNumericFieldData fieldData = null;
         if (fieldType == null) {
             if(missing == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -163,11 +163,11 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         } else {
             final MappedFieldType fieldType;
             if (field != null) {
-                fieldType = context.getMapperService().fieldType(field);
+                fieldType = context.fieldMapper(field);
             } else {
                 deprecationLogger.deprecate("seed_requires_field",
                     "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
-                fieldType = context.getMapperService().fieldType(IdFieldMapper.NAME);
+                fieldType = context.fieldMapper(IdFieldMapper.NAME);
             }
             if (fieldType == null) {
                 if (context.getMapperService().documentMapper() == null) {

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -125,7 +125,7 @@ public final class QueryParserHelper {
                 fieldName = fieldName + fieldSuffix;
             }
 
-            MappedFieldType fieldType = context.getMapperService().fieldType(fieldName);
+            MappedFieldType fieldType = context.fieldMapper(fieldName);
             if (fieldType == null) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -624,7 +624,7 @@ public class QueryStringQueryParser extends XQueryParser {
 
     private Query existsQuery(String fieldName) {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-            (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fieldType(FieldNamesFieldMapper.NAME);
+            (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             return new MatchNoDocsQuery("No mappings yet");
         }

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -278,9 +278,10 @@ final class DefaultSearchContext extends SearchContext {
             filters.add(typeFilter);
         }
 
+        NestedHelper nestedHelper = new NestedHelper(mapperService()::getObjectMapper, mapperService()::fieldType);
         if (mapperService().hasNested()
-                && new NestedHelper(mapperService()).mightMatchNestedDocs(query)
-                && (aliasFilter == null || new NestedHelper(mapperService()).mightMatchNestedDocs(aliasFilter))) {
+            && nestedHelper.mightMatchNestedDocs(query)
+            && (aliasFilter == null || nestedHelper.mightMatchNestedDocs(aliasFilter))) {
             filters.add(Queries.newNonNestedFilter(mapperService().getIndexSettings().getIndexVersionCreated()));
         }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -961,7 +961,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             context.fetchSourceContext(source.fetchSource());
         }
         if (source.docValueFields() != null) {
-            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(context.mapperService(), source.docValueFields());
+            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(context.mapperService()::simpleMatchToFullName,
+                context.mapperService().getIndexSettings().getMaxDocvalueFields(), source.docValueFields());
             context.docValuesContext(docValuesContext);
         }
         if (source.fetchFields() != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -618,7 +618,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     protected TopHitsAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subfactoriesBuilder)
             throws IOException {
         long innerResultWindow = from() + size();
-        int maxInnerResultWindow = queryShardContext.getMapperService().getIndexSettings().getMaxInnerResultWindow();
+        int maxInnerResultWindow = queryShardContext.getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(
                 "Top hits result window is too large, the top hits aggregator [" + name + "]'s from + size must be less " +

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
@@ -110,7 +110,8 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
             subSearchContext.storedFieldsContext(storedFieldsContext);
         }
         if (docValueFields != null) {
-            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(searchContext.mapperService(), docValueFields);
+            FetchDocValuesContext docValuesContext = FetchDocValuesContext.create(searchContext.mapperService()::simpleMatchToFullName,
+                searchContext.mapperService().getIndexSettings().getMaxDocvalueFields(), docValueFields);
             subSearchContext.docValuesContext(docValuesContext);
         }
         if (fetchFields != null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
@@ -19,11 +19,12 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.mapper.MapperService;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * All the required context to pull a field from the doc values.
@@ -31,16 +32,16 @@ import java.util.List;
 public class FetchDocValuesContext {
     private final List<FieldAndFormat> fields;
 
-    public static FetchDocValuesContext create(MapperService mapperService,
+    public static FetchDocValuesContext create(Function<String, Set<String>> simpleMatchToFullName,
+                                               int maxAllowedDocvalueFields,
                                                List<FieldAndFormat> fieldPatterns) {
         List<FieldAndFormat> fields = new ArrayList<>();
         for (FieldAndFormat field : fieldPatterns) {
-            Collection<String> fieldNames = mapperService.simpleMatchToFullName(field.field);
+            Collection<String> fieldNames = simpleMatchToFullName.apply(field.field);
             for (String fieldName: fieldNames) {
                 fields.add(new FieldAndFormat(fieldName, field.format));
             }
         }
-        int maxAllowedDocvalueFields = mapperService.getIndexSettings().getMaxDocvalueFields();
         if (fields.size() > maxAllowedDocvalueFields) {
             throw new IllegalArgumentException(
                 "Trying to retrieve too many docvalue_fields. Must be less than or equal to: [" + maxAllowedDocvalueFields

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -297,7 +297,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
         if (shardSize != null) {
             suggestionContext.setShardSize(shardSize);
         }
-        MappedFieldType mappedFieldType = mapperService.fieldType(suggestionContext.getField());
+        MappedFieldType mappedFieldType = context.fieldMapper(suggestionContext.getField());
         if (mappedFieldType == null || mappedFieldType instanceof CompletionFieldMapper.CompletionFieldType == false) {
             throw new IllegalArgumentException("Field [" + suggestionContext.getField() + "] is not a completion suggest field");
         }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5803,7 +5803,8 @@ public class InternalEngineTests extends EngineTestCase {
                     put(defaultSettings.getSettings()).put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), false)).build());
             try (InternalEngine engine = createEngine(config(indexSettings, store, createTempDir(), newMergePolicy(), null))) {
                 AssertionError error = expectThrows(AssertionError.class,
-                    () -> engine.newChangesSnapshot("test", createMapperService("test"), 0, randomNonNegativeLong(), randomBoolean()));
+                    () -> engine.newChangesSnapshot("test", createMapperService("test"),
+                        0, randomNonNegativeLong(), randomBoolean()));
                 assertThat(error.getMessage(), containsString("does not have soft-deletes enabled"));
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
@@ -52,12 +52,10 @@ public class IdFieldTypeTests extends ESTestCase {
         IndexSettings mockSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
         Mockito.when(context.getIndexSettings()).thenReturn(mockSettings);
         Mockito.when(context.indexVersionCreated()).thenReturn(indexSettings.getAsVersion(IndexMetadata.SETTING_VERSION_CREATED, null));
-
         MapperService mapperService = Mockito.mock(MapperService.class);
         Collection<String> types = Collections.emptySet();
         Mockito.when(context.queryTypes()).thenReturn(types);
         Mockito.when(context.getMapperService()).thenReturn(mapperService);
-
         MappedFieldType ft = new IdFieldMapper.IdFieldType(() -> false);
         Query query = ft.termQuery("id", context);
         assertEquals(new TermInSetQuery("_id", Uid.encodeId("id")), query);

--- a/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
@@ -90,7 +90,7 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, false);
         searcher.doc(0, fieldsVisitor);
 
-        fieldsVisitor.postProcess(mapperService);
+        fieldsVisitor.postProcess(mapperService::fieldType, mapperService.documentMapper());
         assertThat(fieldsVisitor.fields().size(), equalTo(10));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));

--- a/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.DistanceFeatureQueryBuilder.Origin;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.joda.time.DateTime;
@@ -85,8 +84,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
             double pivotDouble = DistanceUnit.DEFAULT.parse(pivot, DistanceUnit.DEFAULT);
             expectedQuery = LatLonPoint.newDistanceFeatureQuery(fieldName, boost, originGeoPoint.lat(), originGeoPoint.lon(), pivotDouble);
         } else { // if (fieldName.equals(DATE_FIELD_NAME))
-            MapperService mapperService = context.getMapperService();
-            DateFieldType fieldType = (DateFieldType) mapperService.fieldType(fieldName);
+            DateFieldType fieldType = (DateFieldType) context.fieldMapper(fieldName);
             long originLong = fieldType.parseToLong(origin, true, null, null, context::nowInMillis);
             TimeValue pivotVal = TimeValue.parseTimeValue(pivot, DistanceFeatureQueryBuilder.class.getSimpleName() + ".pivot");
             long pivotLong;

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         String fieldPattern = queryBuilder.fieldName();
         Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
         Collection<String> mappedFields = fields.stream().filter((field) -> context.getObjectMapper(field) != null
-                || context.getMapperService().fieldType(field) != null).collect(Collectors.toList());
+                || context.fieldMapper(field) != null).collect(Collectors.toList());
         if (mappedFields.size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             return;
@@ -100,11 +100,11 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
                     BooleanClause booleanClause = booleanQuery.clauses().get(i);
                     assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
                 }
-            } else if (context.getMapperService().fieldType(field).hasDocValues()) {
+            } else if (context.fieldMapper(field).hasDocValues()) {
                 assertThat(constantScoreQuery.getQuery(), instanceOf(DocValuesFieldExistsQuery.class));
                 DocValuesFieldExistsQuery dvExistsQuery = (DocValuesFieldExistsQuery) constantScoreQuery.getQuery();
                 assertEquals(field, dvExistsQuery.getField());
-            } else if (context.getMapperService().fieldType(field).getTextSearchInfo().hasNorms()) {
+            } else if (context.fieldMapper(field).getTextSearchInfo().hasNorms()) {
                 assertThat(constantScoreQuery.getQuery(), instanceOf(NormsFieldExistsQuery.class));
                 NormsFieldExistsQuery normsExistsQuery = (NormsFieldExistsQuery) constantScoreQuery.getQuery();
                 assertEquals(field, normsExistsQuery.getField());

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -1060,7 +1060,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(TEXT_FIELD_NAME + ":*");
         Query query = queryBuilder.toQuery(context);
         if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_1_0)
-                && (context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
+                && (context.fieldMapper(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
             assertThat(query, equalTo(new ConstantScoreQuery(new NormsFieldExistsQuery(TEXT_FIELD_NAME))));
         } else {
             assertThat(query, equalTo(new ConstantScoreQuery(new TermQuery(new Term("_field_names", TEXT_FIELD_NAME)))));
@@ -1071,7 +1071,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryBuilder = new QueryStringQueryBuilder("_exists_:" + value);
             query = queryBuilder.toQuery(context);
             if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_1_0)
-                && (context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
+                && (context.fieldMapper(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
                 assertThat(query, equalTo(new ConstantScoreQuery(new NormsFieldExistsQuery(TEXT_FIELD_NAME))));
             } else {
                 assertThat(query, equalTo(new ConstantScoreQuery(new TermQuery(new Term("_field_names", TEXT_FIELD_NAME)))));

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -60,10 +59,8 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         Mockito.when(context.index()).thenReturn(settings.getIndex());
         Mockito.when(context.getShardId()).thenReturn(0);
         Mockito.when(context.getIndexSettings()).thenReturn(settings);
-        MapperService mapperService = Mockito.mock(MapperService.class);
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("foo", NumberType.LONG);
-        Mockito.when(mapperService.fieldType(Mockito.anyString())).thenReturn(ft);
-        Mockito.when(context.getMapperService()).thenReturn(mapperService);
+        Mockito.when(context.fieldMapper(Mockito.anyString())).thenReturn(ft);
         builder.toFunction(context);
         assertWarnings("As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
     }

--- a/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -101,111 +101,115 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
         mapperService = indexService.mapperService();
     }
 
+    private static NestedHelper buildNestedHelper(MapperService mapperService) {
+        return new NestedHelper(mapperService::getObjectMapper, mapperService::fieldType);
+    }
+
     public void testMatchAll() {
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(new MatchAllDocsQuery()));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(new MatchAllDocsQuery()));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchAllDocsQuery(), "nested_missing"));
     }
 
     public void testMatchNo() {
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(new MatchNoDocsQuery()));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested1"));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested2"));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested3"));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(new MatchNoDocsQuery()));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested1"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested2"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested3"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(new MatchNoDocsQuery(), "nested_missing"));
     }
 
     public void testTermsQuery() {
         Query termsQuery = mapperService.fieldType("foo").termsQuery(Collections.singletonList("bar"), null);
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
         termsQuery = mapperService.fieldType("nested1.foo").termsQuery(Collections.singletonList("bar"), null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
         termsQuery = mapperService.fieldType("nested2.foo").termsQuery(Collections.singletonList("bar"), null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
         termsQuery = mapperService.fieldType("nested3.foo").termsQuery(Collections.singletonList("bar"), null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
     }
 
     public void testTermQuery() {
         Query termQuery = mapperService.fieldType("foo").termQuery("bar", null);
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(termQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
         termQuery = mapperService.fieldType("nested1.foo").termQuery("bar", null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termQuery));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
         termQuery = mapperService.fieldType("nested2.foo").termQuery("bar", null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
         termQuery = mapperService.fieldType("nested3.foo").termQuery("bar", null);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(termQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
     }
 
     public void testRangeQuery() {
         QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
         Query rangeQuery = mapperService.fieldType("foo2").rangeQuery(2, 5, true, true, null, null, null, context);
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
         rangeQuery = mapperService.fieldType("nested1.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
         rangeQuery = mapperService.fieldType("nested2.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
         rangeQuery = mapperService.fieldType("nested3.foo2").rangeQuery(2, 5, true, true, null, null, null, context);
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
     }
 
     public void testDisjunction() {
@@ -213,57 +217,57 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                 .add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
                 .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
                 .build();
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested1.foo", "bar")), Occur.SHOULD)
                 .add(new TermQuery(new Term("nested1.foo", "baz")), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested2.foo", "bar")), Occur.SHOULD)
                 .add(new TermQuery(new Term("nested2.foo", "baz")), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested3.foo", "bar")), Occur.SHOULD)
                 .add(new TermQuery(new Term("nested3.foo", "baz")), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
                 .add(new MatchAllDocsQuery(), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested1.foo", "bar")), Occur.SHOULD)
                 .add(new MatchAllDocsQuery(), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested2.foo", "bar")), Occur.SHOULD)
                 .add(new MatchAllDocsQuery(), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested3.foo", "bar")), Occur.SHOULD)
                 .add(new MatchAllDocsQuery(), Occur.SHOULD)
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
     }
 
     private static Occur requiredOccur() {
@@ -275,57 +279,57 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                 .add(new TermQuery(new Term("foo", "bar")), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested1.foo", "bar")), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested2.foo", "bar")), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
 
         bq = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term("nested3.foo", "bar")), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
 
         bq = new BooleanQuery.Builder()
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested1"));
 
         bq = new BooleanQuery.Builder()
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested2"));
 
         bq = new BooleanQuery.Builder()
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .add(new MatchAllDocsQuery(), requiredOccur())
                 .build();
-        assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(bq));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNestedDocs(bq));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(bq, "nested3"));
     }
 
     public void testNested() throws IOException {
@@ -340,11 +344,11 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                 .build();
         assertEquals(expectedChildQuery, query.getChildQuery());
 
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(query));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(query));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
 
         queryBuilder = new NestedQueryBuilder("nested1", new TermQueryBuilder("nested1.foo", "bar"), ScoreMode.Avg);
         query = (ESToParentBlockJoinQuery) queryBuilder.toQuery(context);
@@ -353,11 +357,11 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
         expectedChildQuery = new TermQuery(new Term("nested1.foo", "bar"));
         assertEquals(expectedChildQuery, query.getChildQuery());
 
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(query));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(query));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
 
         queryBuilder = new NestedQueryBuilder("nested2", new TermQueryBuilder("nested2.foo", "bar"), ScoreMode.Avg);
         query = (ESToParentBlockJoinQuery) queryBuilder.toQuery(context);
@@ -369,11 +373,11 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                 .build();
         assertEquals(expectedChildQuery, query.getChildQuery());
 
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(query));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(query));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
 
         queryBuilder = new NestedQueryBuilder("nested3", new TermQueryBuilder("nested3.foo", "bar"), ScoreMode.Avg);
         query = (ESToParentBlockJoinQuery) queryBuilder.toQuery(context);
@@ -385,10 +389,10 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                 .build();
         assertEquals(expectedChildQuery, query.getChildQuery());
 
-        assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(query));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
-        assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
+        assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(query));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested1"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested2"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested3"));
+        assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(query, "nested_missing"));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -81,7 +81,6 @@ import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.fieldvisitor.IdOnlyFieldVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParseContext;

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -81,6 +81,7 @@ import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.fieldvisitor.IdOnlyFieldVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParseContext;
@@ -1052,9 +1053,9 @@ public abstract class EngineTestCase extends ESTestCase {
      * Reads all engine operations that have been processed by the engine from Lucene index.
      * The returned operations are sorted and de-duplicated, thus each sequence number will be have at most one operation.
      */
-    public static List<Translog.Operation> readAllOperationsInLucene(Engine engine, MapperService mapper) throws IOException {
+    public static List<Translog.Operation> readAllOperationsInLucene(Engine engine, MapperService mapperService) throws IOException {
         final List<Translog.Operation> operations = new ArrayList<>();
-        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapper, 0, Long.MAX_VALUE, false)) {
+        try (Translog.Snapshot snapshot = engine.newChangesSnapshot("test", mapperService, 0, Long.MAX_VALUE, false)) {
             Translog.Operation op;
             while ((op = snapshot.next()) != null){
                 operations.add(op);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -123,7 +123,7 @@ public final class DocumentPermissions {
                 Query roleQuery = queryShardContext.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
                 if (queryShardContext.getMapperService().hasNested()) {
-                    NestedHelper nestedHelper = new NestedHelper(queryShardContext.getMapperService());
+                    NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::fieldMapper);
                     if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)
                                 .add(Queries.newNonNestedFilter(queryShardContext.indexVersionCreated()), FILTER).build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.Uid;
@@ -328,7 +329,8 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                     if (liveDocs == null || liveDocs.get(i)) {
                         rootFieldsVisitor.reset();
                         leafReader.document(i, rootFieldsVisitor);
-                        rootFieldsVisitor.postProcess(targetShard.mapperService());
+                        DocumentMapper documentMapper = targetShard.mapperService().documentMapper();
+                        rootFieldsVisitor.postProcess(targetShard.mapperService()::fieldType, documentMapper);
                         Uid uid = rootFieldsVisitor.uid();
                         BytesReference source = rootFieldsVisitor.source();
                         assert source != null : "_source is null but should have been filtered out at snapshot time";

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -49,7 +49,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -49,7 +49,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
@@ -238,9 +238,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                     () -> { throw new UnsupportedOperationException(); },
                     null
                 );
-                final MapperService mapperService = context.getMapperService();
-                final Text typeText = mapperService.documentMapper().typeText();
-
+                final Text typeText = context.getMapperService().documentMapper().typeText();
                 final MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.multiSearchRequest.requests().size()];
                 for (int i = 0; i < request.multiSearchRequest.requests().size(); i++) {
                     final SearchSourceBuilder searchSourceBuilder = request.multiSearchRequest.requests().get(i).source();
@@ -260,7 +258,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
 
                         visitor.reset();
                         searcher.doc(scoreDoc.doc, visitor);
-                        visitor.postProcess(mapperService);
+                        visitor.postProcess(context::fieldMapper, context.getMapperService().documentMapper());
                         final SearchHit hit = new SearchHit(
                             scoreDoc.doc,
                             visitor.uid().id(),

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
@@ -71,7 +71,6 @@ abstract class AbstractScriptFieldTypeTestCase extends ESTestCase {
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.fieldType(anyString())).thenReturn(mappedFieldType);
         QueryShardContext context = mock(QueryShardContext.class);
-        when(context.getMapperService()).thenReturn(mapperService);
         if (mappedFieldType != null) {
             when(context.fieldMapper(anyString())).thenReturn(mappedFieldType);
             when(context.getSearchAnalyzer(any())).thenReturn(mappedFieldType.getTextSearchInfo().getSearchAnalyzer());


### PR DESCRIPTION
This is the backport of #63239

QueryShardContext has a getter that allows to have access to MapperService. In many cases, it is misused to lookup field types which QueryShardContext has a specific method for. This commit replaces those usages with a function String -> MappedFieldType.

There are also a few other places where MapperService is retrieved to call methods that are also available directly on QueryShardContext, which are replaced as part of this commit too.