### PR TITLE
Adds quotes to value containing : in runtime_fields test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -183,7 +183,7 @@ setup:
             term:
               voltage_times_ten: 58
   - match: {hits.hits.0._explanation.value: 1.0}
-  - match: {hits.hits.0._explanation.description: voltage_times_ten:58}
+  - match: {hits.hits.0._explanation.description: "voltage_times_ten:58"}
   - match: {hits.hits.0._explanation.details.0.value: 1.0}
   - match: {hits.hits.0._explanation.details.0.description: 'boost * runtime_field_score'}
   - match: {hits.hits.0._explanation.details.0.details.0.value: 1.0}


### PR DESCRIPTION
This Pull Request wraps a value containing `:` in quotes so the YAML parser doesn't error when trying to load this test file.

Also in `7.x`: #63543