### PR TITLE
[ML] fix inference binary classification predication label and feature importance

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
@@ -213,7 +213,6 @@ public class EnsembleInferenceModel implements InferenceModel {
                     classificationLabel(topClasses.v1().getValue(), classificationLabels),
                     topClasses.v2(),
                     transformFeatureImportanceClassification(decodedFeatureImportance,
-                        value.getValue(),
                         classificationLabels,
                         classificationConfig.getPredictionFieldType()),
                     config,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModel.java
@@ -180,7 +180,6 @@ public class TreeInferenceModel implements InferenceModel {
                     classificationLabel(classificationValue.getValue(), classificationLabels),
                     topClasses.v2(),
                     InferenceHelpers.transformFeatureImportanceClassification(decodedFeatureImportance,
-                        classificationValue.getValue(),
                         classificationLabels,
                         classificationConfig.getPredictionFieldType()),
                     config,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
@@ -13,17 +13,27 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class PredictionFieldTypeTests extends ESTestCase {
 
+    private static final String NOT_BOOLEAN = "not_boolean";
+
     public void testTransformPredictedValueBoolean() {
-        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(null, randomBoolean() ? null : randomAlphaOfLength(10)),
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(null, randomBoolean() ? null : NOT_BOOLEAN),
             is(nullValue()));
-        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, randomBoolean() ? null : randomAlphaOfLength(10)),
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, randomBoolean() ? null : NOT_BOOLEAN),
             is(true));
-        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, randomBoolean() ? null : randomAlphaOfLength(10)),
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, randomBoolean() ? null : NOT_BOOLEAN),
             is(false));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, "1"), is(true));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, "0"), is(false));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, "TruE"), is(true));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(0.0, "fAlsE"), is(false));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, "0"), is(false));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, "1"), is(true));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, "TruE"), is(true));
+        assertThat(PredictionFieldType.BOOLEAN.transformPredictedValue(1.0, "fAlse"), is(false));
         expectThrows(IllegalArgumentException.class,
-            () -> PredictionFieldType.BOOLEAN.transformPredictedValue(0.1, randomBoolean() ? null : randomAlphaOfLength(10)));
+            () -> PredictionFieldType.BOOLEAN.transformPredictedValue(0.1, randomBoolean() ? null : NOT_BOOLEAN));
         expectThrows(IllegalArgumentException.class,
-            () -> PredictionFieldType.BOOLEAN.transformPredictedValue(1.1, randomBoolean() ? null : randomAlphaOfLength(10)));
+            () -> PredictionFieldType.BOOLEAN.transformPredictedValue(1.1, randomBoolean() ? null : NOT_BOOLEAN));
     }
 
     public void testTransformPredictedValueString() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
@@ -165,7 +165,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
                 .stream()
                 .map(i -> ((SingleValueInferenceResults)i).valueAsString())
                 .collect(Collectors.toList()),
-            contains("not_to_be", "to_be"));
+            contains("no", "yes"));
 
         // Get top classes
         request = new InternalInferModelAction.Request(modelId2, toInfer, new ClassificationConfigUpdate(2, null, null, null, null), true);
@@ -174,14 +174,14 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         ClassificationInferenceResults classificationInferenceResults =
             (ClassificationInferenceResults)response.getInferenceResults().get(0);
 
-        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("not_to_be"));
-        assertThat(classificationInferenceResults.getTopClasses().get(1).getClassification(), equalTo("to_be"));
+        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("no"));
+        assertThat(classificationInferenceResults.getTopClasses().get(1).getClassification(), equalTo("yes"));
         assertThat(classificationInferenceResults.getTopClasses().get(0).getProbability(),
             greaterThan(classificationInferenceResults.getTopClasses().get(1).getProbability()));
 
         classificationInferenceResults = (ClassificationInferenceResults)response.getInferenceResults().get(1);
-        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("to_be"));
-        assertThat(classificationInferenceResults.getTopClasses().get(1).getClassification(), equalTo("not_to_be"));
+        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("yes"));
+        assertThat(classificationInferenceResults.getTopClasses().get(1).getClassification(), equalTo("no"));
         // they should always be in order of Most probable to least
         assertThat(classificationInferenceResults.getTopClasses().get(0).getProbability(),
             greaterThan(classificationInferenceResults.getTopClasses().get(1).getProbability()));
@@ -192,7 +192,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
 
         classificationInferenceResults = (ClassificationInferenceResults)response.getInferenceResults().get(0);
         assertThat(classificationInferenceResults.getTopClasses(), hasSize(1));
-        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("to_be"));
+        assertThat(classificationInferenceResults.getTopClasses().get(0).getClassification(), equalTo("yes"));
     }
 
     public void testInferModelMultiClassModel() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -114,13 +114,13 @@ public class LocalModelTests extends ESTestCase {
             mock(CircuitBreaker.class));
         result = getSingleValue(model, fields, ClassificationConfigUpdate.EMPTY_PARAMS);
         assertThat(result.value(), equalTo(0.0));
-        assertThat(result.valueAsString(), equalTo("not_to_be"));
+        assertThat(result.valueAsString(), equalTo("no"));
 
         classificationResult = (ClassificationInferenceResults)getSingleValue(model,
             fields,
             new ClassificationConfigUpdate(1, null, null, null, null));
         assertThat(classificationResult.getTopClasses().get(0).getProbability(), closeTo(0.5498339973124778, 0.0000001));
-        assertThat(classificationResult.getTopClasses().get(0).getClassification(), equalTo("not_to_be"));
+        assertThat(classificationResult.getTopClasses().get(0).getClassification(), equalTo("no"));
         assertThat(model.getLatestStatsAndReset().getInferenceCount(), equalTo(2L));
 
         classificationResult = (ClassificationInferenceResults)getSingleValue(model,
@@ -169,11 +169,11 @@ public class LocalModelTests extends ESTestCase {
 
         IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
         writeResult(result, document, "result_field", modelId);
-        assertThat(document.getFieldValue("result_field.predicted_value", String.class), equalTo("not_to_be"));
+        assertThat(document.getFieldValue("result_field.predicted_value", String.class), equalTo("no"));
         List<?> list = document.getFieldValue("result_field.top_classes", List.class);
         assertThat(list.size(), equalTo(2));
-        assertThat(((Map<String, Object>)list.get(0)).get("class_name"), equalTo("not_to_be"));
-        assertThat(((Map<String, Object>)list.get(1)).get("class_name"), equalTo("to_be"));
+        assertThat(((Map<String, Object>)list.get(0)).get("class_name"), equalTo("no"));
+        assertThat(((Map<String, Object>)list.get(1)).get("class_name"), equalTo("yes"));
 
         result = getInferenceResult(model, fields, new ClassificationConfigUpdate(2, null, null, null, PredictionFieldType.NUMBER));
 
@@ -440,7 +440,7 @@ public class LocalModelTests extends ESTestCase {
             .addNode(TreeNode.builder(2).setLeafValue(0.0))
             .build();
         return Ensemble.builder()
-            .setClassificationLabels(includeLabels ? Arrays.asList("not_to_be", "to_be") : null)
+            .setClassificationLabels(includeLabels ? Arrays.asList("no", "yes") : null)
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))


### PR DESCRIPTION
When calculating feature importance, the leaf values directly correlate the value of the importance. 

Consequently, positive leaf values -> positive feature importance

negative leaf values -> negative feature importance. 

It follows that for binary classification, this is done such that the importance relates to the leaf values, which relate directly to the "probability of class 1".

So, the feature importance calculated is always for the importance as it relates to class 1.

The inverse is the importance as it relates to class 0.