### PR TITLE
Document standard metadata entries.

### DIFF
--- a/docs/reference/mapping/params/meta.asciidoc
+++ b/docs/reference/mapping/params/meta.asciidoc
@@ -29,3 +29,22 @@ than or equal to 50.
 
 NOTE: Field metadata is updatable by submitting a mapping update. The metadata
 of the update will override the metadata of the existing field.
+
+Elastic products use the following standard metadata entries for fields. You
+can follow these same metadata conventions to get a better out-of-the-box
+experience with your data. 
+
+unit::
+
+  The unit associated with a numeric field: `"percent"`, `"byte"` or a
+  <<time-units,time unit>>. By default, a field does not have a unit.
+  Only valid for numeric fields. The convention for percents is to use
+  value `1` to mean `100%`.
+
+metric_type::
+
+  The  metric type of a numeric field: `"gauge"` or `"counter"`. A gauge is a
+  single-value measurement that can go up or down over time, such as a
+  temperature. A counter is a single-value cumulative counter that only goes
+  up, such as the number of requests processed by a web server. By default,
+  no metric type is associated with a field. Only valid for numeric fields.


### PR DESCRIPTION
We standardize on some metadata entries that we plan to later leverage
in Kibana in order to provide a better out-of-the-box experience, e.g.
different visualizations make sense on gauges and counters.

Backport of #61941.
