### PR TITLE
[7.9] [DOCS] Adds huber and msle metrics to Evaluate API example calls (#63414)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -298,7 +298,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.price_prediction", <4>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {"offset": 10},
+        "huber": {"delta": 1.5}
       }
     }
   }
@@ -335,7 +337,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }
@@ -374,7 +378,9 @@ POST _ml/data_frame/_evaluate
       "predicted_field": "ml.G3_prediction", <3>
       "metrics": {  
         "r_squared": {},
-        "mse": {}
+        "mse": {},
+        "msle": {},
+        "huber": {}
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Adds huber and msle metrics to Evaluate API example calls (#63414)