### PR TITLE
[DOCS] Clarifies the effect of per-field boosting

### DIFF
--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -59,7 +59,9 @@ GET /_search
 }
 --------------------------------------------------
 
-<1> The `subject` field is three times as important as the `message` field.
+<1> The `subject` field's score is multipled by three while the `message` field's score is
+unchanged. Note that this does not imply that the `subject` field is three times as important as the
+`message` field due to the differences in term and document statistics across fields.
 
 If no `fields` are provided, the `multi_match` query defaults to the `index.query.default_field`
 index settings, which in turn defaults to `*`. `*` extracts all fields in the mapping that

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -59,9 +59,8 @@ GET /_search
 }
 --------------------------------------------------
 
-<1> The `subject` field's score is multipled by three while the `message` field's score is
-unchanged. Note that this does not imply that the `subject` field is three times as important as the
-`message` field due to the differences in term and document statistics across fields.
+<1> The query multiplies the `subject` field's score by three but leaves the
+`message` field's score unchanged.
 
 If no `fields` are provided, the `multi_match` query defaults to the `index.query.default_field`
 index settings, which in turn defaults to `*`. `*` extracts all fields in the mapping that


### PR DESCRIPTION
The original description of per-field boosting is incorrect. Boosting a
field does not imply that it is more important relative to other fields.
It simply means that the score is multiplied by the supplied boost
value. Due to the differences in each field's term and document
statistics, it's not possible to imply relative importance of fields
based on the per-field boost value alone.