### PR TITLE
Add the missing apikey.* fields to the logfile audit layout for docker builds

### DIFF
--- a/distribution/docker/src/docker/config/log4j2.properties
+++ b/distribution/docker/src/docker/config/log4j2.properties
@@ -47,7 +47,7 @@ appender.audit_rolling.type = Console
 appender.audit_rolling.name = audit_rolling
 appender.audit_rolling.layout.type = PatternLayout
 appender.audit_rolling.layout.pattern = {\
-"type": "audit", \
+"type":"audit", \
 "timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss,SSSZ}"\
 %varsNotEmpty{, "node.name":"%enc{%map{node.name}}{JSON}"}\
 %varsNotEmpty{, "node.id":"%enc{%map{node.id}}{JSON}"}\
@@ -55,6 +55,7 @@ appender.audit_rolling.layout.pattern = {\
 %varsNotEmpty{, "host.ip":"%enc{%map{host.ip}}{JSON}"}\
 %varsNotEmpty{, "event.type":"%enc{%map{event.type}}{JSON}"}\
 %varsNotEmpty{, "event.action":"%enc{%map{event.action}}{JSON}"}\
+%varsNotEmpty{, "authentication.type":"%enc{%map{authentication.type}}{JSON}"}\
 %varsNotEmpty{, "user.name":"%enc{%map{user.name}}{JSON}"}\
 %varsNotEmpty{, "user.run_by.name":"%enc{%map{user.run_by.name}}{JSON}"}\
 %varsNotEmpty{, "user.run_as.name":"%enc{%map{user.run_as.name}}{JSON}"}\
@@ -62,6 +63,8 @@ appender.audit_rolling.layout.pattern = {\
 %varsNotEmpty{, "user.run_by.realm":"%enc{%map{user.run_by.realm}}{JSON}"}\
 %varsNotEmpty{, "user.run_as.realm":"%enc{%map{user.run_as.realm}}{JSON}"}\
 %varsNotEmpty{, "user.roles":%map{user.roles}}\
+%varsNotEmpty{, "apikey.id":"%enc{%map{apikey.id}}{JSON}"}\
+%varsNotEmpty{, "apikey.name":"%enc{%map{apikey.name}}{JSON}"}\
 %varsNotEmpty{, "origin.type":"%enc{%map{origin.type}}{JSON}"}\
 %varsNotEmpty{, "origin.address":"%enc{%map{origin.address}}{JSON}"}\
 %varsNotEmpty{, "realm":"%enc{%map{realm}}{JSON}"}\
@@ -85,6 +88,7 @@ appender.audit_rolling.layout.pattern = {\
 # "host.ip" the local bound ip (i.e. the ip listening for connections)
 # "event.type" a received REST request is translated into one or more transport requests. This indicates which processing layer generated the event "rest" or "transport" (internal)
 # "event.action" the name of the audited event, eg. "authentication_failed", "access_granted", "run_as_granted", etc.
+# "authentication.type" one of "realm", "api_key", "token", "anonymous" or "internal"
 # "user.name" the subject name as authenticated by a realm
 # "user.run_by.name" the original authenticated subject name that is impersonating another one.
 # "user.run_as.name" if this "event.action" is of a run_as type, this is the subject name to be impersonated as.
@@ -92,6 +96,8 @@ appender.audit_rolling.layout.pattern = {\
 # "user.run_by.realm" the realm name of the impersonating subject ("user.run_by.name")
 # "user.run_as.realm" if this "event.action" is of a run_as type, this is the realm name the impersonated user is looked up from
 # "user.roles" the roles array of the user; these are the roles that are granting privileges
+# "apikey.id" this field is present if and only if the "authentication.type" is "api_key"
+# "apikey.name" this field is present if and only if the "authentication.type" is "api_key"
 # "origin.type" it is "rest" if the event is originating (is in relation to) a REST request; possible other values are "transport" and "ip_filter"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated
@@ -106,7 +112,7 @@ appender.audit_rolling.layout.pattern = {\
 # "opaque_id" opaque value conveyed by the "X-Opaque-Id" request header
 # "x_forwarded_for" the addresses from the "X-Forwarded-For" request header, as a verbatim string value (not an array)
 # "transport.profile" name of the transport profile in case this is a "connection_granted" or "connection_denied" event
-# "rule" name of the applied rulee if the "origin.type" is "ip_filter"
+# "rule" name of the applied rule if the "origin.type" is "ip_filter"
 # "event.category" fixed value "elasticsearch-audit"
 
 logger.xpack_security_audit_logfile.name = org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail

--- a/x-pack/plugin/core/src/main/config/log4j2.properties
+++ b/x-pack/plugin/core/src/main/config/log4j2.properties
@@ -11,17 +11,17 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "host.ip":"%enc{%map{host.ip}}{JSON}"}\
                 %varsNotEmpty{, "event.type":"%enc{%map{event.type}}{JSON}"}\
                 %varsNotEmpty{, "event.action":"%enc{%map{event.action}}{JSON}"}\
+                %varsNotEmpty{, "authentication.type":"%enc{%map{authentication.type}}{JSON}"}\
                 %varsNotEmpty{, "user.name":"%enc{%map{user.name}}{JSON}"}\
                 %varsNotEmpty{, "user.run_by.name":"%enc{%map{user.run_by.name}}{JSON}"}\
                 %varsNotEmpty{, "user.run_as.name":"%enc{%map{user.run_as.name}}{JSON}"}\
                 %varsNotEmpty{, "user.realm":"%enc{%map{user.realm}}{JSON}"}\
                 %varsNotEmpty{, "user.run_by.realm":"%enc{%map{user.run_by.realm}}{JSON}"}\
                 %varsNotEmpty{, "user.run_as.realm":"%enc{%map{user.run_as.realm}}{JSON}"}\
+                %varsNotEmpty{, "user.roles":%map{user.roles}}\
                 %varsNotEmpty{, "apikey.id":"%enc{%map{apikey.id}}{JSON}"}\
                 %varsNotEmpty{, "apikey.name":"%enc{%map{apikey.name}}{JSON}"}\
-                %varsNotEmpty{, "user.roles":%map{user.roles}}\
                 %varsNotEmpty{, "origin.type":"%enc{%map{origin.type}}{JSON}"}\
-                %varsNotEmpty{, "authentication.type":"%enc{%map{authentication.type}}{JSON}"}\
                 %varsNotEmpty{, "origin.address":"%enc{%map{origin.address}}{JSON}"}\
                 %varsNotEmpty{, "realm":"%enc{%map{realm}}{JSON}"}\
                 %varsNotEmpty{, "url.path":"%enc{%map{url.path}}{JSON}"}\
@@ -44,6 +44,7 @@ appender.audit_rolling.layout.pattern = {\
 # "host.ip" the local bound ip (i.e. the ip listening for connections)
 # "event.type" a received REST request is translated into one or more transport requests. This indicates which processing layer generated the event "rest" or "transport" (internal)
 # "event.action" the name of the audited event, eg. "authentication_failed", "access_granted", "run_as_granted", etc.
+# "authentication.type" one of "realm", "api_key", "token", "anonymous" or "internal"
 # "user.name" the subject name as authenticated by a realm
 # "user.run_by.name" the original authenticated subject name that is impersonating another one.
 # "user.run_as.name" if this "event.action" is of a run_as type, this is the subject name to be impersonated as.
@@ -51,6 +52,8 @@ appender.audit_rolling.layout.pattern = {\
 # "user.run_by.realm" the realm name of the impersonating subject ("user.run_by.name")
 # "user.run_as.realm" if this "event.action" is of a run_as type, this is the realm name the impersonated user is looked up from
 # "user.roles" the roles array of the user; these are the roles that are granting privileges
+# "apikey.id" this field is present if and only if the "authentication.type" is "api_key"
+# "apikey.name" this field is present if and only if the "authentication.type" is "api_key"
 # "origin.type" it is "rest" if the event is originating (is in relation to) a REST request; possible other values are "transport" and "ip_filter"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated
@@ -65,7 +68,7 @@ appender.audit_rolling.layout.pattern = {\
 # "opaque_id" opaque value conveyed by the "X-Opaque-Id" request header
 # "x_forwarded_for" the addresses from the "X-Forwarded-For" request header, as a verbatim string value (not an array)
 # "transport.profile" name of the transport profile in case this is a "connection_granted" or "connection_denied" event
-# "rule" name of the applied rulee if the "origin.type" is "ip_filter"
+# "rule" name of the applied rule if the "origin.type" is "ip_filter"
 # "event.category" fixed value "elasticsearch-audit"
 
 appender.audit_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_audit-%d{yyyy-MM-dd}.json


### PR DESCRIPTION
Atm there are two log4j2.properties files that we have to modify whenever the pattern layout changes when adding new fields to the security audit trail. There are tests (`LoggingAuditTrailTests`) that check the pattern form the log4j2.properties file from the `x-pack:plugin:core` module, but no mechanism to ensure that the patterns stay equal across the two. The last bit is to be handled separately in  https://github.com/elastic/elasticsearch/pull/63516 .