### PR TITLE
[7.10] Fix failure in AppendProcessorTests.testAppendingUniqueValueToScalar 

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
@@ -179,7 +179,7 @@ public class AppendProcessorTests extends ESTestCase {
         String field = RandomDocumentPicks.addRandomField(random(), ingestDocument, originalValue);
 
         List<Object> valuesToAppend = new ArrayList<>();
-        String newValue = randomAlphaOfLengthBetween(1, 10);
+        String newValue = randomValueOtherThan(originalValue, () -> randomAlphaOfLengthBetween(1, 10));
         valuesToAppend.add(newValue);
         Processor appendProcessor = createAppendProcessor(field, valuesToAppend, false);
         appendProcessor.execute(ingestDocument);


### PR DESCRIPTION
Fixes #62411

Backport of #62453
