### PR TITLE
SQL: Improve parser error message for `ESCAPE`

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -283,7 +283,8 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 escape = escapeString.charAt(0);
                 // these chars already have a meaning
                 if (escape == '%' || escape == '_') {
-                    throw new ParsingException(source(escapeCtx.escape), "Char [{}] cannot be used for escaping", escape);
+                    throw new ParsingException(source(escapeCtx.escape),
+                            "Char [{}] cannot be used for escaping as it's one of the wildcard chars [%_]", escape);
                 }
                 // lastly validate that escape chars (if present) are followed by special chars
                 for (int i = 0; i < pattern.length(); i++) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/LikeEscapingParsingTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/LikeEscapingParsingTests.java
@@ -74,9 +74,9 @@ public class LikeEscapingParsingTests extends ESTestCase {
 
     public void testEscapingWildcards() {
         assertThat(error("'string' ESCAPE '%'"),
-                is("line 1:27: Char [%] cannot be used for escaping"));
+                is("line 1:27: Char [%] cannot be used for escaping as it's one of the wildcard chars [%_]"));
         assertThat(error("'string' ESCAPE '_'"),
-            is("line 1:27: Char [_] cannot be used for escaping"));
+            is("line 1:27: Char [_] cannot be used for escaping as it's one of the wildcard chars [%_]"));
     }
 
     public void testCanUseStarWithoutEscaping() {


### PR DESCRIPTION
Mentions the list of wildchars in case a wildchar is used as an
`ESCAPE` character.

Relates #63428