### PR TITLE
Retry wget tasks in Dockerfile

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -61,10 +61,14 @@ RUN apk add gnupg gcc make musl-dev openssl-dev openssl-libs-static file
 RUN mkdir /work
 WORKDIR /work
 
-# Fetch curl sources and files for validation
-RUN wget "https://daniel.haxx.se/mykey.asc" -O "curl-gpg.pub" && \\
-    wget "\${TARBALL_URL}.asc" -O "\${TARBALL_PATH}.asc" && \\
-    wget "\${TARBALL_URL}" -O "\${TARBALL_PATH}"
+# Fetch curl sources and files for validation. Note that alpine's `wget` doesn't have retry options.
+RUN for iter in {1..10}; do \\
+      wget "https://daniel.haxx.se/mykey.asc" -O "curl-gpg.pub" && \\
+      wget "\${TARBALL_URL}.asc" -O "\${TARBALL_PATH}.asc" && \\
+      wget "\${TARBALL_URL}" -O "\${TARBALL_PATH}" && \\
+      exit_code=0 || exit_code=\$? && echo "wget error: retry \$iter in 10s" && sleep 10; \\
+    done; \\
+    (exit \$exit_code)
 
 # Validate source
 RUN gpg --import --always-trust "curl-gpg.pub" && \\
@@ -216,7 +220,8 @@ RUN for iter in {1..10}; do \\
       ${package_manager} update --setopt=tsflags=nodocs -y && \\
       ${package_manager} install --setopt=tsflags=nodocs -y \\
         nc shadow-utils zip unzip findutils procps-ng && \\
-      ${package_manager} clean all && exit_code=0 && break || exit_code=\$? && echo "${package_manager} error: retry \$iter in 10s" && \\
+      ${package_manager} clean all && \\
+      exit_code=0 && break || exit_code=\$? && echo "${package_manager} error: retry \$iter in 10s" && \\
       sleep 10; \\
     done; \\
     (exit \$exit_code)

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -62,13 +62,18 @@ RUN mkdir /work
 WORKDIR /work
 
 # Fetch curl sources and files for validation. Note that alpine's `wget` doesn't have retry options.
-RUN for iter in {1..10}; do \\
-      wget "https://daniel.haxx.se/mykey.asc" -O "curl-gpg.pub" && \\
-      wget "\${TARBALL_URL}.asc" -O "\${TARBALL_PATH}.asc" && \\
-      wget "\${TARBALL_URL}" -O "\${TARBALL_PATH}" && \\
-      exit_code=0 || exit_code=\$? && echo "wget error: retry \$iter in 10s" && sleep 10; \\
-    done; \\
-    (exit \$exit_code)
+RUN function retry_wget() { \\
+      local URL="\$1" ; \\
+      local DEST="\$2" ; \\
+      for iter in {1..10}; do \\
+        wget "\$URL" -O "\$DEST" && \\
+        exit_code=0 && break || exit_code=\$? && echo "wget error fetching \$URL: retry \$iter in 10s" && sleep 10; \\
+      done; \\
+      return \$exit_code ; \\
+    } ; \\
+    retry_wget "https://daniel.haxx.se/mykey.asc" "curl-gpg.pub" && \\
+    retry_wget "\${TARBALL_URL}.asc" "\${TARBALL_PATH}.asc" && \\
+    retry_wget "\${TARBALL_URL}" "\${TARBALL_PATH}"
 
 # Validate source
 RUN gpg --import --always-trust "curl-gpg.pub" && \\


### PR DESCRIPTION
Following #52519, our Docker build pulls down `curl` sources in an
Alpine Linux container using `wget`. However that version of `wget`
doesn't support any retry flags. Since network issues can cause build
failures, wrap the `wget` calls in the same retry construct used for
`yum` commands elsewhere.

Closes #63600.