### PR TITLE
[Docs] Correct default scroll_size for update by query

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -772,7 +772,7 @@ end::scroll[]
 tag::scroll_size[]
 `scroll_size`::
 (Optional, integer) Size of the scroll request that powers the operation.
-Defaults to 100.
+Defaults to 1000.
 end::scroll_size[]
 
 tag::search-failures[]


### PR DESCRIPTION
The current [_update_by_query documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#docs-update-by-query-api-query-params) mentions a `scroll_size` default of 100 and later another default of 1000.
I believe we use the default of 1000 defined in [AbstractBulkByScrollRequest here](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java#L47) and changed the documentation
accordingly. 
This should also be used by "_delete_by_query" and the change in the common parameter doc should also reflect that already.

Closes #63637