### PR TITLE
Remove opensuse 42 from vagrant tests

### DIFF
--- a/.ci/matrix-vagrant-packaging.yml
+++ b/.ci/matrix-vagrant-packaging.yml
@@ -14,7 +14,6 @@ OS:
   - fedora-29
   - oel-6
   - oel-7
-  - opensuse-42
   - sles-12
   - ubuntu-1604
   - ubuntu-1804

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,12 +134,6 @@ Vagrant.configure(2) do |config|
       dnf_docker config
     end
   end
-  'opensuse-42'.tap do |box|
-    config.vm.define box, define_opts do |config|
-      config.vm.box = 'elastic/opensuse-42-x86_64'
-      suse_common config, box
-    end
-  end
   'sles-12'.tap do |box|
     config.vm.define box, define_opts do |config|
       config.vm.box = 'elastic/sles-12-x86_64'


### PR DESCRIPTION
Opensuse 42 has not worked in a while. The test image is unmaintained,
and cannot be launched. It was removed from CI packaging test runs, but
still remained in vagrant tests. This commit removes it from vagrant
tests.