### PR TITLE
Consider query when optimizing date rounding (backport of #63403)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/StringStatsAggregationBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/StringStatsAggregationBuilder.java
@@ -24,11 +24,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -49,7 +49,7 @@ import java.util.Objects;
  * doesn't support any "server" side things like
  * {@linkplain Writeable#writeTo(StreamOutput)},
  * {@linkplain AggregationBuilder#rewrite(QueryRewriteContext)}, or
- * {@linkplain AbstractAggregationBuilder#build(QueryShardContext, AggregatorFactory)}.
+ * {@linkplain AbstractAggregationBuilder#build(AggregationContext, AggregatorFactory)}.
  */
 public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilder<StringStatsAggregationBuilder> {
     public static final String NAME = "string_stats";
@@ -102,7 +102,7 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
             AggregatorFactory parent, Builder subFactoriesBuilder) throws IOException {
         throw new UnsupportedOperationException();
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/TopMetricsAggregationBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/TopMetricsAggregationBuilder.java
@@ -23,11 +23,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 
@@ -44,7 +44,7 @@ import java.util.Map;
  * doesn't support any "server" side things like
  * {@linkplain Writeable#writeTo(StreamOutput)},
  * {@linkplain AggregationBuilder#rewrite(QueryRewriteContext)}, or
- * {@linkplain AbstractAggregationBuilder#build(QueryShardContext, AggregatorFactory)}.
+ * {@linkplain AbstractAggregationBuilder#build(AggregationContext, AggregatorFactory)}.
  */
 public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<TopMetricsAggregationBuilder> {
     public static final String NAME = "top_metrics";
@@ -100,7 +100,7 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subfactoriesBuilder)
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subfactoriesBuilder)
             throws IOException {
         throw new UnsupportedOperationException();
     }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
@@ -22,11 +22,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ArrayValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
@@ -75,11 +75,11 @@ public class MatrixStatsAggregationBuilder extends ArrayValuesSourceAggregationB
     }
 
     @Override
-    protected MatrixStatsAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected MatrixStatsAggregatorFactory innerBuild(AggregationContext context,
                                                         Map<String, ValuesSourceConfig> configs,
                                                         AggregatorFactory parent,
                                                         AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new MatrixStatsAggregatorFactory(name, configs, multiValueMode, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new MatrixStatsAggregatorFactory(name, configs, multiValueMode, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
@@ -18,13 +18,13 @@
  */
 package org.elasticsearch.search.aggregations.matrix.stats;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ArrayValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -41,11 +41,11 @@ final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFact
     MatrixStatsAggregatorFactory(String name,
                                     Map<String, ValuesSourceConfig> configs,
                                     MultiValueMode multiValueMode,
-                                    QueryShardContext queryShardContext,
+                                    AggregationContext context,
                                     AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactoriesBuilder,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, configs, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, configs, context, parent, subFactoriesBuilder, metadata);
         this.multiValueMode = multiValueMode;
     }
 

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregationBuilder.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -190,24 +189,24 @@ public abstract class ArrayValuesSourceAggregationBuilder<AB extends ArrayValues
     }
 
     @Override
-    protected final ArrayValuesSourceAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected final ArrayValuesSourceAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                                                Builder subFactoriesBuilder) throws IOException {
-        Map<String, ValuesSourceConfig> configs = resolveConfig(queryShardContext);
-        ArrayValuesSourceAggregatorFactory factory = innerBuild(queryShardContext, configs, parent, subFactoriesBuilder);
+        Map<String, ValuesSourceConfig> configs = resolveConfig(context);
+        ArrayValuesSourceAggregatorFactory factory = innerBuild(context, configs, parent, subFactoriesBuilder);
         return factory;
     }
 
-    protected Map<String, ValuesSourceConfig> resolveConfig(QueryShardContext queryShardContext) {
+    protected Map<String, ValuesSourceConfig> resolveConfig(AggregationContext context) {
         HashMap<String, ValuesSourceConfig> configs = new HashMap<>();
         for (String field : fields) {
-            ValuesSourceConfig config = ValuesSourceConfig.resolveUnregistered(queryShardContext, userValueTypeHint, field, null,
+            ValuesSourceConfig config = ValuesSourceConfig.resolveUnregistered(context, userValueTypeHint, field, null,
                 missingMap.get(field), null, format, CoreValuesSourceType.BYTES);
             configs.put(field, config);
         }
         return configs;
     }
 
-    protected abstract ArrayValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected abstract ArrayValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                                      Map<String, ValuesSourceConfig> configs,
                                                                      AggregatorFactory parent,
                                                                      AggregatorFactories.Builder subFactoriesBuilder) throws IOException;

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregatorFactory.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -36,10 +35,10 @@ public abstract class ArrayValuesSourceAggregatorFactory
     protected Map<String, ValuesSourceConfig> configs;
 
     public ArrayValuesSourceAggregatorFactory(String name, Map<String, ValuesSourceConfig> configs,
-                                              QueryShardContext queryShardContext, AggregatorFactory parent,
+                                              AggregationContext context, AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder,
                                               Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, context, parent, subFactoriesBuilder, metadata);
         this.configs = configs;
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
@@ -26,12 +26,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.join.mapper.ParentIdFieldMapper;
 import org.elasticsearch.join.mapper.ParentJoinFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -102,36 +102,36 @@ public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<C
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        Builder subFactoriesBuilder) throws IOException {
-        return new ChildrenAggregatorFactory(name, config, childFilter, parentFilter, queryShardContext, parent,
+        return new ChildrenAggregatorFactory(name, config, childFilter, parentFilter, context, parent,
                 subFactoriesBuilder, metadata);
     }
 
     @Override
-    protected ValuesSourceConfig resolveConfig(QueryShardContext queryShardContext) {
+    protected ValuesSourceConfig resolveConfig(AggregationContext context) {
         ValuesSourceConfig config;
 
-        ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(queryShardContext.getMapperService());
+        ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(context::getFieldType, context::getMapper);
         if (parentJoinFieldMapper == null) {
             // Unmapped field case
-            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), queryShardContext);
+            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), context);
             return config;
         }
 
         ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
         if (parentIdFieldMapper == null) {
             // Unmapped field case
-            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), queryShardContext);
+            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), context);
             return config;
         }
 
         parentFilter = parentIdFieldMapper.getParentFilter();
         childFilter = parentIdFieldMapper.getChildFilter(childType);
         MappedFieldType fieldType = parentIdFieldMapper.fieldType();
-        config = ValuesSourceConfig.resolveFieldOnly(fieldType, queryShardContext);
+        config = ValuesSourceConfig.resolveFieldOnly(fieldType, context);
         return config;
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregatorFactory.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregatorFactory.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.join.aggregations;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -28,6 +27,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes.WithOrdinals;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -48,7 +48,7 @@ public class ChildrenAggregatorFactory extends ValuesSourceAggregatorFactory {
                                         ValuesSourceConfig config,
                                         Query childFilter,
                                         Query parentFilter,
-                                        QueryShardContext context,
+                                        AggregationContext context,
                                         AggregatorFactory parent,
                                         AggregatorFactories.Builder subFactoriesBuilder,
                                         Map<String, Object> metadata) throws IOException {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
@@ -26,12 +26,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.join.mapper.ParentIdFieldMapper;
 import org.elasticsearch.join.mapper.ParentJoinFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -102,27 +102,27 @@ public class ParentAggregationBuilder extends ValuesSourceAggregationBuilder<Par
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        Builder subFactoriesBuilder) throws IOException {
-        return new ParentAggregatorFactory(name, config, childFilter, parentFilter, queryShardContext, parent,
+        return new ParentAggregatorFactory(name, config, childFilter, parentFilter, context, parent,
                 subFactoriesBuilder, metadata);
     }
 
     @Override
-    protected ValuesSourceConfig resolveConfig(QueryShardContext queryShardContext) {
+    protected ValuesSourceConfig resolveConfig(AggregationContext context) {
         ValuesSourceConfig config;
-        ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(queryShardContext.getMapperService());
+        ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(context::getFieldType, context::getMapper);
         ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
         if (parentIdFieldMapper != null) {
             parentFilter = parentIdFieldMapper.getParentFilter();
             childFilter = parentIdFieldMapper.getChildFilter(childType);
             MappedFieldType fieldType = parentIdFieldMapper.fieldType();
-            config = ValuesSourceConfig.resolveFieldOnly(fieldType, queryShardContext);
+            config = ValuesSourceConfig.resolveFieldOnly(fieldType, context);
         } else {
             // unmapped case
-            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), queryShardContext);
+            config = ValuesSourceConfig.resolveUnmapped(defaultValueSourceType(), context);
         }
         return config;
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregatorFactory.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregatorFactory.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.join.aggregations;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -28,6 +27,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes.WithOrdinals;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -48,11 +48,11 @@ public class ParentAggregatorFactory extends ValuesSourceAggregatorFactory {
                                    ValuesSourceConfig config,
                                    Query childFilter,
                                    Query parentFilter,
-                                   QueryShardContext queryShardContext,
+                                   AggregationContext context,
                                    AggregatorFactory parent,
                                    AggregatorFactories.Builder subFactoriesBuilder,
                                    Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
 
         this.childFilter = childFilter;
         this.parentFilter = parentFilter;

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -32,18 +32,17 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -56,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -81,19 +81,27 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     /**
+     * Returns the {@link ParentJoinFieldMapper} associated with the {@code context} or null
+     * if there is no parent-join field in this mapping.
+     */
+    public static ParentJoinFieldMapper getMapper(QueryShardContext context) {
+        return getMapper(context::getFieldType, context.getMapperService().documentMapper().mappers()::getMapper);
+    }
+
+    /**
      * Returns the {@link ParentJoinFieldMapper} associated with the <code>service</code> or null
      * if there is no parent-join field in this mapping.
      */
-    public static ParentJoinFieldMapper getMapper(MapperService service) {
+    public static ParentJoinFieldMapper getMapper(
+        Function<String, MappedFieldType> typeLookup,
+        Function<String, Mapper> mapperLookup
+    ) {
         MetaJoinFieldMapper.MetaJoinFieldType fieldType =
-            (MetaJoinFieldMapper.MetaJoinFieldType) service.fieldType(MetaJoinFieldMapper.NAME);
+            (MetaJoinFieldMapper.MetaJoinFieldType) typeLookup.apply(MetaJoinFieldMapper.NAME);
         if (fieldType == null) {
             return null;
         }
-        DocumentMapper mapper = service.documentMapper();
-        String joinField = fieldType.getJoinField();
-        MappingLookup fieldMappers = mapper.mappers();
-        return (ParentJoinFieldMapper) fieldMappers.getMapper(joinField);
+        return (ParentJoinFieldMapper) mapperLookup.apply(fieldType.getJoinField());
     }
 
     private static String getParentIdFieldName(String joinFieldName, String parentName) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -308,7 +308,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
         }
 
-        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
+        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context);
         if (joinFieldMapper == null) {
             if (ignoreUnmapped) {
                 return new MatchNoDocsQuery();

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
@@ -166,7 +166,7 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
         }
 
-        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
+        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context);
         if (joinFieldMapper == null) {
             if (ignoreUnmapped) {
                 return new MatchNoDocsQuery();

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -69,7 +69,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
     @Override
     protected void doBuild(SearchContext context, InnerHitsContext innerHitsContext) throws IOException {
         QueryShardContext queryShardContext = context.getQueryShardContext();
-        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.mapperService());
+        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getQueryShardContext());
         if (joinFieldMapper != null) {
             String name = innerHitBuilder.getName() != null ? innerHitBuilder.getName() : typeName;
             JoinFieldInnerHitSubContext joinFieldInnerHits = new JoinFieldInnerHitSubContext(name, context, typeName,

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -161,7 +161,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
         }
 
-        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context.getMapperService());
+        ParentJoinFieldMapper joinFieldMapper = ParentJoinFieldMapper.getMapper(context);
         if (joinFieldMapper == null) {
             if (ignoreUnmapped) {
                 return new MatchNoDocsQuery();

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -102,7 +102,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
         }));
 
         // Doc without join
-        ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "0",
+        ParsedDocument doc = docMapper.parse(new SourceToParse("test", "_doc", "0",
             BytesReference.bytes(XContentFactory.jsonBuilder().startObject().endObject()), XContentType.JSON));
         assertNull(doc.rootDoc().getBinaryValue("join_field"));
 
@@ -140,7 +140,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
 
         // Unknown join name
         exc = expectThrows(MapperParsingException.class,
-            () -> docMapper.parse(new SourceToParse("test", "type", "1",
+            () -> docMapper.parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                     .field("join_field", "unknown")
                     .endObject()), XContentType.JSON)));

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -19,132 +19,87 @@
 
 package org.elasticsearch.join.mapper;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.util.Collection;
-import java.util.Collections;
 
+import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.containsString;
 
-public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
+public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
     @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return Collections.singletonList(ParentJoinPlugin.class);
+    protected Collection<? extends Plugin> getPlugins() {
+        return singleton(new ParentJoinPlugin());
     }
 
     public void testSingleLevel() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .field("parent", "child")
-                    .endObject()
-                .endObject()
-            .endObject()
-            .endObject());
-        IndexService service = createIndex("test");
-        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("join_field");
+            b.field("type", "join").startObject("relations").field("parent", "child").endObject();
+            b.endObject();
+        }));
+        DocumentMapper docMapper = mapperService.documentMapper();
+        assertSame(
+            docMapper.mappers().getMapper("join_field"),
+            ParentJoinFieldMapper.getMapper(mapperService::fieldType, mapperService.documentMapper().mappers()::getMapper)
+        );
 
         // Doc without join
-        ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "0",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject().endObject()), XContentType.JSON));
+        ParsedDocument doc = docMapper.parse(source(b -> {}));
         assertNull(doc.rootDoc().getBinaryValue("join_field"));
 
         // Doc parent
-        doc = docMapper.parse(new SourceToParse("test", "type", "1",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .field("join_field", "parent")
-                .endObject()), XContentType.JSON));
+        doc = docMapper.parse(source(b -> b.field("join_field", "parent")));
         assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("parent", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
 
         // Doc child
-        doc = docMapper.parse(new SourceToParse("test", "type", "2",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("join_field")
-                    .field("name", "child")
-                    .field("parent", "1")
-                .endObject()
-                .endObject()), XContentType.JSON, "1"));
+        doc = docMapper.parse(source("2", b -> b.startObject("join_field").field("name", "child").field("parent", "1").endObject(), "1"));
         assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
 
         // Unknown join name
         MapperException exc = expectThrows(MapperParsingException.class,
-            () -> docMapper.parse(new SourceToParse("test", "type", "1",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                    .field("join_field", "unknown")
-                    .endObject()), XContentType.JSON)));
+            () -> docMapper.parse(source(b -> b.field("join_field", "unknown"))));
         assertThat(exc.getRootCause().getMessage(), containsString("unknown join name [unknown] for field [join_field]"));
     }
 
     public void testParentIdSpecifiedAsNumber() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                        .startObject("relations")
-                            .field("parent", "child")
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject());
-        IndexService service = createIndex("test");
-        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "2",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("join_field")
-                .field("name", "child")
-                .field("parent", 1)
-                .endObject()
-                .endObject()), XContentType.JSON, "1"));
+        DocumentMapper docMapper = createDocumentMapper(mapping(b -> {
+            b.startObject("join_field");
+            b.field("type", "join").startObject("relations").field("parent", "child").endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc = docMapper.parse(
+            source("2", b -> b.startObject("join_field").field("name", "child").field("parent", 1).endObject(), "1")
+        );
         assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
-        doc = docMapper.parse(new SourceToParse("test", "type", "2",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("join_field")
-                .field("name", "child")
-                .field("parent", 1.0)
-                .endObject()
-                .endObject()), XContentType.JSON, "1"));
+
+        doc = docMapper.parse(source("2", b -> b.startObject("join_field").field("name", "child").field("parent", 1.0).endObject(), "1"));
         assertEquals("1.0", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
     }
 
     public void testMultipleLevels() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .field("parent", "child")
-                        .field("child", "grand_child")
-                    .endObject()
-                .endObject()
-            .endObject()
-            .endObject());
-        IndexService service = createIndex("test");
-        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        DocumentMapper docMapper = createDocumentMapper(mapping(b -> {
+            b.startObject("join_field");
+            b.field("type", "join");
+            b.startObject("relations").field("parent", "child").field("child", "grand_child").endObject();
+            b.endObject();
+        }));
 
         // Doc without join
         ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "0",
@@ -152,53 +107,34 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         assertNull(doc.rootDoc().getBinaryValue("join_field"));
 
         // Doc parent
-        doc = docMapper.parse(new SourceToParse("test", "type", "1",
-            BytesReference.bytes(XContentFactory.jsonBuilder()
-                .startObject()
-                    .field("join_field", "parent")
-                .endObject()), XContentType.JSON));
+        doc = docMapper.parse(source(b -> b.field("join_field", "parent")));
         assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("parent", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
 
         // Doc child
-        doc = docMapper.parse(new SourceToParse("test", "type", "2",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("join_field")
-                    .field("name", "child")
-                    .field("parent", "1")
-                .endObject()
-                .endObject()), XContentType.JSON, "1"));
+        doc = docMapper.parse(source("2", b -> b.startObject("join_field").field("name", "child").field("parent", "1").endObject(), "1"));
         assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
         assertEquals("2", doc.rootDoc().getBinaryValue("join_field#child").utf8ToString());
         assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
 
         // Doc child missing parent
-        MapperException exc = expectThrows(MapperParsingException.class,
-            () -> docMapper.parse(new SourceToParse("test", "type", "2",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                    .field("join_field", "child")
-                    .endObject()), XContentType.JSON, "1")));
+        MapperException exc = expectThrows(
+            MapperParsingException.class,
+            () -> docMapper.parse(source("2", b -> b.field("join_field", "child"), "1"))
+        );
         assertThat(exc.getRootCause().getMessage(), containsString("[parent] is missing for join field [join_field]"));
 
         // Doc child missing routing
-        exc = expectThrows(MapperParsingException.class,
-            () -> docMapper.parse(new SourceToParse("test", "type", "2",
-                BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                    .startObject("join_field")
-                    .field("name", "child")
-                    .field("parent", "1")
-                    .endObject()
-                    .endObject()), XContentType.JSON)));
+        exc = expectThrows(
+            MapperParsingException.class,
+            () -> docMapper.parse(source(b -> b.startObject("join_field").field("name", "child").field("parent", "1").endObject()))
+        );
         assertThat(exc.getRootCause().getMessage(), containsString("[routing] is missing for join field [join_field]"));
 
         // Doc grand_child
