### PR TITLE
Adapt Shard Generation Assertion for 7.x (#63625)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/InFlightShardSnapshotStates.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InFlightShardSnapshotStates.java
@@ -102,9 +102,9 @@ public final class InFlightShardSnapshotStates {
     }
 
     private static boolean assertGenerationConsistency(Map<String, Map<Integer, String>> generations, String indexName,
-                                                       int shardId, String activeGeneration) {
+                                                       int shardId, @Nullable String activeGeneration) {
         final String bestGeneration = generations.getOrDefault(indexName, Collections.emptyMap()).get(shardId);
-        assert bestGeneration == null || activeGeneration.equals(bestGeneration);
+        assert bestGeneration == null || activeGeneration == null || activeGeneration.equals(bestGeneration);
         return true;
     }
 


### PR DESCRIPTION
In 7.x we can have `null` generations so we need to adjust the `assert`
accordingly.
See e.g. failure https://gradle-enterprise.elastic.co/s/dgypleytdotfu/tests/:server:internalClusterTest/org.elasticsearch.snapshots.ConcurrentSnapshotsIT/testConcurrentSnapshotWorksWithOldVersionRepo

backport of #63625 