### PR TITLE
Allow MappedFieldType impls to hide themselves from field caps

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -8,6 +8,12 @@ setup:
                 properties:
                   text:
                     type:     text
+                  text_with_subs:
+                    type:     text
+                    index_prefixes:
+                      min_chars: 2
+                      max_chars: 3
+                    index_phrases: true
                   keyword:
                     type:     keyword
                   number:
@@ -316,3 +322,18 @@ setup:
   - match: {fields.misc.unmapped.searchable:            false}
   - match: {fields.misc.unmapped.aggregatable:          false}
   - match: {fields.misc.unmapped.indices:               ["test2", "test3"]}
+
+---
+"Field caps exclude text implementation subfields":
+  - skip:
+      version: " - 8.0.0"
+      reason: subfields excluded in 7.11
+
+  - do:
+      field_caps:
+        index: 'test1,test2,test3'
+        fields: [ text_with_subs ]
+
+  - match: { fields.text_with_subs: true }
+  - match: { fields.text_with_subs._index_prefix: false }
+  - match: { fields.text_with_subs._index_phrase: false }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -48,9 +48,9 @@ public class IndexFieldCapabilities implements Writeable {
      * @param isAggregatable Whether this field can be aggregated on.
      * @param meta Metadata about the field.
      */
-    IndexFieldCapabilities(String name, String type,
-                           boolean isSearchable, boolean isAggregatable,
-                           Map<String, String> meta) {
+    public IndexFieldCapabilities(String name, String type,
+                                  boolean isSearchable, boolean isAggregatable,
+                                  Map<String, String> meta) {
 
         this.name = name;
         this.type = type;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -124,8 +124,10 @@ public class TransportFieldCapabilitiesIndexAction
             if (ft != null) {
                 if (indicesService.isMetadataField(mapperService.getIndexSettings().getIndexVersionCreated(), field)
                     || fieldPredicate.test(ft.name())) {
-                    IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(field, ft.familyTypeName(),
-                        ft.isSearchable(), ft.isAggregatable(), ft.meta());
+                    IndexFieldCapabilities fieldCap = ft.fieldCaps();
+                    if (fieldCap == null) {
+                        continue;
+                    }
                     responseMap.put(field, fieldCap);
                 } else {
                     continue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.time.DateMathParser;
@@ -109,6 +110,10 @@ public abstract class MappedFieldType {
     /** Returns the field family type, as used in field capabilities */
     public String familyTypeName() {
         return typeName();
+    }
+
+    public IndexFieldCapabilities fieldCaps() {
+        return new IndexFieldCapabilities(name, familyTypeName(), isSearchable(), isAggregatable(), meta);
     }
 
     public String name() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -112,6 +112,12 @@ public abstract class MappedFieldType {
         return typeName();
     }
 
+    /**
+     * Returns the capabilities of this field.
+     *
+     * If the field should not be returned as part of a Field Capabilities call,
+     * implementations can return {@code null}
+     */
     public IndexFieldCapabilities fieldCaps() {
         return new IndexFieldCapabilities(name, familyTypeName(), isSearchable(), isAggregatable(), meta);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -57,6 +57,7 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
@@ -460,6 +461,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
+        public IndexFieldCapabilities fieldCaps() {
+            return null;    // don't show impl sub-fields in fieldcaps
+        }
+
+        @Override
         public String typeName() {
             return "phrase";
         }
@@ -490,6 +496,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
             this.minChars = minChars;
             this.maxChars = maxChars;
             this.parentField = parentField;
+        }
+
+        @Override
+        public IndexFieldCapabilities fieldCaps() {
+            return null;    // don't show impl subfields in field caps
         }
 
         @Override


### PR DESCRIPTION
Text fields can optionally index their content in multiple ways to speed up
phrase or prefix queries, implemented via named subfields with specialised
analysis chains.  As these subfields need to be searchable, they have their
own FieldMappers and MappedFieldTypes; unfortunately, this means that
they can end up being returned in calls to the `field_caps` endpoint, where
really they are implementation details and should be hidden from users.

This commit adds a `fieldCaps()` method directly to MappedFieldType,
called by the field capabilities action.  Field types that should be hidden
from `field_caps` can return `null` from this method, and will be excluded
from the response.

Fixes #63446 