### PR TITLE
[DOCS] Correct relevance calculation for distance_feature

### DIFF
--- a/docs/reference/query-dsl/distance-feature-query.asciidoc
+++ b/docs/reference/query-dsl/distance-feature-query.asciidoc
@@ -211,7 +211,7 @@ The `distance_feature` query calculates a document's
 <<relevance-scores,relevance score>> as follows:
 
 ```
-relevance score = boost * pivot / (pivot + distance)
+relevance score = weight * pivot / (pivot + distance)
 ```
 
 The `distance` is the absolute difference between the `origin` value and a

--- a/docs/reference/query-dsl/distance-feature-query.asciidoc
+++ b/docs/reference/query-dsl/distance-feature-query.asciidoc
@@ -214,6 +214,7 @@ The `distance_feature` query calculates a document's
 relevance score = weight * pivot / (pivot + distance)
 ```
 
+The `weight` is `boost^2`.
 The `distance` is the absolute difference between the `origin` value and a
 document's field value.
 


### PR DESCRIPTION
The relevance score calculation for `distance_feature` appears to use `weight`, not `boost`. In most (all?) cases, `weight` seems to be `boost^2`. Sample calls and portions of responses below.

1. Configure the index and documents as listed [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/query-dsl-distance-feature-query.html#distance-feature-index-setup).

2. Search with the default boost:

```
GET items/_search
{
  "query": {
    "bool": {
      "should": {
        "distance_feature": {
          "field": "location",
          "pivot": "1000m",
          "origin": [-71.3, 41.15],
          "boost": 1
        }
      }
    }
  }
}
```

Top result (document 2) has a score of 1.0.

3. Increase boost to 3:

```
GET items/_search
{
  "query": {
    "bool": {
      "should": {
        "distance_feature": {
          "field": "location",
          "pivot": "1000m",
          "origin": [-71.3, 41.15],
          "boost": 3
        }
      }
    }
  }
}
```

Top result now has a score of 9, not 3, like you'd expect based on the documentation.

4. Explain the result:

```
GET items/_explain/2
{
  "query": {
    "bool": {
      "should": {
        "distance_feature": {
          "field": "location",
          "pivot": "1000m",
          "origin": [-71.3, 41.15],
          "boost": 3
        }
      }
    }
  }
}

"value": 9.0,
"description": "Distance score, computed as weight * pivotDistance / (pivotDistance + abs(distance)) from:",
"details": [
  {
    "value": 9.0,
    "description": "weight",
    "details": []
  },
  ...
]
```

The explain description references `weight`, so it seems OK to use it in the documentation, as well.

5. The same logic appears to apply to dates:

```
GET items/_search
{
  "query": {
    "bool": {
      "should": {
        "distance_feature": {
          "field": "production_date",
          "pivot": "10d",
          "origin": "1514764800000",
          "boost": 3
        }
      }
    }
  }
}
```

I'm not clear on the distinction between `this.boost` and `boost`, but you can see them being multiplied in line 73 of `LongScriptFieldDistanceFeatureQuery`:

```
float weight = LongScriptFieldDistanceFeatureQuery.this.boost * boost;
```