### PR TITLE
Preserve backing index ordering for data streams

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -577,7 +577,6 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                     case DATA_STREAM:
                         IndexAbstraction.DataStream dataStream = (IndexAbstraction.DataStream) ia;
                         String[] backingIndices = dataStream.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
-                        Arrays.sort(backingIndices);
                         dataStreams.add(new ResolvedDataStream(
                             dataStream.getName(),
                             backingIndices,


### PR DESCRIPTION
The resolve index API incorrectly sorts the backing indices returned for data streams. The backing indices on a data stream are an ordered list in which the last index is always the write index so sorting them may produce incorrect results once [migration of existing indices to data streams](https://github.com/elastic/elasticsearch/issues/61046) is permitted.

