### PR TITLE
[DOCS] EQL: Update `allow_no_indices` default

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -63,15 +63,15 @@ NOTE: Unlike the <<search-search,search API>>, the EQL search API returns an
 error for requests that target only missing or closed indices regardless of
 this argument.
 +
-If `false`, any wildcard expression or <<indices-aliases,index alias>> that
-targets only missing or closed indices returns an error. For example, if `foo`
-is an index but `bar` is not, a request targeting `foo*,bar*` returns an
-error.
+If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
+value that targets only missing or closed indices returns an error. For example,
+if an index starts with `foo` but no index starts with `bar`, a request
+targeting `foo*,bar*` returns an error.
 +
 If `true`, only requests that exclusively target missing or closed indices
-return an error. For example, if `foo` is an index but `bar` is not, a request
-targeting `foo*,bar*` does not return an error. However, a request that targets
-only `bar*` still returns an error.
+return an error. For example, if an index starts with `foo` but no index starts
+with `bar`, a request targeting `foo*,bar*` does not return an error. However, a
+request that targets only `bar*` still returns an error.
 +
 Defaults to `true`.
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -68,10 +68,10 @@ targets only missing or closed indices returns an error. For example, if `foo`
 is an index but `bar` is not, a request targeting `foo*,bar*` returns an
 error.
 +
-If `true`, only requests that target only missing or closed indices return an error.
-For example, if `foo` is an index but `bar` is not, a request targeting
-`foo*,bar*` does not return an error. However, a request that targets only
-`bar*` still returns an error.
+If `true`, only requests that exclusively target missing or closed indices
+return an error. For example, if `foo` is an index but `bar` is not, a request
+targeting `foo*,bar*` does not return an error. However, a request that targets
+only `bar*` still returns an error.
 +
 Defaults to `true`.
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -59,8 +59,8 @@ To search all data streams and indices in a cluster, use
 `allow_no_indices`::
 (Optional, boolean)
 +
-NOTE: The behavior of this parameter differs from the standard
-`allow_no_indices` parameter.
+NOTE: This parameter's behavior differs from the `allow_no_indices` parameter
+used in other <<multi-index,multi-target APIs>>.
 +
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
 value that targets only missing or closed indices returns an error. This applies

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -60,8 +60,8 @@ To search all data streams and indices in a cluster, use
 (Optional, boolean)
 +
 NOTE: Unlike the <<search-search,search API>>, the EQL search API returns an
-error for requests that target only missing or closed indices regardless of
-this argument.
+error for requests that exclusively target missing or closed indices, regardless
+of this argument.
 +
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
 value that targets only missing or closed indices returns an error. For example,

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -62,17 +62,17 @@ To search all data streams and indices in a cluster, use
 NOTE: This parameter's behavior differs from the `allow_no_indices` parameter
 used in other <<multi-index,multi-target APIs>>.
 +
-If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value that targets only missing or closed indices returns an error. This applies
-even if the request targets other open indices. For example, if an index starts
-with `foo` but no index starts with `bar`, a request targeting `foo*,bar*`
-returns an error.
+If `false`, requests return an error if any wildcard expression, <<indices-aliases,index alias>>, or `_all`
+value targets only missing or closed indices. This behavior applies
+even if the request targets other open indices. For example, a request
+targeting `foo*,bar*` returns an error if any index starts with `foo`, but no
+index starts with `bar`.
 +
