### PR TITLE
Flush translog writer before adding new operation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -197,6 +197,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             if (buffer == null) {
                 buffer = new ReleasableBytesStreamOutput(bigArrays);
             }
+            assert bufferedBytes == buffer.size();
             final long offset = totalOffset;
             totalOffset += data.length();
             data.writeTo(buffer);

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -87,6 +87,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
 
     private LongArrayList nonFsyncedSequenceNumbers = new LongArrayList(64);
     private final int forceWriteThreshold;
+    private volatile long bufferedBytes;
     private ReleasableBytesStreamOutput buffer;
 
     private final Map<Long, Tuple<BytesReference, Exception>> seenSequenceNumbers;
@@ -185,8 +186,12 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
      * @throws IOException if writing to the translog resulted in an I/O exception
      */
     public Translog.Location add(final BytesReference data, final long seqNo) throws IOException {
+        long bufferedBytesBeforeAdd = this.bufferedBytes;
+        if (bufferedBytesBeforeAdd >= forceWriteThreshold) {
+            writeBufferedOps(Long.MAX_VALUE, bufferedBytesBeforeAdd >= forceWriteThreshold * 4);
+        }
+
         final Translog.Location location;
-        final long bytesBufferedAfterAdd;
         synchronized (this) {
             ensureOpen();
             if (buffer == null) {
@@ -209,11 +214,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             assert assertNoSeqNumberConflict(seqNo, data);
 
             location = new Translog.Location(generation, offset, data.length());
-            bytesBufferedAfterAdd = buffer.size();
-        }
-
-        if (bytesBufferedAfterAdd >= forceWriteThreshold) {
-            writeBufferedOps(Long.MAX_VALUE, bytesBufferedAfterAdd >= forceWriteThreshold * 4);
+            bufferedBytes = buffer.size();
         }
 
         return location;
@@ -458,6 +459,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         if (this.buffer != null) {
             ReleasableBytesStreamOutput toWrite = this.buffer;
             this.buffer = null;
+            this.bufferedBytes = 0;
             return new ReleasableBytesReference(toWrite.bytes(), toWrite);
         } else {
             return ReleasableBytesReference.wrap(BytesArray.EMPTY);
@@ -551,6 +553,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             synchronized (this) {
                 Releasables.closeWhileHandlingException(buffer);
                 buffer = null;
+                bufferedBytes = 0;
             }
             IOUtils.close(checkpointChannel, channel);
         }


### PR DESCRIPTION
Currently we flush the Translog buffer when a new operation causes the
buffer to breach 1MB. This introduces a scenario where an exception is
thrown AFTER the writer has accepted the operation. To avoid this, this
commit flushes the Translog in an #add call before adding a new
operation.

This fixes #63299.