### PR TITLE
[DOCS] Adds AUC ROC classification metric to the API examples

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -537,15 +537,9 @@ The API returns the following result:
 {
   "classification" : {
     "auc_roc" : {
-      "score" : 0.8941788639536681, <1>
-      "doc_count" : 4169 <2>
+      "score" : 0.8941788639536681
     }
   }
 }
 --------------------------------------------------
 // TEST[skip:TBD]
-
-<1> AUC ROC score.
-<2> The number of documents that are used for calculating the AUC ROC score. 
-These documents have the target class – in this case `dog` – in the list of 
-their top classes.

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -532,7 +532,7 @@ all the other classes are treated as negative.
 
 The API returns the following result:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 {
   "classification" : {

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -504,7 +504,7 @@ a `predicted_class`.
 --------------------------------------------------
 POST _ml/data_frame/_evaluate
 {
-   "index": "auc-roc-class",
+   "index": "animal_classification",
    "evaluation": {
       "classification": { <1>
          "actual_field": "animal_class", <2>
@@ -543,6 +543,8 @@ The API returns the following result:
   }
 }
 --------------------------------------------------
+// TEST[skip:TBD]
+
 <1> AUC ROC score.
 <2> The number of documents that are used for calculating the AUC ROC score. 
 These documents have the target class – in this case `dog` – in the list of 

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -192,10 +192,10 @@ belongs.
     positive.
 
     `class_name`::::
-      (Required, string) Name of the only class that will be treated as
-      positive during AUC ROC calculation. Other classes will be treated as
-      negative ("one-vs-all" strategy). All the evaluated documents must have `class_name`
-      in the list of their top classes.
+      (Required, string) Name of the only class that is treated as positive 
+      during AUC ROC calculation. Other classes are treated as negative 
+      ("one-vs-all" strategy). All the evaluated documents must have 
+      `class_name` in the list of their top classes.
 
     `include_curve`::::
       (Optional, boolean) Whether or not the curve should be returned in
@@ -497,3 +497,50 @@ predictions associated with the class.
 <5> The number of cats in the dataset that are incorrectly classified as dogs.
 <6> The number of documents that are classified as a class that is not listed as 
 a `predicted_class`.
+
+
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{
+   "index": "auc-roc-class",
+   "evaluation": {
+      "classification": { <1>
+         "actual_field": "animal_class", <2>
+         "predicted_field": "ml.animal_class_prediction", <3>
+         "metrics": {
+            "auc_roc" : { <4>
+              "class_name": "dog" <5>
+            }
+         }
+      }
+   }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+<1> The evaluation type.
+<2> The field that contains the ground truth value for the actual animal 
+classification. This is required in order to evaluate results.
+<3> The field that contains the predicted value for animal classification by 
+the {classanalysis}.
+<4> Specifies the metric for the evaluation.
+<5> Specifies the class name that is treated as positive during the evaluation, 
+all the other classes are treated as negative.
+
+[source,console]
+--------------------------------------------------
+{
+  "classification" : {
+    "auc_roc" : {
+      "score" : 0.8941788639536681, <1>
+      "doc_count" : 4169 <2>
+    }
+  }
+}
+--------------------------------------------------
+<1> AUC ROC score.
+<2> The number of documents that are used for calculating the AUC ROC score. 
+These documents have the target class – in this case `dog` – in the list of 
+their top classes.

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -529,6 +529,9 @@ the {classanalysis}.
 <5> Specifies the class name that is treated as positive during the evaluation, 
 all the other classes are treated as negative.
 
+
+The API returns the following result:
+
 [source,console]
 --------------------------------------------------
 {

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -508,10 +508,9 @@ POST _ml/data_frame/_evaluate
    "evaluation": {
       "classification": { <1>
          "actual_field": "animal_class", <2>
-         "predicted_field": "ml.animal_class_prediction", <3>
          "metrics": {
-            "auc_roc" : { <4>
-              "class_name": "dog" <5>
+            "auc_roc" : { <3>
+              "class_name": "dog" <4>
             }
          }
       }
@@ -523,10 +522,8 @@ POST _ml/data_frame/_evaluate
 <1> The evaluation type.
 <2> The field that contains the ground truth value for the actual animal 
 classification. This is required in order to evaluate results.
-<3> The field that contains the predicted value for animal classification by 
-the {classanalysis}.
-<4> Specifies the metric for the evaluation.
-<5> Specifies the class name that is treated as positive during the evaluation, 
+<3> Specifies the metric for the evaluation.
+<4> Specifies the class name that is treated as positive during the evaluation, 
 all the other classes are treated as negative.
 
 


### PR DESCRIPTION
## Overview

This PR adds a classification evaluation example API call that specifies `auc_roc` as an evaluation metric. It also adds an example response and footnotes to the snippets.

### Preview

[Classification examples](https://elasticsearch_63563.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html#ml-evaluate-classification-example)