### PR TITLE
remove unnecessary try catch

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1774,11 +1774,7 @@ public class InternalEngine extends Engine {
             lastCommittedSegmentInfos = store.readLastCommittedSegmentsInfo();
         } catch (Exception e) {
             if (isClosed.get() == false) {
-                try {
-                    logger.warn("failed to read latest segment infos on flush", e);
-                } catch (Exception inner) {
-                    e.addSuppressed(inner);
-                }
+                logger.warn("failed to read latest segment infos on flush", e);
                 if (Lucene.isCorruptionException(e)) {
                     throw new FlushFailedEngineException(shardId, e);
                 }


### PR DESCRIPTION
In [#19231](https://github.com/elastic/elasticsearch/pull/19231/commits/a6f00c5a879ab11b8c650506129ef14ce32b601a), a "try catch" was added surrounding a log line.
```java
    try {
        logger.warn("failed to read latest segment infos on flush", e);
    } catch (Exception inner) {
        e.addSuppressed(inner);
    }
```
, which I think it's unnecessary. Should we just remove it? 