### PR TITLE
EQL: Fix translation of bool fields

### DIFF
--- a/x-pack/plugin/eql/src/test/resources/mapping-default.json
+++ b/x-pack/plugin/eql/src/test/resources/mapping-default.json
@@ -87,6 +87,9 @@
         },
         "constant_keyword" : {
             "type" : "constant_keyword"
+        },
+        "bool" : {
+            "type" : "boolean"
         }
     }
 }

--- a/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
@@ -145,6 +145,49 @@ process where endsWith(user_name, "c")
 {"wildcard":{"user_name":{"wildcard":"*c","boost":1.0}}}],"boost":1.0}}
 ;
 
+fieldNoEquals
+process where bool
+;
+{"bool":{"must":[
+{"term":{"bool":{"value":true,
+;
+
+fieldNoEqualsInExpression
+process where length(file_name) > 0 and bool
+;
+{"bool":{"must":[
+{"term":{"bool":{"value":true,
+;
+
+
+fieldEqualsTrue
+process where bool == true
+;
+{"bool":{"must":[
+{"term":{"bool":{"value":true,
+;
+
+fieldEqualsFalse
+process where bool == false
+;
+{"bool":{"must":[
+{"term":{"bool":{"value":false
+;
+
+fieldNotEqualsTrue
+process where bool != true
+;
+{"bool":{"must_not":[
+{"term":{"bool":{"value":true
+;
+
+fieldNotEqualsFalse
+process where bool != false
+;
+{"bool":{"must_not":[
+{"term":{"bool":{"value":false
+;
+
 lengthFunctionWithExactSubField
 process where length(file_name) > 0
 ;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/BinaryScalarFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/BinaryScalarFunction.java
@@ -31,7 +31,10 @@ public abstract class BinaryScalarFunction extends ScalarFunction {
         if (newChildren.size() != 2) {
             throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
         }
-        return replaceChildren(newChildren.get(0), newChildren.get(1));
+        Expression newLeft = newChildren.get(0);
+        Expression newRight = newChildren.get(1);
+
+        return left.equals(newLeft) && right.equals(newRight) ? this : replaceChildren(newLeft, newRight);
     }
 
     protected abstract BinaryScalarFunction replaceChildren(Expression newLeft, Expression newRight);
@@ -63,7 +66,7 @@ public abstract class BinaryScalarFunction extends ScalarFunction {
         Check.isTrue(index > 0, "invalid package {}", prefix);
         return Scripts.binaryMethod("{" + prefix.substring(0, index) + "}", scriptMethodName(), leftScript, rightScript, dataType());
     }
-    
+
     protected String scriptMethodName() {
         return getClass().getSimpleName().toLowerCase(Locale.ROOT);
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -9,6 +9,7 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.Order;
+import org.elasticsearch.xpack.ql.expression.function.Function;
 import org.elasticsearch.xpack.ql.expression.function.scalar.SurrogateFunction;
 import org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.ql.expression.predicate.BinaryPredicate;
@@ -70,15 +71,15 @@ public final class OptimizerRules {
      * This rule must always be placed after {@link BooleanLiteralsOnTheRight}, since it looks at TRUE/FALSE literals' existence
      * on the right hand-side of the {@link Equals}/{@link NotEquals} expressions.
      */
-    public static final class BooleanEqualsSimplification extends OptimizerExpressionRule {
+    public static final class BooleanFunctionEqualsElimination extends OptimizerExpressionRule {
 
-        public BooleanEqualsSimplification() {
+        public BooleanFunctionEqualsElimination() {
             super(TransformDirection.UP);
         }
 
         @Override
         protected Expression rule(Expression e) {
-            if (e instanceof Equals || e instanceof NotEquals) {
+            if ((e instanceof Equals || e instanceof NotEquals) && ((BinaryComparison) e).left() instanceof Function)   {
                 // for expression "==" or "!=" TRUE/FALSE, return the expression itself or its negated variant
                 BinaryComparison bc = (BinaryComparison) e;
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Mod;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Mul;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Sub;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThanOrEqual;
@@ -35,7 +36,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.LikePattern;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLike;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLikePattern;
-import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanEqualsSimplification;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanFunctionEqualsElimination;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanSimplification;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons;
@@ -275,20 +276,33 @@ public class OptimizerRulesTests extends ESTestCase {
         assertEquals(expected, simplification.rule(actual));
     }
 
-    public void testBoolEqualsSimplification() {
-        BooleanEqualsSimplification s = new BooleanEqualsSimplification();
+    public void testBoolEqualsSimplificationOnExpressions() {
+        BooleanFunctionEqualsElimination s = new BooleanFunctionEqualsElimination();
+        Expression exp = new GreaterThan(EMPTY, getFieldAttribute(), L(0), null);
 
-        assertEquals(DUMMY_EXPRESSION, s.rule(new Equals(EMPTY, DUMMY_EXPRESSION, TRUE)));
-        assertEquals(new Not(EMPTY, DUMMY_EXPRESSION), s.rule(new Equals(EMPTY, DUMMY_EXPRESSION, FALSE)));
+        assertEquals(exp, s.rule(new Equals(EMPTY, exp, TRUE)));
+        assertEquals(new Not(EMPTY, exp), s.rule(new Equals(EMPTY, exp, FALSE)));
+    }
 
-        assertEquals(new Not(EMPTY, DUMMY_EXPRESSION), s.rule(notEqualsOf(DUMMY_EXPRESSION, TRUE)));
-        assertEquals(DUMMY_EXPRESSION, s.rule(notEqualsOf(DUMMY_EXPRESSION, FALSE)));
+    public void testBoolEqualsSimplificationOnFields() {
+        BooleanFunctionEqualsElimination s = new BooleanFunctionEqualsElimination();
 
-        assertEquals(NULL, s.rule(new Equals(EMPTY, NULL, TRUE)));
-        assertEquals(new Not(EMPTY, NULL), s.rule(new Equals(EMPTY, NULL, FALSE)));
+        FieldAttribute field = getFieldAttribute();
 
-        assertEquals(new Not(EMPTY, NULL), s.rule(notEqualsOf(NULL, TRUE)));
-        assertEquals(NULL, s.rule(notEqualsOf(NULL, FALSE)));
+        List<? extends BinaryComparison> comparisons = Arrays.asList(
+            new Equals(EMPTY, field, TRUE),
+            new Equals(EMPTY, field, FALSE),
+            notEqualsOf(field, TRUE),
+            notEqualsOf(field, FALSE),
+            new Equals(EMPTY, NULL, TRUE),
+            new Equals(EMPTY, NULL, FALSE),
+            notEqualsOf(NULL, TRUE),
+            notEqualsOf(NULL, FALSE)
+        );
+
+        for (BinaryComparison comparison : comparisons) {
+            assertEquals(comparison, s.rule(comparison));
+        }
     }
 
     //


### PR DESCRIPTION
This commit fixes two issues in dealing with bool fields in EQL:
- avoid simplifications of field == true expressions
- adding comparison to clauses on fields missing logic (where bool)

Fix #63693