### PR TITLE
SQL: enhance IN operator support for formatted date fields. (backport of #63483)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -154,6 +154,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
     public Object visitOperatorExpressionDefault(EqlBaseParser.OperatorExpressionDefaultContext ctx) {
         Expression expr = expression(ctx.primaryExpression());
         Source source = source(ctx);
+        ZoneId zoneId = params.zoneId();
 
         PredicateContext predicate = ctx.predicate();
 
@@ -162,7 +163,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
         }
 
         List<Expression> container = expressions(predicate.expression());
-        Expression checkInSet = new In(source, expr, container);
+        Expression checkInSet = new In(source, expr, container, zoneId);
 
         return predicate.NOT() != null ? new Not(source, checkInSet) : checkInSet;
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,16 +35,22 @@ public class In extends ScalarFunction {
 
     private final Expression value;
     private final List<Expression> list;
+    private final ZoneId zoneId;
 
     public In(Source source, Expression value, List<Expression> list) {
+        this(source, value, list, null);
+    }
+
+    public In(Source source, Expression value, List<Expression> list, ZoneId zoneId) {
         super(source, CollectionUtils.combine(list, value));
         this.value = value;
         this.list = new ArrayList<>(new LinkedHashSet<>(list));
+        this.zoneId = zoneId;
     }
 
     @Override
     protected NodeInfo<In> info() {
-        return NodeInfo.create(this, In::new, value(), list());
+        return NodeInfo.create(this, In::new, value(), list(), zoneId());
     }
 
     @Override
@@ -51,7 +58,11 @@ public class In extends ScalarFunction {
         if (newChildren.size() < 2) {
             throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
         }
-        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1));
+        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
+    }
+
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
     public Expression value() {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -392,18 +392,32 @@ public final class ExpressionTranslators {
             if (in.value() instanceof FieldAttribute) {
                 // equality should always be against an exact match (which is important for strings)
                 FieldAttribute fa = (FieldAttribute) in.value();
+                DataType dt = fa.dataType();
+
                 List<Expression> list = in.list();
-
-                // TODO: this needs to be handled inside the optimizer
-                list.removeIf(e -> DataTypes.isNull(e.dataType()));
-                DataType dt = list.get(0).dataType();
                 Set<Object> set = new LinkedHashSet<>(CollectionUtils.mapSize(list.size()));
+                list.forEach(e -> {
+                    // TODO: this needs to be handled inside the optimizer
+                    if (DataTypes.isNull(e.dataType()) == false) {
+                        set.add(handler.convert(valueOf(e), dt));
+                    }
+                });
 
-                for (Expression e : list) {
-                    set.add(handler.convert(valueOf(e), dt));
+                if (dt == DATETIME) {
+                    DateFormatter formatter = DateFormatter.forPattern(DATE_FORMAT);
+
+                    q = null;
+                    for (Object o : set) {
+                        assert o instanceof ZonedDateTime : "expected a ZonedDateTime, but got: " + o.getClass().getName();
+                        // see comment in Ranges#doTranslate() as to why formatting as String is required
+                        String zdt = formatter.format((ZonedDateTime) o);
+                        RangeQuery right = new RangeQuery(in.source(), fa.exactAttribute().name(),
+                                zdt, true, zdt, true, formatter.pattern(), in.zoneId());
+                        q = q == null ? right : new BoolQuery(in.source(), false, q, right);
+                    }
+                } else {
+                    q = new TermsQuery(in.source(), fa.exactAttribute().name(), set);
                 }
-
-                q = new TermsQuery(in.source(), fa.exactAttribute().name(), set);
             } else {
                 q = new ScriptQuery(in.source(), in.asScript());
             }

--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.csv-spec
@@ -131,21 +131,30 @@ SELECT COUNT(*), TRUNCATE(emp_no, -2) t FROM test_emp WHERE 'aaabbb' RLIKE 'a{2,
 ;
 
 inWithCompatibleDateTypes
-SELECT birth_date FROM test_emp WHERE birth_date IN ({d '1959-07-23'},CAST('1959-12-25T12:12:12' AS TIMESTAMP)) OR birth_date IS NULL ORDER BY birth_date;
+SELECT birth_date FROM test_emp WHERE birth_date IN ({d '1959-07-23'}, CAST('1959-12-25T00:00:00' AS TIMESTAMP), '1964-06-02T00:00:00.000Z') OR birth_date IS NULL ORDER BY birth_date;
 
-     birth_date:ts       
+     birth_date:ts
 ------------------------
 1959-07-23T00:00:00.000Z
 1959-07-23T00:00:00.000Z
 1959-12-25T00:00:00.000Z
-null                    
-null                    
-null                    
-null                    
-null                    
-null                    
-null                    
-null                    
-null                    
-null                    
+1964-06-02T00:00:00.000Z
+null
+null
+null
+null
+null
+null
+null
+null
+null
+null
+;
+
+inWithCompatibleTimeTypes
+SELECT count(*) AS c FROM test_emp WHERE birth_date::time IN ('00:00:00Z'::TIME, '00:00:00.000Z');
+
+   c:l
+---------------
+90
 ;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
@@ -129,3 +129,6 @@ whereWithInAndNullHandling1
 SELECT last_name l FROM "test_emp" WHERE languages in (2, 10)AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
 whereWithInAndNullHandling2
 SELECT last_name l FROM "test_emp" WHERE languages in (2, null, 10) AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
+
+whereWithInAndMultipleValueTypes
+SELECT last_name l FROM test_emp WHERE hire_date in('1986-06-26T00:00:00.000Z'::datetime, '1986-08-28T00:00:00.000Z');

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
@@ -12,8 +12,8 @@ import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeConverter;
-import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,9 +23,13 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
         super(source, value, list);
     }
 
+    public In(Source source, Expression value, List<Expression> list, ZoneId zoneId) {
+        super(source, value, list, zoneId);
+    }
+
     @Override
     protected NodeInfo<org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.In> info() {
-        return NodeInfo.create(this, In::new, value(), list());
+        return NodeInfo.create(this, In::new, value(), list(), zoneId());
     }
 
     @Override
@@ -33,7 +37,7 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
         if (newChildren.size() < 2) {
             throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
         }
-        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1));
+        return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
     }
 
     @Override
