### PR TITLE
Fix type name in testSystemIndexMetadataIsUpgraded 

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1461,7 +1461,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63457")
     public void testSystemIndexMetadataIsUpgraded() throws Exception {
         final String systemIndexWarning = "this request accesses system indices: [.tasks], but in a future major version, direct " +
             "access to system indices will be prevented by default";
@@ -1473,7 +1472,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
             Request bulk = new Request("POST", "/_bulk");
             bulk.addParameter("refresh", "true");
-            bulk.setJsonEntity("{\"index\": {\"_index\": \"test_index_old\", \"_type\" : \"_doc\"}}\n" +
+            bulk.setJsonEntity("{\"index\": {\"_index\": \"test_index_old\", \"_type\" : \"" + type + "\"}}\n" +
                 "{\"f1\": \"v1\", \"f2\": \"v2\"}\n");
         if (isRunningAgainstAncientCluster() == false) {
             bulk.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));


### PR DESCRIPTION
This test used `_doc` as the mapping type name, which needs to be set
to `doc` for versions prior to 6.7.0. This commit fixes the test to use
the proper type name for the current BWC version.

Fixes https://github.com/elastic/elasticsearch/issues/63457