### PR TITLE
Apply publish to the logger-usage plugin

### DIFF
--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -18,6 +18,7 @@
  */
 
 apply plugin: 'elasticsearch.java'
+apply plugin: 'elasticsearch.publish'
 
 dependencies {
   api 'org.ow2.asm:asm:7.1'


### PR DESCRIPTION
The `LoggerUsagePrecommitPlugin` supports external usage of the logger-usage
project. However, the logger-usage project is not currently published. This 
commit adds the publish plugin to the logger-usage project. 

====

Note - this was noticed while testing the external consumption of the build project for
an un-related concern. 