### PR TITLE
[7.10] [DOCS] EQL: Move to beta (#63284)

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Delete async EQL search</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 Deletes an <<eql-search-async,async EQL search>> or a
 <<eql-search-store-sync-eql-search,stored synchronous EQL search>>. The API also

--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -3,7 +3,7 @@
 [[eql-ex-threat-detection]]
 == Example: Detect threats with EQL
 
-experimental::[]
+beta::[]
 
 This example tutorial shows you how you can use EQL to detect security threats
 and other suspicious behavior. In the scenario, you're tasked with detecting

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>EQL</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 {eql-ref}/index.html[Event Query Language (EQL)] is a query language for
 event-based, time series data, such as logs.

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Function reference</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 {es} supports the following <<eql-functions,EQL functions>>. Most EQL functions
 are case-sensitive by default.

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Get async EQL search</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 Returns the current status and available results for an <<eql-search-async,async
 EQL search>> or a <<eql-search-store-sync-eql-search,stored synchronous EQL

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Pipe reference</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 {es} supports the following <<eql-pipes,EQL pipes>>.
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Syntax reference</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 IMPORTANT: {es} supports a subset of {eql-ref}/index.html[EQL syntax]. See
 <<eql-syntax-limitations>>.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] EQL: Move to beta (#63284)