### PR TITLE
[DOCS] Fix the default value of scroll_size for update-by-query and d…

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -772,7 +772,7 @@ end::scroll[]
 tag::scroll_size[]
 `scroll_size`::
 (Optional, integer) Size of the scroll request that powers the operation.
-Defaults to 100.
+Defaults to 1000.
 end::scroll_size[]
 
 tag::search-failures[]


### PR DESCRIPTION
Closes #63637.
The  default value of `scroll_size` in `update-by-query` and `delete-by-query` API is 1000 actually, but the value is 100 in the document.