### PR TITLE
[Transform] add support for "missing" aggregation

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -660,6 +660,7 @@ supported:
 * <<search-aggregations-metrics-geocentroid-aggregation,Geo centroid>>
 * <<search-aggregations-metrics-max-aggregation,Max>>
 * <<search-aggregations-metrics-min-aggregation,Min>>
+* <<search-aggregations-bucket-missing-aggregation,Missing>>
 * <<search-aggregations-metrics-percentile-aggregation,Percentiles>>
 * <<search-aggregations-bucket-rare-terms-aggregation, Rare Terms>>
 * <<search-aggregations-metrics-scripted-metric-aggregation,Scripted metric>>

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -87,10 +87,13 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
         // get and check some users
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_0", 3.776978417);
+        assertOneCount(transformIndex + "/_search?q=reviewer:user_0", "hits.hits._source.affiliate_missing", 0);
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_5", 3.72);
+        assertOneCount(transformIndex + "/_search?q=reviewer:user_5", "hits.hits._source.affiliate_missing", 25);
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_11", 3.846153846);
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_20", 3.769230769);
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_26", 3.918918918);
+        assertOneCount(transformIndex + "/_search?q=reviewer:user_26", "hits.hits._source.affiliate_missing", 0);
     }
 
     public void testSimpleDataStreamPivot() throws Exception {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -66,7 +66,6 @@ public final class TransformAggregations {
         "ip_range",
         "matrix_stats",
         "median_absolute_deviation",
-        "missing",
         "nested",
         "percentile_ranks",
         "range",
@@ -110,7 +109,8 @@ public final class TransformAggregations {
         PERCENTILES("percentiles", DOUBLE),
         FILTER("filter", LONG),
         TERMS("terms", FLATTENED),
-        RARE_TERMS("rare_terms", FLATTENED);
+        RARE_TERMS("rare_terms", FLATTENED),
+        MISSING("missing", LONG);
 
         private final String aggregationType;
         private final String targetMapping;


### PR DESCRIPTION
add support for the missing (bucket) aggregation (counts docs with a configured missing field value) in
transform. The output is mapped to `name:count`, the mapping type is `long`.

Doc changes: https://elasticsearch_63651.docs-preview.app.elstc.co/diff