### PR TITLE
[7.x] [ML] use node.roles as node.ml is deprecated in test external cluster (#63566)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -138,6 +138,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             throw new IllegalStateException("error trying to get keystore path", e);
         }
         Settings.Builder builder = Settings.builder();
+        builder.putList("node.roles", Collections.emptyList());
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
         builder.put(SecurityField.USER_SETTING.getKey(), "x_pack_rest_user:" + SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
         builder.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), true);


### PR DESCRIPTION
Adjusts the external test cluster settings to use the new `node.roles` settings instead of the
`node.<role_name>: <boolean>` settings.

closes #63553

