### PR TITLE
[7.x] [DOCS] Fix dup word in ShardRouting hashcode method. (#63452)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -570,7 +570,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
-     * Cache hash code in same same way as {@link String#hashCode()}) using racy single-check idiom
+     * Cache hash code in the same way as {@link String#hashCode()}) using racy single-check idiom
      * as it is mainly used in single-threaded code ({@link BalancedShardsAllocator}).
      */
     private int hashCode; // default to 0


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix dup word in ShardRouting hashcode method. (#63452)