### PR TITLE
[Transform] increase timeout in testStopWaitForCheckpoint

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIntegTestCase.java
@@ -144,8 +144,9 @@ abstract class TransformIntegTestCase extends ESRestTestCase {
 
     // workaround for https://github.com/elastic/elasticsearch/issues/62204
     protected StartTransformResponse startTransformWithRetryOnConflict(String id, RequestOptions options) throws Exception {
+        final int totalRetries = 10;
         ElasticsearchStatusException lastConflict = null;
-        for (int retries = 10; retries > 0; --retries) {
+        for (int retries = totalRetries; retries > 0; --retries) {
             try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
                 return restClient.transform().startTransform(new StartTransformRequest(id), options);
             } catch (ElasticsearchStatusException e) {
@@ -162,7 +163,7 @@ abstract class TransformIntegTestCase extends ESRestTestCase {
                 }
 
                 lastConflict = e;
-                Thread.sleep(5);
+                Thread.sleep(5 * (1 + totalRetries - retries));
             }
         }
         throw lastConflict;


### PR DESCRIPTION
increase the overall timeout by increasing the wait time after every retry.

fixes #63365

Note: There haven't been any failures recently, the last one failed due to a timeout of `50ms`, this wasn't enough on a slow VM. The new global timeout waits `275ms`.