### PR TITLE
[7.x] Persist all template alias settings on PUT template  (#63162)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -799,8 +799,13 @@ public class MetadataIndexTemplateService {
         }
 
         for (Alias alias : request.aliases) {
-            AliasMetadata aliasMetadata = AliasMetadata.builder(alias.name()).filter(alias.filter())
-                .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
+            AliasMetadata aliasMetadata = AliasMetadata.builder(alias.name())
+                .filter(alias.filter())
+                .indexRouting(alias.indexRouting())
+                .searchRouting(alias.searchRouting())
+                .writeIndex(alias.writeIndex())
+                .isHidden(alias.isHidden())
+                .build();
             templateBuilder.putAlias(aliasMetadata);
         }
         IndexTemplateMetadata template = templateBuilder.build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -233,7 +233,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         final String aliasName = "alias_with_settings";
         PutRequest request = new PutRequest("api", templateName);
         request.patterns(singletonList("te*"));
-        request.mappings("{}");
+        request.putMapping("_doc", "{}");
         Alias alias = new Alias(aliasName)
             .filter(randomBoolean() ? null : "{\"term\":{\"user_id\":12}}")
             .indexRouting(randomBoolean() ? null : "route1")

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.PutRequest;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -225,6 +226,38 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         assertThat(errors.size(), equalTo(1));
         assertThat(errors.get(0), instanceOf(IllegalArgumentException.class));
         assertThat(errors.get(0).getMessage(), equalTo("failed to parse filter for alias [invalid_alias]"));
+    }
+
+    public void testIndexTemplateWithAlias() throws Exception {
+        final String templateName = "template_with_alias";
+        final String aliasName = "alias_with_settings";
+        PutRequest request = new PutRequest("api", templateName);
+        request.patterns(singletonList("te*"));
+        request.mappings("{}");
+        Alias alias = new Alias(aliasName)
+            .filter(randomBoolean() ? null : "{\"term\":{\"user_id\":12}}")
+            .indexRouting(randomBoolean() ? null : "route1")
+            .searchRouting(randomBoolean() ? null :"route2")
+            .isHidden(randomBoolean() ? null : randomBoolean())
+            .writeIndex(randomBoolean() ? null : randomBoolean());
+        Set<Alias> aliases = new HashSet<>();
+        aliases.add(alias);
+        request.aliases(aliases);
+
+        List<Throwable> errors = putTemplateDetail(request);
+        assertThat(errors, is(empty()));
+
+        final Metadata metadata = client().admin().cluster().prepareState().get().getState().metadata();
+        IndexTemplateMetadata template = metadata.templates().get(templateName);
+        ImmutableOpenMap<String, AliasMetadata> aliasMap = template.getAliases();
+        assertThat(aliasMap.size(), equalTo(1));
+        AliasMetadata metaAlias = aliasMap.get(aliasName);
+        String filterString = metaAlias.filter() == null ? null : metaAlias.filter().string();
+        assertThat(filterString, equalTo(alias.filter()));
+        assertThat(metaAlias.indexRouting(), equalTo(alias.indexRouting()));
+        assertThat(metaAlias.searchRouting(), equalTo(alias.searchRouting()));
+        assertThat(metaAlias.isHidden(), equalTo(alias.isHidden()));
+        assertThat(metaAlias.writeIndex(), equalTo(alias.writeIndex()));
     }
 
     public void testFindTemplates() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Persist all template alias settings on PUT template  (#63162)