@@ -47,6 +51,7 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
 
     @Override
     protected boolean areCompatible(DataType left, DataType right) {
-        return SqlDataTypes.areCompatible(left, right);
+        // "left" is the reference type that all other values in the "right" IN-set need to convert to
+        return SqlDataTypeConverter.canConvert(right, left);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -233,7 +233,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 if (pCtx.query() != null) {
                     throw new ParsingException(source, "IN query not supported yet");
                 }
-                e = new In(source, exp, expressions(pCtx.valueExpression()));
+                e = new In(source, exp, expressions(pCtx.valueExpression()), zoneId);
                 break;
             case SqlBaseParser.LIKE:
                 e = new Like(source, exp, visitPattern(pCtx.pattern()));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -665,14 +665,10 @@ public class VerifierErrorMessagesTests extends ESTestCase {
                 error("SELECT int FROM test GROUP BY int HAVING 2 < ABS(int)"));
     }
 
-    public void testInWithDifferentDataTypes() {
-        assertEquals("1:8: 2nd argument of [1 IN (2, '3', 4)] must be [integer], found value ['3'] type [keyword]",
-            error("SELECT 1 IN (2, '3', 4)"));
-    }
-
-    public void testInWithDifferentDataTypesFromLeftValue() {
-        assertEquals("1:8: 1st argument of [1 IN ('foo', 'bar')] must be [integer], found value ['foo'] type [keyword]",
-            error("SELECT 1 IN ('foo', 'bar')"));
+    public void testInWithIncompatibleDataTypes() {
+        assertEquals("1:8: 1st argument of ['2000-02-02T00:00:00Z'::date IN ('02:02:02Z'::time)] must be [date], " +
+                "found value ['02:02:02Z'::time] type [time]",
+            error("SELECT '2000-02-02T00:00:00Z'::date IN ('02:02:02Z'::time)"));
     }
 
     public void testInWithFieldInListOfValues() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -77,6 +78,7 @@ import org.junit.BeforeClass;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -982,6 +984,39 @@ public class QueryTranslatorTests extends ESTestCase {
         TermsQuery tq = (TermsQuery) query;
         assertEquals("{\"terms\":{\"keyword\":[\"foo\",\"lala\"],\"boost\":1.0}}",
             tq.asBuilder().toString().replaceAll("\\s", ""));
+    }
+
+    public void testTranslateInExpression_WhereClause_Datetime() {
+        ZoneId zoneId = randomZone();
+        String[] dates = {"2002-02-02T02:02:02.222Z", "2003-03-03T03:03:03.333Z"};
+        LogicalPlan p = plan("SELECT * FROM test WHERE date IN ('" + dates[0] + "'::datetime, '" + dates[1] + "'::datetime)", zoneId);
+        assertTrue(p instanceof Project);
+        p = ((Project) p).child();
+        assertTrue(p instanceof Filter);
+        Expression condition = ((Filter) p).condition();
+        QueryTranslation translation = translate(condition);
+
+        Query query = translation.query;
+        assertTrue(query instanceof BoolQuery);
+        BoolQuery bq = (BoolQuery) query;
+        assertFalse(bq.isAnd());
+        assertTrue(bq.left() instanceof RangeQuery);
+        assertTrue(bq.right() instanceof RangeQuery);
+        List<Tuple<String, RangeQuery>> tuples = Arrays.asList(new Tuple<>(dates[0], (RangeQuery)bq.left()),
+            new Tuple<>(dates[1], (RangeQuery) bq.right()));
+
+        for (Tuple<String, RangeQuery> t: tuples) {
+            String date = t.v1();
+            RangeQuery rq = t.v2();
+
+            assertEquals("date", rq.field());
+            assertEquals(date, rq.upper().toString());
+            assertEquals(date, rq.lower().toString());
+            assertEquals(zoneId, rq.zoneId());
+            assertTrue(rq.includeLower());
+            assertTrue(rq.includeUpper());
+            assertEquals(DATE_FORMAT, rq.format());
+        }
     }
 
     public void testTranslateInExpression_WhereClause_Painless() {


### PR DESCRIPTION
Extend allowed conversions (#63483)

* SQL: IN operator incorrectly handling specified date format (#58932)

In `IN` operator, the ExpressionTranslator<In> translates expression into terms query, but when the expression is date format, the terms query get unexpected results. This commit changes the terms query into bool should query when data type is `DATETIME`.

* fix IN values conversion for fields. add tests

In case the IN operator compares against a field, its translation logic
takes the first type in the value set and converts subsequent values to
it. This commit will change that to have the field type be considered as
the reference and have the values in the IN set be converted by it.

The IN operator is also changed to validate types by their
convertibility, not compatibility.

These allow more confortable implicit conversions (of the type `WHERE
ip_field in ('127.0.0.1', ...)`).

Tests have been added to check the DATETIME handling of the IN operator.

* Add IN test with TIME values

Add CSV test to test IN against a TIME convered value.

Co-authored-by: yinanwu <yinanwu@tencent.com>
(cherry picked from commit 45a6023a0d5793b197f55242ab6912b632695a49)