-        doc = docMapper.parse(new SourceToParse("test", "type", "3",
-            BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("join_field")
-                    .field("name", "grand_child")
-                    .field("parent", "2")
-                .endObject()
-                .endObject()), XContentType.JSON, "1"));
+        doc = docMapper.parse(
+            source("3", b -> b.startObject("join_field").field("name", "grand_child").field("parent", "2").endObject(), "1")
+        );
         assertEquals("2", doc.rootDoc().getBinaryValue("join_field#child").utf8ToString());
         assertEquals("grand_child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
 
@@ -212,250 +148,220 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testUpdateRelations() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-            .startObject("join_field")
-                .field("type", "join")
-                .startObject("relations")
-                    .field("parent", "child")
-                    .array("child", "grand_child1", "grand_child2")
-                .endObject()
-            .endObject()
-            .endObject().endObject());
-        IndexService indexService = createIndex("test");
-        DocumentMapper docMapper = indexService.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.field("parent", "child");
+                    b.array("child", "grand_child1", "grand_child2");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .array("child", "grand_child1", "grand_child2")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-                () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE));
-            assertThat(exc.getMessage(), containsString("cannot remove parent [parent] in join field [join_field]"));
-        }
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.array("child", "grand_child1", "grand_child2");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(exc.getMessage(), containsString("cannot remove parent [parent] in join field [join_field]"));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .field("parent", "child")
-                        .field("child", "grand_child1")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-                () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE));
-            assertThat(exc.getMessage(), containsString("cannot remove child [grand_child2] in join field [join_field]"));
-        }
+        exc = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.field("parent", "child");
+                    b.array("child", "grand_child1");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(exc.getMessage(), containsString("cannot remove child [grand_child2] in join field [join_field]"));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .field("uber_parent", "parent")
-                        .field("parent", "child")
-                        .array("child", "grand_child1", "grand_child2")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-                () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE));
-            assertThat(exc.getMessage(), containsString("cannot create child [parent] from an existing parent"));
-        }
+        exc = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.field("uber_parent", "parent");
+                    b.field("parent", "child");
+                    b.array("child", "grand_child1", "grand_child2");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(exc.getMessage(), containsString("cannot create child [parent] from an existing parent"));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .field("parent", "child")
-                        .array("child", "grand_child1", "grand_child2")
-                        .field("grand_child2", "grand_grand_child")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-                () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE));
-            assertThat(exc.getMessage(), containsString("cannot create parent [grand_child2] from an existing child]"));
-        }
+        exc = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.field("parent", "child");
+                    b.array("child", "grand_child1", "grand_child2");
+                    b.field("grand_child2", "grand_grand_child");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(exc.getMessage(), containsString("cannot create parent [grand_child2] from an existing child]"));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .array("parent", "child", "child2")
-                        .array("child", "grand_child1", "grand_child2")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            docMapper = indexService.mapperService().merge("_doc", new CompressedXContent(updateMapping),
-                MapperService.MergeReason.MAPPING_UPDATE);
-            ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
-            assertNotNull(mapper);
-            assertEquals("join_field", mapper.name());
-            assertTrue(mapper.hasChild("child2"));
-            assertFalse(mapper.hasParent("child2"));
-            assertTrue(mapper.hasChild("grand_child2"));
-            assertFalse(mapper.hasParent("grand_child2"));
-        }
+        merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.array("parent", "child", "child2");
+                    b.array("child", "grand_child1", "grand_child2");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(
+            mapperService::fieldType,
+            mapperService.documentMapper().mappers()::getMapper
+        );
+        assertNotNull(mapper);
+        assertEquals("join_field", mapper.name());
+        assertTrue(mapper.hasChild("child2"));
+        assertFalse(mapper.hasParent("child2"));
+        assertTrue(mapper.hasChild("grand_child2"));
+        assertFalse(mapper.hasParent("grand_child2"));
 
