### PR TITLE
[7.x] [DOCS] allow_duplicates option for append processor (#62336)

### DIFF
--- a/docs/reference/ingest/processors/append.asciidoc
+++ b/docs/reference/ingest/processors/append.asciidoc
@@ -17,6 +17,8 @@ Accepts a single value or an array of values.
 | Name      | Required  | Default  | Description
 | `field`  | yes       | -        | The field to be appended to. Supports <<accessing-template-fields,template snippets>>.
 | `value`  | yes       | -        | The value to be appended. Supports <<accessing-template-fields,template snippets>>.
+| `allow_duplicates` | no | true  | If `false`, the processor does not append
+values already present in the field.
 include::common-options.asciidoc[]
 |======
 


### PR DESCRIPTION
Documents the `allow_duplicates` option added in #61916

Backport of #62336