### PR TITLE
GeoContextMapping validates references twice (#63718)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -144,12 +144,6 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
      */
     @Override
     public Set<String> parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
-        if (fieldName != null) {
-            MappedFieldType fieldType = parseContext.mapperService().fieldType(fieldName);
-            if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
-                throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
-            }
-        }
         final Set<String> contexts = new HashSet<>();
         Token token = parser.currentToken();
         if (token == Token.START_ARRAY) {


### PR DESCRIPTION
Backport of #63718

When a completion field specifies a geo-point context, we need to validate that the field being referred to is effectively a geo-point field defined in the mappings. That is currently done as part of the GeoContextMapping#validateReferences method, and also while parsing the completion field mapper. The latter check can be removed, which allows for further cleanups as it's the only scenario where ParseContext needs to look up a field type through the mapper service.