-        {
-            final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-                .startObject("join_field")
-                    .field("type", "join")
-                    .startObject("relations")
-                        .array("parent", "child", "child2")
-                        .array("child", "grand_child1", "grand_child2")
-                        .array("other", "child_other1", "child_other2")
-                    .endObject()
-                .endObject()
-                .endObject().endObject());
-            docMapper = indexService.mapperService().merge("_doc", new CompressedXContent(updateMapping),
-                MapperService.MergeReason.MAPPING_UPDATE);
-            ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
-            assertNotNull(mapper);
-            assertEquals("join_field", mapper.name());
-            assertTrue(mapper.hasParent("other"));
-            assertFalse(mapper.hasChild("other"));
-            assertTrue(mapper.hasChild("child_other1"));
-            assertFalse(mapper.hasParent("child_other1"));
-            assertTrue(mapper.hasChild("child_other2"));
-            assertFalse(mapper.hasParent("child_other2"));
-        }
+        merge(mapperService, mapping(b -> {
+            b.startObject("join_field");
+            {
+                b.field("type", "join");
+                b.startObject("relations");
+                {
+                    b.array("parent", "child", "child2");
+                    b.array("child", "grand_child1", "grand_child2");
+                    b.array("other", "child_other1", "child_other2");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        mapper = ParentJoinFieldMapper.getMapper(
+            mapperService::fieldType,
+            mapperService.documentMapper().mappers()::getMapper
+        );
+        assertNotNull(mapper);
+        assertEquals("join_field", mapper.name());
+        assertTrue(mapper.hasParent("other"));
+        assertFalse(mapper.hasChild("other"));
+        assertTrue(mapper.hasChild("child_other1"));
+        assertFalse(mapper.hasParent("child_other1"));
+        assertTrue(mapper.hasChild("child_other2"));
+        assertFalse(mapper.hasParent("child_other2"));
     }
 
     public void testInvalidJoinFieldInsideObject() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-            .startObject("object")
-                .startObject("properties")
-                    .startObject("join_field")
-                        .field("type", "join")
-                        .startObject("relations")
-                            .field("parent", "child")
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject()
-            .endObject().endObject());
-        IndexService indexService = createIndex("test");
-        MapperParsingException exc = expectThrows(MapperParsingException.class,
-            () -> indexService.mapperService().merge("type", new CompressedXContent(mapping),
-                MapperService.MergeReason.MAPPING_UPDATE));
+        MapperParsingException exc = expectThrows(MapperParsingException.class, () -> createMapperService(mapping(b -> {
+            b.startObject("object");
+            {
+                b.startObject("properties");
+                {
+                    b.startObject("join_field");
+                    b.field("type", "join").startObject("relations").field("parent", "child").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
         assertThat(exc.getRootCause().getMessage(),
             containsString("join field [object.join_field] cannot be added inside an object or in a multi-field"));
     }
 
     public void testInvalidJoinFieldInsideMultiFields() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
-            .startObject("number")
-                .field("type", "integer")
-                .startObject("fields")
-                    .startObject("join_field")
-                        .field("type", "join")
-                        .startObject("relations")
-                            .field("parent", "child")
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject()
-            .endObject().endObject());
-        IndexService indexService = createIndex("test");
-        MapperParsingException exc = expectThrows(MapperParsingException.class,
-            () -> indexService.mapperService().merge("type", new CompressedXContent(mapping),
-                MapperService.MergeReason.MAPPING_UPDATE));
-        assertThat(exc.getRootCause().getMessage(),
-            containsString("join field [number.join_field] cannot be added inside an object or in a multi-field"));
+        MapperParsingException exc = expectThrows(MapperParsingException.class, () -> createMapperService(mapping(b -> {
+            b.startObject("number");
+            {
+                b.field("type", "integer");
+                b.startObject("fields");
+                {
+                    b.startObject("join_field");
+                    {
+                        b.field("type", "join").startObject("relations").field("parent", "child").endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(
+            exc.getRootCause().getMessage(),
+            containsString("join field [number.join_field] cannot be added inside an object or in a multi-field")
+        );
     }
 
     public void testMultipleJoinFields() throws Exception {
-        IndexService indexService = createIndex("test");
         {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-                .startObject("properties")
-                    .startObject("join_field")
-                        .field("type", "join")
-                        .startObject("relations")
-                            .field("parent", "child")
-                            .field("child", "grand_child")
-                        .endObject()
-                    .endObject()
-                    .startObject("another_join_field")
-                        .field("type", "join")
-                        .startObject("relations")
-                            .field("product", "item")
-                        .endObject()
-                    .endObject()
-                .endObject()
-                .endObject());
-            MapperParsingException exc = expectThrows(MapperParsingException.class, () -> indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE));
+            MapperParsingException exc = expectThrows(MapperParsingException.class, () -> createMapperService(mapping(b -> {
+                b.startObject("join_field");
+                b.field("type", "join");
+                b.startObject("relations").field("parent", "child").field("child", "grand_child").endObject();
+                b.endObject();
+                b.startObject("another_join_field");
+                b.field("type", "join");
+                b.startObject("relations").field("product", "item").endObject().endObject();
+            })));
             assertThat(exc.getMessage(), containsString("Field [_parent_join] is defined more than once"));
         }
 
         {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-                .startObject("properties")
-                    .startObject("join_field")
-                        .field("type", "join")
-                        .startObject("relations")
-                            .field("parent", "child")
-                            .field("child", "grand_child")
-                        .endObject()
-                    .endObject()
-                .endObject()
-                .endObject());
-            indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-            String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-                .startObject("properties")
-                    .startObject("another_join_field")
-                        .field("type", "join")
-                    .endObject()
-                .endObject()
-                .endObject());
-            MapperParsingException exc = expectThrows(MapperParsingException.class, () -> indexService.mapperService().merge("type",
-                new CompressedXContent(updateMapping), MapperService.MergeReason.MAPPING_UPDATE));
+            MapperService mapperService = createMapperService(mapping(b -> {
+                b.startObject("join_field");
+                b.field("type", "join");
+                b.startObject("relations").field("parent", "child").field("child", "grand_child").endObject();
+                b.endObject();
+            }));
+            // Updating the mapping with another join field also fails
+            MapperParsingException exc = expectThrows(
+                MapperParsingException.class,
+                () -> merge(mapperService, mapping(b -> b.startObject("another_join_field").field("type", "join").endObject()))
+            );
             assertThat(exc.getMessage(), containsString("Field [_parent_join] is defined more than once"));
         }
     }
 
     public void testEagerGlobalOrdinals() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
+        MapperService mapperService = createMapperService(mapping(b -> b
                 .startObject("join_field")
                     .field("type", "join")
                     .startObject("relations")
                         .field("parent", "child")
                         .field("child", "grand_child")
                     .endObject()
-                .endObject()
-            .endObject()
-            .endObject());
-        IndexService service = createIndex("test");
-        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
-        assertFalse(service.mapperService().fieldType("join_field").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fieldType("join_field#parent"));
-        assertTrue(service.mapperService().fieldType("join_field#parent").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fieldType("join_field#child"));
-        assertTrue(service.mapperService().fieldType("join_field#child").eagerGlobalOrdinals());
+                .endObject()));
+        assertFalse(mapperService.fieldType("join_field").eagerGlobalOrdinals());
+        assertNotNull(mapperService.fieldType("join_field#parent"));
+        assertTrue(mapperService.fieldType("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(mapperService.fieldType("join_field#child"));
+        assertTrue(mapperService.fieldType("join_field#child").eagerGlobalOrdinals());
 
-        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
+        merge(mapperService, mapping(b -> b
                 .startObject("join_field")
                     .field("type", "join")
                     .field("eager_global_ordinals", false)
@@ -463,15 +369,11 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                         .field("parent", "child")
                         .field("child", "grand_child")
                     .endObject()
-                .endObject()
-            .endObject()
-            .endObject());
-        service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE);
-        assertFalse(service.mapperService().fieldType("join_field").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fieldType("join_field#parent"));
-        assertFalse(service.mapperService().fieldType("join_field#parent").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fieldType("join_field#child"));
-        assertFalse(service.mapperService().fieldType("join_field#child").eagerGlobalOrdinals());
+                .endObject()));
+        assertFalse(mapperService.fieldType("join_field").eagerGlobalOrdinals());
+        assertNotNull(mapperService.fieldType("join_field#parent"));
+        assertFalse(mapperService.fieldType("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(mapperService.fieldType("join_field#child"));
+        assertFalse(mapperService.fieldType("join_field#child").eagerGlobalOrdinals());
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
@@ -65,6 +64,7 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.InternalMax;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -502,10 +502,10 @@ public class TransportSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        protected AggregatorFactory doBuild(QueryShardContext queryShardContext,
+        protected AggregatorFactory doBuild(AggregationContext context,
                                             AggregatorFactory parent,
                                             AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-            return new AggregatorFactory(name, queryShardContext, parent, subFactoriesBuilder, metadata) {
+            return new AggregatorFactory(name, context, parent, subFactoriesBuilder, metadata) {
                 @Override
                 protected Aggregator createInternal(SearchContext searchContext,
                                                     Aggregator parent,

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -58,7 +58,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.aggregations.support.AggregationUsageService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.transport.RemoteClusterAware;
@@ -542,9 +541,5 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public BitsetFilterCache getBitsetFilterCache() {
         return bitsetFilterCache;
-    }
-
-    public AggregationUsageService getUsageService() {
-        return valuesSourceRegistry.getUsageService();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -82,6 +82,8 @@ import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.AggregationContext.ProductionAggregationContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseContext;
 import org.elasticsearch.search.dfs.DfsPhase;
@@ -931,8 +933,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
         context.terminateAfter(source.terminateAfter());
         if (source.aggregations() != null && includeAggregations) {
+            AggregationContext aggContext = new ProductionAggregationContext(
+                queryShardContext,
+                context.parsedQuery() == null ? null : context.parsedQuery().query()
+            );
             try {
-                AggregatorFactories factories = source.aggregations().build(queryShardContext, null);
+                AggregatorFactories factories = source.aggregations().build(aggContext, null);
                 context.aggregations(new SearchContextAggregations(factories, multiBucketConsumerService.create()));
             } catch (IOException e) {
                 throw new AggregationInitializationException("Failed to create aggregators", e);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -135,13 +135,13 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
     }
 
     @Override
-    public final AggregatorFactory build(QueryShardContext queryShardContext, AggregatorFactory parent) throws IOException {
-        AggregatorFactory factory = doBuild(queryShardContext, parent, factoriesBuilder);
-        queryShardContext.getUsageService().incAggregationUsage(getType(), factory.getStatsSubtype());
+    public final AggregatorFactory build(AggregationContext context, AggregatorFactory parent) throws IOException {
+        AggregatorFactory factory = doBuild(context, parent, factoriesBuilder);
+        context.getUsageService().incAggregationUsage(getType(), factory.getStatsSubtype());
         return factory;
     }
 
-    protected abstract AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected abstract AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                                  AggregatorFactories.Builder subfactoriesBuilder) throws IOException;
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -25,10 +25,10 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -66,7 +66,7 @@ public abstract class AggregationBuilder
     }
 
     /** Internal: build an {@link AggregatorFactory} based on the configuration of this builder. */
-    protected abstract AggregatorFactory build(QueryShardContext queryShardContext, AggregatorFactory parent) throws IOException;
+    protected abstract AggregatorFactory build(AggregationContext context, AggregatorFactory parent) throws IOException;
 
     /** Associate metadata with this {@link AggregationBuilder}. */
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -31,12 +31,12 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.search.aggregations.support.AggregationPath.PathElement;
 import org.elasticsearch.search.internal.SearchContext;
@@ -337,14 +337,14 @@ public class AggregatorFactories {
             return e;
         }
 
-        public AggregatorFactories build(QueryShardContext queryShardContext, AggregatorFactory parent) throws IOException {
+        public AggregatorFactories build(AggregationContext context, AggregatorFactory parent) throws IOException {
             if (aggregationBuilders.isEmpty() && pipelineAggregatorBuilders.isEmpty()) {
                 return EMPTY;
             }
             AggregatorFactory[] aggFactories = new AggregatorFactory[aggregationBuilders.size()];
             int i = 0;
             for (AggregationBuilder agg : aggregationBuilders) {
-                aggFactories[i] = agg.build(queryShardContext, parent);
+                aggFactories[i] = agg.build(context, parent);
                 ++i;
             }
             return new AggregatorFactories(aggFactories);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
@@ -28,13 +28,13 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregator.KeyedFilter;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -210,9 +210,9 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subFactoriesBuilder)
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
             throws IOException {
-        int maxFilters = queryShardContext.getIndexSettings().getMaxAdjacencyMatrixFilters();
+        int maxFilters = context.getIndexSettings().getMaxAdjacencyMatrixFilters();
         if (filters.size() > maxFilters){
             throw new IllegalArgumentException(
                     "Number of filters is too large, must be less than or equal to: [" + maxFilters + "] but was ["
@@ -220,8 +220,7 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
                             + "This limit can be set by changing the [" + IndexSettings.MAX_ADJACENCY_MATRIX_FILTERS_SETTING.getKey()
                             + "] index level setting.");
         }
-        return new AdjacencyMatrixAggregatorFactory(name, filters, separator, queryShardContext, parent,
-                subFactoriesBuilder, metadata);
+        return new AdjacencyMatrixAggregatorFactory(name, filters, separator, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
@@ -23,12 +23,12 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregator.KeyedFilter;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -42,17 +42,17 @@ public class AdjacencyMatrixAggregatorFactory extends AggregatorFactory {
     private final String separator;
 
     public AdjacencyMatrixAggregatorFactory(String name, List<KeyedFilter> filters, String separator,
-                                            QueryShardContext queryShardContext, AggregatorFactory parent,
+                                            AggregationContext context, AggregatorFactory parent,
                                             AggregatorFactories.Builder subFactories, Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
-        IndexSearcher contextSearcher = queryShardContext.searcher();
+        super(name, context, parent, subFactories, metadata);
+        IndexSearcher contextSearcher = context.searcher();
         this.separator = separator;
         weights = new Weight[filters.size()];
         keys = new String[filters.size()];
         for (int i = 0; i < filters.size(); ++i) {
             KeyedFilter keyedFilter = filters.get(i);
             keys[i] = keyedFilter.key();
-            Query filter = keyedFilter.filter().toQuery(queryShardContext);
+            Query filter = context.buildQuery(keyedFilter.filter());
             weights[i] = contextSearcher.createWeight(contextSearcher.rewrite(filter), ScoreMode.COMPLETE_NO_SCORES, 1f);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -24,12 +24,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 
 import java.io.IOException;
@@ -204,7 +204,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                         AggregatorFactories.Builder subfactoriesBuilder) throws IOException {
         AggregatorFactory invalid = checkParentIsNullOrNested(parent);
         if (invalid != null) {
@@ -213,7 +213,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         }
         CompositeValuesSourceConfig[] configs = new CompositeValuesSourceConfig[sources.size()];
         for (int i = 0; i < configs.length; i++) {
-            configs[i] = sources.get(i).build(queryShardContext);
+            configs[i] = sources.get(i).build(context);
             if (configs[i].valuesSource().needsScores()) {
                 throw new IllegalArgumentException("[sources] cannot access _score");
             }
@@ -244,8 +244,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         } else {
             afterKey = null;
         }
-        return new CompositeAggregationFactory(name, queryShardContext, parent, subfactoriesBuilder, metadata, size,
-            configs, afterKey);
+        return new CompositeAggregationFactory(name, context, parent, subfactoriesBuilder, metadata, size, configs, afterKey);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.composite;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -34,10 +34,10 @@ class CompositeAggregationFactory extends AggregatorFactory {
     private final CompositeValuesSourceConfig[] sources;
     private final CompositeKey afterKey;
 
-    CompositeAggregationFactory(String name, QueryShardContext queryShardContext, AggregatorFactory parent,
+    CompositeAggregationFactory(String name, AggregationContext context, AggregatorFactory parent,
                                 AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata,
                                 int size, CompositeValuesSourceConfig[] sources, CompositeKey afterKey) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, context, parent, subFactoriesBuilder, metadata);
         this.size = size;
         this.sources = sources;
         this.afterKey = afterKey;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -25,11 +25,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -285,19 +286,17 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
     }
 
     /**
-     * Creates a {@link CompositeValuesSourceConfig} for this source.
-     *  @param queryShardContext   The shard context for this source.
-     * @param config    The {@link ValuesSourceConfig} for this source.
+     * Actually build the values source and its associated configuration.
      */
-    protected abstract CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext,
+    protected abstract CompositeValuesSourceConfig innerBuild(ValuesSourceRegistry registry,
                                                                 ValuesSourceConfig config) throws IOException;
 
     protected abstract ValuesSourceType getDefaultValuesSourceType();
 
-    public final CompositeValuesSourceConfig build(QueryShardContext queryShardContext) throws IOException {
-        ValuesSourceConfig config = ValuesSourceConfig.resolve(queryShardContext,
+    public final CompositeValuesSourceConfig build(AggregationContext context) throws IOException {
+        ValuesSourceConfig config = ValuesSourceConfig.resolve(context,
             userValueTypeHint, field, script, null, timeZone(), format, getDefaultValuesSourceType());
-        return innerBuild(queryShardContext, config);
+        return innerBuild(context.getValuesSourceRegistry(), config);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
@@ -319,10 +318,9 @@ public class DateHistogramValuesSourceBuilder
     }
 
     @Override
-    protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
+    protected CompositeValuesSourceConfig innerBuild(ValuesSourceRegistry registry, ValuesSourceConfig config) throws IOException {
         Rounding rounding = dateHistogramInterval.createRounding(timeZone(), offset);
-        return queryShardContext.getValuesSourceRegistry()
-            .getAggregator(REGISTRY_KEY, config)
+        return registry.getAggregator(REGISTRY_KEY, config)
             .apply(config, rounding, name, config.script() != null, format(), missingBucket(), order());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.bucket.geogrid.CellIdSource;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
@@ -206,9 +205,8 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     }
 
     @Override
-    protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
-            .getAggregator(REGISTRY_KEY, config)
+    protected CompositeValuesSourceConfig innerBuild(ValuesSourceRegistry registry, ValuesSourceConfig config) throws IOException {
+        return registry.getAggregator(REGISTRY_KEY, config)
             .apply(config, precision, geoBoundingBox(), name, script() != null, format(), missingBucket(), order());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -175,9 +174,8 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
     }
 
     @Override
-    protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
-            .getAggregator(REGISTRY_KEY, config)
+    protected CompositeValuesSourceConfig innerBuild(ValuesSourceRegistry registry, ValuesSourceConfig config) throws IOException {
+        return registry.getAggregator(REGISTRY_KEY, config)
             .apply(config, interval, name, script() != null, format(), missingBucket(), order());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -206,9 +205,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
     }
 
     @Override
-    protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
-            .getAggregator(REGISTRY_KEY, config)
-            .apply(config, name, script() != null, format(), missingBucket(), order());
+    protected CompositeValuesSourceConfig innerBuild(ValuesSourceRegistry registry, ValuesSourceConfig config) throws IOException {
+        return registry.getAggregator(REGISTRY_KEY, config).apply(config, name, script() != null, format(), missingBucket(), order());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -25,12 +25,12 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -98,9 +98,9 @@ public class FilterAggregationBuilder extends AbstractAggregationBuilder<FilterA
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                         AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new FilterAggregatorFactory(name, filter, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new FilterAggregatorFactory(name, filter, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
@@ -24,12 +24,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -37,13 +37,13 @@ import java.util.Map;
 
 public class FilterAggregatorFactory extends AggregatorFactory {
 
+    private final Query filter;
     private Weight weight;
-    private Query filter;
 
-    public FilterAggregatorFactory(String name, QueryBuilder filterBuilder, QueryShardContext queryShardContext,
+    public FilterAggregatorFactory(String name, QueryBuilder filterBuilder, AggregationContext context,
             AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
-        filter = filterBuilder.toQuery(queryShardContext);
+        super(name, context, parent, subFactoriesBuilder, metadata);
+        filter = context.buildQuery(filterBuilder);
     }
 
     /**
@@ -57,7 +57,7 @@ public class FilterAggregatorFactory extends AggregatorFactory {
      */
     public Weight getWeight() {
         if (weight == null) {
-            IndexSearcher contextSearcher = queryShardContext.searcher();
+            IndexSearcher contextSearcher = context.searcher();
             try {
                 weight = contextSearcher.createWeight(contextSearcher.rewrite(filter), ScoreMode.COMPLETE_NO_SCORES, 1f);
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -27,13 +27,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -223,9 +223,9 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subFactoriesBuilder)
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
         throws IOException {
-        return new FiltersAggregatorFactory(name, filters, keyed, otherBucket, otherBucketKey, queryShardContext, parent,
+        return new FiltersAggregatorFactory(name, filters, keyed, otherBucket, otherBucketKey, context, parent,
             subFactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorFactory.java
@@ -23,13 +23,13 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -46,9 +46,9 @@ public class FiltersAggregatorFactory extends AggregatorFactory {
     private final String otherBucketKey;
 
     public FiltersAggregatorFactory(String name, List<KeyedFilter> filters, boolean keyed, boolean otherBucket,
-                                    String otherBucketKey, QueryShardContext queryShardContext, AggregatorFactory parent,
+                                    String otherBucketKey, AggregationContext context, AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactories, Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.keyed = keyed;
         this.otherBucket = otherBucket;
         this.otherBucketKey = otherBucketKey;
@@ -57,7 +57,7 @@ public class FiltersAggregatorFactory extends AggregatorFactory {
         for (int i = 0; i < filters.size(); ++i) {
             KeyedFilter keyedFilter = filters.get(i);
             this.keys[i] = keyedFilter.key();
-            this.filters[i] = keyedFilter.filter().toQuery(queryShardContext);
+            this.filters[i] = context.buildQuery(keyedFilter.filter());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -29,10 +29,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.BucketUtils;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -128,7 +128,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
      */
     protected abstract ValuesSourceAggregatorFactory createFactory(
         String name, ValuesSourceConfig config, int precision, int requiredSize, int shardSize,
-        GeoBoundingBox geoBoundingBox, QueryShardContext queryShardContext, AggregatorFactory parent,
+        GeoBoundingBox geoBoundingBox, AggregationContext context, AggregatorFactory parent,
         Builder subFactoriesBuilder, Map<String, Object> metadata
     ) throws IOException;
 
@@ -178,7 +178,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent, Builder subFactoriesBuilder)
                     throws IOException {
@@ -200,7 +200,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         if (shardSize < requiredSize) {
             shardSize = requiredSize;
         }
-        return createFactory(name, config, precision, requiredSize, shardSize, geoBoundingBox, queryShardContext, parent,
+        return createFactory(name, config, precision, requiredSize, shardSize, geoBoundingBox, context, parent,
                 subFactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
@@ -23,11 +23,11 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.GeoGridAggregatorSupplier;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -71,11 +71,11 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
     @Override
     protected ValuesSourceAggregatorFactory createFactory(
         String name, ValuesSourceConfig config, int precision, int requiredSize, int shardSize,
-            GeoBoundingBox geoBoundingBox, QueryShardContext queryShardContext,
+            GeoBoundingBox geoBoundingBox, AggregationContext context,
             AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
             Map<String, Object> metadata) throws IOException {
         return new GeoHashGridAggregatorFactory(name, config, precision, requiredSize, shardSize, geoBoundingBox,
-            queryShardContext, parent, subFactoriesBuilder, metadata);
+            context, parent, subFactoriesBuilder, metadata);
     }
 
     private GeoHashGridAggregationBuilder(GeoHashGridAggregationBuilder clone, AggregatorFactories.Builder factoriesBuilder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
@@ -21,13 +21,13 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.geometry.utils.Geohash;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -48,10 +48,10 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory 
     private final GeoBoundingBox geoBoundingBox;
 
     GeoHashGridAggregatorFactory(String name, ValuesSourceConfig config, int precision, int requiredSize,
-                                 int shardSize, GeoBoundingBox geoBoundingBox, QueryShardContext queryShardContext,
+                                 int shardSize, GeoBoundingBox geoBoundingBox, AggregationContext context,
                                  AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                  Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.precision = precision;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
@@ -76,7 +76,7 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory 
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(GeoHashGridAggregationBuilder.REGISTRY_KEY, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
@@ -22,11 +22,11 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.GeoGridAggregatorSupplier;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -70,10 +70,10 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
     @Override
     protected ValuesSourceAggregatorFactory createFactory(
             String name, ValuesSourceConfig config, int precision, int requiredSize, int shardSize,
-            GeoBoundingBox geoBoundingBox, QueryShardContext queryShardContext, AggregatorFactory parent,
+            GeoBoundingBox geoBoundingBox, AggregationContext context, AggregatorFactory parent,
             AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata) throws IOException {
         return new GeoTileGridAggregatorFactory(name, config, precision, requiredSize, shardSize, geoBoundingBox,
-            queryShardContext, parent, subFactoriesBuilder, metadata);
+            context, parent, subFactoriesBuilder, metadata);
     }
 
     private GeoTileGridAggregationBuilder(GeoTileGridAggregationBuilder clone, AggregatorFactories.Builder factoriesBuilder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.common.geo.GeoBoundingBox;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -46,10 +46,10 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory 
     private final GeoBoundingBox geoBoundingBox;
 
     GeoTileGridAggregatorFactory(String name, ValuesSourceConfig config, int precision, int requiredSize,
-                                 int shardSize, GeoBoundingBox geoBoundingBox, QueryShardContext queryShardContext,
+                                 int shardSize, GeoBoundingBox geoBoundingBox, AggregationContext context,
                                  AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                  Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.precision = precision;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
@@ -74,7 +74,7 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory 
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(GeoTileGridAggregationBuilder.REGISTRY_KEY, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregationBuilder.java
@@ -23,11 +23,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -71,9 +71,9 @@ public class GlobalAggregationBuilder extends AbstractAggregationBuilder<GlobalA
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subFactoriesBuilder)
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
             throws IOException {
-        return new GlobalAggregatorFactory(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new GlobalAggregatorFactory(name, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorFactory.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.search.aggregations.bucket.global;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -33,11 +33,11 @@ import java.util.Map;
 public class GlobalAggregatorFactory extends AggregatorFactory {
 
     public GlobalAggregatorFactory(String name,
-                                    QueryShardContext queryShardContext,
+                                    AggregationContext context,
                                     AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactories,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -28,11 +28,11 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -196,7 +196,7 @@ public class AutoDateHistogramAggregationBuilder extends ValuesSourceAggregation
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                        AggregatorFactory parent, Builder subFactoriesBuilder) throws IOException {
         RoundingInfo[] roundings = buildRoundings(timeZone(), getMinimumIntervalExpression());
         int maxRoundingInterval = Arrays.stream(roundings,0, roundings.length-1)
@@ -204,14 +204,14 @@ public class AutoDateHistogramAggregationBuilder extends ValuesSourceAggregation
             .flatMapToInt(Arrays::stream)
             .boxed()
             .reduce(Integer::max).get();
-        Settings settings = queryShardContext.getIndexSettings().getNodeSettings();
+        Settings settings = context.getIndexSettings().getNodeSettings();
         int maxBuckets = MultiBucketConsumerService.MAX_BUCKET_SETTING.get(settings);
         int bucketCeiling = maxBuckets / maxRoundingInterval;
         if (numBuckets > bucketCeiling) {
             throw new IllegalArgumentException(NUM_BUCKETS_FIELD.getPreferredName()+
                 " must be less than " + bucketCeiling);
         }
-        return new AutoDateHistogramAggregatorFactory(name, config, numBuckets, roundings, queryShardContext, parent,
+        return new AutoDateHistogramAggregatorFactory(name, config, numBuckets, roundings, context, parent,
             subFactoriesBuilder,
             metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.common.Rounding.Prepared;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.IntArray;
@@ -70,7 +69,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
         AggregatorFactories factories,
         int targetBuckets,
         RoundingInfo[] roundingInfos,
-        Function<Rounding, Rounding.Prepared> roundingPreparer,
         ValuesSourceConfig valuesSourceConfig,
         SearchContext aggregationContext,
         Aggregator parent,
@@ -83,7 +81,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                 factories,
                 targetBuckets,
                 roundingInfos,
-                roundingPreparer,
                 valuesSourceConfig,
                 aggregationContext,
                 parent,
@@ -94,7 +91,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                 factories,
                 targetBuckets,
                 roundingInfos,
-                roundingPreparer,
                 valuesSourceConfig,
                 aggregationContext,
                 parent,
@@ -119,7 +115,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
         AggregatorFactories factories,
         int targetBuckets,
         RoundingInfo[] roundingInfos,
-        Function<Rounding, Rounding.Prepared> roundingPreparer,
         ValuesSourceConfig valuesSourceConfig,
         SearchContext aggregationContext,
         Aggregator parent,
@@ -132,7 +127,7 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.formatter = valuesSourceConfig.format();
         this.roundingInfos = roundingInfos;
-        this.roundingPreparer = roundingPreparer;
+        this.roundingPreparer = valuesSourceConfig.roundingPreparer();
     }
 
     @Override
@@ -251,7 +246,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
             AggregatorFactories factories,
             int targetBuckets,
             RoundingInfo[] roundingInfos,
-            Function<Rounding, Prepared> roundingPreparer,
             ValuesSourceConfig valuesSourceConfig,
             SearchContext aggregationContext,
             Aggregator parent,
@@ -262,7 +256,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                 factories,
                 targetBuckets,
                 roundingInfos,
-                roundingPreparer,
                 valuesSourceConfig,
                 aggregationContext,
                 parent,
@@ -457,7 +450,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
             AggregatorFactories factories,
             int targetBuckets,
             RoundingInfo[] roundingInfos,
-            Function<Rounding, Rounding.Prepared> roundingPreparer,
             ValuesSourceConfig valuesSourceConfig,
             SearchContext aggregationContext,
             Aggregator parent,
@@ -469,7 +461,6 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                 factories,
                 targetBuckets,
                 roundingInfos,
-                roundingPreparer,
                 valuesSourceConfig,
                 aggregationContext,
                 parent,
@@ -483,7 +474,7 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
             maxes.set(0, Long.MIN_VALUE);
             preparedRoundings = new Rounding.Prepared[roundingInfos.length];
             // Prepare the first rounding because we know we'll need it.
-            preparedRoundings[0] = roundingPreparer.apply(roundingInfos[0].rounding);
+            preparedRoundings[0] = prepareRounding(0);
             bucketOrds = new LongKeyedBucketOrds.FromMany(context.bigArrays());
             liveBucketCountUnderestimate = context.bigArrays().newIntArray(1, true);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
@@ -19,13 +19,12 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.elasticsearch.common.Rounding;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -35,7 +34,6 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
 
 public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggregatorFactory {
 
@@ -54,11 +52,11 @@ public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggreg
                                               ValuesSourceConfig config,
                                               int numBuckets,
                                               RoundingInfo[] roundingInfos,
-                                              QueryShardContext queryShardContext,
+                                              AggregationContext context,
                                               AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder,
                                               Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.numBuckets = numBuckets;
         this.roundingInfos = roundingInfos;
     }
@@ -68,16 +66,13 @@ public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggreg
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        AutoDateHistogramAggregatorSupplier aggregatorSupplier = queryShardContext.getValuesSourceRegistry()
+        AutoDateHistogramAggregatorSupplier aggregatorSupplier = context.getValuesSourceRegistry()
             .getAggregator(AutoDateHistogramAggregationBuilder.REGISTRY_KEY, config);
-        Function<Rounding, Rounding.Prepared> roundingPreparer =
-                config.getValuesSource().roundingPreparer(searchContext.getQueryShardContext().getIndexReader());
         return aggregatorSupplier.build(
             name,
             factories,
             numBuckets,
             roundingInfos,
-            roundingPreparer,
             config,
             searchContext,
             parent,
@@ -95,7 +90,6 @@ public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggreg
             factories,
             numBuckets,
             roundingInfos,
-            Rounding::prepareForUnknown,
             config,
             searchContext,
             parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorSupplier.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Rounding;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
@@ -29,7 +28,6 @@ import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.function.Function;
 
 @FunctionalInterface
 public interface AutoDateHistogramAggregatorSupplier {
@@ -39,7 +37,6 @@ public interface AutoDateHistogramAggregatorSupplier {
         int numBuckets,
         AutoDateHistogramAggregationBuilder.RoundingInfo[] roundingInfos,
         @Nullable
-        Function<Rounding, Rounding.Prepared> roundingPreparer,
         ValuesSourceConfig valuesSourceConfig,
         SearchContext aggregationContext,
         Aggregator parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -27,13 +27,13 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -437,7 +437,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
@@ -447,14 +447,14 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
         LongBounds roundedBounds = null;
         if (this.extendedBounds != null) {
             // parse any string bounds to longs and round
-            roundedBounds = this.extendedBounds.parseAndValidate(name, "extended_bounds" , queryShardContext, config.format())
+            roundedBounds = this.extendedBounds.parseAndValidate(name, "extended_bounds" , context::nowInMillis, config.format())
                 .round(rounding);
         }
 
         LongBounds roundedHardBounds = null;
         if (this.hardBounds != null) {
             // parse any string bounds to longs and round
-            roundedHardBounds = this.hardBounds.parseAndValidate(name, "hard_bounds" , queryShardContext, config.format())
+            roundedHardBounds = this.hardBounds.parseAndValidate(name, "hard_bounds" , context::nowInMillis, config.format())
                 .round(rounding);
         }
 
@@ -480,7 +480,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
             rounding,
             roundedBounds,
             roundedHardBounds,
-            queryShardContext,
+            context,
             parent,
             subFactoriesBuilder,
             metadata);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationSupplier.java
@@ -36,7 +36,6 @@ public interface DateHistogramAggregationSupplier {
     Aggregator build(String name,
                      AggregatorFactories factories,
                      Rounding rounding,
-                     Rounding.Prepared preparedRounding,
                      BucketOrder order,
                      boolean keyed,
                      long minDocCount,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -28,8 +28,8 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
@@ -72,7 +72,6 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         String name,
         AggregatorFactories factories,
         Rounding rounding,
-        Rounding.Prepared preparedRounding,
         BucketOrder order,
         boolean keyed,
         long minDocCount,
@@ -87,7 +86,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
 
         super(name, factories, aggregationContext, parent, CardinalityUpperBound.MANY, metadata);
         this.rounding = rounding;
-        this.preparedRounding = preparedRounding;
+        this.preparedRounding = valuesSourceConfig.roundingPreparer().apply(rounding);
         this.order = order;
         order.validate(this);
         this.keyed = keyed;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
@@ -21,12 +21,12 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.collect.List;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -64,12 +64,12 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
         Rounding rounding,
         LongBounds extendedBounds,
         LongBounds hardBounds,
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.order = order;
         this.keyed = keyed;
         this.minDocCount = minDocCount;
@@ -88,17 +88,12 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        DateHistogramAggregationSupplier aggregatorSupplier = queryShardContext.getValuesSourceRegistry()
+        DateHistogramAggregationSupplier aggregatorSupplier = context.getValuesSourceRegistry()
             .getAggregator(DateHistogramAggregationBuilder.REGISTRY_KEY, config);
-        // TODO: Is there a reason not to get the prepared rounding in the supplier itself?
-        Rounding.Prepared preparedRounding = config.getValuesSource()
-            .roundingPreparer(queryShardContext.getIndexReader())
-            .apply(rounding);
         return aggregatorSupplier.build(
             name,
             factories,
             rounding,
-            preparedRounding,
             order,
             keyed,
             minDocCount,
@@ -116,7 +111,7 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
                                             Map<String, Object> metadata) throws IOException {
-        return new DateHistogramAggregator(name, factories, rounding, null, order, keyed, minDocCount, extendedBounds, hardBounds,
+        return new DateHistogramAggregator(name, factories, rounding, order, keyed, minDocCount, extendedBounds, hardBounds,
             config, searchContext, parent, CardinalityUpperBound.NONE, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -79,7 +79,6 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         String name,
         AggregatorFactories factories,
         Rounding rounding,
-        Rounding.Prepared preparedRounding,
         BucketOrder order,
         boolean keyed,
         long minDocCount,
@@ -94,7 +93,7 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
 
         super(name, factories, aggregationContext, parent, CardinalityUpperBound.MANY, metadata);
         this.rounding = rounding;
-        this.preparedRounding = preparedRounding;
+        this.preparedRounding = valuesSourceConfig.roundingPreparer().apply(rounding);
         this.order = order;
         order.validate(this);
         this.keyed = keyed;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -25,13 +25,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -355,7 +355,7 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
@@ -371,7 +371,7 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
             }
         }
         return new HistogramAggregatorFactory(name, config, interval, offset, order, keyed, minDocCount, extendedBounds,
-            hardBounds, queryShardContext, parent, subFactoriesBuilder, metadata);
+            hardBounds, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
@@ -20,12 +20,12 @@
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.collect.List;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -67,11 +67,11 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                                         long minDocCount,
                                         DoubleBounds extendedBounds,
                                         DoubleBounds hardBounds,
-                                        QueryShardContext queryShardContext,
+                                        AggregationContext context,
                                         AggregatorFactory parent,
                                         AggregatorFactories.Builder subFactoriesBuilder,
                                         Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.interval = interval;
         this.offset = offset;
         this.order = order;
@@ -90,7 +90,7 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(HistogramAggregationBuilder.REGISTRY_KEY, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBounds.java
@@ -31,11 +31,11 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.LongSupplier;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -152,16 +152,16 @@ public class LongBounds implements ToXContentFragment, Writeable {
     /**
      * Parse the bounds and perform any delayed validation. Returns the result of the parsing.
      */
-    LongBounds parseAndValidate(String aggName, String boundsName, QueryShardContext queryShardContext, DocValueFormat format) {
+    LongBounds parseAndValidate(String aggName, String boundsName, LongSupplier nowInMillis, DocValueFormat format) {
         Long min = this.min;
         Long max = this.max;
         assert format != null;
         if (minAsStr != null) {
-            min = format.parseLong(minAsStr, false, queryShardContext::nowInMillis);
+            min = format.parseLong(minAsStr, false, nowInMillis);
         }
         if (maxAsStr != null) {
             // TODO: Should we rather pass roundUp=true?
-            max = format.parseLong(maxAsStr, false, queryShardContext::nowInMillis);
+            max = format.parseLong(maxAsStr, false, nowInMillis);
         }
         if (min != null && max != null && min.compareTo(max) > 0) {
             throw new IllegalArgumentException("[" + boundsName + ".min][" + min + "] cannot be greater than " +

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
@@ -25,11 +25,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -155,11 +155,11 @@ public class VariableWidthHistogramAggregationBuilder extends ValuesSourceAggreg
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        Settings settings = queryShardContext.getIndexSettings().getNodeSettings();
+        Settings settings = context.getIndexSettings().getNodeSettings();
         int maxBuckets = MultiBucketConsumerService.MAX_BUCKET_SETTING.get(settings);
         if (numBuckets > maxBuckets) {
             throw new IllegalArgumentException(NUM_BUCKETS_FIELD.getPreferredName() + " must be less than " + maxBuckets);
@@ -187,7 +187,7 @@ public class VariableWidthHistogramAggregationBuilder extends ValuesSourceAggreg
                 + NUM_BUCKETS_FIELD.getPreferredName() + " but was [" + mergePhaseInit + "<" + numBuckets + "] for [" + name + "]");
         }
         return new VariableWidthHistogramAggregatorFactory(name, config, numBuckets, shardSize, initialBuffer,
-            queryShardContext, parent, subFactoriesBuilder, metadata);
+            context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -52,11 +52,11 @@ public class VariableWidthHistogramAggregatorFactory extends ValuesSourceAggrega
                                             int numBuckets,
                                             int shardSize,
                                             int initialBuffer,
-                                            QueryShardContext queryShardContext,
+                                            AggregationContext context,
                                             AggregatorFactory parent,
                                             AggregatorFactories.Builder subFactoriesBuilder,
                                             Map<String, Object> metadata) throws IOException{
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.numBuckets = numBuckets;
         this.shardSize = shardSize;
         this.initialBuffer = initialBuffer;
@@ -74,7 +74,7 @@ public class VariableWidthHistogramAggregatorFactory extends ValuesSourceAggrega
                     + "] cannot be nested inside an aggregation that collects more than a single bucket."
             );
         }
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(VariableWidthHistogramAggregationBuilder.REGISTRY_KEY, config)
             .build(name, factories, numBuckets, shardSize, initialBuffer, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregationBuilder.java
@@ -24,10 +24,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -98,11 +98,11 @@ public class MissingAggregationBuilder extends ValuesSourceAggregationBuilder<Mi
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new MissingAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new MissingAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.missing;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -39,10 +39,10 @@ public class MissingAggregatorFactory extends ValuesSourceAggregatorFactory {
         builder.register(MissingAggregationBuilder.REGISTRY_KEY, CoreValuesSourceType.ALL_CORE, MissingAggregator::new, true);
     }
 
-    public MissingAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    public MissingAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                                     AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class MissingAggregatorFactory extends ValuesSourceAggregatorFactory {
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(MissingAggregationBuilder.REGISTRY_KEY, config)
             .build(name, factories, config, searchContext, parent, cardinality, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
@@ -25,12 +25,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -92,13 +92,13 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext,
+    protected AggregatorFactory doBuild(AggregationContext context,
                                             AggregatorFactory parent,
                                             Builder subFactoriesBuilder) throws IOException {
-        ObjectMapper childObjectMapper = queryShardContext.getObjectMapper(path);
+        ObjectMapper childObjectMapper = context.getObjectMapper(path);
         if (childObjectMapper == null) {
             // in case the path has been unmapped:
-            return new NestedAggregatorFactory(name, null, null, queryShardContext,
+            return new NestedAggregatorFactory(name, null, null, context,
                 parent, subFactoriesBuilder, metadata);
         }
 
@@ -106,11 +106,11 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
             throw new AggregationExecutionException("[nested] nested path [" + path + "] is not nested");
         }
         try {
-            ObjectMapper parentObjectMapper = queryShardContext.nestedScope().nextLevel(childObjectMapper);
-            return new NestedAggregatorFactory(name, parentObjectMapper, childObjectMapper, queryShardContext,
+            ObjectMapper parentObjectMapper = context.nestedScope().nextLevel(childObjectMapper);
+            return new NestedAggregatorFactory(name, parentObjectMapper, childObjectMapper, context,
                 parent, subFactoriesBuilder, metadata);
         } finally {
-            queryShardContext.nestedScope().previousLevel();
+            context.nestedScope().previousLevel();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.search.aggregations.bucket.nested;
 
 import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -38,9 +38,9 @@ public class NestedAggregatorFactory extends AggregatorFactory {
     private final ObjectMapper childObjectMapper;
 
     NestedAggregatorFactory(String name, ObjectMapper parentObjectMapper, ObjectMapper childObjectMapper,
-                            QueryShardContext queryShardContext, AggregatorFactory parent, AggregatorFactories.Builder subFactories,
+                            AggregationContext context, AggregatorFactory parent, AggregatorFactories.Builder subFactories,
                             Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.parentObjectMapper = parentObjectMapper;
         this.childObjectMapper = childObjectMapper;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.search.aggregations.bucket.nested;
 
 import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -38,10 +38,10 @@ public class ReverseNestedAggregatorFactory extends AggregatorFactory {
     private final ObjectMapper parentObjectMapper;
 
     public ReverseNestedAggregatorFactory(String name, boolean unmapped, ObjectMapper parentObjectMapper,
-                                          QueryShardContext queryShardContext, AggregatorFactory parent,
+                                          AggregationContext context, AggregatorFactory parent,
                                           AggregatorFactories.Builder subFactories,
                                           Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.unmapped = unmapped;
         this.parentObjectMapper = parentObjectMapper;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeAggregatorFactory.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Unmapped;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -60,11 +60,11 @@ public class AbstractRangeAggregatorFactory<R extends Range> extends ValuesSourc
                                           R[] ranges,
                                           boolean keyed,
                                           InternalRange.Factory<?, ?> rangeFactory,
-                                          QueryShardContext queryShardContext,
+                                          AggregationContext context,
                                           AggregatorFactory parent,
                                           AggregatorFactories.Builder subFactoriesBuilder,
                                           Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.ranges = ranges;
         this.keyed = keyed;
         this.rangeFactory = rangeFactory;
@@ -86,7 +86,7 @@ public class AbstractRangeAggregatorFactory<R extends Range> extends ValuesSourc
         Map<String, Object> metadata
     ) throws IOException {
 
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(registryKey, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorFactory.java
@@ -18,11 +18,11 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -45,10 +45,10 @@ public class BinaryRangeAggregatorFactory extends ValuesSourceAggregatorFactory 
     public BinaryRangeAggregatorFactory(String name,
             ValuesSourceConfig config,
             List<BinaryRangeAggregator.Range> ranges, boolean keyed,
-            QueryShardContext queryShardContext,
+            AggregationContext context,
             AggregatorFactory parent, Builder subFactoriesBuilder,
             Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.ranges = ranges;
         this.keyed = keyed;
     }
@@ -67,7 +67,7 @@ public class BinaryRangeAggregatorFactory extends ValuesSourceAggregatorFactory 
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(IpRangeAggregationBuilder.REGISTRY_KEY, config)
             .build(name, factories, config.getValuesSource(), config.format(), ranges, keyed, searchContext, parent, cardinality, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
@@ -21,11 +21,11 @@ package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -301,7 +301,7 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
     }
 
     @Override
-    protected DateRangeAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected DateRangeAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                     AggregatorFactory parent,
                                                     AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
         // We need to call processRanges here so they are parsed and we know whether `now` has been used before we make
@@ -314,23 +314,23 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
             String fromAsString = range.getFromAsString();
             String toAsString = range.getToAsString();
             if (fromAsString != null) {
-                from = parser.parseDouble(fromAsString, false, queryShardContext::nowInMillis);
+                from = parser.parseDouble(fromAsString, false, context::nowInMillis);
             } else if (Double.isFinite(from)) {
                 // from/to provided as double should be converted to string and parsed regardless to support
                 // different formats like `epoch_millis` vs. `epoch_second` with numeric input
-                from = parser.parseDouble(Long.toString((long) from), false, queryShardContext::nowInMillis);
+                from = parser.parseDouble(Long.toString((long) from), false, context::nowInMillis);
             }
             if (toAsString != null) {
-                to = parser.parseDouble(toAsString, false, queryShardContext::nowInMillis);
+                to = parser.parseDouble(toAsString, false, context::nowInMillis);
             } else if (Double.isFinite(to)) {
-                to = parser.parseDouble(Long.toString((long) to), false, queryShardContext::nowInMillis);
+                to = parser.parseDouble(Long.toString((long) to), false, context::nowInMillis);
             }
             return new RangeAggregator.Range(range.getKey(), from, fromAsString, to, toAsString);
         });
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
         }
-        return new DateRangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, queryShardContext, parent, subFactoriesBuilder,
+        return new DateRangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorFactory.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class DateRangeAggregatorFactory extends AbstractRangeAggregatorFactory<R
         RangeAggregator.Range[] ranges,
         boolean keyed,
         InternalRange.Factory<?, ?> rangeFactory,
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metadata
@@ -47,7 +47,7 @@ public class DateRangeAggregatorFactory extends AbstractRangeAggregatorFactory<R
             ranges,
             keyed,
             rangeFactory,
-            queryShardContext,
+            context,
             parent,
             subFactoriesBuilder,
             metadata

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -31,10 +31,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -434,7 +434,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        Builder subFactoriesBuilder) throws IOException {
@@ -442,7 +442,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
         }
-        return new GeoDistanceRangeAggregatorFactory(name, config, origin, ranges, unit, distanceType, keyed, queryShardContext, parent,
+        return new GeoDistanceRangeAggregatorFactory(name, config, origin, ranges, unit, distanceType, keyed, context, parent,
                 subFactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
@@ -28,12 +28,12 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder.Range;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -92,10 +92,10 @@ public class GeoDistanceRangeAggregatorFactory extends ValuesSourceAggregatorFac
 
     public GeoDistanceRangeAggregatorFactory(String name, ValuesSourceConfig config, GeoPoint origin,
                                              Range[] ranges, DistanceUnit unit, GeoDistance distanceType, boolean keyed,
-                                             QueryShardContext queryShardContext, AggregatorFactory parent,
+                                             AggregationContext context, AggregatorFactory parent,
                                              AggregatorFactories.Builder subFactoriesBuilder,
                                              Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.origin = origin;
         this.ranges = ranges;
         this.unit = unit;
@@ -118,7 +118,7 @@ public class GeoDistanceRangeAggregatorFactory extends ValuesSourceAggregatorFac
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(GeoDistanceAggregationBuilder.REGISTRY_KEY, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
@@ -31,11 +31,11 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -382,9 +382,8 @@ public final class IpRangeAggregationBuilder extends ValuesSourceAggregationBuil
 
     @Override
     protected ValuesSourceAggregatorFactory innerBuild(
-        QueryShardContext queryShardContext, ValuesSourceConfig config,
-        AggregatorFactory parent, Builder subFactoriesBuilder)
-                    throws IOException {
+                AggregationContext context, ValuesSourceConfig config,
+                AggregatorFactory parent, Builder subFactoriesBuilder) throws IOException {
         List<BinaryRangeAggregator.Range> ranges = new ArrayList<>();
         if(this.ranges.size() == 0){
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
@@ -393,7 +392,7 @@ public final class IpRangeAggregationBuilder extends ValuesSourceAggregationBuil
             ranges.add(new BinaryRangeAggregator.Range(range.key, toBytesRef(range.from), toBytesRef(range.to)));
         }
         return new BinaryRangeAggregatorFactory(name, config, ranges,
-                keyed, queryShardContext, parent, subFactoriesBuilder, metadata);
+                keyed, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
@@ -21,12 +21,12 @@ package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -147,7 +147,7 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
     }
 
     @Override
-    protected RangeAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected RangeAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                 AggregatorFactory parent,
                                                 AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
         // We need to call processRanges here so they are parsed before we make the decision of whether to cache the request
@@ -157,18 +157,17 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
             Double from = range.from;
             Double to = range.to;
             if (range.fromAsStr != null) {
-                from = parser.parseDouble(range.fromAsStr, false, queryShardContext::nowInMillis);
+                from = parser.parseDouble(range.fromAsStr, false, context::nowInMillis);
             }
             if (range.toAsStr != null) {
-                to = parser.parseDouble(range.toAsStr, false, queryShardContext::nowInMillis);
+                to = parser.parseDouble(range.toAsStr, false, context::nowInMillis);
             }
             return new Range(range.key, from, range.fromAsStr, to, range.toAsStr);
         });
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
         }
-        return new RangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, queryShardContext, parent, subFactoriesBuilder,
-                metadata);
+        return new RangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.InternalRange.Factory;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class RangeAggregatorFactory extends AbstractRangeAggregatorFactory<Range
         Range[] ranges,
         boolean keyed,
         Factory<?, ?> rangeFactory,
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metadata
@@ -49,7 +49,7 @@ public class RangeAggregatorFactory extends AbstractRangeAggregatorFactory<Range
             ranges,
             keyed,
             rangeFactory,
-            queryShardContext,
+            context,
             parent,
             subFactoriesBuilder,
             metadata

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -159,11 +159,11 @@ public class DiversifiedAggregationBuilder extends ValuesSourceAggregationBuilde
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        Builder subFactoriesBuilder) throws IOException {
-        return new DiversifiedAggregatorFactory(name, config, shardSize, maxDocsPerValue, executionHint, queryShardContext, parent,
+        return new DiversifiedAggregatorFactory(name, config, shardSize, maxDocsPerValue, executionHint, context, parent,
                 subFactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket.sampler;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -27,6 +26,7 @@ import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregator.ExecutionMode;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -101,9 +101,9 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory 
     private final String executionHint;
 
     DiversifiedAggregatorFactory(String name, ValuesSourceConfig config, int shardSize, int maxDocsPerValue,
-                                 String executionHint, QueryShardContext queryShardContext, AggregatorFactory parent,
+                                 String executionHint, AggregationContext context, AggregatorFactory parent,
                                  AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.shardSize = shardSize;
         this.maxDocsPerValue = maxDocsPerValue;
         this.executionHint = executionHint;
@@ -115,7 +115,7 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory 
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
 
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(DiversifiedAggregationBuilder.REGISTRY_KEY, config)
             .build(name, shardSize, factories, searchContext, parent, metadata, config, maxDocsPerValue, executionHint);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
@@ -24,11 +24,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -89,9 +89,9 @@ public class SamplerAggregationBuilder extends AbstractAggregationBuilder<Sample
     }
 
     @Override
-    protected SamplerAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subFactoriesBuilder)
+    protected SamplerAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
             throws IOException {
-        return new SamplerAggregatorFactory(name, shardSize, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new SamplerAggregatorFactory(name, shardSize, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.sampler;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -33,9 +33,9 @@ public class SamplerAggregatorFactory extends AggregatorFactory {
 
     private final int shardSize;
 
-    SamplerAggregatorFactory(String name, int shardSize, QueryShardContext queryShardContext, AggregatorFactory parent,
+    SamplerAggregatorFactory(String name, int shardSize, AggregationContext context, AggregatorFactory parent,
                              AggregatorFactories.Builder subFactories, Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.shardSize = shardSize;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -24,10 +24,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -174,12 +174,12 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
         return new RareTermsAggregatorFactory(name, config, includeExclude,
-            queryShardContext, parent, subFactoriesBuilder, metadata, maxDocCount, precision);
+            context, parent, subFactoriesBuilder, metadata, maxDocCount, precision);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -29,6 +28,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -151,10 +151,10 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     RareTermsAggregatorFactory(String name, ValuesSourceConfig config,
                                       IncludeExclude includeExclude,
-                                      QueryShardContext queryShardContext,
+                                      AggregationContext context,
                                       AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                       Map<String, Object> metadata, int maxDocCount, double precision) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.includeExclude = includeExclude;
         this.maxDocCount = maxDocCount;
         this.precision = precision;
@@ -180,7 +180,7 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(RareTermsAggregationBuilder.REGISTRY_KEY, config)
             .build(
                 name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
@@ -27,13 +27,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.JLHScore;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -292,13 +292,13 @@ public class SignificantTermsAggregationBuilder extends ValuesSourceAggregationB
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        SignificanceHeuristic executionHeuristic = this.significanceHeuristic.rewrite(queryShardContext);
+        SignificanceHeuristic executionHeuristic = significanceHeuristic.rewrite(context);
         return new SignificantTermsAggregatorFactory(name, config, includeExclude, executionHint, filterBuilder,
-                bucketCountThresholds, executionHeuristic, queryShardContext, parent, subFactoriesBuilder, metadata);
+                bucketCountThresholds, executionHeuristic, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
@@ -34,6 +33,7 @@ import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketUtils;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -160,11 +160,11 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                                       QueryBuilder backgroundFilter,
                                       TermsAggregator.BucketCountThresholds bucketCountThresholds,
                                       SignificanceHeuristic significanceHeuristic,
-                                      QueryShardContext queryShardContext,
+                                      AggregationContext context,
                                       AggregatorFactory parent,
                                       AggregatorFactories.Builder subFactoriesBuilder,
                                       Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
 
         if (config.hasValues()) {
             if (config.fieldContext().fieldType().isSearchable() == false) {
@@ -201,7 +201,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        SignificantTermsAggregatorSupplier aggregatorSupplier = queryShardContext.getValuesSourceRegistry()
+        SignificantTermsAggregatorSupplier aggregatorSupplier = context.getValuesSourceRegistry()
             .getAggregator(SignificantTermsAggregationBuilder.REGISTRY_KEY, config);
 
         BucketCountThresholds bucketCountThresholds = new BucketCountThresholds(this.bucketCountThresholds);
@@ -222,7 +222,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         }
 
         SignificanceLookup lookup = new SignificanceLookup(
-            queryShardContext,
+            context,
             config.fieldContext().fieldType(),
             config.format(),
             backgroundFilter

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
@@ -35,6 +34,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -324,12 +324,12 @@ public class SignificantTextAggregationBuilder extends AbstractAggregationBuilde
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                         Builder subFactoriesBuilder) throws IOException {
-        SignificanceHeuristic executionHeuristic = this.significanceHeuristic.rewrite(queryShardContext);
+        SignificanceHeuristic executionHeuristic = this.significanceHeuristic.rewrite(context);
 
         return new SignificantTextAggregatorFactory(name, includeExclude, filterBuilder,
-                bucketCountThresholds, executionHeuristic, queryShardContext, parent, subFactoriesBuilder,
+                bucketCountThresholds, executionHeuristic, context, parent, subFactoriesBuilder,
                 fieldName, sourceFieldNames, filterDuplicateText, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -35,6 +34,7 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -347,12 +347,12 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
         return new TermsAggregatorFactory(name, config, order, includeExclude, executionHint, collectMode,
-                bucketCountThresholds, showTermDocCountError, queryShardContext, parent, subFactoriesBuilder, metadata);
+                bucketCountThresholds, showTermDocCountError, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -37,6 +36,7 @@ import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketUtils;
 import org.elasticsearch.search.aggregations.bucket.terms.NumericTermsAggregator.ResultStrategy;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -181,11 +181,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                            SubAggCollectionMode collectMode,
                            TermsAggregator.BucketCountThresholds bucketCountThresholds,
                            boolean showTermDocCountError,
-                           QueryShardContext queryShardContext,
+                           AggregationContext context,
                            AggregatorFactory parent,
                            AggregatorFactories.Builder subFactoriesBuilder,
                            Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.order = order;
         this.includeExclude = includeExclude;
         this.executionHint = executionHint;
@@ -229,7 +229,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        TermsAggregatorSupplier aggregatorSupplier = queryShardContext.getValuesSourceRegistry()
+        TermsAggregatorSupplier aggregatorSupplier = context.getValuesSourceRegistry()
             .getAggregator(TermsAggregationBuilder.REGISTRY_KEY, config);
         BucketCountThresholds bucketCountThresholds = new BucketCountThresholds(this.bucketCountThresholds);
         if (InternalOrder.isKeyOrder(order) == false

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
@@ -25,10 +25,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SignificantTermsHeuristicScoreScript;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -105,9 +105,8 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     }
 
     @Override
-    public SignificanceHeuristic rewrite(QueryShardContext queryShardContext) {
-        SignificantTermsHeuristicScoreScript.Factory compiledScript = queryShardContext.compile(script,
-                SignificantTermsHeuristicScoreScript.CONTEXT);
+    public SignificanceHeuristic rewrite(AggregationContext context) {
+        SignificantTermsHeuristicScoreScript.Factory compiledScript = context.compile(script, SignificantTermsHeuristicScoreScript.CONTEXT);
         return new ExecutableScriptHeuristic(script, compiledScript.newInstance());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/SignificanceHeuristic.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/SignificanceHeuristic.java
@@ -21,9 +21,9 @@ package org.elasticsearch.search.aggregations.bucket.terms.heuristic;
 
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 /**
  * Heuristic for that {@link SignificantTerms} uses to pick out significant terms.
@@ -65,10 +65,10 @@ public abstract class SignificanceHeuristic implements NamedWriteable, ToXConten
     /**
      * Provides a hook for subclasses to provide a version of the heuristic
      * prepared for execution on data on a shard. 
-     * @param queryShardContext the shard context on the data node
+     * @param context the shard context on the data node
      * @return a version of this heuristic suitable for execution
      */
-    public SignificanceHeuristic rewrite(QueryShardContext queryShardContext) {
+    public SignificanceHeuristic rewrite(AggregationContext context) {
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -84,10 +84,10 @@ public class AvgAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     }
 
     @Override
-    protected AvgAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected AvgAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                               AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new AvgAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new AvgAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -35,10 +35,10 @@ import java.util.Map;
 
 class AvgAggregatorFactory extends ValuesSourceAggregatorFactory {
 
-    AvgAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    AvgAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                          AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                          Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
@@ -63,7 +63,7 @@ class AvgAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(AvgAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -25,10 +25,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -132,10 +132,10 @@ public final class CardinalityAggregationBuilder
     }
 
     @Override
-    protected CardinalityAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected CardinalityAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                       AggregatorFactory parent,
                                                       AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new CardinalityAggregatorFactory(name, config, precisionThreshold, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new CardinalityAggregatorFactory(name, config, precisionThreshold, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -39,11 +39,11 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     CardinalityAggregatorFactory(String name, ValuesSourceConfig config,
                                     Long precisionThreshold,
-                                    QueryShardContext queryShardContext,
+                                    AggregationContext context,
                                     AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactoriesBuilder,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.precisionThreshold = precisionThreshold;
     }
 
@@ -65,7 +65,7 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(CardinalityAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, precision(), searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -103,10 +103,10 @@ public class ExtendedStatsAggregationBuilder
     }
 
     @Override
-    protected ExtendedStatsAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected ExtendedStatsAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                         AggregatorFactory parent,
                                                         AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new ExtendedStatsAggregatorFactory(name, config, sigma, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new ExtendedStatsAggregatorFactory(name, config, sigma, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -41,11 +41,11 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
     ExtendedStatsAggregatorFactory(String name,
                                     ValuesSourceConfig config,
                                     double sigma,
-                                    QueryShardContext queryShardContext,
+                                    AggregationContext context,
                                     AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactoriesBuilder,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.sigma = sigma;
     }
 
@@ -71,7 +71,7 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(ExtendedStatsAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, sigma, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -110,10 +110,10 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
     }
 
     @Override
-    protected GeoBoundsAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected GeoBoundsAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                     AggregatorFactory parent,
                                                     AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new GeoBoundsAggregatorFactory(name, config, wrapLongitude, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new GeoBoundsAggregatorFactory(name, config, wrapLongitude, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -40,11 +40,11 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory {
     GeoBoundsAggregatorFactory(String name,
                                 ValuesSourceConfig config,
                                 boolean wrapLongitude,
-                                QueryShardContext queryShardContext,
+                                AggregationContext context,
                                 AggregatorFactory parent,
                                 AggregatorFactories.Builder subFactoriesBuilder,
                                 Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.wrapLongitude = wrapLongitude;
     }
 
@@ -62,7 +62,7 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(GeoBoundsAggregationBuilder.REGISTRY_KEY, config)
             .build(name, searchContext, parent, config, wrapLongitude, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -88,10 +88,10 @@ public class GeoCentroidAggregationBuilder
     }
 
     @Override
-    protected GeoCentroidAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected GeoCentroidAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                       AggregatorFactory parent,
                                                       AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new GeoCentroidAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new GeoCentroidAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -37,11 +37,11 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     GeoCentroidAggregatorFactory(String name,
                                     ValuesSourceConfig config,
-                                    QueryShardContext queryShardContext,
+                                    AggregationContext context,
                                     AggregatorFactory parent,
                                     AggregatorFactories.Builder subFactoriesBuilder,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -58,7 +58,7 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(GeoCentroidAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -86,10 +86,10 @@ public class MaxAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     }
 
     @Override
-    protected MaxAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected MaxAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                               AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new MaxAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new MaxAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -43,10 +43,10 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory {
                 true);
     }
 
-    MaxAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    MaxAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                          AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                          Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -63,7 +63,7 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(MaxAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
@@ -24,10 +24,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -113,12 +113,12 @@ public class MedianAbsoluteDeviationAggregationBuilder extends LeafOnly<ValuesSo
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        AggregatorFactories.Builder subFactoriesBuilder)
         throws IOException {
-        return new MedianAbsoluteDeviationAggregatorFactory(name, config, queryShardContext,
+        return new MedianAbsoluteDeviationAggregatorFactory(name, config, context,
             parent, subFactoriesBuilder, metadata, compression);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -39,13 +39,13 @@ public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggreg
 
     MedianAbsoluteDeviationAggregatorFactory(String name,
                                              ValuesSourceConfig config,
-                                             QueryShardContext queryShardContext,
+                                             AggregationContext context,
                                              AggregatorFactory parent,
                                              AggregatorFactories.Builder subFactoriesBuilder,
                                              Map<String, Object> metadata,
                                              double compression) throws IOException {
 
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.compression = compression;
     }
 
@@ -80,7 +80,7 @@ public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggreg
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(MedianAbsoluteDeviationAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config.getValuesSource(), config.format(), searchContext, parent, metadata, compression);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -86,10 +86,10 @@ public class MinAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     }
 
     @Override
-    protected MinAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected MinAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                               AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new MinAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new MinAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -43,10 +43,10 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory {
             true);
     }
 
-    MinAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    MinAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                          AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                          Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -63,7 +63,7 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(MinAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -95,11 +95,11 @@ public class PercentileRanksAggregationBuilder extends AbstractPercentilesAggreg
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                                      ValuesSourceConfig config,
                                                                      AggregatorFactory parent,
                                                                      AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new PercentileRanksAggregatorFactory(name, config, values, configOrDefault(), keyed, queryShardContext,
+        return new PercentileRanksAggregatorFactory(name, config, values, configOrDefault(), keyed, context,
                     parent, subFactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -55,11 +55,11 @@ class PercentileRanksAggregatorFactory extends ValuesSourceAggregatorFactory {
                                      double[] percents,
                                      PercentilesConfig percentilesConfig,
                                      boolean keyed,
-                                     QueryShardContext queryShardContext,
+                                     AggregationContext context,
                                      AggregatorFactory parent,
                                      AggregatorFactories.Builder subFactoriesBuilder,
                                      Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.percents = percents;
         this.percentilesConfig = percentilesConfig;
         this.keyed = keyed;
@@ -81,7 +81,7 @@ class PercentileRanksAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(PercentileRanksAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config.getValuesSource(), searchContext, parent, percents, percentilesConfig, keyed, config.format(), metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -129,12 +129,14 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
-                                                                    ValuesSourceConfig config,
-                                                                    AggregatorFactory parent,
-                                                                    AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
+    protected ValuesSourceAggregatorFactory innerBuild(
+        AggregationContext context,
+        ValuesSourceConfig config,
+        AggregatorFactory parent,
+        AggregatorFactories.Builder subFactoriesBuilder
+    ) throws IOException {
         return new PercentilesAggregatorFactory(name, config, values, configOrDefault(), keyed,
-            queryShardContext, parent, subFactoriesBuilder, metadata);
+            context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -55,10 +55,10 @@ class PercentilesAggregatorFactory extends ValuesSourceAggregatorFactory {
     }
 
     PercentilesAggregatorFactory(String name, ValuesSourceConfig config, double[] percents,
-                                 PercentilesConfig percentilesConfig, boolean keyed, QueryShardContext queryShardContext,
+                                 PercentilesConfig percentilesConfig, boolean keyed, AggregationContext context,
                                  AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                  Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.percents = percents;
         this.percentilesConfig = percentilesConfig;
         this.keyed = keyed;
@@ -80,7 +80,7 @@ class PercentilesAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(PercentilesAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config.getValuesSource(), searchContext, parent, percents, percentilesConfig, keyed, config.format(), metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -24,13 +24,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -212,7 +212,7 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
     }
 
     @Override
-    protected ScriptedMetricAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected ScriptedMetricAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                                       Builder subfactoriesBuilder) throws IOException {
 
         if (combineScript == null) {
@@ -229,25 +229,25 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
         ScriptedMetricAggContexts.InitScript.Factory compiledInitScript;
         Map<String, Object> initScriptParams;
         if (initScript != null) {
-            compiledInitScript = queryShardContext.compile(initScript, ScriptedMetricAggContexts.InitScript.CONTEXT);
+            compiledInitScript = context.compile(initScript, ScriptedMetricAggContexts.InitScript.CONTEXT);
             initScriptParams = initScript.getParams();
         } else {
             compiledInitScript = null;
             initScriptParams = Collections.emptyMap();
         }
 
-        ScriptedMetricAggContexts.MapScript.Factory compiledMapScript = queryShardContext.compile(mapScript,
+        ScriptedMetricAggContexts.MapScript.Factory compiledMapScript = context.compile(mapScript,
             ScriptedMetricAggContexts.MapScript.CONTEXT);
         Map<String, Object> mapScriptParams = mapScript.getParams();
 
 
-        ScriptedMetricAggContexts.CombineScript.Factory compiledCombineScript = queryShardContext.compile(combineScript,
+        ScriptedMetricAggContexts.CombineScript.Factory compiledCombineScript = context.compile(combineScript,
             ScriptedMetricAggContexts.CombineScript.CONTEXT);
         Map<String, Object> combineScriptParams = combineScript.getParams();
 
         return new ScriptedMetricAggregatorFactory(name, compiledMapScript, mapScriptParams, compiledInitScript,
                 initScriptParams, compiledCombineScript, combineScriptParams, reduceScript,
-                params, queryShardContext.lookup(), queryShardContext, parent, subfactoriesBuilder, metadata);
+                params, context, parent, subfactoriesBuilder, metadata);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.SearchParseException;
@@ -28,8 +27,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,7 +44,6 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
     private final Map<String, Object> combineScriptParams;
     private final Script reduceScript;
     private final Map<String, Object> aggParams;
-    private final SearchLookup lookup;
     @Nullable
     private final ScriptedMetricAggContexts.InitScript.Factory initScript;
     private final Map<String, Object> initScriptParams;
@@ -60,13 +58,12 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
         Map<String, Object> combineScriptParams,
         Script reduceScript,
         Map<String, Object> aggParams,
-        SearchLookup lookup,
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactories,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.mapScript = mapScript;
         this.mapScriptParams = mapScriptParams;
         this.initScript = initScript;
@@ -74,7 +71,6 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
         this.combineScript = combineScript;
         this.combineScriptParams = combineScriptParams;
         this.reduceScript = reduceScript;
-        this.lookup = lookup;
         this.aggParams = aggParams;
     }
 
@@ -89,7 +85,7 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
 
         return new ScriptedMetricAggregator(
             name,
-            lookup,
+            context.lookup(),
             aggParams,
             initScript,
             initScriptParams,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -86,10 +86,10 @@ public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.Leaf
     }
 
     @Override
-    protected StatsAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected StatsAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                                 AggregatorFactory parent,
                                                 AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new StatsAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new StatsAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -37,11 +37,11 @@ class StatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     StatsAggregatorFactory(String name,
                             ValuesSourceConfig config,
-                            QueryShardContext queryShardContext,
+                            AggregationContext context,
                             AggregatorFactory parent,
                             AggregatorFactories.Builder subFactoriesBuilder,
                             Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
@@ -66,7 +66,7 @@ class StatsAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(StatsAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregationBuilder.java
@@ -23,10 +23,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -86,10 +86,10 @@ public class SumAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     }
 
     @Override
-    protected SumAggregatorFactory innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config,
+    protected SumAggregatorFactory innerBuild(AggregationContext context, ValuesSourceConfig config,
                                               AggregatorFactory parent,
                                               AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new SumAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new SumAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -37,11 +37,11 @@ class SumAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     SumAggregatorFactory(String name,
                             ValuesSourceConfig config,
-                            QueryShardContext queryShardContext,
+                            AggregationContext context,
                             AggregatorFactory parent,
                             AggregatorFactories.Builder subFactoriesBuilder,
                             Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
@@ -67,7 +67,7 @@ class SumAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(SumAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.FieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -36,6 +35,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
@@ -615,10 +615,10 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     }
 
     @Override
-    protected TopHitsAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subfactoriesBuilder)
+    protected TopHitsAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subfactoriesBuilder)
             throws IOException {
         long innerResultWindow = from() + size();
-        int maxInnerResultWindow = queryShardContext.getIndexSettings().getMaxInnerResultWindow();
+        int maxInnerResultWindow = context.getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(
                 "Top hits result window is too large, the top hits aggregator [" + name + "]'s from + size must be less " +
@@ -631,8 +631,8 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         List<ScriptFieldsContext.ScriptField> scriptFields = new ArrayList<>();
         if (this.scriptFields != null) {
             for (ScriptField field : this.scriptFields) {
-                FieldScript.Factory factory = queryShardContext.compile(field.script(), FieldScript.CONTEXT);
-                FieldScript.LeafFactory searchScript = factory.newFactory(field.script().getParams(), queryShardContext.lookup());
+                FieldScript.Factory factory = context.compile(field.script(), FieldScript.CONTEXT);
+                FieldScript.LeafFactory searchScript = factory.newFactory(field.script().getParams(), context.lookup());
                 scriptFields.add(new org.elasticsearch.search.fetch.subphase.ScriptFieldsContext.ScriptField(
                     field.fieldName(), searchScript, field.ignoreFailure()));
             }
@@ -642,10 +642,10 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         if (sorts == null) {
             optionalSort = Optional.empty();
         } else {
-            optionalSort = SortBuilder.buildSort(sorts, queryShardContext);
+            optionalSort = context.buildSort(sorts);
         }
         return new TopHitsAggregatorFactory(name, from, size, explain, version, seqNoAndPrimaryTerm, trackScores, optionalSort,
-            highlightBuilder, storedFieldsContext, docValueFields, fetchFields, scriptFields, fetchSourceContext, queryShardContext, parent,
+            highlightBuilder, storedFieldsContext, docValueFields, fetchFields, scriptFields, fetchSourceContext, context, parent,
             subfactoriesBuilder, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
 import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
@@ -70,11 +70,11 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
                                 List<FieldAndFormat> fetchFields,
                                 List<ScriptFieldsContext.ScriptField> scriptFields,
                                 FetchSourceContext fetchSourceContext,
-                                QueryShardContext queryShardContext,
+                                AggregationContext context,
                                 AggregatorFactory parent,
                                 AggregatorFactories.Builder subFactories,
                                 Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactories, metadata);
+        super(name, context, parent, subFactories, metadata);
         this.from = from;
         this.size = size;
         this.explain = explain;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregationBuilder.java
@@ -24,10 +24,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -92,11 +92,11 @@ public class ValueCountAggregationBuilder extends ValuesSourceAggregationBuilder
     }
 
     @Override
-    protected ValueCountAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValueCountAggregatorFactory innerBuild(AggregationContext context,
                                                         ValuesSourceConfig config,
                                                         AggregatorFactory parent,
                                                         AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new ValueCountAggregatorFactory(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new ValueCountAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -39,10 +39,10 @@ class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory {
         builder.register(ValueCountAggregationBuilder.REGISTRY_KEY, CoreValuesSourceType.ALL_CORE, ValueCountAggregator::new, true);
     }
 
-    ValueCountAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    ValueCountAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                                 AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                 Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -59,7 +59,7 @@ class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(ValueCountAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, searchContext, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregationBuilder.java
@@ -26,11 +26,11 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorFactory;
@@ -110,13 +110,13 @@ public class WeightedAvgAggregationBuilder extends MultiValuesSourceAggregationB
     }
 
     @Override
-    protected MultiValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected MultiValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                             Map<String, ValuesSourceConfig> configs,
                                                             Map<String, QueryBuilder> filters,
                                                             DocValueFormat format,
                                                             AggregatorFactory parent,
                                                             Builder subFactoriesBuilder) throws IOException {
-        return new WeightedAvgAggregatorFactory(name, configs, format, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new WeightedAvgAggregatorFactory(name, configs, format, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -38,10 +38,10 @@ import static org.elasticsearch.search.aggregations.metrics.WeightedAvgAggregati
 class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory {
 
     WeightedAvgAggregatorFactory(String name, Map<String, ValuesSourceConfig> configs,
-                                 DocValueFormat format, QueryShardContext queryShardContext, AggregatorFactory parent,
+                                 DocValueFormat format, AggregationContext context, AggregatorFactory parent,
                                  AggregatorFactories.Builder subFactoriesBuilder,
                                  Map<String, Object> metadata) throws IOException {
-        super(name, configs, format, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, configs, format, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -58,8 +58,7 @@ class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory {
                                             Aggregator parent,
                                             CardinalityUpperBound cardinality,
                                             Map<String, Object> metadata) throws IOException {
-        MultiValuesSource.NumericMultiValuesSource numericMultiVS
-            = new MultiValuesSource.NumericMultiValuesSource(configs, queryShardContext);
+        MultiValuesSource.NumericMultiValuesSource numericMultiVS = new MultiValuesSource.NumericMultiValuesSource(configs);
         if (numericMultiVS.areValuesSourcesEmpty()) {
             return createUnmapped(searchContext, parent, metadata);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.support;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.ObjectMapper;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.support.NestedScope;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.sort.SortAndFormats;
+import org.elasticsearch.search.sort.SortBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Everything used to build and execute aggregations and the
+ * {@link ValuesSource data sources} that power them.
+ * <p>
+ * In production we always use the {@link ProductionAggregationContext} but
+ * this is {@code abstract} so that tests can build it without creating the
+ * massing {@link QueryShardContext}.
+ */
+public abstract class AggregationContext {
+    /**
+     * The query at the top level of the search in which these aggregations are running.
+     */
+    public abstract Query query();
+
+    /**
+     * The time in milliseconds that is shared across all resources involved. Even across shards and nodes.
+     */
+    public abstract long nowInMillis();
+
+    /**
+     * Lookup the context for a field.
+     */
+    public final FieldContext buildFieldContext(String field) {
+        MappedFieldType ft = getFieldType(field);
+        if (ft == null) {
+            // The field is unmapped
+            return null;
+        }
+        return new FieldContext(field, buildFieldData(ft), ft);
+    }
+
+    /**
+     * Lookup the context for an already resolved field type.
+     */
+    public final FieldContext buildFieldContext(MappedFieldType ft) {
+        return new FieldContext(ft.name(), buildFieldData(ft), ft);
+    }
+
+    /**
+     * Build field data.
+     */
+    protected abstract IndexFieldData<?> buildFieldData(MappedFieldType ft);
+
+    /**
+     * Lookup a {@link MappedFieldType} by path.
+     */
+    public abstract MappedFieldType getFieldType(String path);
+
+    /**
+     * Lookup a field {@link Mapper} by path.
+     */
+    public abstract Mapper getMapper(String path);
+
+    /**
+     * Compile a script.
+     */
+    public abstract <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context);
+
+    /**
+     * Fetch the shared {@link SearchLookup}.
+     */
+    public abstract SearchLookup lookup();
+
+    /**
+     * The {@link ValuesSourceRegistry} to resolve {@link Aggregator}s and the like.
+     */
+    public abstract ValuesSourceRegistry getValuesSourceRegistry();
+
+    /**
+     * The {@link AggregationUsageService} used to track which aggregations are
+     * actually used.
+     */
+    public final AggregationUsageService getUsageService() {
+        return getValuesSourceRegistry().getUsageService();
+    }
+
+    /**
+     * Utility to share and track large arrays.
+     */
+    public abstract BigArrays bigArrays();
+
+    /**
+     * The searcher that will execute this query.
+     */
+    public abstract IndexSearcher searcher();
+
+    /**
+     * Build a query.
+     */
+    public abstract Query buildQuery(QueryBuilder builder) throws IOException;
+
+    /**
+     * The settings for the index against which this search is running.
+     */
+    public abstract IndexSettings getIndexSettings();
+
+    /**
+     * Compile a sort.
+     */
+    public abstract Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders) throws IOException;
+
+    /**
+     * Find an {@link ObjectMapper}.
+     */
+    public abstract ObjectMapper getObjectMapper(String path);
+
+    /**
+     * Access the nested scope. Stay away from this unless you are dealing with nested.
+     */
+    public abstract NestedScope nestedScope();
+
+    /**
+     * Implementation of {@linkplain AggregationContext} for production usage
+     * that wraps our ubiquitous {@link QueryShardContext} and the top level
+     * {@link Query}. Unit tests should avoid using this because it requires
+     * a <strong>huge</strong> portion of a real Elasticsearch node.
+     */
+    public static class ProductionAggregationContext extends AggregationContext {
+        private final QueryShardContext context;
+        private final Query query;
+
+        public ProductionAggregationContext(QueryShardContext context, Query query) {
+            this.context = context;
+            this.query = query;
+        }
+
+        @Override
+        public Query query() {
+            return query;
+        }
+
+        @Override
+        public long nowInMillis() {
+            return context.nowInMillis();
+        }
+
+        @Override
+        protected IndexFieldData<?> buildFieldData(MappedFieldType ft) {
+            return context.getForField(ft);
+        }
+
+        @Override
+        public MappedFieldType getFieldType(String path) {
+            return context.getFieldType(path);
+        }
+
+        @Override
+        public Mapper getMapper(String path) {
+            return context.getMapperService().documentMapper().mappers().getMapper(path);
+        }
+
+        @Override
+        public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> scriptContext) {
+            return context.compile(script, scriptContext);
+        }
+
+        @Override
+        public SearchLookup lookup() {
+            return context.lookup();
+        }
+
+        @Override
+        public ValuesSourceRegistry getValuesSourceRegistry() {
+            return context.getValuesSourceRegistry();
+        }
+
+        @Override
+        public BigArrays bigArrays() {
+            return context.bigArrays();
+        }
+
+        @Override
+        public IndexSearcher searcher() {
+            return context.searcher();
+        }
+
+        @Override
+        public Query buildQuery(QueryBuilder builder) throws IOException {
+            return builder.toQuery(context);
+        }
+
+        @Override
+        public IndexSettings getIndexSettings() {
+            return context.getIndexSettings();
+        }
+
+        @Override
+        public Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders) throws IOException {
+            return SortBuilder.buildSort(sortBuilders, context);
+        }
+
+        @Override
+        public ObjectMapper getObjectMapper(String path) {
+            return context.getObjectMapper(path);
+        }
+
+        @Override
+        public NestedScope nestedScope() {
+            return context.nestedScope();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -21,6 +21,11 @@ package org.elasticsearch.search.aggregations.support;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -44,7 +49,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
-import java.util.function.LongSupplier;
 
 /**
  * {@link CoreValuesSourceType} holds the {@link ValuesSourceType} implementations for the core aggregations package.
@@ -63,7 +67,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
 
             if ((fieldContext.indexFieldData() instanceof IndexNumericFieldData) == false) {
                 // TODO: Is this the correct exception type here?
@@ -80,8 +84,9 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
-            Number missing = docValueFormat.parseDouble(rawMissing.toString(), false, now);
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
+            Number missing = docValueFormat.parseDouble(rawMissing.toString(), false, context::nowInMillis);
             return MissingValues.replaceMissing((ValuesSource.Numeric) valuesSource, missing);
         }
 
@@ -113,7 +118,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
             ValuesSource dataSource;
             if (indexFieldData instanceof IndexOrdinalsFieldData) {
@@ -129,7 +134,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
             final BytesRef missing = docValueFormat.parseBytesRef(rawMissing.toString());
             if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals) {
                 return MissingValues.replaceMissing((ValuesSource.Bytes.WithOrdinals) valuesSource, missing);
@@ -150,7 +156,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
             if (!(fieldContext.indexFieldData() instanceof IndexGeoPointFieldData)) {
                 // TODO: Is this the correct exception type here?
                 throw new IllegalArgumentException("Expected geo_point type on field [" + fieldContext.field() +
@@ -161,7 +167,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
             // TODO: also support the structured formats of geo points
             final GeoPoint missing = new GeoPoint(rawMissing.toString());
             return MissingValues.replaceMissing((ValuesSource.GeoPoint) valuesSource, missing);
@@ -185,7 +192,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
             MappedFieldType fieldType = fieldContext.fieldType();
 
             if (fieldType instanceof RangeFieldMapper.RangeFieldType == false) {
@@ -197,7 +204,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
             throw new IllegalArgumentException("Can't apply missing values on a " + valuesSource.getClass());
         }
     },
@@ -213,13 +221,14 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
-            return BYTES.getField(fieldContext, script);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+            return BYTES.getField(fieldContext, script, context);
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
-            return BYTES.replaceMissing(valuesSource, rawMissing, docValueFormat, now);
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
+            return BYTES.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
         }
 
         @Override
@@ -239,8 +248,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
-            ValuesSource.Numeric dataSource = fieldData(fieldContext);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+            ValuesSource.Numeric dataSource = fieldData(fieldContext, context);
             if (script != null) {
                 // Value script case
                 return new ValuesSource.Numeric.WithScript(dataSource, script);
@@ -248,19 +257,12 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             return dataSource;
         }
 
-        private ValuesSource.Numeric fieldData(FieldContext fieldContext) {
+        private ValuesSource.Numeric fieldData(FieldContext fieldContext, AggregationContext context) {
             if ((fieldContext.indexFieldData() instanceof IndexNumericFieldData) == false) {
                 throw new IllegalArgumentException("Expected numeric type on field [" + fieldContext.field() +
                     "], but got [" + fieldContext.fieldType().typeName() + "]");
             }
-            if (fieldContext.fieldType().isSearchable() == false
-                    || fieldContext.fieldType() instanceof DateFieldType == false) {
-                /*
-                 * We can't implement roundingPreparer in these cases because
-                 * we can't look up the min and max date without both the
-                 * search index (the first test) and the resolution which is
-                 * on the DateFieldType.
-                 */
+            if (fieldContext.fieldType() instanceof DateFieldType == false) {
                 return new ValuesSource.Numeric.FieldData((IndexNumericFieldData) fieldContext.indexFieldData());
             }
             return new ValuesSource.Numeric.FieldData((IndexNumericFieldData) fieldContext.indexFieldData()) {
@@ -272,24 +274,71 @@ public enum CoreValuesSourceType implements ValuesSourceType {
                  * this implementation. Which is correct.
                  */
                 @Override
-                public Function<Rounding, Rounding.Prepared> roundingPreparer(IndexReader reader) throws IOException {
+                public Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
                     DateFieldType dft = (DateFieldType) fieldContext.fieldType();
-                    byte[] min = PointValues.getMinPackedValue(reader, fieldContext.field());
-                    if (min == null) {
-                        // There aren't any indexes values so we don't need to optimize.
+                    /*
+                     * The range of dates, min first, then max. This is an array so we can
+                     * write to it inside the QueryVisitor below.
+                     */
+                    long[] range = new long[] {Long.MIN_VALUE, Long.MAX_VALUE};
+
+                    // Check the search index for bounds
+                    if (fieldContext.fieldType().isSearchable()) {
+                        /*
+                         * We can't look up the min and max date without both the
+                         * search index (isSearchable) and the resolution which
+                         * is on the DateFieldType.
+                         */
+                        byte[] min = PointValues.getMinPackedValue(context.searcher().getIndexReader(), fieldContext.field());
+                        if (min != null) {
+                            // null means that there aren't values in the index
+                            byte[] max = PointValues.getMaxPackedValue(context.searcher().getIndexReader(), fieldContext.field());
+                            range[0] = dft.resolution().parsePointAsMillis(min);
+                            range[1] = dft.resolution().parsePointAsMillis(max);
+                        }
+                    }
+
+                    // Check the query for bounds
+                    if (context.query() != null) {
+                        context.query().visit(new QueryVisitor() {
+                            @Override
+                            public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
+                                // Ignore queries that aren't "MUST"
+                                if (occur != Occur.MUST) {
+                                    return QueryVisitor.EMPTY_VISITOR;
+                                }
+                                return this;
+                            };
+
+                            @Override
+                            public boolean acceptField(String field) {
+                                return field.equals(fieldContext.fieldType().name());
+                            };
+
+                            @Override
+                            public void visitLeaf(Query query) {
+                                if (query instanceof PointRangeQuery) {
+                                    PointRangeQuery prq = (PointRangeQuery) query;
+                                    range[0] = Math.max(range[0], dft.resolution().parsePointAsMillis(prq.getLowerPoint()));
+                                    range[1] = Math.min(range[1], dft.resolution().parsePointAsMillis(prq.getUpperPoint()));
+                                }
+                            };
+                        });
+                    }
+
+                    if (range[0] == Long.MIN_VALUE && range[1] == Long.MAX_VALUE) {
+                        // Didn't find any bounds
                         return Rounding::prepareForUnknown;
                     }
-                    byte[] max = PointValues.getMaxPackedValue(reader, fieldContext.field());
-                    long minUtcMillis = dft.resolution().parsePointAsMillis(min);
-                    long maxUtcMillis = dft.resolution().parsePointAsMillis(max);
-                    return rounding -> rounding.prepare(minUtcMillis, maxUtcMillis);
+                    return rounding -> rounding.prepare(range[0], range[1]);
                 }
             };
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
-            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, now);
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
+            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
         }
 
         @Override
@@ -314,13 +363,14 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
-            return NUMERIC.getField(fieldContext, script);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+            return NUMERIC.getField(fieldContext, script, context);
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
-            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, now);
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
+                                           AggregationContext context) {
+            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSource.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.support;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 
 import java.io.IOException;
@@ -35,8 +34,7 @@ public abstract class MultiValuesSource <VS extends ValuesSource> {
     protected Map<String, VS> values;
 
     public static class NumericMultiValuesSource extends MultiValuesSource<ValuesSource.Numeric> {
-        public NumericMultiValuesSource(Map<String, ValuesSourceConfig> valuesSourceConfigs,
-                                        QueryShardContext context) {
+        public NumericMultiValuesSource(Map<String, ValuesSourceConfig> valuesSourceConfigs) {
             values = new HashMap<>(valuesSourceConfigs.size());
             for (Map.Entry<String, ValuesSourceConfig> entry : valuesSourceConfigs.entrySet()) {
                 final ValuesSource valuesSource = entry.getValue().getValuesSource();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
@@ -167,18 +166,19 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
     protected abstract ValuesSourceType defaultValueSourceType();
 
     @Override
-    protected final MultiValuesSourceAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected final MultiValuesSourceAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                                                Builder subFactoriesBuilder) throws IOException {
         Map<String, ValuesSourceConfig> configs = new HashMap<>(fields.size());
         Map<String, QueryBuilder> filters = new HashMap<>(fields.size());
         fields.forEach((key, value) -> {
-            ValuesSourceConfig config = ValuesSourceConfig.resolveUnregistered(queryShardContext, userValueTypeHint,
+            ValuesSourceConfig config = ValuesSourceConfig.resolveUnregistered(context, userValueTypeHint,
                 value.getFieldName(), value.getScript(), value.getMissing(), value.getTimeZone(), format, defaultValueSourceType());
             configs.put(key, config);
             filters.put(key, value.getFilter());
         });
         DocValueFormat docValueFormat = resolveFormat(format, userValueTypeHint, defaultValueSourceType());
-        return innerBuild(queryShardContext, configs, filters, docValueFormat, parent, subFactoriesBuilder);
+
+        return innerBuild(context, configs, filters, docValueFormat, parent, subFactoriesBuilder);
     }
 
 
@@ -195,7 +195,7 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
         return valueFormat;
     }
 
-    protected abstract MultiValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected abstract MultiValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                                      Map<String, ValuesSourceConfig> configs,
                                                                      Map<String, QueryBuilder> filters,
                                                                      DocValueFormat format, AggregatorFactory parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -36,10 +35,10 @@ public abstract class MultiValuesSourceAggregatorFactory extends AggregatorFacto
     protected final DocValueFormat format;
 
     public MultiValuesSourceAggregatorFactory(String name, Map<String, ValuesSourceConfig> configs,
-                                              DocValueFormat format, QueryShardContext queryShardContext,
+                                              DocValueFormat format, AggregationContext context,
                                               AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                               Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, context, parent, subFactoriesBuilder, metadata);
         this.configs = configs;
         this.format = format;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -76,7 +76,7 @@ public abstract class ValuesSource {
      * This returns a {@linkplain Function} because auto date histogram will
      * need to call it many times over the course of running the aggregation.
      */
-    public abstract Function<Rounding, Rounding.Prepared> roundingPreparer(IndexReader reader) throws IOException;
+    protected abstract Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException;
 
     /**
      * Check if this values source supports using global ordinals
@@ -106,7 +106,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer(IndexReader reader) throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
             // TODO lookup the min and max rounding when appropriate
             return Rounding::prepareForUnknown;
         }
@@ -122,7 +122,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public final Function<Rounding, Rounding.Prepared> roundingPreparer(IndexReader reader) throws IOException {
+        public final Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
             throw new AggregationExecutionException("can't round a [BYTES]");
         }
 
@@ -387,7 +387,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer(IndexReader reader) throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
             return Rounding::prepareForUnknown;
         }
 
@@ -584,7 +584,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public final Function<Rounding, Rounding.Prepared> roundingPreparer(IndexReader reader) throws IOException {
+        public final Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
             throw new AggregationExecutionException("can't round a [GEO_POINT]");
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.AbstractObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
@@ -354,19 +353,19 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
     }
 
     @Override
-    protected final ValuesSourceAggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected final ValuesSourceAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                                           Builder subFactoriesBuilder) throws IOException {
-        ValuesSourceConfig config = resolveConfig(queryShardContext);
-        if (queryShardContext.getValuesSourceRegistry().isRegistered(getRegistryKey())) {
+        ValuesSourceConfig config = resolveConfig(context);
+        if (context.getValuesSourceRegistry().isRegistered(getRegistryKey())) {
             /*
             if the aggregation uses the values source registry, test if the resolved values source type is compatible with this aggregation.
             This call will throw if the mapping isn't registered, which is what we want.  Note that we need to throw from here because
             AbstractAggregationBuilder#build, which called this, will attempt to register the agg usage next, and if the usage is invalid
             that will fail with a weird error.
              */
-            queryShardContext.getValuesSourceRegistry().getAggregator(getRegistryKey(), config);
+            context.getValuesSourceRegistry().getAggregator(getRegistryKey(), config);
         }
-        ValuesSourceAggregatorFactory factory = innerBuild(queryShardContext, config, parent, subFactoriesBuilder);
+        ValuesSourceAggregatorFactory factory = innerBuild(context, config, parent, subFactoriesBuilder);
         return factory;
     }
 
@@ -380,12 +379,21 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
      */
     protected abstract ValuesSourceType defaultValueSourceType();
 
-    protected ValuesSourceConfig resolveConfig(QueryShardContext queryShardContext) {
-        return ValuesSourceConfig.resolve(queryShardContext,
+    /**
+     * Aggregations should override this if they need non-standard logic for resolving where to get values from.  For example, join
+     * aggregations (like Parent and Child) ask the user to specify one side of the join and then look up the other field to read values
+     * from.
+     *
+     * The default implementation just uses the field and/or script the user provided.
+     *
+     * @return A {@link ValuesSourceConfig} configured based on the parsed field and/or script.
+     */
+    protected ValuesSourceConfig resolveConfig(AggregationContext context) {
+        return ValuesSourceConfig.resolve(context,
                 this.userValueTypeHint, field, script, missing, timeZone, format, this.defaultValueSourceType());
     }
 
-    protected abstract ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected abstract ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                                 ValuesSourceConfig config,
                                                                 AggregatorFactory parent,
                                                                 Builder subFactoriesBuilder) throws IOException;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -33,10 +32,10 @@ public abstract class ValuesSourceAggregatorFactory extends AggregatorFactory {
 
     protected ValuesSourceConfig config;
 
-    public ValuesSourceAggregatorFactory(String name, ValuesSourceConfig config, QueryShardContext queryShardContext,
+    public ValuesSourceAggregatorFactory(String name, ValuesSourceConfig config, AggregationContext context,
                                          AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                          Map<String, Object> metadata) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, context, parent, subFactoriesBuilder, metadata);
         this.config = config;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
@@ -23,10 +23,8 @@ import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.time.ZoneId;
-import java.util.function.LongSupplier;
 
 /**
-=======
  * {@link ValuesSourceType} represents a collection of fields that share a common set of operations, for example all numeric fields.
  * Aggregations declare their support for a given ValuesSourceType (via {@link ValuesSourceRegistry.Builder#register}),
  * and should then not need to care about the fields which use that ValuesSourceType.
@@ -69,9 +67,10 @@ public interface ValuesSourceType {
      *
      * @param fieldContext - The field being wrapped
      * @param script - Optional script that might be applied over the field
+     * @param context context for the aggregation fetching the field
      * @return - Field specialization of the base {@link ValuesSource}
      */
-    ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
+    ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context);
 
     /**
      * Apply the given missing value to an already-constructed {@link ValuesSource}.  Types which do not support missing values should throw
@@ -80,11 +79,11 @@ public interface ValuesSourceType {
      * @param valuesSource - The original {@link ValuesSource}
      * @param rawMissing - The missing value we got from the parser, typically a string or number
      * @param docValueFormat - The format to use for further parsing the user supplied value, e.g. a date format
-     * @param now - Used in conjunction with the formatter, should return the current time in milliseconds
+     * @param context - Context for this aggregation used to handle {@link AggregationContext#nowInMillis() "now"}
      * @return - Wrapper over the provided {@link ValuesSource} to apply the given missing value
      */
     ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat,
-                                LongSupplier now);
+                                AggregationContext context);
 
     /**
      * This method provides a hook for specifying a type-specific formatter.  When {@link ValuesSourceConfig} can resolve a

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.search.aggregations.pipeline.InternalDerivative;
 import org.elasticsearch.search.aggregations.pipeline.MovAvgModel;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.SimpleModel;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -414,7 +415,7 @@ public class SearchModuleTests extends ESTestCase {
         }
 
         @Override
-        protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+        protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                            ValuesSourceConfig config,
                                                            AggregatorFactory parent,
                                                            Builder subFactoriesBuilder) throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.search.aggregations;
 
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.search.aggregations.support.AggregationContext.ProductionAggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -59,8 +61,8 @@ public class AggregationCollectorTests extends ESSingleNodeTestCase {
         try (XContentParser aggParser = createParser(JsonXContent.jsonXContent, agg)) {
             aggParser.nextToken();
             SearchContext context = createSearchContext(index);
-            final AggregatorFactories factories =
-                AggregatorFactories.parseAggregators(aggParser).build(context.getQueryShardContext(), null);
+            final AggregatorFactories factories = AggregatorFactories.parseAggregators(aggParser)
+                .build(new ProductionAggregationContext(context.getQueryShardContext(), new MatchAllDocsQuery()), null);
             final Aggregator[] aggregators = factories.createTopLevelAggregators(context);
             assertEquals(1, aggregators.length);
             return aggregators[0].scoreMode().needsScores();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
@@ -26,18 +26,16 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -48,7 +46,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AggregatorBaseTests extends ESSingleNodeTestCase {
+public class AggregatorBaseTests extends MapperServiceTestCase {
 
     class BogusAggregator extends AggregatorBase {
         BogusAggregator(SearchContext searchContext, Aggregator parent) throws IOException {
@@ -96,7 +94,7 @@ public class AggregatorBaseTests extends ESSingleNodeTestCase {
         String fieldName,
         NumberFieldMapper.NumberType numType,
         boolean indexed,
-        QueryShardContext context
+        AggregationContext context
     ) {
         MappedFieldType ft
             = new NumberFieldMapper.NumberFieldType(fieldName, numType, indexed, false, true, false, null, Collections.emptyMap());
@@ -107,7 +105,7 @@ public class AggregatorBaseTests extends ESSingleNodeTestCase {
         String fieldName,
         DateFieldMapper.Resolution resolution,
         boolean indexed,
-        QueryShardContext context
+        AggregationContext context
     ) {
         MappedFieldType ft = new DateFieldMapper.DateFieldType(fieldName, indexed, false, true,
             DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, resolution, null, Collections.emptyMap());
@@ -115,11 +113,8 @@ public class AggregatorBaseTests extends ESSingleNodeTestCase {
     }
 
     public void testShortcutIsApplicable() throws IOException {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> b.field("field", "abc"))), context -> {
             for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
                 assertNotNull(
                     pointReaderShim(mockSearchContext(new MatchAllDocsQuery()), null, getVSConfig("number", type, true, context))
@@ -175,6 +170,6 @@ public class AggregatorBaseTests extends ESSingleNodeTestCase {
                 ).apply(scratch),
                 equalTo(expected.toEpochMilli())
             );
-        }
+        });
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
@@ -75,8 +75,8 @@ public class AdjacencyMatrixAggregationBuilderTests extends ESTestCase {
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
             () -> builder.doBuild(aggContext, null, new AggregatorFactories.Builder()));
         assertThat(ex.getMessage(), equalTo("Number of filters is too large, must be less than or equal to: [2] but was [3]."
-            + "This limit can be set by changing the [" + SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey()
-            + "] setting."));
+            + "This limit can be set by changing the [" + IndexSettings.MAX_ADJACENCY_MATRIX_FILTERS_SETTING.getKey()
+            + "] index level setting."));
 
         // filter size not grater than max size should return an instance of AdjacencyMatrixAggregatorFactory
         Map<String, QueryBuilder> emptyFilters = Collections.emptyMap();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
@@ -19,11 +19,21 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.test.ESTestCase;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.SourceToParse;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-public class CoreValuesSourceTypeTests extends ESTestCase {
+public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
 
     public void testFromString() {
         assertThat(CoreValuesSourceType.fromString("numeric"), equalTo(CoreValuesSourceType.NUMERIC));
@@ -32,8 +42,79 @@ public class CoreValuesSourceTypeTests extends ESTestCase {
         assertThat(CoreValuesSourceType.fromString("range"), equalTo(CoreValuesSourceType.RANGE));
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> CoreValuesSourceType.fromString("does_not_exist"));
-        assertThat(e.getMessage(),
-            equalTo("No enum constant org.elasticsearch.search.aggregations.support.CoreValuesSourceType.DOES_NOT_EXIST"));
+        assertThat(
+            e.getMessage(),
+            equalTo("No enum constant org.elasticsearch.search.aggregations.support.CoreValuesSourceType.DOES_NOT_EXIST")
+        );
         expectThrows(NullPointerException.class, () -> CoreValuesSourceType.fromString(null));
+    }
+
+    public void testDatePrepareRoundingWithNothing() throws IOException {
+        withAggregationContext(dateMapperService(), org.elasticsearch.common.collect.List.of(), context -> {
+            Rounding rounding = mock(Rounding.class);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            verify(rounding).prepareForUnknown();
+        });
+    }
+
+    public void testDatePrepareRoundingWithDocs() throws IOException {
+        long min = randomLongBetween(0, 1000000);
+        long max = randomLongBetween(min + 1, 100000000000L);
+        withAggregationContext(dateMapperService(), docsWithDatesBetween(min, max), context -> {
+            Rounding rounding = mock(Rounding.class);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            verify(rounding).prepare(min, max);
+        });
+    }
+
+    public void testDatePrepareRoundingWithQuery() throws IOException {
+        long min = randomLongBetween(0, 1000000);
+        long max = randomLongBetween(min + 10, 100000000000L);
+        MapperService mapperService = dateMapperService();
+        Query query = mapperService.fieldType("field")
+            .rangeQuery(min, max, true, true, ShapeRelation.CONTAINS, null, null, createQueryShardContext(mapperService));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(), query, context -> {
+            Rounding rounding = mock(Rounding.class);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            verify(rounding).prepare(min, max);
+        });
+    }
+
+    public void testDatePrepareRoundingWithDocAndQuery() throws IOException {
+        long min = randomLongBetween(0, 1000000);
+        long minQuery, minDocs;
+        if (randomBoolean()) {
+            minQuery = min;
+            minDocs = min - 1;
+        } else {
+            minQuery = min - 1;
+            minDocs = min;
+        }
+        long max = randomLongBetween(min + 10, 100000000000L);
+        long maxQuery, maxDocs;
+        if (randomBoolean()) {
+            maxQuery = max;
+            maxDocs = max + 1;
+        } else {
+            maxQuery = max + 1;
+            maxDocs = max;
+        }
+        MapperService mapperService = dateMapperService();
+        Query query = mapperService.fieldType("field")
+            .rangeQuery(minQuery, maxQuery, true, true, ShapeRelation.CONTAINS, null, null, createQueryShardContext(mapperService));
+        withAggregationContext(mapperService, docsWithDatesBetween(minDocs, maxDocs), query, context -> {
+            Rounding rounding = mock(Rounding.class);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            verify(rounding).prepare(min, max);
+        });
+    }
+
+
+    private MapperService dateMapperService() throws IOException {
+        return createMapperService(fieldMapping(b -> b.field("type", "date")));
+    }
+
+    private List<SourceToParse> docsWithDatesBetween(long min, long max) throws IOException {
+        return org.elasticsearch.common.collect.List.of(source(b -> b.field("field", min)), source(b -> b.field("field", max)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -22,278 +22,197 @@ package org.elasticsearch.search.aggregations.support;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.TypeFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.io.IOException;
 
 // TODO: This whole set of tests needs to be rethought.
-public class ValuesSourceConfigTests extends ESSingleNodeTestCase {
-
+public class ValuesSourceConfigTests extends MapperServiceTestCase {
     public void testKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "bytes", "type=keyword");
-        client().prepareIndex("index", "type", "1")
-                .setSource("bytes", "abc")
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "bytes", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> b.field("field", "abc"))), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Bytes valuesSource = (ValuesSource.Bytes) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(new BytesRef("abc"), values.nextValue());
-        }
+        });
     }
 
     public void testEmptyKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "bytes", "type=keyword");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "bytes", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Bytes valuesSource = (ValuesSource.Bytes) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
             assertFalse(values.advanceExact(0));
-
-            config = ValuesSourceConfig.resolve(
-                    context, null, "bytes", null, "abc", null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, null, "field", null, "abc", null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Bytes) config.getValuesSource();
             values = valuesSource.bytesValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(new BytesRef("abc"), values.nextValue());
-        }
+        });
     }
 
     public void testUnmappedKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, ValueType.STRING, "bytes", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(mapping(b -> {}));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, ValueType.STRING, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Bytes valuesSource = (ValuesSource.Bytes) config.getValuesSource();
             assertNotNull(valuesSource);
             assertFalse(config.hasValues());
 
-            config = ValuesSourceConfig.resolve(
-                    context, ValueType.STRING, "bytes", null, "abc", null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, ValueType.STRING, "field", null, "abc", null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Bytes) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(new BytesRef("abc"), values.nextValue());
-        }
+        });
     }
 
     public void testLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "long", "type=long");
-        client().prepareIndex("index", "type", "1")
-                .setSource("long", 42)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "long", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "long")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> b.field("field", 42))), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(42, values.nextValue());
-        }
+        });
     }
 
     public void testEmptyLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "long", "type=long");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "long", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "long")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertFalse(values.advanceExact(0));
 
-            config = ValuesSourceConfig.resolve(
-                    context, null, "long", null, 42, null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, null, "field", null, 42, null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Numeric) config.getValuesSource();
             values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(42, values.nextValue());
-        }
+        });
     }
 
     public void testUnmappedLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, ValueType.NUMBER, "long", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(mapping(b -> {}));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, ValueType.NUMBER, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
             assertNotNull(valuesSource);
             assertFalse(config.hasValues());
 
-            config = ValuesSourceConfig.resolve(
-                    context, ValueType.NUMBER, "long", null, 42, null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, ValueType.NUMBER, "field", null, 42, null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(42, values.nextValue());
-        }
+        });
     }
 
     public void testBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "bool", "type=boolean");
-        client().prepareIndex("index", "type", "1")
-                .setSource("bool", true)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "bool", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "boolean")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> b.field("field", true))), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(1, values.nextValue());
-        }
+        });
     }
 
     public void testEmptyBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-                "bool", "type=boolean");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, null, "bool", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "boolean")));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertFalse(values.advanceExact(0));
 
-            config = ValuesSourceConfig.resolve(
-                    context, null, "bool", null, true, null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, null, "field", null, true, null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Numeric) config.getValuesSource();
             values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(1, values.nextValue());
-        }
+        });
     }
 
     public void testUnmappedBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1")
-                .setSource()
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                    context, ValueType.BOOLEAN, "bool", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(mapping(b -> {}));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> {})), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, ValueType.BOOLEAN, "field", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Numeric valuesSource = (ValuesSource.Numeric) config.getValuesSource();
             assertNotNull(valuesSource);
             assertFalse(config.hasValues());
 
-            config = ValuesSourceConfig.resolve(
-                    context, ValueType.BOOLEAN, "bool", null, true, null, null, CoreValuesSourceType.BYTES);
+            config = ValuesSourceConfig.resolve(context, ValueType.BOOLEAN, "field", null, true, null, null, CoreValuesSourceType.BYTES);
             valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedNumericDocValues values = valuesSource.longValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(1, values.nextValue());
-        }
+        });
     }
 
-    public void testTypeFieldDeprecation() {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                context, null, TypeFieldMapper.NAME, null, null, null, null, CoreValuesSourceType.BYTES);
-            assertWarnings(TypeFieldMapper.TYPES_DEPRECATION_MESSAGE);
-        }
+    public void testTypeFieldDeprecation() throws IOException {
+        MapperService mapperService = createMapperService(mapping(b -> {}));
+        withAggregationContext(
+            mapperService,
+            org.elasticsearch.common.collect.List.of(source(b -> {})),
+            context -> {
+                ValuesSourceConfig.resolve(context, null, TypeFieldMapper.NAME, null, null, null, null, CoreValuesSourceType.BYTES);
+            }
+        );
+        assertWarnings(TypeFieldMapper.TYPES_DEPRECATION_MESSAGE);
     }
 
     public void testFieldAlias() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type",
-            "field", "type=keyword", "alias", "type=alias,path=field");
-        client().prepareIndex("index", "type", "1")
-            .setSource("field", "value")
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .get();
-
-        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
-            QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
-            ValuesSourceConfig config = ValuesSourceConfig.resolve(
-                context, ValueType.STRING, "alias", null, null, null, null, CoreValuesSourceType.BYTES);
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field").field("type", "keyword").endObject();
+            b.startObject("alias").field("type", "alias").field("path", "field").endObject();
+        }));
+        withAggregationContext(mapperService, org.elasticsearch.common.collect.List.of(source(b -> b.field("field", "value"))), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, ValueType.STRING, "alias", null, null, null, null, CoreValuesSourceType.BYTES);
             ValuesSource.Bytes valuesSource = (ValuesSource.Bytes) config.getValuesSource();
 
-            LeafReaderContext ctx = searcher.getIndexReader().leaves().get(0);
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
             SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(new BytesRef("value"), values.nextValue());
-        }
+        });
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistryTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregatorSupplier;
 import org.elasticsearch.test.ESTestCase;
@@ -33,13 +32,13 @@ import static org.mockito.Mockito.when;
 public class ValuesSourceRegistryTests extends ESTestCase {
 
     public void testAggregatorNotFoundException() {
-        final QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        final AggregationScript.Factory mockAggScriptFactory = mock(AggregationScript.Factory.class);
+        AggregationContext context = mock(AggregationContext.class);
+        AggregationScript.Factory mockAggScriptFactory = mock(AggregationScript.Factory.class);
         when(mockAggScriptFactory.newFactory(Mockito.any(), Mockito.any())).thenReturn(mock(AggregationScript.LeafFactory.class));
-        when(queryShardContext.compile(Mockito.any(), Mockito.any())).thenReturn(mockAggScriptFactory);
+        when(context.compile(Mockito.any(), Mockito.any())).thenReturn(mockAggScriptFactory);
 
         ValuesSourceConfig fieldOnly = ValuesSourceConfig.resolve(
-            queryShardContext,
+            context,
             null,
             "field",
             null,
@@ -50,7 +49,7 @@ public class ValuesSourceRegistryTests extends ESTestCase {
         );
 
         ValuesSourceConfig scriptOnly = ValuesSourceConfig.resolve(
-            queryShardContext,
+            context,
             null,
             null,
             mockScript("fakeScript"),

--- a/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/search/aggregations/DelayedShardAggregationBuilder.java
+++ b/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/search/aggregations/DelayedShardAggregationBuilder.java
@@ -26,8 +26,8 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -90,19 +90,19 @@ public class DelayedShardAggregationBuilder extends AbstractAggregationBuilder<D
     @Override
     @SuppressWarnings("unchecked")
     protected AggregatorFactory doBuild(
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subfactoriesBuilder
     ) throws IOException {
 
         // Disable the request cache
-        queryShardContext.nowInMillis();
+        context.nowInMillis();
 
         final FilterAggregationBuilder filterAgg = new FilterAggregationBuilder(name, QueryBuilders.matchAllQuery()).subAggregations(
             subfactoriesBuilder
         );
-        final AggregatorFactory factory = filterAgg.build(queryShardContext, parent);
-        return new AggregatorFactory(name, queryShardContext, parent, subfactoriesBuilder, metadata) {
+        final AggregatorFactory factory = filterAgg.build(context, parent);
+        return new AggregatorFactory(name, context, parent, subfactoriesBuilder, metadata) {
             @Override
             protected Aggregator createInternal(
                 SearchContext searchContext,

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -23,14 +23,20 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -40,21 +46,34 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.sort.SortAndFormats;
+import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -65,6 +84,11 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Test case that lets you easilly build {@link MapperService} based on some
+ * mapping. Useful when you don't need to spin up an entire index but do
+ * need most of the trapping of the mapping.
+ */
 public abstract class MapperServiceTestCase extends ESTestCase {
 
     protected static final Settings SETTINGS = Settings.builder().put("index.version.created", Version.CURRENT).build();
@@ -166,10 +190,15 @@ public abstract class MapperServiceTestCase extends ESTestCase {
     }
 
     protected final SourceToParse source(CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
+        return source("1", build, null);
+    }
+
+    protected final SourceToParse source(String id, CheckedConsumer<XContentBuilder, IOException> build, @Nullable String routing)
+        throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         build.accept(builder);
         builder.endObject();
-        return new SourceToParse("test", "_doc", "1", BytesReference.bytes(builder), XContentType.JSON);
+        return new SourceToParse("test", "_doc", id, BytesReference.bytes(builder), XContentType.JSON, routing);
     }
 
     protected final SourceToParse source(String source) {
@@ -225,7 +254,111 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         });
     }
 
-    QueryShardContext createQueryShardContext(MapperService mapperService) {
+    private AggregationContext aggregationContext(MapperService mapperService, IndexSearcher searcher, Query query) {
+        return new AggregationContext() {
+            @Override
+            public IndexSearcher searcher() {
+                return searcher;
+            }
+
+            @Override
+            public Query query() {
+                return query;
+            }
+
+            @Override
+            public long nowInMillis() {
+                return 0;
+            }
+
+            @Override
+            public Mapper getMapper(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public SearchLookup lookup() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ValuesSourceRegistry getValuesSourceRegistry() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public IndexSettings getIndexSettings() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public MappedFieldType getFieldType(String path) {
+                return mapperService.fieldType(path);
+            }
+
+            @Override
+            public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Query buildQuery(QueryBuilder builder) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected IndexFieldData<?> buildFieldData(MappedFieldType ft) {
+                return ft.fielddataBuilder("test", null).build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
+            }
+
+            @Override
+            public BigArrays bigArrays() {
+                return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+            }
+
+            @Override
+            public ObjectMapper getObjectMapper(String path) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NestedScope nestedScope() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    protected final void withAggregationContext(
+        MapperService mapperService,
+        List<SourceToParse> docs,
+        CheckedConsumer<AggregationContext, IOException> test
+    ) throws IOException {
+        withAggregationContext(mapperService, docs, null, test);
+    }
+    
+    protected final void withAggregationContext(
+        MapperService mapperService,
+        List<SourceToParse> docs,
+        Query query,
+        CheckedConsumer<AggregationContext, IOException> test
+    ) throws IOException {
+        withLuceneIndex(
+            mapperService,
+            writer -> {
+                for (SourceToParse doc: docs) {
+                    writer.addDocuments(mapperService.documentMapper().parse(doc).docs());
+                }
+            },
+            reader -> test.accept(aggregationContext(mapperService, new IndexSearcher(reader), query))
+        );
+    }
+
+    protected QueryShardContext createQueryShardContext(MapperService mapperService) {
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
         when(queryShardContext.getFieldType(anyString())).thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()));
         when(queryShardContext.isFieldMapped(anyString()))

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -110,6 +110,8 @@ import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuil
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.AggregationContext.ProductionAggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -254,7 +256,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         throws IOException {
         @SuppressWarnings("unchecked")
         A aggregator = (A) aggregationBuilder.rewrite(searchContext.getQueryShardContext())
-            .build(searchContext.getQueryShardContext(), null)
+            .build(new ProductionAggregationContext(searchContext.getQueryShardContext(), searchContext.query()), null)
             .create(searchContext, null, CardinalityUpperBound.ONE);
         return aggregator;
     }
@@ -915,9 +917,9 @@ public abstract class AggregatorTestCase extends ESTestCase {
         }
 
         @Override
-        protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subfactoriesBuilder)
+        protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subfactoriesBuilder)
                 throws IOException {
-            return new AggregatorFactory(name, queryShardContext, parent, subfactoriesBuilder, metadata) {
+            return new AggregatorFactory(name, context, parent, subfactoriesBuilder, metadata) {
                 @Override
                 protected Aggregator createInternal(
                     SearchContext searchContext,
@@ -938,8 +940,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
                         @Override
                         public InternalAggregation buildEmptyAggregation() {
-                            // TODO Auto-generated method stub
-                            return null;
+                            throw new UnsupportedOperationException();
                         }
                     };
                 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
@@ -10,13 +10,13 @@ import org.elasticsearch.index.fielddata.IndexHistogramFieldData;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.util.Locale;
-import java.util.function.LongSupplier;
 
 public enum AnalyticsValuesSourceType implements ValuesSourceType {
     HISTOGRAM() {
@@ -32,7 +32,7 @@ public enum AnalyticsValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
 
             if (!(indexFieldData instanceof IndexHistogramFieldData)) {
@@ -43,7 +43,12 @@ public enum AnalyticsValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
+        public ValuesSource replaceMissing(
+            ValuesSource valuesSource,
+            Object rawMissing,
+            DocValueFormat docValueFormat,
+            AggregationContext context
+        ) {
             throw new IllegalArgumentException("Can't apply missing values on a " + valuesSource.getClass());
         }
     };

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.analytics.aggregations.support;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.Rounding.Prepared;
@@ -25,7 +24,7 @@ public class HistogramValuesSource {
         public abstract HistogramValues getHistogramValues(LeafReaderContext context) throws IOException;
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer(IndexReader reader) throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
             throw new AggregationExecutionException("can't round a [histogram]");
         }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
@@ -10,11 +10,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -103,11 +103,11 @@ public class BoxplotAggregationBuilder extends ValuesSourceAggregationBuilder.Le
     }
 
     @Override
-    protected BoxplotAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected BoxplotAggregatorFactory innerBuild(AggregationContext context,
                                                   ValuesSourceConfig config,
                                                   AggregatorFactory parent,
                                                   AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new BoxplotAggregatorFactory(name, config, compression, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new BoxplotAggregatorFactory(name, config, compression, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorFactory.java
@@ -6,11 +6,11 @@
 
 package org.elasticsearch.xpack.analytics.boxplot;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -37,11 +37,11 @@ public class BoxplotAggregatorFactory extends ValuesSourceAggregatorFactory {
     BoxplotAggregatorFactory(String name,
                              ValuesSourceConfig config,
                              double compression,
-                             QueryShardContext queryShardContext,
+                             AggregationContext context,
                              AggregatorFactory parent,
                              AggregatorFactories.Builder subFactoriesBuilder,
                              Map<String, Object> metadata) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.compression = compression;
     }
 
@@ -60,7 +60,7 @@ public class BoxplotAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(BoxplotAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config.getValuesSource(), config.format(), compression, searchContext, parent, metadata);
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
@@ -11,12 +11,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -99,13 +99,12 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
 
     @Override
     protected RateAggregatorFactory innerBuild(
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         ValuesSourceConfig config,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder
     ) throws IOException {
-
-        return new RateAggregatorFactory(name, config, rateUnit, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new RateAggregatorFactory(name, config, rateUnit, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
@@ -139,7 +138,7 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
     }
 
     @Override
-    protected ValuesSourceConfig resolveConfig(QueryShardContext queryShardContext) {
+    protected ValuesSourceConfig resolveConfig(AggregationContext context) {
         if (field() == null && script() == null) {
             return new ValuesSourceConfig(
                 CoreValuesSourceType.NUMERIC,
@@ -150,10 +149,10 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
                 1.0,
                 null,
                 DocValueFormat.RAW,
-                queryShardContext::nowInMillis
+                context
             );
         } else {
-            return super.resolveConfig(queryShardContext);
+            return super.resolveConfig(context);
         }
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorFactory.java
@@ -12,12 +12,12 @@ import java.util.Map;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -34,12 +34,12 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
         String name,
         ValuesSourceConfig config,
         Rounding.DateTimeUnit rateUnit,
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.rateUnit = rateUnit;
     }
 
@@ -75,7 +75,7 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound bucketCardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(RateAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, rateUnit, searchContext, parent, metadata);
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
@@ -10,10 +10,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -78,11 +78,11 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
     }
 
     @Override
-    protected StringStatsAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected StringStatsAggregatorFactory innerBuild(AggregationContext context,
                                                       ValuesSourceConfig config,
                                                       AggregatorFactory parent,
                                                       AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
-        return new StringStatsAggregatorFactory(name, config, showDistribution, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new StringStatsAggregatorFactory(name, config, showDistribution, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorFactory.java
@@ -6,11 +6,11 @@
 
 package org.elasticsearch.xpack.analytics.stringstats;
 
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -26,10 +26,10 @@ class StringStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     StringStatsAggregatorFactory(String name, ValuesSourceConfig config,
                                  Boolean showDistribution,
-                                 QueryShardContext queryShardContext,
+                                 AggregationContext context,
                                  AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata)
                                     throws IOException {
-        super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.showDistribution = showDistribution;
     }
 
@@ -51,7 +51,7 @@ class StringStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
                                           Aggregator parent,
                                           CardinalityUpperBound cardinality,
                                           Map<String, Object> metadata) throws IOException {
-        return queryShardContext.getValuesSourceRegistry()
+        return context.getValuesSourceRegistry()
             .getAggregator(StringStatsAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config.getValuesSource(), showDistribution, config.format(), searchContext, parent, metadata);
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -12,12 +12,12 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ContextParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
 import org.elasticsearch.search.sort.SortBuilder;
 
@@ -120,10 +120,9 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
     }
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent, Builder subFactoriesBuilder)
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
             throws IOException {
-        return new TopMetricsAggregatorFactory(name, queryShardContext, parent, subFactoriesBuilder, metadata, sortBuilders,
-                size, metricFields);
+        return new TopMetricsAggregatorFactory(name, context, parent, subFactoriesBuilder, metadata, sortBuilders, size, metricFields);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
@@ -8,11 +8,11 @@ package org.elasticsearch.xpack.analytics.topmetrics;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
 import org.elasticsearch.search.aggregations.support.ValueType;
@@ -40,10 +40,10 @@ public class TopMetricsAggregatorFactory extends AggregatorFactory {
     private final int size;
     private final List<MultiValuesSourceFieldConfig> metricFields;
 
-    public TopMetricsAggregatorFactory(String name, QueryShardContext queryShardContext, AggregatorFactory parent,
+    public TopMetricsAggregatorFactory(String name, AggregationContext context, AggregatorFactory parent,
             Builder subFactoriesBuilder, Map<String, Object> metadata, List<SortBuilder<?>> sortBuilders,
             int size, List<MultiValuesSourceFieldConfig> metricFields) throws IOException {
-        super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
+        super(name, context, parent, subFactoriesBuilder, metadata);
         this.sortBuilders = sortBuilders;
         this.size = size;
         this.metricFields = metricFields;
@@ -60,7 +60,7 @@ public class TopMetricsAggregatorFactory extends AggregatorFactory {
         }
         List<TopMetricsAggregator.MetricSource> metricSources = metricFields.stream().map(config -> {
                     ValuesSourceConfig resolved = ValuesSourceConfig.resolve(
-                            searchContext.getQueryShardContext(), ValueType.NUMERIC,
+                            context, ValueType.NUMERIC,
                             config.getFieldName(), config.getScript(), config.getMissing(), config.getTimeZone(), null,
                         CoreValuesSourceType.NUMERIC);
                     return new TopMetricsAggregator.MetricSource(config.getFieldName(), resolved.format(),

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregationBuilder.java
@@ -13,11 +13,11 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregationBuilder;
@@ -127,7 +127,7 @@ public class TTestAggregationBuilder extends MultiValuesSourceAggregationBuilder
 
     @Override
     protected MultiValuesSourceAggregatorFactory innerBuild(
-        QueryShardContext queryShardContext,
+        AggregationContext context,
         Map<String, ValuesSourceConfig> configs,
         Map<String, QueryBuilder> filters,
         DocValueFormat format,
@@ -147,7 +147,7 @@ public class TTestAggregationBuilder extends MultiValuesSourceAggregationBuilder
         }
 
         return new TTestAggregatorFactory(name, configs, testType, tails,
-            filterA, filterB, format, queryShardContext, parent,
+            filterA, filterB, format, context, parent,
             subFactoriesBuilder, metadata);
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext.ProductionAggregationContext;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -364,8 +365,10 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
                 SearchContext searchContext = createSearchContext(indexSearcher, createIndexSettings(), new MatchAllDocsQuery(),
                         new MultiBucketConsumer(Integer.MAX_VALUE, breaker.getBreaker(CircuitBreaker.REQUEST)), breaker, doubleFields());
                 TopMetricsAggregationBuilder builder = simpleBuilder(new FieldSortBuilder("s").order(SortOrder.ASC));
-                Aggregator aggregator = builder.build(searchContext.getQueryShardContext(), null)
-                    .create(searchContext, null, CardinalityUpperBound.ONE);
+                Aggregator aggregator = builder.build(
+                    new ProductionAggregationContext(searchContext.getQueryShardContext(), searchContext.query()),
+                    null
+                ).create(searchContext, null, CardinalityUpperBound.ONE);
                 aggregator.preCollection();
                 assertThat(indexReader.leaves(), hasSize(1));
                 LeafBucketCollector leaf = aggregator.getLeafCollector(indexReader.leaves().get(0));

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -18,6 +17,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -72,12 +72,12 @@ public class CancellingAggregationBuilder extends AbstractAggregationBuilder<Can
 
 
     @Override
-    protected AggregatorFactory doBuild(QueryShardContext queryShardContext, AggregatorFactory parent,
+    protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent,
                                         AggregatorFactories.Builder subfactoriesBuilder) throws IOException {
         final FilterAggregationBuilder filterAgg = new FilterAggregationBuilder(name, QueryBuilders.matchAllQuery());
         filterAgg.subAggregations(subfactoriesBuilder);
-        final AggregatorFactory factory = filterAgg.build(queryShardContext, parent);
-        return new AggregatorFactory(name, queryShardContext, parent, subfactoriesBuilder, metadata) {
+        final AggregatorFactory factory = filterAgg.build(context, parent);
+        return new AggregatorFactory(name, context, parent, subfactoriesBuilder, metadata) {
             @Override
             protected Aggregator createInternal(SearchContext searchContext,
                                                 Aggregator parent,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
@@ -11,10 +11,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -78,7 +78,7 @@ public class MockDeprecatedAggregationBuilder extends ValuesSourceAggregationBui
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory innerBuild(QueryShardContext queryShardContext,
+    protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
                                                        Builder subFactoriesBuilder) throws IOException {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
@@ -6,10 +6,8 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.support;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.common.Rounding.Prepared;
 import org.elasticsearch.index.fielddata.DocValueBits;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -39,7 +37,7 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
     public abstract MultiGeoShapeValues geoShapeValues(LeafReaderContext context);
 
     @Override
-    public Function<Rounding, Prepared> roundingPreparer(IndexReader reader) throws IOException {
+    protected Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
         throw new AggregationExecutionException("can't round a [geo_shape]");
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValueType;
@@ -23,7 +24,6 @@ import org.elasticsearch.xpack.spatial.index.fielddata.IndexGeoShapeFieldData;
 import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
 
 import java.io.IOException;
-import java.util.function.LongSupplier;
 
 public class GeoShapeValuesSourceType implements Writeable, ValuesSourceType {
 
@@ -45,7 +45,7 @@ public class GeoShapeValuesSourceType implements Writeable, ValuesSourceType {
     }
 
     @Override
-    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
         boolean isGeoPoint = fieldContext.indexFieldData() instanceof IndexGeoPointFieldData;
         boolean isGeoShape = fieldContext.indexFieldData() instanceof IndexGeoShapeFieldData;
         if (isGeoPoint == false && isGeoShape == false) {
@@ -59,7 +59,12 @@ public class GeoShapeValuesSourceType implements Writeable, ValuesSourceType {
     }
 
     @Override
-    public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
+    public ValuesSource replaceMissing(
+        ValuesSource valuesSource,
+        Object rawMissing,
+        DocValueFormat docValueFormat,
+        AggregationContext context
+    ) {
         GeoShapeValuesSource geoShapeValuesSource = (GeoShapeValuesSource) valuesSource;
         final MultiGeoShapeValues.GeoShapeValue missing = MultiGeoShapeValues.GeoShapeValue.missing(rawMissing.toString());
         return new GeoShapeValuesSource() {


### PR DESCRIPTION
Before this change we inspected the index when optimizing
`date_histogram` aggregations, precalculating the divisions for the
buckets for the entire range of dates on the index so long as there
aren't a ton of these buckets. This works very well when you query all
of the dates in the index which is quite common - after all, folks
frequently want to query a week of data and have daily indices.

But it doesn't work as well when the index is much larger than the
query. This is quite common when dumping data into ES just to
investigate it but less common in the traditional time series use case.
But even there it still happens, it is just less impactful. Consider
the default query produced by Kibana's Discover app: a range of 15
minutes and a interval of 30 seconds. This optimization saves something
like 3 to 12 nanoseconds per document, so that 15 minutes would have to
have hundreds of millions of documents for it to be impactful.

Anyway, this commit takes the query into account when precalculating the
buckets. Mostly this is good when you have "dirty data". Immagine
loading 80 billion docs in an index to investigate them. Most of them
have dates around 2015 and 2016 but some have dates in 1970 and
others have dates in 2030. These outlier dates are "dirty" "garbage".
Well, without this change a `date_histogram` across many of these docs
is significantly slowed down because we don't precalculate the range due
to the outliers. That's just rude! So this change takes the query into
account.

The bulk of the code change here is plumbing the query into place. It
turns out that its a *ton* of plumbing, so instead of just adding a
`Query` member in hundreds of args replace `QueryShardContext` with a
new `AggregationContext` which does two things:
1. Has the top level `Query`.
2. Exposes just the parts of `QueryShardContext` that we actually need
   to run aggregation. This lets us simplify a few tests now and will
   let us simplify many, many tests later.
