### PR TITLE
Replace usage of Project#exec with ExecOperations in LoggedExec

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -20,7 +20,6 @@ package org.elasticsearch.gradle;
 
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.logging.Logger;
@@ -117,15 +116,11 @@ public class LoggedExec extends Exec implements FileSystemOperationsAware {
         setErrorOutput(out);
     }
 
-    public static ExecResult exec(Project project, Action<ExecSpec> action) {
-        return genericExec(project::exec, action);
-    }
-
     public static ExecResult exec(ExecOperations execOperations, Action<ExecSpec> action) {
         return genericExec(execOperations::exec, action);
     }
 
-    public static ExecResult javaexec(Project project, Action<JavaExecSpec> action) {
+    public static ExecResult javaexec(ExecOperations project, Action<JavaExecSpec> action) {
         return genericExec(project::javaexec, action);
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -132,7 +132,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
                 String effectiveRefSpec = maybeAlignedRefSpec(logger, refspec);
 
                 logger.lifecycle("Performing checkout of {}...", refspec);
-                LoggedExec.exec(project, spec -> {
+                LoggedExec.exec(execOperations, spec -> {
                     spec.workingDir(checkoutDir);
                     spec.commandLine("git", "checkout", effectiveRefSpec);
                 });

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
@@ -24,7 +24,9 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
 
+import javax.inject.Inject;
 import java.io.File;
 
 /**
@@ -34,14 +36,17 @@ import java.io.File;
 public class JarHellTask extends PrecommitTask {
 
     private FileCollection classpath;
+    private ExecOperations execOperations;
 
-    public JarHellTask() {
+    @Inject
+    public JarHellTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
         setDescription("Runs CheckJarHell on the configured classpath");
     }
 
     @TaskAction
     public void runJarHellCheck() {
-        LoggedExec.javaexec(getProject(), spec -> {
+        LoggedExec.javaexec(execOperations, spec -> {
             spec.environment("CLASSPATH", getClasspath().getAsPath());
             spec.setMain("org.elasticsearch.bootstrap.JarHell");
         });

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/LoggerUsageTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/LoggerUsageTask.java
@@ -30,7 +30,9 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
 
+import javax.inject.Inject;
 import java.io.File;
 
 /**
@@ -40,14 +42,17 @@ import java.io.File;
 public class LoggerUsageTask extends PrecommitTask {
 
     private FileCollection classpath;
+    private ExecOperations execOperations;
 
-    public LoggerUsageTask() {
+    @Inject
+    public LoggerUsageTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
         setDescription("Runs LoggerUsageCheck on output directories of all source sets");
     }
 
     @TaskAction
     public void runLoggerUsageTask() {
-        LoggedExec.javaexec(getProject(), spec -> {
+        LoggedExec.javaexec(execOperations, spec -> {
             spec.setMain("org.elasticsearch.test.loggerusage.ESLoggerUsageChecker");
             spec.classpath(getClasspath());
             getClassDirectories().forEach(spec::args);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -33,6 +33,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.process.ExecOperations;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     private final ReaperService reaper;
     private final FileSystemOperations fileSystemOperations;
     private final ArchiveOperations archiveOperations;
+    private final ExecOperations execOperations;
     private int nodeIndex = 0;
 
     public ElasticsearchCluster(
@@ -76,6 +78,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         ReaperService reaper,
         FileSystemOperations fileSystemOperations,
         ArchiveOperations archiveOperations,
+        ExecOperations execOperations,
         File workingDirBase
     ) {
         this.path = path;
@@ -84,10 +87,20 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         this.reaper = reaper;
         this.fileSystemOperations = fileSystemOperations;
         this.archiveOperations = archiveOperations;
+        this.execOperations = execOperations;
         this.workingDirBase = workingDirBase;
         this.nodes = project.container(ElasticsearchNode.class);
         this.nodes.add(
-            new ElasticsearchNode(path, clusterName + "-0", project, reaper, fileSystemOperations, archiveOperations, workingDirBase)
+            new ElasticsearchNode(
+                path,
+                clusterName + "-0",
+                project,
+                reaper,
+                fileSystemOperations,
+                archiveOperations,
+                execOperations,
+                workingDirBase
+            )
         );
         // configure the cluster name eagerly so nodes know about it
         this.nodes.all((node) -> node.defaultConfig.put("cluster.name", safeName(clusterName)));
@@ -110,7 +123,16 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
         for (int i = nodes.size(); i < numberOfNodes; i++) {
             this.nodes.add(
-                new ElasticsearchNode(path, clusterName + "-" + i, project, reaper, fileSystemOperations, archiveOperations, workingDirBase)
+                new ElasticsearchNode(
+                    path,
+                    clusterName + "-" + i,
+                    project,
+                    reaper,
+                    fileSystemOperations,
+                    archiveOperations,
+                    execOperations,
+                    workingDirBase
+                )
             );
         }
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -55,6 +55,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.process.ExecOperations;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -125,6 +126,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final ReaperService reaper;
     private final FileSystemOperations fileSystemOperations;
     private final ArchiveOperations archiveOperations;
+    private final ExecOperations execOperations;
 
     private final AtomicBoolean configurationFrozen = new AtomicBoolean(false);
     private final Path workingDir;
@@ -173,6 +175,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         ReaperService reaper,
         FileSystemOperations fileSystemOperations,
         ArchiveOperations archiveOperations,
+        ExecOperations execOperations,
         File workingDirBase
     ) {
         this.path = path;
@@ -181,6 +184,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         this.reaper = reaper;
         this.fileSystemOperations = fileSystemOperations;
         this.archiveOperations = archiveOperations;
+        this.execOperations = execOperations;
         workingDir = workingDirBase.toPath().resolve(safeName(name)).toAbsolutePath();
         confPathRepo = workingDir.resolve("repo");
         configFile = workingDir.resolve("config/elasticsearch.yml");
@@ -685,7 +689,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             );
         }
         try (InputStream byteArrayInputStream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8))) {
-            LoggedExec.exec(project, spec -> {
+            LoggedExec.exec(execOperations, spec -> {
                 spec.setEnvironment(getESEnvironment());
                 spec.workingDir(getDistroDir());
                 spec.executable(OS.conditionalString().onUnix(() -> "./bin/" + tool).onWindows(() -> "cmd").supply());

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -38,6 +38,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskState;
+import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -60,6 +61,11 @@ public class TestClustersPlugin implements Plugin<Project> {
 
     @Inject
     protected ArchiveOperations getArchiveOperations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected ExecOperations getExecOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -109,6 +115,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 reaper,
                 getFileSystemOperations(),
                 getArchiveOperations(),
+                getExecOperations(),
                 new File(project.getBuildDir(), "testclusters")
             )
         );

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantMachine.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantMachine.java
@@ -28,6 +28,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -63,13 +64,18 @@ public class VagrantMachine {
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    protected ExecOperations getExecOperations() {
+        throw new UnsupportedOperationException();
+    }
+
     public void execute(Action<VagrantExecSpec> action) {
         VagrantExecSpec vagrantSpec = new VagrantExecSpec();
         action.execute(vagrantSpec);
 
         Objects.requireNonNull(vagrantSpec.command);
 
-        LoggedExec.exec(project, execSpec -> {
+        LoggedExec.exec(getExecOperations(), execSpec -> {
             execSpec.setExecutable("vagrant");
             File vagrantfile = extension.getVagrantfile();
             execSpec.setEnvironment(System.getenv()); // pass through env


### PR DESCRIPTION
As part of moving towards supporting gradle configuration cache, we should avoid using 
project in task actions. Therefore we refactored the LoggedExec#exec method to use the 
injectable ExecOperations service instead

fixes #63052