### PR TITLE
Add isFieldMapped method to QueryShardContext (#63322)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -95,10 +95,6 @@ public class FieldsVisitor extends StoredFieldVisitor {
         }
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
             MappedFieldType fieldType = fieldTypeLookup.apply(entry.getKey());
-            if (fieldType == null) {
-                throw new IllegalStateException("Field [" + entry.getKey()
-                    + "] exists in the index but not in mappings");
-            }
             List<Object> fieldValues = entry.getValue();
             for (int i = 0; i < fieldValues.size(); i++) {
                 fieldValues.set(i, fieldType.valueForDisplay(fieldValues.get(i)));

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -302,7 +302,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
 
         // ToParentBlockJoinQuery requires that the inner query only matches documents
         // in its child space
-        NestedHelper nestedHelper = new NestedHelper(context.getMapperService()::getObjectMapper, context.getMapperService()::fieldType);
+        NestedHelper nestedHelper = new NestedHelper(context::getObjectMapper, context::isFieldMapped);
         if (nestedHelper.mightMatchNonNestedDocs(innerQuery, path)) {
             innerQuery = Queries.filtered(innerQuery, nestedObjectMapper.nestedTypeFilter());
         }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -242,8 +242,24 @@ public class QueryShardContext extends QueryRewriteContext {
         return mapperService.simpleMatchToFullName(pattern);
     }
 
+    /**
+     * Returns the {@link MappedFieldType} for the provided field name.
+     * If the field is not mapped, the behaviour depends on the index.query.parse.allow_unmapped_fields setting, which defaults to true.
+     * In case unmapped fields are allowed, null is returned when the field is not mapped.
+     * In case unmapped fields are not allowed, either an exception is thrown or the field is automatically mapped as a text field.
+     * @throws QueryShardException if unmapped fields are not allowed and automatically mapping unmapped fields as text is disabled.
+     * @see QueryShardContext#setAllowUnmappedFields(boolean)
+     * @see QueryShardContext#setMapUnmappedFieldAsString(boolean)
+     */
     public MappedFieldType fieldMapper(String name) {
         return failIfFieldMappingNotFound(name, mapperService.fieldType(name));
+    }
+
+    /**
+     * Returns true if the field identified by the provided name is mapped, false otherwise
+     */
+    public boolean isFieldMapped(String name) {
+        return mapperService.fieldType(name) != null;
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -475,15 +475,15 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         if (from == null && to == null) {
-            /**
+            /*
              * Open bounds on both side, we can rewrite to an exists query
              * if the {@link FieldNamesFieldMapper} is enabled.
              */
-            final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-                (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
-            if (fieldNamesFieldType == null) {
+            if (context.isFieldMapped(FieldNamesFieldMapper.NAME) == false) {
                 return new MatchNoDocsQuery("No mappings yet");
             }
+            final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
+                (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
             // Exists query would fail if the fieldNames field is disabled.
             if (fieldNamesFieldType.isEnabled()) {
                 return ExistsQueryBuilder.newFilter(context, fieldName, false);

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
@@ -144,14 +143,13 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldV
 
     @Override
     protected ScoreFunction doToFunction(QueryShardContext context) {
-        MappedFieldType fieldType = context.fieldMapper(field);
         IndexNumericFieldData fieldData = null;
-        if (fieldType == null) {
-            if(missing == null) {
+        if (context.isFieldMapped(field)) {
+            fieldData = context.getForField(context.fieldMapper(field));
+        } else {
+            if (missing == null) {
                 throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]. No 'missing' value defined.");
             }
-        } else {
-            fieldData = context.getForField(fieldType);
         }
         return new FieldValueFactorFunction(field, factor, modifier, missing, fieldData);
     }

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
@@ -161,15 +160,15 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             // DocID-based random score generation
             return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
         } else {
-            final MappedFieldType fieldType;
-            if (field != null) {
-                fieldType = context.fieldMapper(field);
-            } else {
+            String fieldName;
+            if (field == null) {
                 deprecationLogger.deprecate("seed_requires_field",
                     "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
-                fieldType = context.fieldMapper(IdFieldMapper.NAME);
+                fieldName = IdFieldMapper.NAME;
+            } else {
+                fieldName = field;
             }
-            if (fieldType == null) {
+            if (context.isFieldMapped(fieldName) == false) {
                 if (context.getMapperService().documentMapper() == null) {
                     // no mappings: the index is empty anyway
                     return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
@@ -178,12 +177,12 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
                         "] and cannot be used as a source of random numbers.");
             }
             int seed;
-            if (this.seed != null) {
-                seed = this.seed;
-            } else {
+            if (this.seed == null) {
                 seed = hash(context.nowInMillis());
+            } else {
+                seed = this.seed;
             }
-            return new RandomScoreFunction(seed, salt, context.getForField(fieldType));
+            return new RandomScoreFunction(seed, salt, context.getForField(context.fieldMapper(fieldName)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
@@ -32,7 +32,6 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 
 import java.util.function.Function;
@@ -42,11 +41,11 @@ import java.util.function.Function;
 public final class NestedHelper {
 
     private final Function<String, ObjectMapper> objectMapperLookup;
-    private final Function<String, MappedFieldType> fieldTypeLookup;
+    private final Function<String, Boolean> isMappedFieldFunction;
 
-    public NestedHelper(Function<String, ObjectMapper> objectMapperLookup, Function<String, MappedFieldType> fieldTypeLookup) {
+    public NestedHelper(Function<String, ObjectMapper> objectMapperLookup, Function<String, Boolean> isMappedFieldFunction) {
         this.objectMapperLookup = objectMapperLookup;
-        this.fieldTypeLookup = fieldTypeLookup;
+        this.isMappedFieldFunction = isMappedFieldFunction;
     }
 
     /** Returns true if the given query might match nested documents. */
@@ -107,7 +106,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (fieldTypeLookup.apply(field) == null) {
+        if (isMappedFieldFunction.apply(field) == false) {
             // field does not exist
             return false;
         }
@@ -176,7 +175,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (fieldTypeLookup.apply(field) == null) {
+        if (isMappedFieldFunction.apply(field) == false) {
             return false;
         }
         for (String parent = parentObject(field); parent != null; parent = parentObject(parent)) {

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -125,11 +125,11 @@ public final class QueryParserHelper {
                 fieldName = fieldName + fieldSuffix;
             }
 
-            MappedFieldType fieldType = context.fieldMapper(fieldName);
-            if (fieldType == null) {
+            if (context.isFieldMapped(fieldName) == false) {
                 continue;
             }
 
+            MappedFieldType fieldType = context.fieldMapper(fieldName);
             if (acceptMetadataField == false && fieldType.name().startsWith("_")) {
                 // Ignore metadata fields
                 continue;

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -623,16 +623,15 @@ public class QueryStringQueryParser extends XQueryParser {
     }
 
     private Query existsQuery(String fieldName) {
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-            (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
-        if (fieldNamesFieldType == null) {
+        if (context.isFieldMapped(FieldNamesFieldMapper.NAME) == false) {
             return new MatchNoDocsQuery("No mappings yet");
         }
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
+            (FieldNamesFieldMapper.FieldNamesFieldType) context.fieldMapper(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType.isEnabled() == false) {
             // The field_names_field is disabled so we switch to a wildcard query that matches all terms
             return new WildcardQuery(new Term(fieldName, "*"));
         }
-
         return ExistsQueryBuilder.newFilter(context, fieldName, false);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -278,7 +278,7 @@ final class DefaultSearchContext extends SearchContext {
             filters.add(typeFilter);
         }
 
-        NestedHelper nestedHelper = new NestedHelper(mapperService()::getObjectMapper, mapperService()::fieldType);
+        NestedHelper nestedHelper = new NestedHelper(mapperService()::getObjectMapper, field -> mapperService().fieldType(field) != null);
         if (mapperService().hasNested()
             && nestedHelper.mightMatchNestedDocs(query)
             && (aliasFilter == null || nestedHelper.mightMatchNestedDocs(aliasFilter))) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -298,19 +298,17 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
             suggestionContext.setShardSize(shardSize);
         }
         MappedFieldType mappedFieldType = context.fieldMapper(suggestionContext.getField());
-        if (mappedFieldType == null || mappedFieldType instanceof CompletionFieldMapper.CompletionFieldType == false) {
+        if (mappedFieldType instanceof CompletionFieldMapper.CompletionFieldType == false) {
             throw new IllegalArgumentException("Field [" + suggestionContext.getField() + "] is not a completion suggest field");
         }
-        if (mappedFieldType instanceof CompletionFieldMapper.CompletionFieldType) {
-            CompletionFieldMapper.CompletionFieldType type = (CompletionFieldMapper.CompletionFieldType) mappedFieldType;
-            suggestionContext.setFieldType(type);
-            if (type.hasContextMappings() && contextBytes != null) {
-                Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = parseContextBytes(contextBytes,
-                        context.getXContentRegistry(), type.getContextMappings());
-                suggestionContext.setQueryContexts(queryContexts);
-            } else if (contextBytes != null) {
-                throw new IllegalArgumentException("suggester [" + type.name() + "] doesn't expect any context");
-            }
+        CompletionFieldMapper.CompletionFieldType type = (CompletionFieldMapper.CompletionFieldType) mappedFieldType;
+        suggestionContext.setFieldType(type);
+        if (type.hasContextMappings() && contextBytes != null) {
+            Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = parseContextBytes(contextBytes,
+                context.getXContentRegistry(), type.getContextMappings());
+            suggestionContext.setQueryContexts(queryContexts);
+        } else if (contextBytes != null) {
+            throw new IllegalArgumentException("suggester [" + type.name() + "] doesn't expect any context");
         }
         assert suggestionContext.getFieldType() != null : "no completion field type set";
         return suggestionContext;

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         String fieldPattern = queryBuilder.fieldName();
         Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
         Collection<String> mappedFields = fields.stream().filter((field) -> context.getObjectMapper(field) != null
-                || context.fieldMapper(field) != null).collect(Collectors.toList());
+                || context.isFieldMapped(field)).collect(Collectors.toList());
         if (mappedFields.size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             return;
@@ -127,7 +127,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
     }
 
     @Override
-    public void testMustRewrite() throws IOException {
+    public void testMustRewrite() {
         QueryShardContext context = createShardContext();
         context.setAllowUnmappedFields(true);
         ExistsQueryBuilder queryBuilder = new ExistsQueryBuilder("foo");

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -49,7 +51,7 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> new ExponentialDecayFunctionBuilder("", "", null, "", randomDouble()));
     }
 
-    public void testRandomScoreFunctionWithSeed() throws Exception {
+    public void testRandomScoreFunctionWithSeedNoField() throws Exception {
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         builder.seed(42);
         QueryShardContext context = Mockito.mock(QueryShardContext.class);
@@ -59,9 +61,26 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         Mockito.when(context.index()).thenReturn(settings.getIndex());
         Mockito.when(context.getShardId()).thenReturn(0);
         Mockito.when(context.getIndexSettings()).thenReturn(settings);
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("foo", NumberType.LONG);
-        Mockito.when(context.fieldMapper(Mockito.anyString())).thenReturn(ft);
+        Mockito.when(context.fieldMapper(IdFieldMapper.NAME)).thenReturn(new KeywordFieldMapper.KeywordFieldType(IdFieldMapper.NAME));
+        Mockito.when(context.isFieldMapped(IdFieldMapper.NAME)).thenReturn(true);
         builder.toFunction(context);
         assertWarnings("As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
+    }
+
+    public void testRandomScoreFunctionWithSeed() throws Exception {
+        RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
+        builder.setField("foo");
+        builder.seed(42);
+        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
+        IndexSettings settings = new IndexSettings(IndexMetadata.builder("index").settings(indexSettings).build(), Settings.EMPTY);
+        Mockito.when(context.index()).thenReturn(settings.getIndex());
+        Mockito.when(context.getShardId()).thenReturn(0);
+        Mockito.when(context.getIndexSettings()).thenReturn(settings);
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("foo", NumberType.LONG);
+        Mockito.when(context.fieldMapper("foo")).thenReturn(ft);
+        Mockito.when(context.isFieldMapped("foo")).thenReturn(true);
+        builder.toFunction(context);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -102,7 +102,7 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     private static NestedHelper buildNestedHelper(MapperService mapperService) {
-        return new NestedHelper(mapperService::getObjectMapper, mapperService::fieldType);
+        return new NestedHelper(mapperService::getObjectMapper, field -> mapperService.fieldType(field) != null);
     }
 
     public void testMatchAll() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -229,6 +229,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
         when(queryShardContext.getMapperService()).thenReturn(mapperService);
         when(queryShardContext.fieldMapper(anyString())).thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()));
+        when(queryShardContext.isFieldMapped(anyString()))
+            .thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()) != null);
         when(queryShardContext.getIndexAnalyzers()).thenReturn(mapperService.getIndexAnalyzers());
         when(queryShardContext.getSearchQuoteAnalyzer(anyObject())).thenCallRealMethod();
         when(queryShardContext.getSearchAnalyzer(anyObject())).thenCallRealMethod();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -123,7 +123,7 @@ public final class DocumentPermissions {
                 Query roleQuery = queryShardContext.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
                 if (queryShardContext.getMapperService().hasNested()) {
-                    NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::fieldMapper);
+                    NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::isFieldMapped);
                     if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)
                                 .add(Queries.newNonNestedFilter(queryShardContext.indexVersionCreated()), FILTER).build();

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -257,7 +257,12 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
 
                         visitor.reset();
                         searcher.doc(scoreDoc.doc, visitor);
-                        visitor.postProcess(context::fieldMapper, context.getMapperService().documentMapper());
+                        visitor.postProcess(field -> {
+                            if (context.isFieldMapped(field) == false) {
+                                throw new IllegalStateException("Field [" + field + "] exists in the index but not in mappings");
+                            }
+                            return context.fieldMapper(field);
+                        }, context.getMapperService().documentMapper());
                         final SearchHit hit = new SearchHit(
                             scoreDoc.doc,
                             visitor.uid().id(),


### PR DESCRIPTION
This is the backport of #63322

As part of #63239 we have moved some usages of QueryShardContext#getMapperService that were looking up a field type through the fieldType method, to use the existing QueryShardContext#fieldMapper. The latter though has additional handling for unmapped fields when the functionality is enabled, and may throw exception if the field is not mapped. This additional behaviour is not desirable and may cause issues in cases where the callers have their own specific handling for situations where the field is not mapped.

To address this we introduce an additional isFieldMapped method to QueryShardContext that allows to check if a field is mapped or not.

relates to #63239
