### PR TITLE
Remove generics from Mapper.Builder

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -48,7 +48,6 @@ public class RankFeaturesFieldMapper extends ParametrizedFieldMapper {
 
         public Builder(String name) {
             super(name);
-            builder = this;
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -61,13 +61,12 @@ public class MetaJoinFieldMapper extends FieldMapper {
         }
     }
 
-    static class Builder extends FieldMapper.Builder<Builder> {
+    static class Builder extends FieldMapper.Builder {
 
         final String joinField;
 
         Builder(String joinField) {
             super(NAME, Defaults.FIELD_TYPE);
-            builder = this;
             this.joinField = joinField;
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -68,13 +68,12 @@ public final class ParentIdFieldMapper extends FieldMapper {
         }
     }
 
-    static class Builder extends FieldMapper.Builder<Builder> {
+    static class Builder extends FieldMapper.Builder {
         private final String parent;
         private final Set<String> children;
 
         Builder(String name, String parent, Set<String> children) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
             this.parent = parent;
             this.children = children;
         }
@@ -85,7 +84,7 @@ public final class ParentIdFieldMapper extends FieldMapper {
 
         public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
-            return builder;
+            return this;
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -137,24 +137,23 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
         final List<ParentIdFieldMapper.Builder> parentIdFieldBuilders = new ArrayList<>();
         boolean eagerGlobalOrdinals = true;
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
         public Builder addParent(String parent, Set<String> children) {
             String parentIdFieldName = getParentIdFieldName(name, parent);
             parentIdFieldBuilders.add(new ParentIdFieldMapper.Builder(parentIdFieldName, parent, children));
-            return builder;
+            return this;
         }
 
         public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
-            return builder;
+            return this;
         }
 
         @Override
@@ -178,7 +177,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             final IndexSettings indexSettings = parserContext.mapperService().getIndexSettings();
             checkIndexCompatibility(indexSettings, name);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -118,8 +118,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
-    public abstract static class Builder<T extends Builder<T, FT>, FT extends AbstractGeometryFieldType>
-            extends FieldMapper.Builder<T> {
+    public abstract static class Builder extends FieldMapper.Builder {
         protected Boolean ignoreMalformed;
         protected Boolean ignoreZValue;
         protected boolean indexed = true;

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -57,8 +57,7 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         DEFAULT_FIELD_TYPE.freeze();
     }
 
-    public abstract static class Builder<T extends Builder<T, FT>,
-            FT extends AbstractPointGeometryFieldType> extends AbstractGeometryFieldMapper.Builder<T, FT> {
+    public abstract static class Builder extends AbstractGeometryFieldMapper.Builder {
 
         protected ParsedPoint nullValue;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -48,8 +48,7 @@ public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extend
         public static final Explicit<Boolean> COERCE = new Explicit<>(false, false);
     }
 
-    public abstract static class Builder<T extends Builder<T, FT>,
-            FT extends AbstractShapeGeometryFieldType> extends AbstractGeometryFieldMapper.Builder<T, FT> {
+    public abstract static class Builder extends AbstractGeometryFieldMapper.Builder {
         protected Boolean coerce;
         protected Orientation orientation;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -620,15 +620,15 @@ final class DocumentParser {
         }
     }
 
-    private static Mapper.Builder<?> newLongBuilder(String name, Settings settings) {
+    private static Mapper.Builder newLongBuilder(String name, Settings settings) {
         return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, settings);
     }
 
-    private static Mapper.Builder<?> newFloatBuilder(String name, Settings settings) {
+    private static Mapper.Builder newFloatBuilder(String name, Settings settings) {
         return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.FLOAT, settings);
     }
 
-    private static Mapper.Builder<?> createBuilderFromDynamicValue(final ParseContext context,
+    private static Mapper.Builder createBuilderFromDynamicValue(final ParseContext context,
                                                                      XContentParser.Token token,
                                                                      String currentFieldName) throws IOException {
         if (token == XContentParser.Token.VALUE_STRING) {
@@ -747,7 +747,7 @@ final class DocumentParser {
             return;
         }
         final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
-        final Mapper.Builder<?> builder = createBuilderFromDynamicValue(context, token, currentFieldName);
+        final Mapper.Builder builder = createBuilderFromDynamicValue(context, token, currentFieldName);
         Mapper mapper = builder.build(builderContext);
         context.addDynamicMapper(mapper);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -133,7 +133,7 @@ public final class FieldAliasMapper extends Mapper {
         }
     }
 
-    public static class Builder extends Mapper.Builder<FieldAliasMapper.Builder> {
+    public static class Builder extends Mapper.Builder {
         private String name;
         private String path;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -52,7 +52,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         Setting.boolSetting("index.mapping.ignore_malformed", false, Property.IndexScope);
     public static final Setting<Boolean> COERCE_SETTING =
         Setting.boolSetting("index.mapping.coerce", false, Property.IndexScope);
-    public abstract static class Builder<T extends Builder<T>> extends Mapper.Builder<T> {
+    public abstract static class Builder extends Mapper.Builder {
 
         protected final FieldType fieldType;
         protected boolean omitNormsSet = false;
@@ -75,95 +75,95 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             multiFieldsBuilder = new MultiFields.Builder();
         }
 
-        public T index(boolean index) {
+        public Builder index(boolean index) {
             this.indexed = index;
             if (index == false) {
                 this.fieldType.setIndexOptions(IndexOptions.NONE);
             }
-            return builder;
+            return this;
         }
 
-        public T store(boolean store) {
+        public Builder store(boolean store) {
             this.fieldType.setStored(store);
-            return builder;
+            return this;
         }
 
-        public T docValues(boolean docValues) {
+        public FieldMapper.Builder docValues(boolean docValues) {
             this.hasDocValues = docValues;
-            return builder;
+            return this;
         }
 
-        public T storeTermVectors(boolean termVectors) {
+        public Builder storeTermVectors(boolean termVectors) {
             if (termVectors != this.fieldType.storeTermVectors()) {
                 this.fieldType.setStoreTermVectors(termVectors);
             } // don't set it to false, it is default and might be flipped by a more specific option
-            return builder;
+            return this;
         }
 
-        public T storeTermVectorOffsets(boolean termVectorOffsets) {
+        public Builder storeTermVectorOffsets(boolean termVectorOffsets) {
             if (termVectorOffsets) {
                 this.fieldType.setStoreTermVectors(termVectorOffsets);
             }
             this.fieldType.setStoreTermVectorOffsets(termVectorOffsets);
-            return builder;
+            return this;
         }
 
-        public T storeTermVectorPositions(boolean termVectorPositions) {
+        public Builder storeTermVectorPositions(boolean termVectorPositions) {
             if (termVectorPositions) {
                 this.fieldType.setStoreTermVectors(termVectorPositions);
             }
             this.fieldType.setStoreTermVectorPositions(termVectorPositions);
-            return builder;
+            return this;
         }
 
-        public T storeTermVectorPayloads(boolean termVectorPayloads) {
+        public Builder storeTermVectorPayloads(boolean termVectorPayloads) {
             if (termVectorPayloads) {
                 this.fieldType.setStoreTermVectors(termVectorPayloads);
             }
             this.fieldType.setStoreTermVectorPayloads(termVectorPayloads);
-            return builder;
+            return this;
         }
 
-        public T omitNorms(boolean omitNorms) {
+        public Builder omitNorms(boolean omitNorms) {
             this.fieldType.setOmitNorms(omitNorms);
             this.omitNormsSet = true;
-            return builder;
+            return this;
         }
 
-        public T indexOptions(IndexOptions indexOptions) {
+        public Builder indexOptions(IndexOptions indexOptions) {
             this.fieldType.setIndexOptions(indexOptions);
             this.indexOptionsSet = true;
-            return builder;
+            return this;
         }
 
-        public T indexAnalyzer(NamedAnalyzer indexAnalyzer) {
+        public Builder indexAnalyzer(NamedAnalyzer indexAnalyzer) {
             this.indexAnalyzer = indexAnalyzer;
-            return builder;
+            return this;
         }
 
-        public T searchAnalyzer(NamedAnalyzer searchAnalyzer) {
+        public Builder searchAnalyzer(NamedAnalyzer searchAnalyzer) {
             this.searchAnalyzer = searchAnalyzer;
-            return builder;
+            return this;
         }
 
-        public T searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
+        public Builder searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
             this.searchQuoteAnalyzer = searchQuoteAnalyzer;
-            return builder;
+            return this;
         }
 
-        public T setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
+        public Builder setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
-            return builder;
+            return this;
         }
 
-        public T addMultiField(Mapper.Builder<?> mapperBuilder) {
+        public Builder addMultiField(Mapper.Builder mapperBuilder) {
             multiFieldsBuilder.add(mapperBuilder);
-            return builder;
+            return this;
         }
 
-        public T copyTo(CopyTo copyTo) {
+        public Builder copyTo(CopyTo copyTo) {
             this.copyTo = copyTo;
-            return builder;
+            return this;
         }
 
         protected String buildFullName(BuilderContext context) {
@@ -171,10 +171,13 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
 
         /** Set metadata on this field. */
-        public T meta(Map<String, String> meta) {
+        public Builder meta(Map<String, String> meta) {
             this.meta = meta;
-            return (T) this;
+            return this;
         }
+
+        @Override
+        public abstract FieldMapper build(BuilderContext context);
     }
 
     protected FieldType fieldType;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -63,12 +63,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         FIELD_TYPE.freeze();
     }
 
-    public static class Builder extends AbstractPointGeometryFieldMapper.Builder<Builder, GeoPointFieldType> {
+    public static class Builder extends AbstractPointGeometryFieldMapper.Builder {
 
         public Builder(String name) {
             super(name, FIELD_TYPE);
             hasDocValues = true;
-            builder = this;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -63,7 +63,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         FIELD_TYPE.freeze();
     }
 
-    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder,GeoShapeFieldType> {
+    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder {
 
         public Builder(String name) {
             super (name, FIELD_TYPE);

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -184,8 +184,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
 
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(LegacyGeoShapeFieldMapper.class);
 
-    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder,
-        LegacyGeoShapeFieldMapper.GeoShapeFieldType> {
+    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder {
 
         DeprecatedParameters deprecatedParameters;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -58,11 +58,9 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
     }
 
-    public abstract static class Builder<T extends Builder> {
+    public abstract static class Builder {
 
         public String name;
-
-        protected T builder;
 
         protected Builder(String name) {
             this.name = name;
@@ -173,7 +171,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         }
 
-        Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
+        Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
     }
 
     private final String simpleName;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -132,8 +132,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
     }
 
-    @SuppressWarnings("rawtypes")
-    public static class Builder<T extends Builder> extends Mapper.Builder<T> {
+    public static class Builder extends Mapper.Builder {
 
         protected Explicit<Boolean> enabled = new Explicit<>(true, false);
 
@@ -143,30 +142,28 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         protected final List<Mapper.Builder> mappersBuilders = new ArrayList<>();
 
-        @SuppressWarnings("unchecked")
         public Builder(String name) {
             super(name);
-            this.builder = (T) this;
         }
 
-        public T enabled(boolean enabled) {
+        public Builder enabled(boolean enabled) {
             this.enabled = new Explicit<>(enabled, true);
-            return builder;
+            return this;
         }
 
-        public T dynamic(Dynamic dynamic) {
+        public Builder dynamic(Dynamic dynamic) {
             this.dynamic = dynamic;
-            return builder;
+            return this;
         }
 
-        public T nested(Nested nested) {
+        public Builder nested(Nested nested) {
             this.nested = nested;
-            return builder;
+            return this;
         }
 
-        public T add(Mapper.Builder builder) {
+        public Builder add(Mapper.Builder builder) {
             mappersBuilders.add(builder);
-            return this.builder;
+            return this;
         }
 
         @Override
@@ -317,9 +314,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     }
                     String[] fieldNameParts = fieldName.split("\\.");
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
-                    Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
+                    Mapper.Builder fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {
-                        ObjectMapper.Builder<?> intermediate = new ObjectMapper.Builder<>(fieldNameParts[i]);
+                        ObjectMapper.Builder intermediate = new ObjectMapper.Builder(fieldNameParts[i]);
                         intermediate.add(fieldBuilder);
                         fieldBuilder = intermediate;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -496,7 +496,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     /**
      * A Builder for a ParametrizedFieldMapper
      */
-    public abstract static class Builder extends Mapper.Builder<Builder> {
+    public abstract static class Builder extends Mapper.Builder {
 
         protected final MultiFields.Builder multiFieldsBuilder = new MultiFields.Builder();
         protected final CopyTo.Builder copyTo = new CopyTo.Builder();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -57,7 +57,7 @@ public class RootObjectMapper extends ObjectMapper {
         public static final boolean NUMERIC_DETECTION = false;
     }
 
-    public static class Builder extends ObjectMapper.Builder<Builder> {
+    public static class Builder extends ObjectMapper.Builder {
 
         protected Explicit<DynamicTemplate[]> dynamicTemplates = new Explicit<>(new DynamicTemplate[0], false);
         protected Explicit<DateFormatter[]> dynamicDateTimeFormatters = new Explicit<>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
@@ -66,7 +66,6 @@ public class RootObjectMapper extends ObjectMapper {
 
         public Builder(String name) {
             super(name);
-            this.builder = this;
         }
 
         public Builder dynamicDateTimeFormatter(Collection<DateFormatter> dateTimeFormatters) {
@@ -76,6 +75,12 @@ public class RootObjectMapper extends ObjectMapper {
 
         public Builder dynamicTemplates(Collection<DynamicTemplate> templates) {
             this.dynamicTemplates = new Explicit<>(templates.toArray(new DynamicTemplate[0]), true);
+            return this;
+        }
+
+        @Override
+        public RootObjectMapper.Builder add(Mapper.Builder builder) {
+            super.add(builder);
             return this;
         }
 
@@ -391,7 +396,7 @@ public class RootObjectMapper extends ObjectMapper {
             String templateName = "__dynamic__" + dynamicTemplate.name();
             Map<String, Object> fieldTypeConfig = dynamicTemplate.mappingForName(templateName, defaultDynamicType);
             try {
-                Mapper.Builder<?> dummyBuilder = typeParser.parse(templateName, fieldTypeConfig, parserContext);
+                Mapper.Builder dummyBuilder = typeParser.parse(templateName, fieldTypeConfig, parserContext);
                 fieldTypeConfig.remove("type");
                 if (fieldTypeConfig.isEmpty()) {
                     Settings indexSettings = parserContext.mapperService().getIndexSettings().getSettings();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -300,7 +300,7 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
             return this;
         }
 
-        public Builder addMultiField(Mapper.Builder<?> builder) {
+        public Builder addMultiField(Mapper.Builder builder) {
             this.multiFieldsBuilder.add(builder);
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -101,7 +101,7 @@ public class TypeParsers {
     /**
      * Parse common field attributes such as {@code doc_values} or {@code store}.
      */
-    public static void parseField(FieldMapper.Builder<?> builder, String name, Map<String, Object> fieldNode,
+    public static void parseField(FieldMapper.Builder builder, String name, Map<String, Object> fieldNode,
                                   Mapper.TypeParser.ParserContext parserContext) {
         for (Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().iterator(); iterator.hasNext();) {
             Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -258,7 +258,7 @@ public class QueryShardContext extends QueryRewriteContext {
         if (typeParser == null) {
             throw new IllegalArgumentException("No mapper found for type [" + type + "]");
         }
-        final Mapper.Builder<?> builder = typeParser.parse("__anonymous_" + type, Collections.emptyMap(), parserContext);
+        final Mapper.Builder builder = typeParser.parse("__anonymous_" + type, Collections.emptyMap(), parserContext);
         final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(indexSettings.getSettings(), new ContentPath(1));
         Mapper mapper = builder.build(builderContext);
         if (mapper instanceof FieldMapper) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -357,7 +357,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         for (int i = 0; i < nameParts.length - 1; ++i) {
             context.path().add(nameParts[i]);
         }
-        Mapper.Builder<?> builder = new ObjectMapper.Builder<>(nameParts[nameParts.length - 1]).enabled(true);
+        Mapper.Builder builder = new ObjectMapper.Builder(nameParts[nameParts.length - 1]).enabled(true);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
         return (ObjectMapper)builder.build(builderContext);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -56,7 +56,7 @@ public class ExternalMapper extends ParametrizedFieldMapper {
         private final BooleanFieldMapper.Builder boolBuilder = new BooleanFieldMapper.Builder(Names.FIELD_BOOL);
         private final GeoPointFieldMapper.Builder latLonPointBuilder = new GeoPointFieldMapper.Builder(Names.FIELD_POINT);
         private final GeoShapeFieldMapper.Builder shapeBuilder = new GeoShapeFieldMapper.Builder(Names.FIELD_SHAPE);
-        private final Mapper.Builder<?> stringBuilder;
+        private final Mapper.Builder stringBuilder;
         private final String generatedValue;
         private final String mapperName;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -45,7 +45,6 @@ public class FakeStringFieldMapper extends ParametrizedFieldMapper {
 
         public Builder(String name) {
             super(name);
-            builder = this;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -126,7 +126,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
     private static RootObjectMapper createRootObjectMapper(String name, boolean enabled, Map<String, Mapper> mappers) {
         final Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
         final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final RootObjectMapper rootObjectMapper = new RootObjectMapper.Builder(name).enabled(enabled).build(context);
+        final RootObjectMapper rootObjectMapper = (RootObjectMapper) new RootObjectMapper.Builder(name).enabled(enabled).build(context);
 
         mappers.values().forEach(rootObjectMapper::putMapper);
 
@@ -136,7 +136,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
     private static ObjectMapper createObjectMapper(String name, boolean enabled, Map<String, Mapper> mappers) {
         final Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
         final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final ObjectMapper mapper = new ObjectMapper.Builder<>(name).enabled(enabled).build(context);
+        final ObjectMapper mapper = new ObjectMapper.Builder(name).enabled(enabled).build(context);
 
         mappers.values().forEach(mapper::putMapper);
 
@@ -146,7 +146,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
     private static ObjectMapper createNestedMapper(String name, ObjectMapper.Nested nested) {
         final Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
         final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        return new ObjectMapper.Builder<>(name)
+        return new ObjectMapper.Builder(name)
             .nested(nested)
             .build(context);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -146,7 +146,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             builder.parse(name, parserContext, node);
             return builder;

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -55,7 +55,7 @@ public class IndicesModuleTests extends ESTestCase {
 
     private static class FakeMapperParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext)
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
             throws MapperParsingException {
             return null;
         }

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -213,7 +213,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             @Override
             public ObjectMapper getObjectMapper(String name) {
                 BuilderContext context = new BuilderContext(this.getIndexSettings().getSettings(), new ContentPath());
-                return new ObjectMapper.Builder<>(name).nested(Nested.newNested()).build(context);
+                return new ObjectMapper.Builder(name).nested(Nested.newNested()).build(context);
             }
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.equalTo;
  * @deprecated prefer {@link FieldMapperTestCase2}
  */
 @Deprecated
-public abstract class FieldMapperTestCase<T extends FieldMapper.Builder<?>> extends ESSingleNodeTestCase {
+public abstract class FieldMapperTestCase<T extends FieldMapper.Builder> extends ESSingleNodeTestCase {
 
     protected final Settings SETTINGS = Settings.builder()
         .put("index.version.created", Version.CURRENT)

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase2.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldMapperTestCase2.java
@@ -44,7 +44,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Base class for testing {@link FieldMapper}s.
  * @param <T> builder for the mapper to test
  */
-public abstract class FieldMapperTestCase2<T extends FieldMapper.Builder<?>> extends MapperTestCase {
+public abstract class FieldMapperTestCase2<T extends FieldMapper.Builder> extends MapperTestCase {
     private final class Modifier {
         final String property;
         final boolean updateable;

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -90,7 +90,6 @@ public class MockFieldMapper extends ParametrizedFieldMapper {
         protected Builder(String name) {
             super(name);
             this.fieldType = new FakeFieldType(name);
-            this.builder = this;
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -322,7 +322,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             String fieldName = (String) invocation.getArguments()[0];
             if (fieldName.startsWith(NESTEDFIELD_PREFIX)) {
                 BuilderContext context = new BuilderContext(indexSettings.getSettings(), new ContentPath());
-                return new ObjectMapper.Builder<>(fieldName).nested(Nested.newNested()).build(context);
+                return new ObjectMapper.Builder(fieldName).nested(Nested.newNested()).build(context);
             }
             return null;
         });

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -107,7 +107,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         public static final int IGNORE_ABOVE = Integer.MAX_VALUE;
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
         private int depthLimit = Defaults.DEPTH_LIMIT;
         private int ignoreAbove = Defaults.IGNORE_ABOVE;
         private String nullValue = null;
@@ -116,11 +116,10 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
         @Override
-        public Builder indexOptions(IndexOptions indexOptions) {
+        public FieldMapper.Builder indexOptions(IndexOptions indexOptions) {
             if (indexOptions.compareTo(IndexOptions.DOCS_AND_FREQS) > 0) {
                 throw new IllegalArgumentException("The [" + CONTENT_TYPE
                     + "] field does not support positions, got [index_options]="
@@ -139,7 +138,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
         public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
-            return builder;
+            return this;
         }
 
         public Builder ignoreAbove(int ignoreAbove) {
@@ -157,11 +156,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
         public Builder splitQueriesOnWhitespace(boolean splitQueriesOnWhitespace) {
             this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
-            return builder;
+            return this;
         }
 
         @Override
-        public Builder addMultiField(Mapper.Builder<?> mapperBuilder) {
+        public Builder addMultiField(Mapper.Builder mapperBuilder) {
             throw new UnsupportedOperationException("[fields] is not supported for [" + CONTENT_TYPE + "] fields.");
         }
 
@@ -188,7 +187,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.GeoShapeParser;
@@ -68,7 +69,7 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
         FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
     }
 
-    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder, GeoShapeWithDocValuesFieldType> {
+    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder {
 
         private boolean docValuesSet = false;
 
@@ -78,7 +79,7 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
         }
 
         @Override
-        public Builder docValues(boolean docValues) {
+        public FieldMapper.Builder docValues(boolean docValues) {
             docValuesSet = true;
             return super.docValues(docValues);
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -36,10 +36,9 @@ import java.util.Map;
 public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<ParsedCartesianPoint>, List<? extends CartesianPoint>> {
     public static final String CONTENT_TYPE = "point";
 
-    public static class Builder extends AbstractPointGeometryFieldMapper.Builder<Builder, PointFieldType> {
+    public static class Builder extends AbstractPointGeometryFieldMapper.Builder {
         public Builder(String name) {
             super(name, new FieldType());
-            builder = this;
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -43,13 +43,11 @@ import java.util.Map;
 public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry, Geometry> {
     public static final String CONTENT_TYPE = "shape";
 
-    @SuppressWarnings({"unchecked"})
-    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder, ShapeFieldType> {
+    public static class Builder extends AbstractShapeGeometryFieldMapper.Builder {
 
         public Builder(String name) {
             super(name, new FieldType());
             fieldType.setDimensions(7, 4, Integer.BYTES);
-            builder = this;
         }
 
         @Override


### PR DESCRIPTION
We simplified the generics on Mapper.Builder in #56747, but stopped short
of removing them entirely because they were still used in various places in
the code.  Now that most field mappers have been converted to parametrized
form, these generics are no longer useful.  There are very few places where
a fluent Builder pattern is used, almost all in tests, and these can all be
replaced with simple casts; in exchange, we remove lots of visual cruft and
clean up a number of warnings.