### PR TITLE
[7.10] [DOCS] Fix AbstractDiffable typo (#59034)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 /**
  * Abstract diffable object with simple diffs implementation that sends the entire object if object has changed or
- * nothing is object remained the same.
+ * nothing if object remained the same.
  */
 public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffable<T> {
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix AbstractDiffable typo (#59034)