### PR TITLE
Add helper functions for ByteSizeValues of a given unit

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -46,6 +46,30 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
 
     public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);
 
+    public static ByteSizeValue ofBytes(long size) {
+        return new ByteSizeValue(size);
+    }
+
+    public static ByteSizeValue ofKb(long size) {
+        return new ByteSizeValue(size, ByteSizeUnit.KB);
+    }
+
+    public static ByteSizeValue ofMb(long size) {
+        return new ByteSizeValue(size, ByteSizeUnit.MB);
+    }
+
+    public static ByteSizeValue ofGb(long size) {
+        return new ByteSizeValue(size, ByteSizeUnit.GB);
+    }
+
+    public static ByteSizeValue ofTb(long size) {
+        return new ByteSizeValue(size, ByteSizeUnit.TB);
+    }
+
+    public static ByteSizeValue ofPb(long size) {
+        return new ByteSizeValue(size, ByteSizeUnit.PB);
+    }
+
     private final long size;
     private final ByteSizeUnit unit;
 

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -323,6 +324,39 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             } else {
                 assertEquals((int) bytesValue, instance.bytesAsInt());
             }
+        }
+    }
+
+    public void testOfBytes() {
+        testOf(ByteSizeUnit.BYTES, ByteSizeValue::ofBytes);
+    }
+
+    public void testOfKb() {
+        testOf(ByteSizeUnit.KB, ByteSizeValue::ofKb);
+    }
+
+    public void testOfMb() {
+        testOf(ByteSizeUnit.MB, ByteSizeValue::ofMb);
+    }
+
+    public void testOfGb() {
+        testOf(ByteSizeUnit.GB, ByteSizeValue::ofGb);
+    }
+
+    public void testOfTb() {
+        testOf(ByteSizeUnit.TB, ByteSizeValue::ofTb);
+    }
+
+    public void testOfPb() {
+        testOf(ByteSizeUnit.PB, ByteSizeValue::ofPb);
+    }
+
+    private void testOf(ByteSizeUnit unit, Function<Long, ByteSizeValue> byteSizeValueFunction) {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            long size = randomIntBetween(1, 1000);
+            ByteSizeValue expected = new ByteSizeValue(size, unit);
+            ByteSizeValue actual = byteSizeValueFunction.apply(size);
+            assertThat(actual, equalTo(expected));
         }
     }
 }


### PR DESCRIPTION
As a developer that periodically worries about absolute sizes of bytes, I love our good ByteSizeValue abstractions + and the unit sizes.

But, I find the pattern `new ByteSizeValue(<some long>, <some unit>).getBytes()` frustrating. 

This commit adds some simple convenience methods for each byte unit and constructing a ByteSizeValue of the given size for that unit.