### PR TITLE
Move helper into painless (backport of #63439)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -22,6 +22,9 @@ package org.elasticsearch.painless.api;
 import org.elasticsearch.common.hash.MessageDigests;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
@@ -711,5 +714,12 @@ public class Augmentation {
             return receiver.matcher(input);
         }
         return receiver.matcher(new LimitedCharSequence(input, receiver, limitFactor));
+    }
+
+    /**
+     * Convert a {@link TemporalAccessor} into millis since epoch like {@link Instant#toEpochMilli()}.
+     */
+    public static long toEpochMilli(TemporalAccessor v) {
+        return v.getLong(ChronoField.INSTANT_SECONDS) * 1_000 + v.get(ChronoField.NANO_OF_SECOND) / 1_000_000;
     }
 }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.time.temporal.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.time.temporal.txt
@@ -40,6 +40,8 @@ class java.time.temporal.TemporalAccessor {
   boolean isSupported(TemporalField)
   def query(TemporalQuery)
   ValueRange range(TemporalField)
+  # An easy method to convert temporalAccessors to millis since epoch similar to Instan#toEpochMilli.
+  long org.elasticsearch.painless.api.Augmentation toEpochMilli()
 }
 
 class java.time.temporal.TemporalAdjuster {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationTests.java
@@ -285,4 +285,9 @@ public class AugmentationTests extends ScriptTestCase {
         assertEquals("fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9", execDigest("'bar'.sha256()"));
         assertEquals("97df3588b5a3f24babc3851b372f0ba71a9dcdded43b14b9d06961bfc1707d9d", execDigest("'foobarbaz'.sha256()"));
     }
+
+    public void testToEpochMilli() {
+        assertEquals(0L, exec("ZonedDateTime.parse('1970-01-01T00:00:00Z').toEpochMilli()"));
+        assertEquals(1602097376782L, exec("ZonedDateTime.parse('2020-10-07T19:02:56.782Z').toEpochMilli()"));
+    }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
@@ -14,8 +14,6 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,13 +47,6 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
     ) {
         super(fieldName, params, searchLookup, ctx);
         this.formatter = formatter;
-    }
-
-    public static long toEpochMilli(TemporalAccessor v) {
-        // TemporalAccessor is a nanos API so we have to convert.
-        long millis = Math.multiplyExact(v.getLong(ChronoField.INSTANT_SECONDS), 1000);
-        millis = Math.addExact(millis, v.get(ChronoField.NANO_OF_SECOND) / 1_000_000);
-        return millis;
     }
 
     public static class Emit {

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/date_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/date_whitelist.txt
@@ -17,8 +17,6 @@ static_import {
     void emit(org.elasticsearch.xpack.runtimefields.mapper.DateFieldScript, long) bound_to org.elasticsearch.xpack.runtimefields.mapper.DateFieldScript$Emit
     # Parse a value from the source to millis since epoch
     long parse(org.elasticsearch.xpack.runtimefields.mapper.DateFieldScript, def) bound_to org.elasticsearch.xpack.runtimefields.mapper.DateFieldScript$Parse
-    # Add an easy method to convert temporalAccessors to millis since epoch.
-    long toEpochMilli(java.time.temporal.TemporalAccessor) from_class org.elasticsearch.xpack.runtimefields.mapper.DateFieldScript
 }
 
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
@@ -543,7 +543,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                             long epoch = (Long) timestamp;
                                             ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
                                             dt = dt.plus(((Number) params.get("days")).longValue(), ChronoUnit.DAYS);
-                                            emit(toEpochMilli(dt));
+                                            emit(dt.toInstant().toEpochMilli());
                                         }
                                     }
                                 };

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -23,7 +23,7 @@ setup:
                 script:
                   source: |
                     for (def dt : doc['timestamp']) {
-                      emit(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+                      emit(dt.plus(params.days, ChronoUnit.DAYS).toEpochMilli());
                     }
                   params:
                     days: 1
@@ -35,7 +35,7 @@ setup:
                   source: |
                     Instant instant = Instant.ofEpochMilli(parse(params._source.timestamp));
                     ZonedDateTime dt = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
-                    emit(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+                    emit(dt.plus(1, ChronoUnit.DAYS).toEpochMilli());
               # Test returning millis
               the_past:
                 type: runtime
@@ -53,7 +53,7 @@ setup:
                   source: |
                     for (def dt : doc['timestamp']) {
                       for (int i = 0; i < 7; i++) {
-                        emit(toEpochMilli(dt.plus(i, ChronoUnit.DAYS)));
+                        emit(dt.plus(i, ChronoUnit.DAYS).toEpochMilli());
                       }
                     }
               # Test format parameter
@@ -63,7 +63,7 @@ setup:
                 format: yyyy-MM-dd
                 script: |
                   for (def dt : doc['timestamp']) {
-                    emit(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+                    emit(dt.plus(1, ChronoUnit.DAYS).toEpochMilli());
                   }
 
   - do:
@@ -94,7 +94,7 @@ setup:
   - match:
       sensor.mappings.properties.tomorrow.script.source: |
         for (def dt : doc['timestamp']) {
-          emit(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+          emit(dt.plus(params.days, ChronoUnit.DAYS).toEpochMilli());
         }
   - match: {sensor.mappings.properties.tomorrow.script.params: {days: 1} }
   - match: {sensor.mappings.properties.tomorrow.script.lang: painless }
@@ -104,7 +104,7 @@ setup:
   - match:
       sensor.mappings.properties.formatted_tomorrow.script.source: |
         for (def dt : doc['timestamp']) {
-          emit(toEpochMilli(dt.plus(1, ChronoUnit.DAYS)));
+          emit(dt.plus(1, ChronoUnit.DAYS).toEpochMilli());
         }
   - match: {sensor.mappings.properties.formatted_tomorrow.script.lang: painless }
   - match: {sensor.mappings.properties.formatted_tomorrow.format: yyyy-MM-dd }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
@@ -24,7 +24,7 @@ setup:
                 script:
                   source: |
                     for (def dt : doc['timestamp']) {
-                      emit(toEpochMilli(dt.plus(params.days, ChronoUnit.DAYS)));
+                      emit(dt.plus(params.days, ChronoUnit.DAYS).toEpochMilli());
                     }
                   params:
                     days: 1


### PR DESCRIPTION
This moves `TemporalAccessor#toEpochMillis` out of runtime fields and
into painless directly so all contexts can use it. Now something like:
```
ZonedDateTime.parse('2020-10-07T19:02:56.782Z').toEpochMilli()
```
is possible.
