### PR TITLE
[ML] use node.roles as node.ml is deprecated in test external cluster

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -85,9 +86,7 @@ public final class ExternalTestCluster extends TestCluster {
         this.clusterName = clusterName;
         Settings.Builder clientSettingsBuilder = Settings.builder()
             .put(additionalSettings)
-            .put("node.master", false)
-            .put("node.data", false)
-            .put("node.ingest", false)
+            .putList("node.roles", Collections.emptyList())
             .put("node.name", EXTERNAL_CLUSTER_PREFIX + counter.getAndIncrement())
             .put("cluster.name", clusterName)
             .put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange())

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -156,7 +156,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
         }
 
         Settings.Builder builder = Settings.builder();
-        builder.put("node.ml", false);
+        builder.putList("node.roles", Collections.emptyList());
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
         builder.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), true);
         builder.put(XPackSettings.SECURITY_ENABLED.getKey(), true);


### PR DESCRIPTION
Adjusts the external test cluster settings to use the new `node.roles` settings instead of the
`node.<role_name>: <boolean>` settings.

closes https://github.com/elastic/elasticsearch/issues/63553