-If `true`, only requests that exclusively target missing or closed indices
-return an error. If the request targets any open index, it does not return an
-error. For example, if an index starts with `foo` but no index starts with
-`bar`, a request targeting `foo*,bar*` does not return an error. However, a
-request that targets only `bar*` still returns an error.
+If `true`, requests that exclusively target missing or closed indices
+return an error, unless the request targets an open index.
+For example, a request targeting `foo*,bar*` does not return an error
+if any index starts with `foo`, but no index starts with
+`bar`. However, a request that targets only `bar*` still returns an error.
 +
 Defaults to `true`.
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -64,13 +64,15 @@ error for requests that exclusively target missing or closed indices, regardless
 of this argument.
 +
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value that targets only missing or closed indices returns an error. For example,
-if an index starts with `foo` but no index starts with `bar`, a request
-targeting `foo*,bar*` returns an error.
+value that targets only missing or closed indices returns an error. This applies
+even if the request targets other open indices. For example, if an index starts
+with `foo` but no index starts with `bar`, a request targeting `foo*,bar*`
+returns an error.
 +
 If `true`, only requests that exclusively target missing or closed indices
-return an error. For example, if an index starts with `foo` but no index starts
-with `bar`, a request targeting `foo*,bar*` does not return an error. However, a
+return an error. If the request targets any open index, it does not return an
+error. For example, if an index starts with `foo` but no index starts with
+`bar`, a request targeting `foo*,bar*` does not return an error. However, a
 request that targets only `bar*` still returns an error.
 +
 Defaults to `true`.

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -58,11 +58,23 @@ To search all data streams and indices in a cluster, use
 
 `allow_no_indices`::
 (Optional, boolean)
-If `false`, the request returns a `mapping_exception` error when a wildcard
-expression, <<indices-aliases,index alias>>, or `_all` value targets only
-missing or closed indices. If `true`, the request returns a
-`verification_exception` error when targeting only missing or closed indices.
++
+NOTE: Unlike the <<search-search,search API>>, the EQL search API returns an
+error for requests that target only missing or closed indices regardless of
+this argument.
++
+If `false`, any wildcard expression or <<indices-aliases,index alias>> that
+targets only missing or closed indices returns an error. For example, if `foo`
+is an index but `bar` is not, a request targeting `foo*,bar*` returns an
+error.
++
+If `true`, only requests that target only missing or closed indices return an error.
+For example, if `foo` is an index but `bar` is not, a request targeting
+`foo*,bar*` does not return an error. However, a request that targets only
+`bar*` still returns an error.
++
 Defaults to `true`.
