### PR TITLE
Remove some more usages of QueryShardContext#getMapperService

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -238,7 +238,7 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
         leaf.reader().document(segmentDocID, fields);
-        fields.postProcess(mapperService::fieldType, mapperService.documentMapper());
+        fields.postProcess(mapperService::fieldType, mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
 
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -238,7 +238,7 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
         leaf.reader().document(segmentDocID, fields);
-        fields.postProcess(mapperService::fieldType, mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
+        fields.postProcess(mapperService::fieldType, mapperService.documentMapper() == null ? null : mapperService.documentMapper().type());
 
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableSet;
@@ -89,10 +88,9 @@ public class FieldsVisitor extends StoredFieldVisitor {
             : Status.NO;
     }
 
-    public final void postProcess(Function<String, MappedFieldType> fieldTypeLookup, @Nullable Supplier<String> typeSupplier) {
-        if (typeSupplier != null) {
-            type = typeSupplier.get();
-        }
+    public final void postProcess(Function<String, MappedFieldType> fieldTypeLookup, @Nullable String type) {
+        assert this.type == null || this.type.equals(type);
+        this.type = type;
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
             MappedFieldType fieldType = fieldTypeLookup.apply(entry.getKey());
             List<Object> fieldValues = entry.getValue();

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -24,7 +24,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -40,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableSet;
@@ -85,13 +85,13 @@ public class FieldsVisitor extends StoredFieldVisitor {
         // All these fields are single-valued so we can stop when the set is
         // empty
         return requiredFields.isEmpty()
-                ? Status.STOP
-                : Status.NO;
+            ? Status.STOP
+            : Status.NO;
     }
 
-    public final void postProcess(Function<String, MappedFieldType> fieldTypeLookup, @Nullable DocumentMapper mapper) {
-        if (mapper != null) {
-            type = mapper.type();
+    public final void postProcess(Function<String, MappedFieldType> fieldTypeLookup, @Nullable Supplier<String> typeSupplier) {
+        if (typeSupplier != null) {
+            type = typeSupplier.get();
         }
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
             MappedFieldType fieldType = fieldTypeLookup.apply(entry.getKey());

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -281,7 +281,8 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
             // put stored fields into result objects
             if (!fieldVisitor.fields().isEmpty()) {
-                fieldVisitor.postProcess(mapperService::fieldType, mapperService.documentMapper());
+                fieldVisitor.postProcess(mapperService::fieldType,
+                    mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
                 documentFields = new HashMap<>();
                 metadataFields = new HashMap<>();
                 for (Map.Entry<String, List<Object>> entry : fieldVisitor.fields().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -282,7 +282,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             // put stored fields into result objects
             if (!fieldVisitor.fields().isEmpty()) {
                 fieldVisitor.postProcess(mapperService::fieldType,
-                    mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
+                    mapperService.documentMapper() == null ? null : mapperService.documentMapper().type());
                 documentFields = new HashMap<>();
                 metadataFields = new HashMap<>();
                 for (Map.Entry<String, List<Object>> entry : fieldVisitor.fields().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -368,7 +368,7 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         if (analyzer == null) {
             analyzerObj = fieldType.getTextSearchInfo().getSearchAnalyzer();
         } else {
-            analyzerObj = context.getMapperService().getIndexAnalyzers().get(analyzer);
+            analyzerObj = context.getIndexAnalyzers().get(analyzer);
             if (analyzerObj == null) {
                 throw new QueryShardException(context, "[common] analyzer [" + analyzer + "] not found");
             }

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -185,17 +184,16 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         if (idField == null || ids.isEmpty()) {
             throw new IllegalStateException("Rewrite first");
         }
-        final DocumentMapper mapper = context.getMapperService().documentMapper();
         Collection<String> typesForQuery;
         if (types.length == 0) {
             typesForQuery = context.queryTypes();
         } else if (types.length == 1 && Metadata.ALL.equals(types[0])) {
-            typesForQuery = Collections.singleton(mapper.type());
+            typesForQuery = Collections.singleton(context.getType());
         } else {
             typesForQuery = new HashSet<>(Arrays.asList(types));
         }
 
-        if (typesForQuery.contains(mapper.type())) {
+        if (typesForQuery.contains(context.getType())) {
             return idField.termsQuery(new ArrayList<>(ids), context);
         } else {
             return new MatchNoDocsQuery("Type mismatch");

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -63,6 +63,7 @@ import org.elasticsearch.search.aggregations.support.AggregationUsageService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.transport.RemoteClusterAware;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -335,7 +336,7 @@ public class QueryShardContext extends QueryRewriteContext {
     public Collection<String> queryTypes() {
         String[] types = getTypes();
         if (types == null || types.length == 0 || (types.length == 1 && types[0].equals("_all"))) {
-            DocumentMapper mapper = getMapperService().documentMapper();
+            DocumentMapper mapper = mapperService.documentMapper();
             return mapper == null ? Collections.emptyList() : Collections.singleton(mapper.type());
         }
         return Arrays.asList(types);
@@ -517,14 +518,26 @@ public class QueryShardContext extends QueryRewriteContext {
         return mapperService;
     }
 
-    /** Return the current {@link IndexReader}, or {@code null} if no index reader is available,
-     *  for instance if this rewrite context is used to index queries (percolation). */
+    public String getType() {
+        return mapperService.documentMapper() == null ? null : mapperService.documentMapper().type();
+    }
+
+    public boolean typeExists(String type) {
+        return mapperService.documentMapper(type) != null;
+    }
+
+    /**
+     * Return the current {@link IndexReader}, or {@code null} if no index reader is available,
+     * for instance if this rewrite context is used to index queries (percolation).
+     */
     public IndexReader getIndexReader() {
         return searcher == null ? null : searcher.getIndexReader();
     }
 
-    /** Return the current {@link IndexSearcher}, or {@code null} if no index reader is available,
-     *  for instance if this rewrite context is used to index queries (percolation). */
+    /**
+     * Return the current {@link IndexSearcher}, or {@code null} if no index reader is available,
+     * for instance if this rewrite context is used to index queries (percolation).
+     */
     public IndexSearcher searcher() {
         return searcher;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.DocumentMapper;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -130,13 +129,11 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         deprecationLogger.deprecate("type_query", TYPES_DEPRECATION_MESSAGE);
-        //LUCENE 4 UPGRADE document mapper should use bytesref as well?
-        DocumentMapper documentMapper = context.getMapperService().documentMapper(type);
-        if (documentMapper == null) {
+        if (context.typeExists(type)) {
+            return Queries.newNonNestedFilter(context.indexVersionCreated());
+        } else {
             // no type means no documents
             return new MatchNoDocsQuery();
-        } else {
-            return Queries.newNonNestedFilter(context.indexVersionCreated());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -385,7 +385,7 @@ public class FetchPhase {
             FieldsVisitor rootFieldsVisitor = new FieldsVisitor(needSource);
             DocumentMapper documentMapper = context.mapperService().documentMapper();
             loadStoredFields(context::fieldType, documentMapper, storedFieldReader, rootFieldsVisitor, rootDocId);
-            rootFieldsVisitor.postProcess(context::fieldType, documentMapper == null ? null : documentMapper::type);
+            rootFieldsVisitor.postProcess(context::fieldType, documentMapper == null ? null : documentMapper.type());
             rootId = rootFieldsVisitor.uid();
 
             if (needSource) {
@@ -557,7 +557,7 @@ public class FetchPhase {
                                   FieldsVisitor fieldVisitor, int docId) throws IOException {
         fieldVisitor.reset();
         fieldReader.accept(docId, fieldVisitor);
-        fieldVisitor.postProcess(fieldTypeLookup, documentMapper == null ? null : documentMapper::type);
+        fieldVisitor.postProcess(fieldTypeLookup, documentMapper == null ? null : documentMapper.type());
     }
 
     private static void fillDocAndMetaFields(SearchContext context, FieldsVisitor fieldsVisitor,

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -385,7 +385,7 @@ public class FetchPhase {
             FieldsVisitor rootFieldsVisitor = new FieldsVisitor(needSource);
             DocumentMapper documentMapper = context.mapperService().documentMapper();
             loadStoredFields(context::fieldType, documentMapper, storedFieldReader, rootFieldsVisitor, rootDocId);
-            rootFieldsVisitor.postProcess(context::fieldType, documentMapper);
+            rootFieldsVisitor.postProcess(context::fieldType, documentMapper == null ? null : documentMapper::type);
             rootId = rootFieldsVisitor.uid();
 
             if (needSource) {
@@ -557,7 +557,7 @@ public class FetchPhase {
                                   FieldsVisitor fieldVisitor, int docId) throws IOException {
         fieldVisitor.reset();
         fieldReader.accept(docId, fieldVisitor);
-        fieldVisitor.postProcess(fieldTypeLookup, documentMapper);
+        fieldVisitor.postProcess(fieldTypeLookup, documentMapper == null ? null : documentMapper::type);
     }
 
     private static void fillDocAndMetaFields(SearchContext context, FieldsVisitor fieldsVisitor,

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
@@ -52,10 +52,8 @@ public class IdFieldTypeTests extends ESTestCase {
         IndexSettings mockSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
         Mockito.when(context.getIndexSettings()).thenReturn(mockSettings);
         Mockito.when(context.indexVersionCreated()).thenReturn(indexSettings.getAsVersion(IndexMetadata.SETTING_VERSION_CREATED, null));
-        MapperService mapperService = Mockito.mock(MapperService.class);
         Collection<String> types = Collections.emptySet();
         Mockito.when(context.queryTypes()).thenReturn(types);
-        Mockito.when(context.getMapperService()).thenReturn(mapperService);
         MappedFieldType ft = new IdFieldMapper.IdFieldType(() -> false);
         Query query = ft.termQuery("id", context);
         assertEquals(new TermInSetQuery("_id", Uid.encodeId("id")), query);

--- a/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
@@ -90,7 +90,8 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, false);
         searcher.doc(0, fieldsVisitor);
 
-        fieldsVisitor.postProcess(mapperService::fieldType, mapperService.documentMapper());
+        fieldsVisitor.postProcess(mapperService::fieldType,
+            mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
         assertThat(fieldsVisitor.fields().size(), equalTo(10));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));

--- a/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
@@ -91,7 +91,7 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         searcher.doc(0, fieldsVisitor);
 
         fieldsVisitor.postProcess(mapperService::fieldType,
-            mapperService.documentMapper() == null ? null : mapperService.documentMapper()::type);
+            mapperService.documentMapper() == null ? null : mapperService.documentMapper().type());
         assertThat(fieldsVisitor.fields().size(), equalTo(10));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));

--- a/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -77,7 +77,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
             || context.getFieldType(IdFieldMapper.NAME) == null
             // there are types, but disjoint from the query
             || (allTypes == false &&
-            Arrays.asList(queryBuilder.types()).indexOf(context.getMapperService().documentMapper().type()) == -1)) {
+            Arrays.asList(queryBuilder.types()).indexOf(context.getType()) == -1)) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         } else {
             assertThat(query, instanceOf(TermInSetQuery.class));

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -1103,14 +1103,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testDisabledFieldNamesField() throws Exception {
         QueryShardContext context = createShardContext();
-        context.getMapperService().merge("_doc",
-                new CompressedXContent(Strings
-                        .toString(PutMappingRequest.buildFromSimplifiedDef("_doc",
-                                "foo",
-                                "type=text",
-                                "_field_names",
-                                "enabled=false"))),
-                MapperService.MergeReason.MAPPING_UPDATE);
+        getMapperService().merge("_doc",
+            new CompressedXContent(Strings
+                .toString(PutMappingRequest.buildFromSimplifiedDef("_doc",
+                    "foo",
+                    "type=text",
+                    "_field_names",
+                    "enabled=false"))),
+            MapperService.MergeReason.MAPPING_UPDATE);
 
         try {
             QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder("foo:*");
@@ -1119,14 +1119,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             assertThat(query, equalTo(expected));
         } finally {
             // restore mappings as they were before
-            context.getMapperService().merge("_doc",
-                    new CompressedXContent(Strings.toString(
-                            PutMappingRequest.buildFromSimplifiedDef("_doc",
-                                    "foo",
-                                    "type=text",
-                                    "_field_names",
-                                    "enabled=true"))),
-                    MapperService.MergeReason.MAPPING_UPDATE);
+            getMapperService().merge("_doc",
+                new CompressedXContent(Strings.toString(
+                    PutMappingRequest.buildFromSimplifiedDef("_doc",
+                        "foo",
+                        "type=text",
+                        "_field_names",
+                        "enabled=true"))),
+                MapperService.MergeReason.MAPPING_UPDATE);
         }
         assertWarnings(FieldNamesFieldMapper.ENABLED_DEPRECATION_MESSAGE);
     }

--- a/server/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
@@ -38,10 +38,10 @@ public class TypeQueryBuilderTests extends AbstractQueryTestCase<TypeQueryBuilde
 
     @Override
     protected void doAssertLuceneQuery(TypeQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
-        if (createShardContext().getMapperService().documentMapper(queryBuilder.type()) == null) {
-            assertEquals(new MatchNoDocsQuery(), query);
-        } else {
+        if (createShardContext().typeExists(queryBuilder.type())) {
             assertThat(query, equalTo(Queries.newNonNestedFilter(context.indexVersionCreated())));
+        } else {
+            assertEquals(new MatchNoDocsQuery(), query);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -278,12 +278,16 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         return createShardContext(null);
     }
 
+    protected static MapperService getMapperService() {
+        return serviceHolder.mapperService;
+    }
+
     private static class ClientInvocationHandler implements InvocationHandler {
         AbstractBuilderTestCase delegate;
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            if (method.equals(Client.class.getMethod("get", GetRequest.class, ActionListener.class))){
+            if (method.equals(Client.class.getMethod("get", GetRequest.class, ActionListener.class))) {
                 GetResponse getResponse = delegate.executeGet((GetRequest) args[0]);
                 ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
                 if (randomBoolean()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -331,7 +331,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         leafReader.document(i, rootFieldsVisitor);
                         DocumentMapper documentMapper = targetShard.mapperService().documentMapper();
                         rootFieldsVisitor.postProcess(targetShard.mapperService()::fieldType,
-                            documentMapper == null ? null : documentMapper::type);
+                            documentMapper == null ? null : documentMapper.type());
                         Uid uid = rootFieldsVisitor.uid();
                         BytesReference source = rootFieldsVisitor.source();
                         assert source != null : "_source is null but should have been filtered out at snapshot time";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -330,14 +330,15 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         rootFieldsVisitor.reset();
                         leafReader.document(i, rootFieldsVisitor);
                         DocumentMapper documentMapper = targetShard.mapperService().documentMapper();
-                        rootFieldsVisitor.postProcess(targetShard.mapperService()::fieldType, documentMapper);
+                        rootFieldsVisitor.postProcess(targetShard.mapperService()::fieldType,
+                            documentMapper == null ? null : documentMapper::type);
                         Uid uid = rootFieldsVisitor.uid();
                         BytesReference source = rootFieldsVisitor.source();
                         assert source != null : "_source is null but should have been filtered out at snapshot time";
                         Engine.Result result = targetShard.applyIndexOperationOnPrimary(Versions.MATCH_ANY, VersionType.INTERNAL,
                             new SourceToParse(index, uid.type(), uid.id(), source, XContentHelper.xContentType(source),
                                 rootFieldsVisitor.routing()), SequenceNumbers.UNASSIGNED_SEQ_NO, 0,
-                                IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, false);
+                            IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, false);
                         if (result.getResultType() != Engine.Result.Type.SUCCESS) {
                             throw new IllegalStateException("failed applying post restore operation result: " + result
                                 .getResultType(), result.getFailure());

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -234,10 +234,13 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                 final QueryShardContext context = indexService.newQueryShardContext(
                     shardId.id(),
                     searcher,
-                    () -> { throw new UnsupportedOperationException(); },
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    },
                     null
                 );
-                final Text typeText = context.getMapperService().documentMapper().typeText();
+                final String type = context.getType();
+                final Text typeText = new Text(type);
                 final MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[request.multiSearchRequest.requests().size()];
                 for (int i = 0; i < request.multiSearchRequest.requests().size(); i++) {
                     final SearchSourceBuilder searchSourceBuilder = request.multiSearchRequest.requests().get(i).source();
@@ -262,7 +265,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                                 throw new IllegalStateException("Field [" + field + "] exists in the index but not in mappings");
                             }
                             return context.getFieldType(field);
-                        }, context.getMapperService().documentMapper());
+                        }, () -> type);
                         final SearchHit hit = new SearchHit(
                             scoreDoc.doc,
                             visitor.uid().id(),

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -263,7 +263,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                                 throw new IllegalStateException("Field [" + field + "] exists in the index but not in mappings");
                             }
                             return context.getFieldType(field);
-                        }, () -> type);
+                        }, type);
                         final SearchHit hit = new SearchHit(
                             scoreDoc.doc,
                             visitor.uid().id(),

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -234,9 +234,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                 final QueryShardContext context = indexService.newQueryShardContext(
                     shardId.id(),
                     searcher,
-                    () -> {
-                        throw new UnsupportedOperationException();
-                    },
+                    () -> { throw new UnsupportedOperationException(); },
                     null
                 );
                 final String type = context.getType();


### PR DESCRIPTION
The 7.x branch has usages of `QueryShardContext#getMapperService` that revolve around types, which can be replaced by adding a couple of specific methods to `QueryShardContext`.

This commit takes care of those as well as a couple of other usages that can be removed.