### PR TITLE
Copy attributes when backing up and restoring custom configurations

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -58,6 +58,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
@@ -431,7 +432,7 @@ public abstract class PackagingTestCase extends Assert {
         Platforms.onLinux(() -> sh.run("chown -R elasticsearch:elasticsearch " + tempDir));
 
         if (distribution.isPackage()) {
-            Files.copy(installation.envFile, tempDir.resolve("elasticsearch.bk"));// backup
+            Files.copy(installation.envFile, tempDir.resolve("elasticsearch.bk"), StandardCopyOption.COPY_ATTRIBUTES);// backup
             append(installation.envFile, "ES_PATH_CONF=" + tempConf + "\n");
         } else {
             sh.getEnv().put("ES_PATH_CONF", tempConf.toString());
@@ -440,7 +441,7 @@ public abstract class PackagingTestCase extends Assert {
         action.accept(tempConf);
         if (distribution.isPackage()) {
             IOUtils.rm(installation.envFile);
-            Files.copy(tempDir.resolve("elasticsearch.bk"), installation.envFile);
+            Files.copy(tempDir.resolve("elasticsearch.bk"), installation.envFile, StandardCopyOption.COPY_ATTRIBUTES);
         } else {
             sh.getEnv().remove("ES_PATH_CONF");
         }


### PR DESCRIPTION
I ran into an issue when adding a test in #63500. In the case of packages (not archives), the code that handles custom configs was restoring original configuration files with different permissions than what those files had originally. Under the original installation, the configuration "envfile" has permissions `-rw-rw---- 1 root elasticsearch`, but when restored, the file gets permissions `-rw-r----- 1 root root`. This prevents Elasticsearch from starting. We have not run into this issue before now because the package tests that use the `withCustomConfig` method happen to be separated by a test that reinstalls the package.

This issue can be reproduced on the main branch with the following addition to `PackageTests.java`:

```
    public void test91WithCustomConfigTwice() throws Exception {
        withCustomConfig(tempConf -> {
            startElasticsearch();
            stopElasticsearch();
        });

        withCustomConfig(tempConf -> {
            startElasticsearch();
            stopElasticsearch();
        });
    }
```