### PR TITLE
[7.x] [DOCS] Adds huber and msle metrics to Evaluate API example calls (#63414)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -315,7 +315,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.price_prediction", <4>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {"offset": 10},
+        "huber": {"delta": 1.5}
       }
     }
   }
@@ -352,7 +354,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }
@@ -391,7 +395,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds huber and msle metrics to Evaluate API example calls (#63414)