### PR TITLE
Provide an extract only distribution configuration for bwc configurations

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
@@ -27,6 +27,7 @@ import org.apache.tools.zip.ZipFile
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncTest {
 
@@ -158,6 +159,41 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
         file("producer-tar/build/install/someFile.txt").exists()
         !file("producer-tar/build/install/snapshot-1.0.txt").exists()
         file("producer-tar/build/install/snapshot-2.0.txt").exists()
+    }
+
+    @Unroll
+    def "builds extracted distribution via extractedAssemble"() {
+        given:
+        file('someFile.txt') << "some content"
+        settingsFile << """
+            include ':producer-tar'
+        """
+
+        buildFile << """
+        import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+        import org.gradle.api.internal.artifacts.ArtifactAttributes;
+
+        def snapshotFile = file("snapshot.txt")
+        snapshotFile << 'some snapshot content'
+        distribution_archives {
+            producerTar {
+                content {
+                    project.copySpec {
+                        from 'someFile.txt'
+                        from snapshotFile
+                    }
+                }
+            }
+        }
+        """
+        when:
+        def result = gradleRunner(":producer-tar:extractedAssemble").build()
+
+        then: "tar task executed and target folder contains plain tar"
+        result.task(':buildProducer').outcome == TaskOutcome.SUCCESS
+
+        file("producer-tar/build/install").exists()
+        file("producer-tar/build/distributions/elasticsearch.tar.gz").exists() == false
     }
 
     private static boolean assertTarPermissionDefaults(File tarArchive) {

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
@@ -161,7 +161,6 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
         file("producer-tar/build/install/snapshot-2.0.txt").exists()
     }
 
-    @Unroll
     def "builds extracted distribution via extractedAssemble"() {
         given:
         file('someFile.txt') << "some content"

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -89,10 +89,9 @@ public class InternalDistributionArchiveSetupPlugin implements InternalPlugin {
                 extractedConfiguration.getAttributes().attribute(ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
                 sub.getArtifacts().add(EXTRACTED_CONFIGURATION_NAME, distributionArchive.getExpandedDistTask());
                 sub.getTasks().register("extractedAssemble", task ->
-                        // We keep extracted configuration resolvable false to keep
-                        // resolveAllDependencies simple so we rely only on its build dependencies here.
-                        task.dependsOn(extractedConfiguration.getAllArtifacts().getBuildDependencies())
-                );
+                // We keep extracted configuration resolvable false to keep
+                // resolveAllDependencies simple so we rely only on its build dependencies here.
+                task.dependsOn(extractedConfiguration.getAllArtifacts().getBuildDependencies()));
             });
         });
         project.getExtensions().add("distribution_archives", container);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -21,10 +21,8 @@ package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.EmptyDirTask;
 import org.elasticsearch.gradle.tar.SymbolicLinkPreservingTar;
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.tasks.AbstractCopyTask;
@@ -90,12 +88,11 @@ public class InternalDistributionArchiveSetupPlugin implements InternalPlugin {
                 extractedConfiguration.setCanBeResolved(false);
                 extractedConfiguration.getAttributes().attribute(ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
                 sub.getArtifacts().add(EXTRACTED_CONFIGURATION_NAME, distributionArchive.getExpandedDistTask());
-                sub.getTasks().register("extractedAssemble", new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        task.dependsOn(extractedConfiguration.getAllArtifacts().getBuildDependencies());
-                    }
-                });
+                sub.getTasks().register("extractedAssemble", task ->
+                        // We keep extracted configuration resolvable false to keep
+                        // resolveAllDependencies simple so we rely only on its build dependencies here.
+                        task.dependsOn(extractedConfiguration.getAllArtifacts().getBuildDependencies())
+                );
             });
         });
         project.getExtensions().add("distribution_archives", container);


### PR DESCRIPTION
This PR provides a configuration that can be used for bwc setups that allows
bwc setups to create an extracted bwc version es distribution without creating a tar
configuration as done by the default _assemble_ configuration

A later PR will change the bwc setup configuration to rely on this extractedAssemble
configuration when building distributions for bwc testing.

One step closer to finish off https://github.com/elastic/elasticsearch/issues/62115