+
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -56,9 +56,13 @@ To search all data streams and indices in a cluster, use
 [[eql-search-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
-+
-Defaults to `false`.
+`allow_no_indices`::
+(Optional, boolean)
+If `false`, the request returns a `mapping_exception` error when a wildcard
+expression, <<indices-aliases,index alias>>, or `_all` value targets only
+missing or closed indices. If `true`, the request returns a
+`verification_exception` error when targeting only missing or closed indices.
+Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -59,9 +59,8 @@ To search all data streams and indices in a cluster, use
 `allow_no_indices`::
 (Optional, boolean)
 +
-NOTE: Unlike the <<search-search,search API>>, the EQL search API returns an
-error for requests that exclusively target missing or closed indices, regardless
-of this argument.
+NOTE: The behavior of this parameter differs from the standard
+`allow_no_indices` parameter.
 +
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
 value that targets only missing or closed indices returns an error. This applies

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -62,17 +62,16 @@ To search all data streams and indices in a cluster, use
 NOTE: This parameter's behavior differs from the `allow_no_indices` parameter
 used in other <<multi-index,multi-target APIs>>.
 +
-If `false`, requests return an error if any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value targets only missing or closed indices. This behavior applies
-even if the request targets other open indices. For example, a request
-targeting `foo*,bar*` returns an error if any index starts with `foo`, but no
-index starts with `bar`.
+If `false`, the request returns an error if any wildcard expression,
+<<indices-aliases,index alias>>, or `_all` value targets only missing or closed
+indices. This behavior applies even if the request targets other open indices.
+For example, a request targeting `foo*,bar*` returns an error if an index
+starts with `foo` but no index starts with `bar`.
 +
-If `true`, requests that exclusively target missing or closed indices
-return an error, unless the request targets an open index.
-For example, a request targeting `foo*,bar*` does not return an error
-if any index starts with `foo`, but no index starts with
-`bar`. However, a request that targets only `bar*` still returns an error.
+If `true`, only requests that exclusively target missing or closed indices
+return an error. For example, a request targeting `foo*,bar*` does not return an
+error if an index starts with `foo` but no index starts with `bar`. However, a
+request that targets only `bar*` still returns an error.
 +
 Defaults to `true`.
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -41,8 +41,8 @@ tag::allow-no-indices[]
 (Optional, boolean)
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
 value that targets only missing or closed indices returns an error. For example,
-if `foo` is an index but `bar` is not, a request targeting `foo*,bar*` returns
-an error.
+if an index starts with `foo` but no index starts with `bar`, a request
+targeting `foo*,bar*` returns an error.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -39,11 +39,11 @@ end::target-index-aliases[]
 tag::allow-no-indices[]
 `allow_no_indices`::
 (Optional, boolean)
-If `false`, requests return an error if any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value targets only missing or closed indices. This behavior applies
-even if the request targets other open indices. For example, a request
-targeting `foo*,bar*` returns an error if any index starts with `foo`, but no
-index starts with `bar`.
+If `false`, requests return an error if any wildcard expression,
+<<indices-aliases,index alias>>, or `_all` value targets only missing or closed
+indices. This behavior applies even if the request targets other open indices.
+For example, a request targeting `foo*,bar*` returns an error if an index
+starts with `foo` but no index starts with `bar`.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -39,7 +39,7 @@ end::target-index-aliases[]
 tag::allow-no-indices[]
 `allow_no_indices`::
 (Optional, boolean)
-If `false`, requests return an error if any wildcard expression,
+If `false`, the request returns an error if any wildcard expression,
 <<indices-aliases,index alias>>, or `_all` value targets only missing or closed
 indices. This behavior applies even if the request targets other open indices.
 For example, a request targeting `foo*,bar*` returns an error if an index

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -40,9 +40,10 @@ tag::allow-no-indices[]
 `allow_no_indices`::
 (Optional, boolean)
 If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value that targets only missing or closed indices returns an error. For example,
-if an index starts with `foo` but no index starts with `bar`, a request
-targeting `foo*,bar*` returns an error.
+value that targets only missing or closed indices returns an error. This applies
+even if the request targets other open indices. For example, if an index starts
+with `foo` but no index starts with `bar`, a request targeting `foo*,bar*`
+returns an error.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -39,11 +39,11 @@ end::target-index-aliases[]
 tag::allow-no-indices[]
 `allow_no_indices`::
 (Optional, boolean)
-If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
-value that targets only missing or closed indices returns an error. This applies
-even if the request targets other open indices. For example, if an index starts
-with `foo` but no index starts with `bar`, a request targeting `foo*,bar*`
-returns an error.
+If `false`, requests return an error if any wildcard expression, <<indices-aliases,index alias>>, or `_all`
+value targets only missing or closed indices. This behavior applies
+even if the request targets other open indices. For example, a request
+targeting `foo*,bar*` returns an error if any index starts with `foo`, but no
+index starts with `bar`.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -38,9 +38,11 @@ end::target-index-aliases[]
 
 tag::allow-no-indices[]
 `allow_no_indices`::
-(Optional, boolean) If `false`, the request returns an error when a
-wildcard expression, <<indices-aliases,index alias>>, or `_all` value targets
-only missing or closed indices.
+(Optional, boolean)
+If `false`, any wildcard expression, <<indices-aliases,index alias>>, or `_all`
+value that targets only missing or closed indices returns an error. For example,
+if `foo` is an index but `bar` is not, a request targeting `foo*,bar*` returns
+an error.
 end::allow-no-indices[]
 
 tag::allow-no-match-transforms1[]


### PR DESCRIPTION
Relates to #63573 and #62986.

### Preview
https://elasticsearch_63748.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html#eql-search-api-query-params