### PR TITLE
[7.10][ML] Validate dest pipeline exists on transform update (#63494)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.protocol.xpack.license.LicenseStatus;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
@@ -62,6 +63,7 @@ public final class SourceDestValidator {
     public static final String REMOTE_CLUSTER_LICENSE_INACTIVE = "License check failed for remote cluster "
         + "alias [{0}], license is not active";
     public static final String REMOTE_SOURCE_INDICES_NOT_SUPPORTED = "remote source indices are not supported";
+    public static final String PIPELINE_MISSING = "Pipeline with id [{0}] could not be found";
 
     // workaround for 7.x: remoteClusterAliases does not throw
     private static final ClusterNameExpressionResolver clusterNameExpressionResolver = new ClusterNameExpressionResolver();
@@ -69,6 +71,7 @@ public final class SourceDestValidator {
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final RemoteClusterService remoteClusterService;
     private final RemoteClusterLicenseChecker remoteClusterLicenseChecker;
+    private final IngestService ingestService;
     private final String nodeName;
     private final String license;
 
@@ -80,8 +83,10 @@ public final class SourceDestValidator {
         private final IndexNameExpressionResolver indexNameExpressionResolver;
         private final RemoteClusterService remoteClusterService;
         private final RemoteClusterLicenseChecker remoteClusterLicenseChecker;
+        private final IngestService ingestService;
         private final String[] source;
-        private final String dest;
+        private final String destIndex;
+        private final String destPipeline;
         private final String nodeName;
         private final String license;
 
@@ -95,8 +100,10 @@ public final class SourceDestValidator {
             final IndexNameExpressionResolver indexNameExpressionResolver,
             final RemoteClusterService remoteClusterService,
             final RemoteClusterLicenseChecker remoteClusterLicenseChecker,
+            final IngestService ingestService,
             final String[] source,
-            final String dest,
+            final String destIndex,
+            final String destPipeline,
             final String nodeName,
             final String license
         ) {
@@ -104,8 +111,10 @@ public final class SourceDestValidator {
             this.indexNameExpressionResolver = indexNameExpressionResolver;
             this.remoteClusterService = remoteClusterService;
             this.remoteClusterLicenseChecker = remoteClusterLicenseChecker;
+            this.ingestService = ingestService;
             this.source = source;
-            this.dest = dest;
+            this.destIndex = destIndex;
+            this.destPipeline = destPipeline;
             this.nodeName = nodeName;
             this.license = license;
         }
@@ -126,6 +135,10 @@ public final class SourceDestValidator {
             return indexNameExpressionResolver;
         }
 
+        public IngestService getIngestService() {
+            return ingestService;
+        }
+
         public boolean isRemoteSearchEnabled() {
             return remoteClusterLicenseChecker != null;
         }
@@ -134,8 +147,8 @@ public final class SourceDestValidator {
             return source;
         }
 
-        public String getDest() {
-            return dest;
+        public String getDestIndex() {
+            return destIndex;
         }
 
         public String getNodeName() {
@@ -168,11 +181,11 @@ public final class SourceDestValidator {
                     Index singleWriteIndex = indexNameExpressionResolver.concreteWriteIndex(
                         state,
                         IndicesOptions.lenientExpandOpen(),
-                        dest,
+                        destIndex,
                         true,
                         false);
 
-                    resolvedDest = singleWriteIndex != null ? singleWriteIndex.getName() : dest;
+                    resolvedDest = singleWriteIndex != null ? singleWriteIndex.getName() : destIndex;
                 } catch (IllegalArgumentException e) {
                     // stop here as we can not return a single dest index
                     addValidationError(e.getMessage());
@@ -236,6 +249,7 @@ public final class SourceDestValidator {
     public static final SourceDestValidation DESTINATION_IN_SOURCE_VALIDATION = new DestinationInSourceValidation();
     public static final SourceDestValidation DESTINATION_SINGLE_INDEX_VALIDATION = new DestinationSingleIndexValidation();
     public static final SourceDestValidation REMOTE_SOURCE_NOT_SUPPORTED_VALIDATION = new RemoteSourceNotSupportedValidation();
+    public static final SourceDestValidation DESTINATION_PIPELINE_MISSING_VALIDATION = new DestinationPipelineMissingValidation();
 
     /**
      * Create a new Source Dest Validator
@@ -250,29 +264,33 @@ public final class SourceDestValidator {
         IndexNameExpressionResolver indexNameExpressionResolver,
         RemoteClusterService remoteClusterService,
         RemoteClusterLicenseChecker remoteClusterLicenseChecker,
+        IngestService ingestService,
         String nodeName,
         String license
     ) {
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.remoteClusterService = remoteClusterService;
         this.remoteClusterLicenseChecker = remoteClusterLicenseChecker;
+        this.ingestService = ingestService;
         this.nodeName = nodeName;
         this.license = license;
     }
 
     /**
-     * Run validation against source and dest.
+     * Run validation against source and destIndex.
      *
      * @param clusterState The current ClusterState
      * @param source an array of source indexes
-     * @param dest destination index
+     * @param destIndex destination index
+     * @param destPipeline destination pipeline
      * @param validations list of of validations to run
      * @param listener result listener
      */
     public void validate(
         final ClusterState clusterState,
         final String[] source,
-        final String dest,
+        final String destIndex,
+        @Nullable final String destPipeline,
         final List<SourceDestValidation> validations,
         final ActionListener<Boolean> listener
     ) {
@@ -281,8 +299,10 @@ public final class SourceDestValidator {
             indexNameExpressionResolver,
             remoteClusterService,
             remoteClusterLicenseChecker,
+            ingestService,
             source,
-            dest,
+            destIndex,
+            destPipeline,
             nodeName,
             license
         );
@@ -306,7 +326,7 @@ public final class SourceDestValidator {
     }
 
     /**
-     * Validate dest request.
+     * Validate request.
      *
      * This runs a couple of simple validations at request time, to be executed from a {@link ActionRequest}}
      * implementation.
@@ -314,17 +334,17 @@ public final class SourceDestValidator {
      * Note: Source can not be validated at request time as it might contain expressions.
      *
      * @param validationException an ActionRequestValidationException for collection validation problem, can be null
-     * @param dest destination index, null if validation shall be skipped
+     * @param destIndex destination index, null if validation shall be skipped
      */
     public static ActionRequestValidationException validateRequest(
         @Nullable ActionRequestValidationException validationException,
-        @Nullable String dest
+        @Nullable String destIndex
     ) {
         try {
-            if (dest != null) {
-                validateIndexOrAliasName(dest, InvalidIndexNameException::new);
-                if (dest.toLowerCase(Locale.ROOT).equals(dest) == false) {
-                    validationException = addValidationError(getMessage(DEST_LOWERCASE, dest), validationException);
+            if (destIndex != null) {
+                validateIndexOrAliasName(destIndex, InvalidIndexNameException::new);
+                if (destIndex.toLowerCase(Locale.ROOT).equals(destIndex) == false) {
+                    validationException = addValidationError(getMessage(DEST_LOWERCASE, destIndex), validationException);
                 }
             }
         } catch (InvalidIndexNameException ex) {
@@ -408,7 +428,7 @@ public final class SourceDestValidator {
 
         @Override
         public void validate(Context context, ActionListener<Context> listener) {
-            final String destIndex = context.getDest();
+            final String destIndex = context.getDestIndex();
             boolean foundSourceInDest = false;
 
             for (String src : context.getSource()) {
@@ -457,6 +477,19 @@ public final class SourceDestValidator {
         public void validate(Context context, ActionListener<Context> listener) {
             if (context.resolveRemoteSource().isEmpty() == false) {
                 context.addValidationError(REMOTE_SOURCE_INDICES_NOT_SUPPORTED);
+            }
+            listener.onResponse(context);
+        }
+    }
+
+    static class DestinationPipelineMissingValidation implements SourceDestValidation {
+
+        @Override
+        public void validate(Context context, ActionListener<Context> listener) {
+            if (context.destPipeline != null) {
+                if (context.ingestService.getPipeline(context.destPipeline) == null) {
+                    context.addValidationError(PIPELINE_MISSING, context.destPipeline);
+                }
             }
             listener.onResponse(context);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -27,7 +27,6 @@ public class TransformMessages {
     public static final String REST_FAILED_TO_SERIALIZE_TRANSFORM = "Failed to serialise transform [{0}]";
     public static final String TRANSFORM_FAILED_TO_PERSIST_STATS = "Failed to persist transform statistics for transform [{0}]";
     public static final String UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
-    public static final String PIPELINE_MISSING = "Pipeline with id [{0}] could not be found";
 
     public static final String REST_DEPRECATED_ENDPOINT = "[_data_frame/transforms/] is deprecated, use [_transform/] in the future.";
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -93,6 +93,7 @@ public class TransportPutDataFrameAnalyticsAction
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
             null,
+            null,
             clusterService.getNodeName(),
             License.OperationMode.PLATINUM.description()
         );
@@ -128,7 +129,7 @@ public class TransportPutDataFrameAnalyticsAction
             listener::onFailure
         );
 
-        sourceDestValidator.validate(clusterService.state(), config.getSource().getIndex(), config.getDest().getIndex(),
+        sourceDestValidator.validate(clusterService.state(), config.getSource().getIndex(), config.getDest().getIndex(), null,
             SourceDestValidations.ALL_VALIDATIONS, sourceDestValidationListener);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -132,6 +132,7 @@ public class TransportStartDataFrameAnalyticsAction
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
             null,
+            null,
             clusterService.getNodeName(),
             License.OperationMode.PLATINUM.description()
         );
@@ -313,7 +314,7 @@ public class TransportStartDataFrameAnalyticsAction
 
                 // Validate source/dest are valid
                 sourceDestValidator.validate(clusterService.state(), startContext.config.getSource().getIndex(),
-                    startContext.config.getDest().getIndex(), SourceDestValidations.ALL_VALIDATIONS, ActionListener.wrap(
+                    startContext.config.getDest().getIndex(), null, SourceDestValidations.ALL_VALIDATIONS, ActionListener.wrap(
                         aBoolean -> toValidateExtractionPossibleListener.onResponse(startContext), finalListener::onFailure));
             },
             finalListener::onFailure

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -260,7 +260,6 @@ setup:
         body: >
           {
             "source": { "index": "airline-data" },
-            "dest": { "pipeline": "missing-pipeline" },
             "pivot": {
               "group_by": {
                 "time": {"date_histogram": {"fixed_interval": "1h", "field": "time"}}},
@@ -275,7 +274,6 @@ setup:
         body: >
           {
             "source": { "index": "airline-data" },
-            "dest": { "pipeline": "missing-pipeline" },
             "pivot": {
               "group_by": {
                 "time": {"date_histogram": {"fixed_interval": "1h", "field": "time"}}},

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -45,6 +45,16 @@ setup:
             "description": "new description"
           }
 ---
+"Test update transform with missing pipeline":
+  - do:
+      catch: /Pipeline with id \[missing-transform-pipeline\] could not be found/
+      transform.update_transform:
+        transform_id: "updating-airline-transform"
+        body: >
+          {
+            "dest": { "index": "airline-data-by-airline", "pipeline": "missing-transform-pipeline" }
+          }
+---
 "Test update transform with frequency too low":
   - do:
       catch: /minimum permitted \[frequency\] is \[1s\]/

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -76,7 +76,6 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
     private final SecurityContext securityContext;
     private final TransformAuditor auditor;
     private final SourceDestValidator sourceDestValidator;
-    private final IngestService ingestService;
 
     @Inject
     public TransportPutTransformAction(
@@ -141,10 +140,10 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
+            ingestService,
             clusterService.getNodeName(),
             License.OperationMode.BASIC.description()
         );
-        this.ingestService = ingestService;
     }
 
     static HasPrivilegesRequest buildPrivilegeCheck(
@@ -229,6 +228,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             clusterState,
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
+            config.getDestination().getPipeline(),
             request.isDeferValidation() ? SourceDestValidations.NON_DEFERABLE_VALIDATIONS : SourceDestValidations.ALL_VALIDATIONS,
             ActionListener.wrap(
                 validationResponse -> {
@@ -322,22 +322,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             if (request.isDeferValidation()) {
                 validationListener.onResponse(true);
             } else {
-                if (config.getDestination().getPipeline() != null) {
-                    if (ingestService.getPipeline(config.getDestination().getPipeline()) == null) {
-                        listener.onFailure(
-                            new ElasticsearchStatusException(
-                                TransformMessages.getMessage(TransformMessages.PIPELINE_MISSING, config.getDestination().getPipeline()),
-                                RestStatus.BAD_REQUEST
-                            )
-                        );
-                        return;
-                    }
-                }
-                if (request.isDeferValidation()) {
-                    validationListener.onResponse(true);
-                } else {
-                    function.validateQuery(client, config.getSource(), validationListener);
-                }
+                function.validateQuery(client, config.getSource(), validationListener);
             }
         }, listener::onFailure));
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -140,6 +140,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
+            ingestService,
             clusterService.getNodeName(),
             License.OperationMode.BASIC.description()
         );
@@ -269,22 +270,12 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 createTransform(config.getId(), config.getVersion(), config.getFrequency(), config.getSource().requiresRemoteCluster())
             );
             transformConfigHolder.set(config);
-            if (config.getDestination().getPipeline() != null) {
-                if (ingestService.getPipeline(config.getDestination().getPipeline()) == null) {
-                    listener.onFailure(
-                        new ElasticsearchStatusException(
-                            TransformMessages.getMessage(TransformMessages.PIPELINE_MISSING, config.getDestination().getPipeline()),
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
-                    return;
-                }
-            }
 
             sourceDestValidator.validate(
                 clusterService.state(),
                 config.getSource().getIndex(),
                 config.getDestination().getIndex(),
+                config.getDestination().getPipeline(),
                 SourceDestValidations.ALL_VALIDATIONS,
                 validationListener
             );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -29,7 +30,8 @@ public class TransportPreviewTransformActionDeprecated extends TransportPreviewT
         XPackLicenseState licenseState,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
-        Settings settings
+        Settings settings,
+        IngestService ingestService
     ) {
         super(
             PreviewTransformActionDeprecated.NAME,
@@ -40,7 +42,8 @@ public class TransportPreviewTransformActionDeprecated extends TransportPreviewT
             licenseState,
             indexNameExpressionResolver,
             clusterService,
-            settings
+            settings,
+            ingestService
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -31,7 +32,8 @@ public class TransportUpdateTransformActionDeprecated extends TransportUpdateTra
         ClusterService clusterService,
         XPackLicenseState licenseState,
         TransformServices transformServices,
-        Client client
+        Client client,
+        IngestService ingestService
     ) {
         super(
             UpdateTransformActionDeprecated.NAME,
@@ -43,7 +45,8 @@ public class TransportUpdateTransformActionDeprecated extends TransportUpdateTra
             clusterService,
             licenseState,
             transformServices,
-            client
+            client,
+            ingestService
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SourceDestValidations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SourceDestValidations.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.DESTINATION_IN_SOURCE_VALIDATION;
+import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.DESTINATION_PIPELINE_MISSING_VALIDATION;
 import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.DESTINATION_SINGLE_INDEX_VALIDATION;
 import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.REMOTE_SOURCE_VALIDATION;
 import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.SOURCE_MISSING_VALIDATION;
@@ -25,13 +26,14 @@ public final class SourceDestValidations {
     private SourceDestValidations() {}
 
     public static final List<SourceDestValidator.SourceDestValidation> PREVIEW_VALIDATIONS = Arrays.asList(
-        SOURCE_MISSING_VALIDATION, REMOTE_SOURCE_VALIDATION);
+        SOURCE_MISSING_VALIDATION, REMOTE_SOURCE_VALIDATION, DESTINATION_PIPELINE_MISSING_VALIDATION);
 
     public static final List<SourceDestValidator.SourceDestValidation> ALL_VALIDATIONS = Arrays.asList(
         SOURCE_MISSING_VALIDATION,
         REMOTE_SOURCE_VALIDATION,
         DESTINATION_IN_SOURCE_VALIDATION,
-        DESTINATION_SINGLE_INDEX_VALIDATION
+        DESTINATION_SINGLE_INDEX_VALIDATION,
+        DESTINATION_PIPELINE_MISSING_VALIDATION
     );
 
     public static final List<SourceDestValidator.SourceDestValidation> NON_DEFERABLE_VALIDATIONS = Collections.singletonList(


### PR DESCRIPTION
Adds validation that the dest pipeline exists when a transform
is updated. Refactors the pipeline check into the `SourceDestValidator`.

Fixes #59587

Backport of #63494
