### PR TITLE
[7.x] Docs: sync breaking changes from release notes (#63479)

### DIFF
--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -18,54 +18,182 @@ See also <<release-highlights>> and <<es-release-notes>>.
 //tag::notable-breaking-changes[]
 
 [discrete]
-[[breaking_710_search_changes]]
-=== Search Changes
+[[breaking_710_security_changes]]
+=== Authentication changes
 
-[discrete]
-==== Missing checks for `index.max_docvalue_fields_search`
-The setting `index.max_docvalue_fields_search` limits the number of fields that
-can be retrieved through `docvalue_fields` in a search. Previously we only
-checked this limit when `docvalue_fields` appeared in the top-level search
-request body. Now we also enforce the limit when loading doc value fields in
-an `inner_hits` section or in a `top_hits` aggregation.
-
-[discrete]
-[[breaking_710_networking_changes]]
-=== Networking Changes
-
-[discrete]
-==== *.tcp.keep_idle and *.tcp.keep_interval now bounded
-The settings `{network,transport,http}.tcp.keep_idle` and
-`{network,transport,http}.tcp.keep_interval` are now limited to a maximum
-value of 300, which amounts to 5 minutes. This helps ensure that, if
-explicitly configured, only reasonable values are set.
-
-//end::notable-breaking-changes[]
-
-.Repository Stats API is deprecated
+[[api-keys-require-name-property]]
+.API keys now require a `name` property.
 [%collapsible]
 ====
 *Details* +
-The Repository Stats API has been introduced in 7.8.0 as an experimental API
-and was never released. This API is superseded by the <<repositories-metering-apis,Repositories Metering APIs>>
-added in 7.10.0 which should be used instead. The Repository Stats API is
-deprecated starting 7.10.0 and will be removed in 8.0.0.
+The `name` property is now required to create or grant an API key.
+
+[source,js]
+----
+{
+    "...": "...",
+    "api_key": {
+      "name": "key-1"
+    }
+}
+----
+// NOTCONSOLE
 
 *Impact* +
-Use the <<repositories-metering-apis,Repositories Metering APIs>>.
+To avoid errors, specify the `name` property when creating or granting API keys.
 ====
 
-[[mapping-boosts]]
-.The `boost` parameter on field mappings has been deprecated
+[discrete]
+[[breaking_710_indices_changes]]
+=== Indices changes
+
+[[bc-deprecate-rest-api-access-to-system-indices]]
+.REST API access to system indices is deprecated.
 [%collapsible]
 ====
 *Details* +
-Index-time boosts have been deprecated since the 5x line, but it is still possible
+We are deprecating REST API access to system indices. Most REST API requests
+that attempt to access system indices will return the following deprecation
+warning:
+
+[source,text]
+----
+this request accesses system indices: [.system_index_name], but in a future
+major version, direct access to system indices will be prevented by default
+----
+
+The following REST API endpoints access system indices as part of their
+implementation and will not return the deprecation warning:
+
+* `GET _cluster/health`
+* `GET {index}/_recovery`
+* `GET _cluster/allocation/explain`
+* `GET _cluster/state`
+* `POST _cluster/reroute`
+* `GET {index}/_stats`
+* `GET {index}/_segments`
+* `GET {index}/_shard_stores`
+* `GET _cat/[indices,aliases,health,recovery,shards,segments]`
+
+*Impact* +
+To avoid deprecation warnings, do not use unsupported REST APIs to access system
+indices.
+====
+
+
+[discrete]
+[[breaking_710_java_changes]]
+=== Java changes
+
+[[supplier-searchlookup-arg]]
+.The `MappedFieldType#fielddataBuilder` method now accepts a `Supplier<SearchLookup>` argument.
+[%collapsible]
+====
+*Details* +
+To support future feature development, the existing
+`MappedFieldType#fielddataBuilder` method now accepts a new
+`Supplier<SearchLookup>` argument.
+ 
+*Impact* +
+If you develop or maintain a mapper plugin, update your implementation of the
+`MappedFieldType#fielddataBuilder` method to accommodate the new signature.
+====
+
+[discrete]
+[[breaking_710_ml_changes]]
+=== Machine learning changes
+
+[[ml-allow-no-deprecations]]
+.The `allow_no_jobs` and `allow_no_datafeeds` API parameters are deprecated.
+[%collapsible]
+====
+*Details* +
+The `allow_no_jobs` and `allow_no_datafeeds` parameters in {ml} APIs are
+deprecated in favor of `allow_no_match`. The old parameters are still accepted
+by the APIs but a deprecation warning is emitted when the old parameter name is
+used in the request body or as a request parameter. High-level REST client
+classes now send the new `allow_no_match` parameter.
+
+*Impact* +
+To avoid deprecation warnings, use the `allow_no_match` parameter.
+====
+
+[discrete]
+[[breaking_710_mapping_changes]]
+=== Mapping changes
+
+[[mapping-boosts]]
+.The `boost` parameter on field mappings has been deprecated.
+[%collapsible]
+====
+*Details* +
+Index-time boosts have been deprecated since the 5.x line, but it is still possible
 to declare field-specific boosts in the mappings.  This is now deprecated as well,
-and will be removed entirely in 8.0.  Mappings containing field boosts will continue
+and will be removed entirely in 8.0.0.  Mappings containing field boosts will continue
 to work in 7.x but will emit a deprecation warning.
 
 *Impact* +
-The `boost` setting should be removed from templates and mappings.  Use boosts
+The `boost` setting should be removed from templates and mappings. Use boosts
 directly on queries instead.
 ====
+
+[discrete]
+[[breaking_710_networking_changes]]
+=== Networking changes
+
+[keep-idle-and-keep-internal-limits]
+.The `*.tcp.keep_idle` and `*.tcp.keep_interval` settings are now limited to `300` seconds.
+[%collapsible]
+====
+*Details* +
+The `{network,transport,http}.tcp.keep_idle` and
+`{network,transport,http}.tcp.keep_interval` settings now have a maximum
+value of `300` seconds, equivalent to 5 minutes.
+
+*Impact* +
+If specified, ensure the `{network,transport,http}.tcp.keep_idle` and
+`{network,transport,http}.tcp.keep_interval` settings do not exceed `300`
+seconds. Setting `{network,transport,http}.tcp.keep_idle` or
+`{network,transport,http}.tcp.keep_interval` to a value greater than `300`
+seconds in `elasticsearch.yml` will result in an error on startup.
+====
+
+[discrete]
+[[breaking_710_search_changes]]
+=== Search changes
+
+[[max-doc-value-field-search-limits]]
+.The `index.max_docvalue_fields_search` setting now limits doc value fields returned by `inner_hits` or the `top_hits` aggregation.
+[%collapsible]
+====
+*Details* +
+The `index.max_docvalue_fields_search` setting limits the number of doc value
+fields retrieved by a search. Previously, this setting applied only to doc value
+fields returned by the `docvalue_fields` parameter in a top-level search. The
+setting now also applies to doc value fields returned by an `inner_hits` section
+or `top_hits` aggregation.
+
+*Impact* +
+If you use `inner_hits` or the `top_hits` aggregation, ensure
+`index.max_docvalue_fields_search` is configured correctly for your use case.
+====
+
+[discrete]
+[[breaking_710_snapshot_restore_changes]]
+=== Snapshot and restore changes
+
+[[respository-stats-api-deprecated]]
+.The repository stats API has been deprecated.
+[%collapsible]
+====
+*Details* +
+The repository stats API was introduced as an experimental API in 7.8.0. The
+<<repositories-metering-apis,repositories metering APIs>> now replace the
+repository stats API. The repository stats API has been deprecated and will be
+removed in 8.0.0.
+
+*Impact* +
+Use the <<repositories-metering-apis,repositories metering APIs>>. Discontinue
+use of the repository stats API.
+====
+//end::notable-breaking-changes[]


### PR DESCRIPTION
This syncs breaking changes from release notes

Co-authored-by: Lisa Cawley <lcawley@elastic.co>
Co-authored-by: James Rodewig <40268737+jrodewig@users.noreply.github.com>
(cherry picked from commit 2cc0ccb1108b47632544f0bfc357cdc7ad931055)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #63479 