### PR TITLE
[7.10] [DOCS] EQL: Document multi-value field support (#63622)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -693,6 +693,14 @@ another field. This applies even if the fields are changed using a
 <<eql-functions,function>>.
 
 [discrete]
+[[eql-array-fields]]
+==== Array field values are not supported
+
+{es} EQL does not support <<array,array>> field values, also known as
+_multi-value fields_. EQL searches on array field values may return inconsistent
+results.
+
+[discrete]
 [[eql-nested-fields]]
 ==== EQL search on nested fields
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] EQL: Document multi-value field support (#63622)