### PR TITLE
Remove some more QueryShardContext#getMapperService usages (#63389)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -143,7 +143,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) throws IOException {
             NamedAnalyzer analyzer = null;
             if (this.analyzer != null) {
-                analyzer = context.getMapperService().getIndexAnalyzers().get(this.analyzer);
+                analyzer = context.getIndexAnalyzers().get(this.analyzer);
             }
             IntervalsSource source;
             if (useField != null) {
@@ -526,7 +526,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) throws IOException {
             NamedAnalyzer analyzer = null;
             if (this.analyzer != null) {
-                analyzer = context.getMapperService().getIndexAnalyzers().get(this.analyzer);
+                analyzer = context.getIndexAnalyzers().get(this.analyzer);
             }
             IntervalsSource source;
             if (useField != null) {
@@ -641,7 +641,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) {
             NamedAnalyzer analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
             if (this.analyzer != null) {
-                analyzer = context.getMapperService().getIndexAnalyzers().get(this.analyzer);
+                analyzer = context.getIndexAnalyzers().get(this.analyzer);
             }
             IntervalsSource source;
             if (useField != null) {
@@ -778,7 +778,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) {
             NamedAnalyzer analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
             if (this.analyzer != null) {
-                analyzer = context.getMapperService().getIndexAnalyzers().get(this.analyzer);
+                analyzer = context.getIndexAnalyzers().get(this.analyzer);
             }
             IntervalsSource source;
             if (useField != null) {

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -187,10 +187,6 @@ public class QueryShardContext extends QueryRewriteContext {
         this.nestedScope = new NestedScope();
     }
 
-    public IndexAnalyzers getIndexAnalyzers() {
-        return mapperService.getIndexAnalyzers();
-    }
-
     public Similarity getSearchSimilarity() {
         return similarityService != null ? similarityService.similarity(mapperService) : null;
     }
@@ -296,6 +292,10 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public Analyzer getIndexAnalyzer() {
         return mapperService.indexAnalyzer();
+    }
+
+    public IndexAnalyzers getIndexAnalyzers() {
+        return mapperService.getIndexAnalyzers();
     }
 
     public ValuesSourceRegistry getValuesSourceRegistry() {

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -183,7 +183,7 @@ public class MatchQuery {
     }
 
     public void setAnalyzer(String analyzerName) {
-        this.analyzer = context.getMapperService().getIndexAnalyzers().get(analyzerName);
+        this.analyzer = context.getIndexAnalyzers().get(analyzerName);
         if (analyzer == null) {
             throw new IllegalArgumentException("No analyzer found for [" + analyzerName + "]");
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
@@ -298,15 +297,17 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
      * Transfers the text, prefix, regex, analyzer, field, size and shard size settings from the
      * original {@link SuggestionBuilder} to the target {@link SuggestionContext}
      */
-    protected void populateCommonFields(MapperService mapperService, SuggestionSearchContext.SuggestionContext suggestionContext) {
+    protected void populateCommonFields(QueryShardContext context, SuggestionSearchContext.SuggestionContext suggestionContext) {
 
         Objects.requireNonNull(field, "field must not be null");
-
-        MappedFieldType fieldType = mapperService.fieldType(field);
+        if (context.isFieldMapped(field) == false) {
+            throw new IllegalArgumentException("no mapping found for field [" + field + "]");
+        }
+        MappedFieldType fieldType = context.fieldMapper(field);
         if (analyzer == null) {
             suggestionContext.setAnalyzer(fieldType.getTextSearchInfo().getSearchAnalyzer());
         } else {
-            Analyzer luceneAnalyzer = mapperService.getNamedAnalyzer(analyzer);
+            Analyzer luceneAnalyzer = context.getIndexAnalyzers().get(analyzer);
             if (luceneAnalyzer == null) {
                 throw new IllegalArgumentException("analyzer [" + analyzer + "] doesn't exists");
             }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
@@ -289,8 +288,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     public SuggestionContext build(QueryShardContext context) throws IOException {
         CompletionSuggestionContext suggestionContext = new CompletionSuggestionContext(context);
         // copy over common settings to each suggestion builder
-        final MapperService mapperService = context.getMapperService();
-        populateCommonFields(mapperService, suggestionContext);
+        populateCommonFields(context, suggestionContext);
         suggestionContext.setSkipDuplicates(skipDuplicates);
         suggestionContext.setFuzzyOptions(fuzzyOptions);
         suggestionContext.setRegexOptions(regexOptions);

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.search.suggest.SortBy;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.CandidateGenerator;
 
@@ -408,18 +408,18 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
     }
 
     @Override
-    public PhraseSuggestionContext.DirectCandidateGenerator build(MapperService mapperService) throws IOException {
+    public PhraseSuggestionContext.DirectCandidateGenerator build(IndexAnalyzers indexAnalyzers) {
         PhraseSuggestionContext.DirectCandidateGenerator generator = new PhraseSuggestionContext.DirectCandidateGenerator();
         generator.setField(this.field);
         transferIfNotNull(this.size, generator::size);
         if (this.preFilter != null) {
-            generator.preFilter(mapperService.getNamedAnalyzer(this.preFilter));
+            generator.preFilter(indexAnalyzers.get(this.preFilter));
             if (generator.preFilter() == null) {
                 throw new IllegalArgumentException("Analyzer [" + this.preFilter + "] doesn't exists");
             }
         }
         if (this.postFilter != null) {
-            generator.postFilter(mapperService.getNamedAnalyzer(this.postFilter));
+            generator.postFilter(indexAnalyzers.get(this.postFilter));
             if (generator.postFilter() == null) {
                 throw new IllegalArgumentException("Analyzer [" + this.postFilter + "] doesn't exists");
             }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -32,10 +32,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.analysis.AnalyzerComponentsProvider;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -606,10 +606,8 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
     @Override
     public SuggestionContext build(QueryShardContext context) throws IOException {
         PhraseSuggestionContext suggestionContext = new PhraseSuggestionContext(context);
-        MapperService mapperService = context.getMapperService();
         // copy over common settings to each suggestion builder
-        populateCommonFields(mapperService, suggestionContext);
-
+        populateCommonFields(context, suggestionContext);
         suggestionContext.setSeparator(BytesRefs.toBytesRef(this.separator));
         suggestionContext.setRealWordErrorLikelihood(this.realWordErrorLikelihood);
         suggestionContext.setConfidence(this.confidence);
@@ -625,7 +623,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
 
         for (List<CandidateGenerator> candidateGenerators : this.generators.values()) {
             for (CandidateGenerator candidateGenerator : candidateGenerators) {
-                suggestionContext.addGenerator(candidateGenerator.build(mapperService));
+                suggestionContext.addGenerator(candidateGenerator.build(context.getIndexAnalyzers()));
             }
         }
 
@@ -730,6 +728,6 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
     public interface CandidateGenerator extends Writeable, ToXContentObject {
         String getType();
 
-        PhraseSuggestionContext.DirectCandidateGenerator build(MapperService mapperService) throws IOException;
+        PhraseSuggestionContext.DirectCandidateGenerator build(IndexAnalyzers indexAnalyzers) throws IOException;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -445,7 +445,7 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     public SuggestionContext build(QueryShardContext context) throws IOException {
         TermSuggestionContext suggestionContext = new TermSuggestionContext(context);
         // copy over common settings to each suggestion builder
-        populateCommonFields(context.getMapperService(), suggestionContext);
+        populateCommonFields(context, suggestionContext);
         // Transfers the builder settings to the target TermSuggestionContext
         DirectSpellcheckerSettings settings = suggestionContext.getDirectSpellCheckerSettings();
         settings.accuracy(accuracy);

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -752,7 +752,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field._index_phrase");
         assertEquals(1, fields.length);
 
-        try (TokenStream ts = fields[0].tokenStream(queryShardContext.getMapperService().indexAnalyzer(), null)) {
+        try (TokenStream ts = fields[0].tokenStream(mapperService.indexAnalyzer(), null)) {
             CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
             ts.reset();
             assertTrue(ts.incrementToken());

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -31,14 +31,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -402,28 +399,21 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
     }
 
     public void testScriptFilter() throws IOException {
-
         IntervalFilterScript.Factory factory = () -> new IntervalFilterScript() {
             @Override
             public boolean execute(Interval interval) {
                 return interval.getStart() > 3;
             }
         };
-
-        ScriptService scriptService = new ScriptService(Settings.EMPTY, Collections.emptyMap(), Collections.emptyMap()){
+        QueryShardContext context = new QueryShardContext(createShardContext()) {
             @Override
             @SuppressWarnings("unchecked")
             public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
                 assertEquals(IntervalFilterScript.CONTEXT, context);
                 assertEquals(new Script("interval.start > 3"), script);
-                return (FactoryType) factory;
+                return (FactoryType)factory;
             }
         };
-
-        QueryShardContext baseContext = createShardContext();
-        QueryShardContext context = new QueryShardContext(baseContext.getShardId(), baseContext.getIndexSettings(),
-            BigArrays.NON_RECYCLING_INSTANCE, null, null, baseContext.getMapperService(),
-            null, scriptService, null, null, null, null, null, null, null, () -> true, null);
 
         String json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"match\" : { " +
@@ -435,11 +425,9 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         IntervalQueryBuilder builder = (IntervalQueryBuilder) parseQuery(json);
         Query q = builder.toQuery(context);
 
-
         IntervalQuery expected = new IntervalQuery(TEXT_FIELD_NAME,
             new IntervalsSourceProvider.ScriptFilterSource(Intervals.term("term1"), "interval.start > 3", null));
         assertEquals(expected, q);
-
     }
 
     public void testPrefixes() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
@@ -52,6 +53,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.lucene.BytesRefs.toBytesRef;
@@ -164,8 +167,16 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             ScriptService scriptService = mock(ScriptService.class);
             MappedFieldType fieldType = mockFieldType(suggestionBuilder.field());
             when(mapperService.fieldType(any(String.class))).thenReturn(fieldType);
-            when(mapperService.getNamedAnalyzer(any(String.class))).then(
-                    invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
+            IndexAnalyzers indexAnalyzers = new IndexAnalyzers(
+                new HashMap<String, NamedAnalyzer>() {
+                    @Override
+                    public NamedAnalyzer get(Object key) {
+                        return new NamedAnalyzer(key.toString(), AnalyzerScope.INDEX, new SimpleAnalyzer());
+                    }
+                },
+                Collections.emptyMap(),
+                Collections.emptyMap());
+            when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
             when(scriptService.compile(any(Script.class), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(
                     ((Script) invocation.getArguments()[0]).getIdOrCode()));
             QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, BigArrays.NON_RECYCLING_INSTANCE, null,
@@ -206,8 +217,6 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
         MapperService mapperService = mock(MapperService.class);
         ScriptService scriptService = mock(ScriptService.class);
 
-        when(mapperService.searchAnalyzer())
-            .thenReturn(new NamedAnalyzer("mapperServiceSearchAnalyzer", AnalyzerScope.INDEX, new SimpleAnalyzer()));
         when(mapperService.getNamedAnalyzer(any(String.class))).then(
             invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
         QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, BigArrays.NON_RECYCLING_INSTANCE, null,

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -227,7 +227,6 @@ public abstract class MapperServiceTestCase extends ESTestCase {
 
     QueryShardContext createQueryShardContext(MapperService mapperService) {
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.getMapperService()).thenReturn(mapperService);
         when(queryShardContext.fieldMapper(anyString())).thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()));
         when(queryShardContext.isFieldMapped(anyString()))
             .thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()) != null);


### PR DESCRIPTION
This is the backport of #63389

Some callers of `getMapperService` only call `getIndexAnalyzers` on it, which is already available on `QueryShardContext`. This commit moves these callers to call `QueryShardContext#getIndexAnalyzers` directly.

Also, the remaining getMapperService usages in tests can now be removed or replaced.