### PR TITLE
SQL: integer parameter validation in string functions (backport of #63338)

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessor.java
@@ -10,6 +10,7 @@ import org.elasticsearch.xpack.ql.expression.gen.processor.FunctionalEnumBinaryP
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.expression.function.scalar.string.BinaryStringNumericProcessor.BinaryStringNumericOperation;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
@@ -19,7 +20,7 @@ import java.util.function.BiFunction;
  * second parameter as numeric and a string result.
  */
 public class BinaryStringNumericProcessor extends FunctionalEnumBinaryProcessor<String, Number, String, BinaryStringNumericOperation> {
-    
+
     public enum BinaryStringNumericOperation implements BiFunction<String, Number, String> {
         LEFT((s,c) -> {
             int i = c.intValue();
@@ -40,7 +41,7 @@ public class BinaryStringNumericProcessor extends FunctionalEnumBinaryProcessor<
             if (i <= 0) {
                 return null;
             }
-            
+
             StringBuilder sb = new StringBuilder(s.length() * i);
             for (int j = 0; j < i; j++) {
                 sb.append(s);
@@ -51,7 +52,7 @@ public class BinaryStringNumericProcessor extends FunctionalEnumBinaryProcessor<
         BinaryStringNumericOperation(BiFunction<String, Number, String> op) {
             this.op = op;
         }
-        
+
         private final BiFunction<String, Number, String> op;
 
         @Override
@@ -83,9 +84,8 @@ public class BinaryStringNumericProcessor extends FunctionalEnumBinaryProcessor<
         if (!(left instanceof String || left instanceof Character)) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", left);
         }
-        if (!(right instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", right);
-        }
+        // count can be negative, the case is handled by the code, but it must still be int-convertible
+        Check.isFixedNumberAndInRange(right, "count", (long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE);
 
         return super.doProcess(left.toString(), right);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -61,23 +62,17 @@ public class InsertFunctionProcessor implements Processor {
         if (start == null || length == null) {
             return input;
         }
-        if (!(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
-        }
-        if (!(length instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
-        }
-        if (((Number) length).intValue() < 0) {
-            throw new SqlIllegalArgumentException("A positive number is required for [length]; received [{}]", length);
-        }
+
+        Check.isFixedNumberAndInRange(start, "start", (long) Integer.MIN_VALUE + 1, (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         int startInt = ((Number) start).intValue() - 1;
         int realStart = startInt < 0 ? 0 : startInt;
-        
+
         if (startInt > input.toString().length()) {
             return input;
         }
-        
+
         StringBuilder sb = new StringBuilder(input.toString());
         String replString = (replacement.toString());
 
@@ -85,41 +80,41 @@ public class InsertFunctionProcessor implements Processor {
                 realStart + ((Number) length).intValue(),
                 replString).toString();
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        
+
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        
+
         InsertFunctionProcessor other = (InsertFunctionProcessor) obj;
         return Objects.equals(input(), other.input())
                 && Objects.equals(start(), other.start())
                 && Objects.equals(length(), other.length())
                 && Objects.equals(replacement(), other.replacement());
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(input(), start(), length(), replacement());
     }
-    
+
     public Processor input() {
         return input;
     }
-    
+
     public Processor start() {
         return start;
     }
-    
+
     public Processor length() {
         return length;
     }
-    
+
     public Processor replacement() {
         return replacement;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -52,51 +53,52 @@ public class LocateFunctionProcessor implements Processor {
         if (pattern == null) {
             return 0;
         }
-        
+
         if (!(pattern instanceof String || pattern instanceof Character)) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", pattern);
         }
-        if (start != null && !(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
+
+        if (start != null) {
+            Check.isFixedNumberAndInRange(start, "start", (long) Integer.MIN_VALUE + 1, (long) Integer.MAX_VALUE);
         }
-        
+
         String stringInput = input instanceof Character ? input.toString() : (String) input;
         String stringPattern = pattern instanceof Character ? pattern.toString() : (String) pattern;
 
-        return Integer.valueOf(1 + (start != null ? 
+        return Integer.valueOf(1 + (start != null ?
                 stringInput.indexOf(stringPattern, ((Number) start).intValue() - 1)
                 : stringInput.indexOf(stringPattern)));
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        
+
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        
+
         LocateFunctionProcessor other = (LocateFunctionProcessor) obj;
         return Objects.equals(pattern(), other.pattern())
                 && Objects.equals(input(), other.input())
                 && Objects.equals(start(), other.start());
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(pattern(), input(), start());
     }
-    
+
     public Processor pattern() {
         return pattern;
     }
-    
+
     public Processor input() {
         return input;
     }
-    
+
     public Processor start() {
         return start;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -53,54 +54,48 @@ public class SubstringFunctionProcessor implements Processor {
         if (start == null || length == null) {
             return input;
         }
-        if (!(start instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", start);
-        }
-        if (!(length instanceof Number)) {
-            throw new SqlIllegalArgumentException("A number is required; received [{}]", length);
-        }
-        if (((Number) length).intValue() < 0) {
-            throw new SqlIllegalArgumentException("A positive number is required for [length]; received [{}]", length);
-        }
+
+        Check.isFixedNumberAndInRange(start, "start", (long) Integer.MIN_VALUE + 1, (long) Integer.MAX_VALUE);
+        Check.isFixedNumberAndInRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
         return StringFunctionUtils.substring(input instanceof Character ? input.toString() : (String) input,
                 ((Number) start).intValue() - 1, // SQL is 1-based when it comes to string manipulation
                 ((Number) length).intValue());
     }
-    
+
     protected Processor input() {
         return input;
     }
-    
+
     protected Processor start() {
         return start;
     }
-    
+
     protected Processor length() {
         return length;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        
+
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        
+
         SubstringFunctionProcessor other = (SubstringFunctionProcessor) obj;
         return Objects.equals(input(), other.input())
                 && Objects.equals(start(), other.start())
                 && Objects.equals(length(), other.length());
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(input(), start(), length());
     }
-    
+
 
     @Override
     public String getWriteableName() {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/Check.java
@@ -9,7 +9,7 @@ import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
 /**
  * Utility class used for checking various conditions at runtime, inside SQL (hence the specific exception) with
- * minimum amount of code 
+ * minimum amount of code
  */
 public abstract class Check {
 
@@ -34,6 +34,18 @@ public abstract class Check {
     public static void notNull(Object object, String message, Object... values) {
         if (object == null) {
             throw new SqlIllegalArgumentException(message, values);
+        }
+    }
+
+    public static void isFixedNumberAndInRange(Object object, String objectName, Long from, Long to) {
+        if ((object instanceof Number) == false || object instanceof Float || object instanceof Double) {
+            throw new SqlIllegalArgumentException("A fixed point number is required for [{}]; received [{}]", objectName,
+                object.getClass().getTypeName());
+        }
+        Long longValue = ((Number) object).longValue();
+        if (longValue < from || longValue > to) {
+            throw new SqlIllegalArgumentException("[{}] out of the allowed range [{}, {}], received [{}]", objectName, from, to,
+                longValue);
         }
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessorTests.java
@@ -18,11 +18,11 @@ import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTest
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 
 public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTestCase<BinaryStringNumericProcessor> {
-    
+
     @Override
     protected BinaryStringNumericProcessor createTestInstance() {
         return new BinaryStringNumericProcessor(
-                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(1, 128)), 
+                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(1, 128)),
                 new ConstantProcessor(randomInt(256)),
                 randomFrom(BinaryStringNumericOperation.values()));
     }
@@ -31,19 +31,19 @@ public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTe
     protected Reader<BinaryStringNumericProcessor> instanceReader() {
         return BinaryStringNumericProcessor::new;
     }
-    
+
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(Processors.getNamedWriteables());
     }
-    
+
     public void testLeftFunctionWithValidInput() {
         assertEquals("foo", new Left(EMPTY, l("foo bar"), l(3)).makePipe().asProcessor().process(null));
         assertEquals("foo bar", new Left(EMPTY, l("foo bar"), l(7)).makePipe().asProcessor().process(null));
         assertEquals("foo bar", new Left(EMPTY, l("foo bar"), l(123)).makePipe().asProcessor().process(null));
         assertEquals("f", new Left(EMPTY, l('f'), l(1)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testLeftFunctionWithEdgeCases() {
         assertNull(new Left(EMPTY, l("foo bar"), l(null)).makePipe().asProcessor().process(null));
         assertNull(new Left(EMPTY, l(null), l(3)).makePipe().asProcessor().process(null));
@@ -51,15 +51,29 @@ public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTe
         assertEquals("", new Left(EMPTY, l("foo bar"), l(-1)).makePipe().asProcessor().process(null));
         assertEquals("", new Left(EMPTY, l("foo bar"), l(0)).makePipe().asProcessor().process(null));
         assertEquals("", new Left(EMPTY, l('f'), l(0)).makePipe().asProcessor().process(null));
+        assertEquals("", new Left(EMPTY, l('f'), l(Integer.MIN_VALUE)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testLeftFunctionInputValidation() {
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Left(EMPTY, l(5), l(3)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [5]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Left(EMPTY, l("foo bar"), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [baz]", siae.getMessage());
+        assertEquals("A fixed point number is required for [count]; received [java.lang.String]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Left(EMPTY, l("foo"), l((long)Integer.MIN_VALUE - 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [-2147483649]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Left(EMPTY, l("foo"), l((long)Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [2147483648]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Left(EMPTY, l("foo"), l(1.0)).makePipe().asProcessor().process(null));
+        assertEquals("A fixed point number is required for [count]; received [java.lang.Double]", siae.getMessage());
     }
 
     public void testRightFunctionWithValidInput() {
@@ -68,7 +82,7 @@ public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTe
         assertEquals("foo bar", new Right(EMPTY, l("foo bar"), l(123)).makePipe().asProcessor().process(null));
         assertEquals("f", new Right(EMPTY, l('f'), l(1)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testRightFunctionWithEdgeCases() {
         assertNull(new Right(EMPTY, l("foo bar"), l(null)).makePipe().asProcessor().process(null));
         assertNull(new Right(EMPTY, l(null), l(3)).makePipe().asProcessor().process(null));
@@ -76,15 +90,29 @@ public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTe
         assertEquals("", new Right(EMPTY, l("foo bar"), l(-1)).makePipe().asProcessor().process(null));
         assertEquals("", new Right(EMPTY, l("foo bar"), l(0)).makePipe().asProcessor().process(null));
         assertEquals("", new Right(EMPTY, l('f'), l(0)).makePipe().asProcessor().process(null));
+        assertEquals("", new Right(EMPTY, l('f'), l(Integer.MIN_VALUE)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testRightFunctionInputValidation() {
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Right(EMPTY, l(5), l(3)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [5]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Right(EMPTY, l("foo bar"), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [baz]", siae.getMessage());
+        assertEquals("A fixed point number is required for [count]; received [java.lang.String]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Right(EMPTY, l("foo"), l((long)Integer.MIN_VALUE - 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [-2147483649]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Right(EMPTY, l("foo"), l((long)Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [2147483648]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Right(EMPTY, l("foo"), l(1.0)).makePipe().asProcessor().process(null));
+        assertEquals("A fixed point number is required for [count]; received [java.lang.Double]", siae.getMessage());
     }
 
     public void testRepeatFunctionWithValidInput() {
@@ -92,21 +120,35 @@ public class BinaryStringNumericProcessorTests extends AbstractWireSerializingTe
         assertEquals("foo", new Repeat(EMPTY, l("foo"), l(1)).makePipe().asProcessor().process(null));
         assertEquals("fff", new Repeat(EMPTY, l('f'), l(3)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testRepeatFunctionWithEdgeCases() {
         assertNull(new Repeat(EMPTY, l("foo"), l(null)).makePipe().asProcessor().process(null));
         assertNull(new Repeat(EMPTY, l(null), l(3)).makePipe().asProcessor().process(null));
         assertNull(new Repeat(EMPTY, l(null), l(null)).makePipe().asProcessor().process(null));
         assertNull(new Repeat(EMPTY, l("foo"), l(-1)).makePipe().asProcessor().process(null));
         assertNull(new Repeat(EMPTY, l("foo"), l(0)).makePipe().asProcessor().process(null));
+        assertNull(new Repeat(EMPTY, l('f'), l(Integer.MIN_VALUE)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testRepeatFunctionInputsValidation() {
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Repeat(EMPTY, l(5), l(3)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [5]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Repeat(EMPTY, l("foo bar"), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [baz]", siae.getMessage());
+        assertEquals("A fixed point number is required for [count]; received [java.lang.String]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Repeat(EMPTY, l("foo"), l((long)Integer.MIN_VALUE - 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [-2147483649]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Repeat(EMPTY, l("foo"), l((long)Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
+        assertEquals("[count] out of the allowed range [-2147483648, 2147483647], received [2147483648]", siae.getMessage());
+
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Repeat(EMPTY, l("foo"), l(1.0)).makePipe().asProcessor().process(null));
+        assertEquals("A fixed point number is required for [count]; received [java.lang.Double]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
@@ -17,11 +17,11 @@ import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTest
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 
 public class InsertProcessorTests extends AbstractWireSerializingTestCase<InsertFunctionProcessor> {
-    
+
     @Override
     protected InsertFunctionProcessor createTestInstance() {
         return new InsertFunctionProcessor(
-                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)), 
+                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
                 new ConstantProcessor(randomInt(256)),
                 new ConstantProcessor(randomInt(128)),
                 new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 256)));
@@ -31,17 +31,17 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
     protected Reader<InsertFunctionProcessor> instanceReader() {
         return InsertFunctionProcessor::new;
     }
-    
+
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(Processors.getNamedWriteables());
     }
-    
+
     public void testInsertWithValidInputs() {
         assertEquals("bazbar", new Insert(EMPTY, l("foobar"), l(1), l(3), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("foobaz", new Insert(EMPTY, l("foobar"), l(4), l(3), l("baz")).makePipe().asProcessor().process(null));
     }
-    
+
     public void testInsertWithEdgeCases() {
         assertNull(new Insert(EMPTY, l(null), l(4), l(3), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(4), l(3), l(null)).makePipe().asProcessor().process(null));
@@ -52,33 +52,55 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
         assertEquals("bazbar", new Insert(EMPTY, l("foobar"), l(-1), l(3), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("foobaz", new Insert(EMPTY, l("foobar"), l(4), l(30), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("foobaz", new Insert(EMPTY, l("foobar"), l(6), l(1), l('z')).makePipe().asProcessor().process(null));
-        assertEquals("foobarbaz", 
+        assertEquals("foobarbaz",
                 new Insert(EMPTY, l("foobar"), l(7), l(1000), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("foobar", 
+        assertEquals("foobar",
                 new Insert(EMPTY, l("foobar"), l(8), l(1000), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("fzr", new Insert(EMPTY, l("foobar"), l(2), l(4), l('z')).makePipe().asProcessor().process(null));
         assertEquals("CAR", new Insert(EMPTY, l("FOOBAR"), l(1), l(5), l("CA")).makePipe().asProcessor().process(null));
         assertEquals("z", new Insert(EMPTY, l('f'), l(1), l(10), l('z')).makePipe().asProcessor().process(null));
-        
+
         assertEquals("bla", new Insert(EMPTY, l(""), l(1), l(10), l("bla")).makePipe().asProcessor().process(null));
         assertEquals("", new Insert(EMPTY, l(""), l(2), l(10), l("bla")).makePipe().asProcessor().process(null));
     }
-    
+
     public void testInsertInputsValidation() {
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l(5), l(1), l(3), l("baz")).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [5]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l(3), l(66)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [66]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l("c"), l(3), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [c]", siae.getMessage());
+        assertEquals("A fixed point number is required for [start]; received [java.lang.String]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Insert(EMPTY, l("foobar"), l(1), l('z'), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [z]", siae.getMessage());
+        assertEquals("A fixed point number is required for [length]; received [java.lang.Character]", siae.getMessage());
+
+        assertEquals("baroobar", new Insert(EMPTY, l("foobar"), l(Integer.MIN_VALUE + 1), l(1),
+            l("bar")).makePipe().asProcessor().process(null));
         siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("baz")).makePipe().asProcessor().process(null));
-        assertEquals("A positive number is required for [length]; received [-1]", siae.getMessage());
+            () -> new Insert(EMPTY, l("foobarbar"), l(Integer.MIN_VALUE), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[start] out of the allowed range [-2147483647, 2147483647], received [-2147483648]", siae.getMessage());
+
+        assertEquals("foobar", new Insert(EMPTY, l("foobar"), l(Integer.MAX_VALUE), l(1),
+            l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Insert(EMPTY, l("foobar"), l((long) Integer.MAX_VALUE + 1), l(1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[start] out of the allowed range [-2147483647, 2147483647], received [2147483648]", siae.getMessage());
+
+        assertEquals("barfoobar", new Insert(EMPTY, l("foobar"), l(1), l(0), l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Insert(EMPTY, l("foobar"), l(1), l(-1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[length] out of the allowed range [0, 2147483647], received [-1]", siae.getMessage());
+
+        assertEquals("bar", new Insert(EMPTY, l("foobar"), l(1), l(Integer.MAX_VALUE), l("bar")).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Insert(EMPTY, l("foobar"), l(1), l((long) Integer.MAX_VALUE + 1), l("bar")).makePipe().asProcessor().process(null));
+        assertEquals("[length] out of the allowed range [0, 2147483647], received [2147483648]", siae.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateProcessorTests.java
@@ -17,7 +17,7 @@ import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTest
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 
 public class LocateProcessorTests extends AbstractWireSerializingTestCase<LocateFunctionProcessor> {
-    
+
     @Override
     protected LocateFunctionProcessor createTestInstance() {
         // the "start" parameter is optional and is treated as null in the constructor
@@ -25,7 +25,7 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
         // values for it.
         Integer start = frequently() ? randomInt() : null;
         return new LocateFunctionProcessor(
-                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)), 
+                new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
                 new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
                 new ConstantProcessor(start));
     }
@@ -34,17 +34,17 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
     protected Reader<LocateFunctionProcessor> instanceReader() {
         return LocateFunctionProcessor::new;
     }
-    
+
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(Processors.getNamedWriteables());
     }
-    
+
     public void testLocateFunctionWithValidInput() {
         assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(null)).makePipe().asProcessor().process(null));
         assertEquals(7, new Locate(EMPTY, l("bar"), l("foobarbar"), l(5)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testLocateFunctionWithEdgeCasesInputs() {
         assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(null)).makePipe().asProcessor().process(null));
         assertNull(new Locate(EMPTY, l("bar"), l(null), l(3)).makePipe().asProcessor().process(null));
@@ -56,16 +56,28 @@ public class LocateProcessorTests extends AbstractWireSerializingTestCase<Locate
         assertEquals(9, new Locate(EMPTY, l('r'), l("foobarbar"), l(9)).makePipe().asProcessor().process(null));
         assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(-3)).makePipe().asProcessor().process(null));
     }
-    
+
     public void testLocateFunctionValidatingInputs() {
         SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l(5), l("foobarbar"), l(3)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [5]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l("foo"), l(1), l(3)).makePipe().asProcessor().process(null));
         assertEquals("A string/char is required; received [1]", siae.getMessage());
+
         siae = expectThrows(SqlIllegalArgumentException.class,
                 () -> new Locate(EMPTY, l("foobarbar"), l("bar"), l('c')).makePipe().asProcessor().process(null));
-        assertEquals("A number is required; received [c]", siae.getMessage());
+        assertEquals("A fixed point number is required for [start]; received [java.lang.Character]", siae.getMessage());
+
+        assertEquals(4, new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MIN_VALUE + 1)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MIN_VALUE)).makePipe().asProcessor().process(null));
+        assertEquals("[start] out of the allowed range [-2147483647, 2147483647], received [-2147483648]", siae.getMessage());
+
+        assertEquals(0, new Locate(EMPTY, l("bar"), l("foobarbar"), l(Integer.MAX_VALUE)).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class,
+            () -> new Locate(EMPTY, l("bar"), l("foobarbar"), l((long) Integer.MAX_VALUE + 1)).makePipe().asProcessor().process(null));
+        assertEquals("[start] out of the allowed range [-2147483647, 2147483647], received [2147483648]", siae.getMessage());
     }
 }


### PR DESCRIPTION
* SQL: integer parameter validation in string functions (#58923)

In insert, locate, substring function, when argument `start` or `length` is greater than Integer.MAX_INT OR less then Integer.MIN_INT + 1 (note that `start` need to minus 1), it causes overflow and leads to unexpected results.

* Add range checks for BinaryStringNumericProcessors

- Add range checks for Left, Right, Repeat.
- Minor refactorings on initial PR changes.

Co-authored-by: yinanwu <yinanwu@tencent.com>
(cherry picked from commit bf6dc58b93529f977d035a846d083b1c31867694)