### PR TITLE
TextSearchInfo should never get null analyzers (#63472)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -77,7 +77,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
     }
 
     @AfterClass
-    public static void afterClass() throws Exception {
+    public static void afterClass() {
         namedWriteableRegistry = null;
         xContentRegistry = null;
     }
@@ -99,8 +99,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
      * returns a random suggestion builder, setting the common options randomly
      */
     protected SB randomTestBuilder() {
-        SB randomSuggestion = randomSuggestionBuilder();
-        return randomSuggestion;
+        return randomSuggestionBuilder();
     }
 
     public static void setCommonPropertiesOnRandomBuilder(SuggestionBuilder<?> randomSuggestion) {


### PR DESCRIPTION
With #63406 access to search analyzers is now done exclusively via
MappedFieldType. This works now because all MappedFieldType
constructors have either a specified analyzer, or a default, to pass to
TextSearchInfo. To ensure that this continues to be the case, this
commit adds a null check to TextSearchInfo's analyzer parameters.