### PR TITLE
[7.x] Wait for license to be active in PingAndInfoIT before checking in test (#63362)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -56,7 +56,8 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertEquals(versionMap.get("lucene_version"), info.getVersion().getLuceneVersion());
     }
 
-    public void testXPackInfo() throws IOException {
+    public void testXPackInfo() throws Exception {
+        waitForActiveLicense(client());
         XPackInfoRequest request = new XPackInfoRequest();
         request.setCategories(EnumSet.allOf(XPackInfoRequest.Category.class));
         request.setVerbose(true);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Wait for license to be active in PingAndInfoIT before checking in test (#63362)