### PR TITLE
Mark the search 'fields' option as beta.

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -60,6 +60,7 @@ following sections:
 [discrete]
 [[search-fields-param]]
 === Fields
+beta::[]
 
 The `fields` parameter allows for retrieving a list of document fields in
 the search response. It consults both the document `_source` and the index


### PR DESCRIPTION
We've identified two important enhancements that may affect the API:
* Support unmapped fields. #63690
* Finalize how to return nested content. #63709

We expect any API changes from these enhancements to be minor, but want to leave open the possibility for small breaks. For example, we may end up returning unmapped fields by default, or omitting nested fields from the root hit. The impact to users should be quite small.

We're tracking the issues we need to resolve before removing the 'beta' label here: #60985.