### PR TITLE
SQL: Implement to_char function (#54964)

### DIFF
--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -818,6 +818,44 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[formatDateTime]
 include-tagged::{sql-specs}/docs/docs.csv-spec[formatTime]
 --------------------------------------------------
 
+
+[[sql-functions-datetime-to_char]]
+==== `TO_CHAR`
+
+.Synopsis:
+[source, sql]
+--------------------------------------------------
+TO_CHAR(
+    date_exp/datetime_exp/time_exp, <1>
+    string_exp) <2>
+--------------------------------------------------
+
+*Input*:
+
+<1> date/datetime/time expression
+<2> format pattern
+
+*Output*: string
+
+*Description*: Returns the date/datetime/time as a string using the format specified in the 2nd argument. The formatting
+pattern used is one from
+https://www.postgresql.org/docs/9.1/functions-formatting.html#FUNCTIONS-FORMATTING-DATETIME-TABLE[PostgreSQL Template Patterns for Date/Time Formatting]
+or, if the pattern is not found, from Java
+https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html[Pattern Letters and Symbols].
+If any of the two arguments is `null` or the pattern is an empty string `null` is returned.
+
+[NOTE]
+If the 1st argument is of type `time`, then pattern specified by the 2nd argument cannot contain date related units
+(e.g. 'dd', 'MM', 'YYYY', etc.). If it contains such units an error is returned.
+
+*Special Cases*
+
+- Postgres formats `IDDD` and `WW` are not covered.
+- Format Specifier `y` will return year-of-era instead of one/two low-order digits.
+eg.: For year `2009`, `y` will be returning `2009` instead of `9`. For year `43`, `y` format specifier will return `43`.
+- Special characters like `"` , `\` and `%` will be returned as it is without any change. eg.: formatting date `17-sep-2020` with `%M` will return `%9`
+
+
 [[sql-functions-datetime-day]]
 ==== `DAY_OF_MONTH/DOM/DAY`
 

--- a/docs/reference/sql/functions/index.asciidoc
+++ b/docs/reference/sql/functions/index.asciidoc
@@ -59,6 +59,7 @@
 ** <<sql-functions-datetime-datetimeformat>>
 ** <<sql-functions-datetime-datetimeparse>>
 ** <<sql-functions-datetime-format>>
+** <<sql-functions-datetime-to_char>>
 ** <<sql-functions-datetime-timeparse>>
 ** <<sql-functions-datetime-part>>
 ** <<sql-functions-datetime-trunc>>

--- a/x-pack/plugin/sql/qa/server/src/main/resources/command.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/command.csv-spec
@@ -9,15 +9,15 @@ showFunctions
 SHOW FUNCTIONS;
 
     name:s       |    type:s
-AVG              |AGGREGATE      
+AVG              |AGGREGATE
 COUNT            |AGGREGATE
 FIRST            |AGGREGATE
 FIRST_VALUE      |AGGREGATE
 LAST             |AGGREGATE
 LAST_VALUE       |AGGREGATE
 MAX              |AGGREGATE
-MIN              |AGGREGATE      
-SUM              |AGGREGATE      
+MIN              |AGGREGATE
+SUM              |AGGREGATE
 KURTOSIS         |AGGREGATE
 MAD              |AGGREGATE
 PERCENTILE       |AGGREGATE
@@ -64,11 +64,12 @@ DAY_OF_MONTH     |SCALAR
 DAY_OF_WEEK      |SCALAR
 DAY_OF_YEAR      |SCALAR
 DOM              |SCALAR
-DOW              |SCALAR         
+DOW              |SCALAR
 DOY              |SCALAR
 FORMAT           |SCALAR
+TO_CHAR          |SCALAR
 HOUR             |SCALAR
-HOUR_OF_DAY      |SCALAR         
+HOUR_OF_DAY      |SCALAR
 IDOW             |SCALAR
 ISODAYOFWEEK     |SCALAR
 ISODOW           |SCALAR
@@ -78,16 +79,16 @@ ISO_DAY_OF_WEEK  |SCALAR
 ISO_WEEK_OF_YEAR |SCALAR
 IW               |SCALAR
 IWOY             |SCALAR
-MINUTE           |SCALAR         
-MINUTE_OF_DAY    |SCALAR         
-MINUTE_OF_HOUR   |SCALAR         
-MONTH            |SCALAR         
-MONTHNAME        |SCALAR         
-MONTH_NAME       |SCALAR         
-MONTH_OF_YEAR    |SCALAR         
+MINUTE           |SCALAR
+MINUTE_OF_DAY    |SCALAR
+MINUTE_OF_HOUR   |SCALAR
+MONTH            |SCALAR
+MONTHNAME        |SCALAR
+MONTH_NAME       |SCALAR
+MONTH_OF_YEAR    |SCALAR
 NOW              |SCALAR
-QUARTER          |SCALAR         
-SECOND           |SCALAR         
+QUARTER          |SCALAR
+SECOND           |SCALAR
 SECOND_OF_MINUTE |SCALAR
 TIMESTAMPADD     |SCALAR
 TIMESTAMPDIFF    |SCALAR
@@ -96,60 +97,60 @@ TIMESTAMP_DIFF   |SCALAR
 TIME_PARSE       |SCALAR
 TODAY            |SCALAR
 WEEK             |SCALAR
-WEEK_OF_YEAR     |SCALAR         
-YEAR             |SCALAR         
-ABS              |SCALAR         
-ACOS             |SCALAR         
-ASIN             |SCALAR         
-ATAN             |SCALAR         
-ATAN2            |SCALAR         
-CBRT             |SCALAR         
-CEIL             |SCALAR         
-CEILING          |SCALAR         
-COS              |SCALAR         
-COSH             |SCALAR         
-COT              |SCALAR         
-DEGREES          |SCALAR         
-E                |SCALAR         
-EXP              |SCALAR         
-EXPM1            |SCALAR         
-FLOOR            |SCALAR         
-LOG              |SCALAR         
-LOG10            |SCALAR         
-MOD              |SCALAR         
-PI               |SCALAR         
-POWER            |SCALAR         
-RADIANS          |SCALAR         
-RAND             |SCALAR         
-RANDOM           |SCALAR         
-ROUND            |SCALAR         
-SIGN             |SCALAR         
-SIGNUM           |SCALAR         
-SIN              |SCALAR         
-SINH             |SCALAR         
-SQRT             |SCALAR         
-TAN              |SCALAR         
+WEEK_OF_YEAR     |SCALAR
+YEAR             |SCALAR
+ABS              |SCALAR
+ACOS             |SCALAR
+ASIN             |SCALAR
+ATAN             |SCALAR
+ATAN2            |SCALAR
+CBRT             |SCALAR
+CEIL             |SCALAR
+CEILING          |SCALAR
+COS              |SCALAR
+COSH             |SCALAR
+COT              |SCALAR
+DEGREES          |SCALAR
+E                |SCALAR
+EXP              |SCALAR
+EXPM1            |SCALAR
+FLOOR            |SCALAR
+LOG              |SCALAR
+LOG10            |SCALAR
+MOD              |SCALAR
+PI               |SCALAR
+POWER            |SCALAR
+RADIANS          |SCALAR
+RAND             |SCALAR
+RANDOM           |SCALAR
+ROUND            |SCALAR
+SIGN             |SCALAR
+SIGNUM           |SCALAR
+SIN              |SCALAR
+SINH             |SCALAR
+SQRT             |SCALAR
+TAN              |SCALAR
 TRUNC            |SCALAR
 TRUNCATE         |SCALAR
 ASCII            |SCALAR
-BIT_LENGTH       |SCALAR         
-CHAR             |SCALAR         
-CHARACTER_LENGTH |SCALAR         
-CHAR_LENGTH      |SCALAR         
-CONCAT           |SCALAR         
-INSERT           |SCALAR         
-LCASE            |SCALAR         
-LEFT             |SCALAR         
-LENGTH           |SCALAR         
-LOCATE           |SCALAR         
-LTRIM            |SCALAR         
-OCTET_LENGTH     |SCALAR         
-POSITION         |SCALAR         
-REPEAT           |SCALAR         
-REPLACE          |SCALAR         
-RIGHT            |SCALAR         
-RTRIM            |SCALAR         
-SPACE            |SCALAR         
+BIT_LENGTH       |SCALAR
+CHAR             |SCALAR
+CHARACTER_LENGTH |SCALAR
+CHAR_LENGTH      |SCALAR
+CONCAT           |SCALAR
+INSERT           |SCALAR
+LCASE            |SCALAR
+LEFT             |SCALAR
+LENGTH           |SCALAR
+LOCATE           |SCALAR
+LTRIM            |SCALAR
+OCTET_LENGTH     |SCALAR
+POSITION         |SCALAR
+REPEAT           |SCALAR
+REPLACE          |SCALAR
+RIGHT            |SCALAR
+RTRIM            |SCALAR
+SPACE            |SCALAR
 STARTS_WITH      |SCALAR
 SUBSTRING        |SCALAR
 TRIM             |SCALAR
@@ -212,22 +213,22 @@ DAY_NAME       |SCALAR
 DAY_OF_MONTH   |SCALAR
 DAY_OF_WEEK    |SCALAR
 DAY_OF_YEAR    |SCALAR
-HOUR_OF_DAY    |SCALAR         
+HOUR_OF_DAY    |SCALAR
 ISODAYOFWEEK   |SCALAR
 ISO_DAY_OF_WEEK|SCALAR
-MINUTE_OF_DAY  |SCALAR         
+MINUTE_OF_DAY  |SCALAR
 TODAY          |SCALAR
 ;
 
 showTables
 SHOW TABLES;
 
-       name    |  type |  kind   
+       name    |  type |  kind
 logs           |TABLE  |INDEX
 test_alias     |VIEW   |ALIAS
-test_alias_emp |VIEW   |ALIAS 
-test_emp       |TABLE  |INDEX  
-test_emp_copy  |TABLE  |INDEX  
+test_alias_emp |VIEW   |ALIAS
+test_emp       |TABLE  |INDEX
+test_emp_copy  |TABLE  |INDEX
 ;
 
 showTablesSimpleLike
@@ -241,8 +242,8 @@ showTablesMultiLike
 SHOW TABLES LIKE 'test_emp%';
 
  name:s        |type:s |kind:s
-test_emp       |TABLE  |INDEX     
-test_emp_copy  |TABLE  |INDEX     
+test_emp       |TABLE  |INDEX
+test_emp_copy  |TABLE  |INDEX
 ;
 
 showTablesIdentifier
@@ -263,8 +264,8 @@ showTablesIdentifierPatternOnAliases
 SHOW TABLES "test*,-test_emp*";
 
  name:s        | type:s | kind:s
-test_alias     |VIEW    |ALIAS          
-test_alias_emp |VIEW    |ALIAS          
+test_alias     |VIEW    |ALIAS
+test_alias_emp |VIEW    |ALIAS
 ;
 
 // DESCRIBE
@@ -272,7 +273,7 @@ test_alias_emp |VIEW    |ALIAS
 describeSimpleLike
 DESCRIBE LIKE 'test_emp';
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -302,7 +303,7 @@ wildcard_name       |VARCHAR        |keyword
 describeMultiLike
 DESCRIBE LIKE 'test_emp%';
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -332,7 +333,7 @@ wildcard_name       |VARCHAR        |keyword
 describeSimpleIdentifier
 DESCRIBE "test_emp";
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -358,7 +359,7 @@ salary              |INTEGER        |integer
 describeIncludeExcludeIdentifier-Ignore
 DESCRIBE "test_*,-test_alias*";
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.sql.expression.function.grouping.Histogram;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Database;
 import org.elasticsearch.xpack.sql.expression.function.scalar.User;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.ToChar;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.CurrentDate;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.CurrentDateTime;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.CurrentTime;
@@ -184,6 +185,7 @@ public class SqlFunctionRegistry extends FunctionRegistry {
                 def(DateTimeParse.class, DateTimeParse::new, "DATETIME_PARSE"),
                 def(DateTrunc.class, DateTrunc::new, "DATETRUNC", "DATE_TRUNC"),
                 def(Format.class, Format::new, "FORMAT"),
+                def(ToChar.class, ToChar::new, "TO_CHAR"),
                 def(HourOfDay.class, HourOfDay::new, "HOUR_OF_DAY", "HOUR"),
                 def(IsoDayOfWeek.class, IsoDayOfWeek::new, "ISO_DAY_OF_WEEK", "ISODAYOFWEEK", "ISODOW", "IDOW"),
                 def(IsoWeekOfYear.class, IsoWeekOfYear::new, "ISO_WEEK_OF_YEAR", "ISOWEEKOFYEAR", "ISOWEEK", "IWOY", "IW"),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatMapping.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatMapping.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import java.util.function.Function;
+
+class DateTimeFormatMapping {
+
+    private final String pattern;
+    private final String javaPattern;
+    private final Function<String, String> additionalMapper;
+
+    DateTimeFormatMapping(String pattern, String javaPattern, Function<String, String> additionalMapper) {
+        this.pattern = pattern;
+        this.javaPattern = javaPattern;
+        this.additionalMapper = additionalMapper;
+    }
+
+    DateTimeFormatMapping(String pattern, String javaPattern) {
+        this(pattern, javaPattern, null);
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public String getJavaPattern() {
+        return javaPattern;
+    }
+
+    public Function<String, String> getAdditionalMapper() {
+        if (additionalMapper == null) {
+            return Function.identity();
+        }
+
+        return additionalMapper;
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatProcessor.java
@@ -20,7 +20,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.sql.util.DateUtils.asTimeAtZone;
+import static org.elasticsearch.xpack.sql.util.DateUtils.*;
 
 public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
 
@@ -36,12 +36,69 @@ public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
         {"F", "S"},
         {"z", "X"}
     };
+    private static final DateTimeFormatMapping[] JAVA_TIME_TO_CHAR_MAPPINGS = {
+        new DateTimeFormatMapping("MONTH", "MMMM", String::toUpperCase),
+        new DateTimeFormatMapping("Month", "MMMM"),
+        new DateTimeFormatMapping("month", "MMMM", String::toLowerCase),
+        new DateTimeFormatMapping("MON", "MMM", String::toUpperCase),
+        new DateTimeFormatMapping("Mon", "MMM"),
+        new DateTimeFormatMapping("mon", "MMM", String::toLowerCase),
+        new DateTimeFormatMapping("DAY", "EEEE", String::toUpperCase),
+        new DateTimeFormatMapping("Day", "EEEE"),
+        new DateTimeFormatMapping("day", "EEEE", String::toLowerCase),
+        new DateTimeFormatMapping("DY", "E", String::toUpperCase),
+        new DateTimeFormatMapping("Dy", "E"),
+        new DateTimeFormatMapping("dy", "E", String::toLowerCase),
+        new DateTimeFormatMapping("HH12", "hh"),
+        new DateTimeFormatMapping("HH24", "HH"),
+        new DateTimeFormatMapping("HH", "hh"),
+        new DateTimeFormatMapping("MI", "mm"),
+        new DateTimeFormatMapping("SSSS", "A", milliSecondOfDay -> String.valueOf(Integer.parseInt(milliSecondOfDay) / 1000)),
+        new DateTimeFormatMapping("SS", "s"),
+        new DateTimeFormatMapping("MS", "SSS"),
+        new DateTimeFormatMapping("US", "n", nano -> String.format("%06d", (int) (Integer.parseInt(nano) / Math.pow(10.0, Math.max(nano.length() - 6, 0))))),
+        new DateTimeFormatMapping("AM", "a", String::toUpperCase),
+        new DateTimeFormatMapping("am", "a", String::toLowerCase),
+        new DateTimeFormatMapping("PM", "a", String::toUpperCase),
+        new DateTimeFormatMapping("pm", "a", String::toLowerCase),
+        new DateTimeFormatMapping("A.M.", "a", x -> x.charAt(0) + "." + x.charAt(1) + "."),
+        new DateTimeFormatMapping("a.m.", "a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase()),
+        new DateTimeFormatMapping("P.M.", "a", x -> x.charAt(0) + "." + x.charAt(1) + "."),
+        new DateTimeFormatMapping("p.m.", "a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase()),
+        new DateTimeFormatMapping("BC", "G"),
+        new DateTimeFormatMapping("bc", "G", String::toLowerCase),
+        new DateTimeFormatMapping("AD", "G"),
+        new DateTimeFormatMapping("ad", "G", String::toLowerCase),
+        new DateTimeFormatMapping("B.C.", "G", x -> x.charAt(0) + "." + x.charAt(1) + "."),
+        new DateTimeFormatMapping("b.c.", "G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase()),
+        new DateTimeFormatMapping("A.D.", "G", x -> x.charAt(0) + "." + x.charAt(1) + "."),
+        new DateTimeFormatMapping("a.d.", "G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase()),
+        new DateTimeFormatMapping("DDD", "DDD"),
+        new DateTimeFormatMapping("DD", "d"),
+        new DateTimeFormatMapping("ID", "e"),
+        new DateTimeFormatMapping("D", "e", dayOfWeek -> String.valueOf((Integer.parseInt(dayOfWeek) + 1) % 7)),
+        new DateTimeFormatMapping("IW", "ww"),
+        new DateTimeFormatMapping("CC", "YYYY", year -> String.format(year.charAt(0) == '-' ? "%03d" : "%02d", century(Integer.parseInt(year)))),
+        new DateTimeFormatMapping("J", "g", modifiedJulianDay -> String.valueOf(Integer.parseInt(modifiedJulianDay) + 2400001)),
+        new DateTimeFormatMapping("RM", "MM", month -> toRome(Integer.parseInt(month))),
+        new DateTimeFormatMapping("rm", "MM", month -> toRome(Integer.parseInt(month)).toLowerCase()),
+        new DateTimeFormatMapping("IYYY", "YYYY"),
+        new DateTimeFormatMapping("IYY", "YYYY", year -> year.substring(1)),
+        new DateTimeFormatMapping("IY", "YY"),
+        new DateTimeFormatMapping("I", "YY", year -> year.substring(1)),
+        new DateTimeFormatMapping("Y,YYY", "yyyy", year -> year.charAt(0) + "," + year.substring(1)),
+        new DateTimeFormatMapping("YYYY", "yyyy"),
+        new DateTimeFormatMapping("YYY", "yyyy", year -> year.substring(1)),
+        new DateTimeFormatMapping("YY", "yy"),
+        new DateTimeFormatMapping("Y", "yy", year -> year.substring(1)),
+    };
     private final Formatter formatter;
 
 
     public enum Formatter {
         FORMAT,
-        DATE_TIME_FORMAT;
+        DATE_TIME_FORMAT,
+        TO_CHAR;
 
         private String getJavaPattern(String pattern) {
             if (this == FORMAT) {
@@ -77,7 +134,11 @@ public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
                 ta = asTimeAtZone((OffsetTime) timestamp, zoneId);
             }
             try {
-                return DateTimeFormatter.ofPattern(getJavaPattern(patternString), Locale.ROOT).format(ta);
+                if (this == TO_CHAR) {
+                    return formatUsingMappings(ta, patternString);
+                }
+
+                return format(getJavaPattern(patternString), ta);
             } catch (IllegalArgumentException | DateTimeException e) {
                 throw new SqlIllegalArgumentException(
                     "Invalid pattern [{}] is received for formatting date/time [{}]; {}",
@@ -86,6 +147,28 @@ public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
                     e.getMessage()
                 );
             }
+        }
+
+        private String formatUsingMappings(TemporalAccessor temporalAccessor, String pattern) {
+            for (DateTimeFormatMapping mapping : JAVA_TIME_TO_CHAR_MAPPINGS) {
+                if (pattern.contains(mapping.getPattern())) {
+                    var middle = mapping
+                        .getAdditionalMapper()
+                        .apply(format(mapping.getJavaPattern(), temporalAccessor));
+
+                    var parts = pattern.split(mapping.getPattern(), 2);
+                    return formatUsingMappings(temporalAccessor, parts[0])
+                        + middle
+                        + formatUsingMappings(temporalAccessor, parts[1]);
+                }
+            }
+
+            return format(pattern, temporalAccessor);
+        }
+
+        private String format(String pattern, TemporalAccessor temporalAccessor) {
+            return DateTimeFormatter.ofPattern(pattern, Locale.ROOT)
+                .format(temporalAccessor);
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToChar.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToChar.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.function.scalar.BinaryScalarFunction;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+import java.time.ZoneId;
+
+import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFormatProcessor.Formatter.TO_CHAR;
+
+public class ToChar extends BaseDateTimeFormatFunction {
+    public ToChar(Source source, Expression timestamp, Expression pattern, ZoneId zoneId) {
+        super(source, timestamp, pattern, zoneId);
+    }
+
+    @Override
+    protected DateTimeFormatProcessor.Formatter formatter() {
+        return TO_CHAR;
+    }
+
+    @Override
+    protected NodeInfo.NodeCtor3<Expression, Expression, ZoneId, BaseDateTimeFormatFunction> ctor() {
+        return ToChar::new;
+    }
+
+    @Override
+    protected BinaryScalarFunction replaceChildren(Expression timestamp, Expression pattern) {
+        return new ToChar(source(), timestamp, pattern, zoneId());
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
@@ -300,6 +300,10 @@ public class InternalSqlScriptUtils extends InternalQlScriptUtils {
         return (String) Formatter.FORMAT.format(asDateTime(dateTime), pattern, ZoneId.of(tzId));
     }
 
+    public static String toChar(Object dateTime, String pattern, String tzId) {
+        return (String) Formatter.TO_CHAR.format(asDateTime(dateTime), pattern, ZoneId.of(tzId));
+    }
+
     public static Object timeParse(String dateField, String pattern, String tzId) {
         return Parser.TIME.parse(dateField, pattern, ZoneId.of(tzId));
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
@@ -216,6 +216,45 @@ public final class DateUtils {
         }
     }
 
+    public static String toRome(int month) {
+        switch (month) {
+            case 1:
+                return "I";
+            case 2:
+                return "II";
+            case 3:
+                return "III";
+            case 4:
+                return "IV";
+            case 5:
+                return "V";
+            case 6:
+                return "VI";
+            case 7:
+                return "VII";
+            case 8:
+                return "VIII";
+            case 9:
+                return "IX";
+            case 10:
+                return "X";
+            case 11:
+                return "XI";
+            case 12:
+                return "XII";
+            default:
+                return "";
+        }
+    }
+
+    public static int century(int year) {
+        if (year > 0) {
+            return year / 100 + 1;
+        } else {
+            return year / 100 - 1;
+        }
+    }
+
     private static int timeSeparatorIdx(String timestampStr) {
         int separatorIdx = timestampStr.indexOf('-'); // Find the first `-` date separator
         if (separatorIdx == 0) { // first char = `-` denotes a negative year

--- a/x-pack/plugin/sql/src/main/resources/org/elasticsearch/xpack/sql/plugin/sql_whitelist.txt
+++ b/x-pack/plugin/sql/src/main/resources/org/elasticsearch/xpack/sql/plugin/sql_whitelist.txt
@@ -136,6 +136,7 @@ class org.elasticsearch.xpack.sql.expression.function.scalar.whitelist.InternalS
   Integer datePart(String, Object, String)
   String dateTimeFormat(Object, String, String)
   String format(Object, String, String)
+  String toChar(Object, String, String)
   def dateTimeParse(String, String, String)
   def timeParse(String, String, String)
   IntervalDayTime intervalDayTime(String, String)

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.gen.processor.ConstantProcessor;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFormatProcessor.Formatter;
+
+import java.time.Instant;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.elasticsearch.xpack.ql.expression.Literal.NULL;
+import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTestUtils.*;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.*;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypes.TIME;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
+
+public class DateTimeToCharProcessorTests extends AbstractSqlWireSerializingTestCase<DateTimeFormatProcessor> {
+
+    public static DateTimeFormatProcessor randomDateTimeFormatProcessor() {
+        return new DateTimeFormatProcessor(
+            new ConstantProcessor(DateTimeTestUtils.nowWithMillisResolution()),
+            new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
+            randomZone(),
+            randomFrom(Formatter.values())
+        );
+    }
+
+    public static Literal randomTimeLiteral() {
+        return l(OffsetTime.ofInstant(Instant.ofEpochMilli(ESTestCase.randomLong()), ESTestCase.randomZone()), TIME);
+    }
+
+    @Override
+    protected DateTimeFormatProcessor createTestInstance() {
+        return randomDateTimeFormatProcessor();
+    }
+
+    @Override
+    protected Reader<DateTimeFormatProcessor> instanceReader() {
+        return DateTimeFormatProcessor::new;
+    }
+
+    @Override
+    protected ZoneId instanceZoneId(DateTimeFormatProcessor instance) {
+        return instance.zoneId();
+    }
+
+    @Override
+    protected DateTimeFormatProcessor mutateInstance(DateTimeFormatProcessor instance) {
+        return new DateTimeFormatProcessor(
+            new ConstantProcessor(DateTimeTestUtils.nowWithMillisResolution()),
+            new ConstantProcessor(ESTestCase.randomRealisticUnicodeOfLength(128)),
+            randomZone(),
+            randomValueOtherThan(instance.formatter(), () -> randomFrom(Formatter.values()))
+        );
+    }
+
+    public void testSeconds() {
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 1))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("000001");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 12))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("000012");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("000123");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 1234))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("001234");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 12345))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("012345");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("US")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("123456");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("ss.MS")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("37.123");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 1, 0))
+            .withFormat("ss.MS")
+            .isFormattedTo("01.000");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("ss.n")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("37.123456789");
+        assertThat(time(21, 11, 2, 123456789))
+            .withFormat("s-ss")
+            .isFormattedTo("2-02");
+    }
+
+    public void testSecondOfDay() {
+        assertThat(dateTime(2020, 10, 13, 13, 26, 41, 0))
+            .withFormat("SSSS")
+            .isFormattedTo("48401");
+    }
+
+    public void testMinutes() {
+        assertThat(dateTime(2019, 9, 3, 18, 0, 37, 123456789))
+            .withFormat("mm MI")
+            .isFormattedTo("00 00");
+
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("mm MI")
+            .isFormattedTo("10 10");
+
+        assertThat(dateTime(2019, 9, 3, 18, 59, 37, 123456789))
+            .withFormat("mm MI")
+            .isFormattedTo("59 59");
+    }
+
+    public void testHours() {
+        var dateTime = dateTime(2019, 9, 3, 16, 10, 37, 123456789);
+        assertThat(dateTime)
+            .withFormat("HH")
+            .isFormattedTo("04");
+        assertThat(dateTime)
+            .withFormat("HH12")
+            .isFormattedTo("04");
+        assertThat(dateTime)
+            .withFormat("HH24")
+            .isFormattedTo("16");
+        assertThat(dateTime)
+            .withFormat("HH24")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("02");
+    }
+
+    public void testMonths() {
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("M-MM-MMM-MMMM")
+            .isFormattedTo("9-09-Sep-September");
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("Month MONTH month")
+            .isFormattedTo("September SEPTEMBER september");
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("Mon MON mon")
+            .isFormattedTo("Sep SEP sep");
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("%M-\"MM-\\MMM-MMMM")
+            .isFormattedTo("%9-\"09-\\Sep-September");
+    }
+
+    public void testRomeMonths() {
+        assertThat(date(2001, 1, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("I i");
+        assertThat(date(2001, 2, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("II ii");
+        assertThat(date(2001, 3, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("III iii");
+        assertThat(date(2001, 4, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("IV iv");
+        assertThat(date(2001, 5, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("V v");
+        assertThat(date(2001, 6, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("VI vi");
+        assertThat(date(2001, 7, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("VII vii");
+        assertThat(date(2001, 8, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("VIII viii");
+        assertThat(date(2001, 9, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("IX ix");
+        assertThat(date(2001, 10, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("X x");
+        assertThat(date(2001, 11, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("XI xi");
+        assertThat(date(2001, 12, 3, UTC))
+            .withFormat("RM rm")
+            .isFormattedTo("XII xii");
+    }
+
+    public void testYearOfEra() {
+        assertThat(date(2001, 9, 3, UTC))
+            .withFormat("y-yy-yyyy-yyyyy")
+            .isFormattedTo("2001-01-2001-02001");
+
+        assertThat(dateTime(45, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("y-yyyy")
+            .isFormattedTo("45-0045");
+
+        assertThat(dateTime(2017, 1, 1, 1, 1, 1, 0))
+            .withFormat("Y,YYY Y YY YYY YYYY")
+            .isFormattedTo("2,017 7 17 017 2017");
+    }
+
+    public void testWeekBasedYear() {
+        assertThat(date(2017, 1, 1, UTC))
+            .withFormat("IYYY IYY IY I")
+            .isFormattedTo("2016 016 16 6");
+    }
+
+    public void testDayOfWeek() {
+        var zoneId = ZoneId.of("Etc/GMT-10");
+        var dateTime = dateTime(2019, 9, 3, 18, 10, 37, 123456789);
+        assertThat(dateTime)
+            .withFormat("Dy DY dy")
+            .withZoneId(zoneId)
+            .isFormattedTo("Wed WED wed");
+
+        assertThat(dateTime)
+            .withFormat("Day DAY day")
+            .withZoneId(zoneId)
+            .isFormattedTo("Wednesday WEDNESDAY wednesday");
+
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("ID D Day")
+            .isFormattedTo("2 3 Tuesday");
+
+        assertThat(date(2019, 9, 8, UTC))
+            .withFormat("ID D")
+            .isFormattedTo("7 1");
+
+        assertThat(date(2019, 9, 9, UTC))
+            .withFormat("ID D")
+            .isFormattedTo("1 2");
+    }
+
+    public void testDayOfMonth() {
+        assertThat(date(2019, 9, 23, UTC))
+            .withFormat("d")
+            .isFormattedTo("23");
+
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("d")
+            .isFormattedTo("3");
+    }
+
+    public void testDayOfYear() {
+        assertThat(date(2018, 9, 23, UTC))
+            .withFormat("DDD")
+            .isFormattedTo("266");
+
+        assertThat(date(2018, 1, 1, UTC))
+            .withFormat("DDD")
+            .isFormattedTo("001");
+
+        assertThat(date(2019, 9, 23, UTC))
+            .withFormat("DDD")
+            .isFormattedTo("266");
+
+        assertThat(date(2019, 12, 31, UTC))
+            .withFormat("DDD")
+            .isFormattedTo("365");
+
+        assertThat(date(2020, 12, 31, UTC))
+            .withFormat("DDD")
+            .isFormattedTo("366");
+    }
+
+    public void testWeekNumber() {
+        assertThat(date(2020, 1, 1, UTC))
+            .withFormat("W IW")
+            .isFormattedTo("1 01");
+
+//        assertThat(dateTime(2018, 6, 8, 12, 0, 0, 0))
+//            .withFormat("W IW")
+//            .isFormattedTo("2 23");
+    }
+
+    public void testEra() {
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("G AD A.D. a.d. ad")
+            .isFormattedTo("AD AD A.D. a.d. ad");
+
+        assertThat(date(-2019, 9, 3, UTC))
+            .withFormat("G BC A.D. a.d. ad")
+            .isFormattedTo("BC BC B.C. b.c. bc");
+
+        assertThat(date(-2019, 9, 3, UTC))
+            .withFormat("G BC B.C. b.c. bc")
+            .isFormattedTo("BC BC B.C. b.c. bc");
+
+        assertThat(date(2019, 9, 3, UTC))
+            .withFormat("G AD A.D. a.d. ad")
+            .isFormattedTo("AD AD A.D. a.d. ad");
+    }
+
+    public void testQuarterOfYear() {
+        for (int month = 0; month < 12; month++) {
+            assertThat(date(2019, month + 1, 3, UTC))
+                .withFormat("Q")
+                .isFormattedTo(String.valueOf((month / 3) + 1));
+        }
+    }
+
+    public void testJulianDays() {
+        assertThat(dateTime(2017, 1, 1, 1, 1, 1, 0))
+            .withFormat("J")
+            .isFormattedTo("2457755");
+
+        assertThat(dateTime(500, 4, 11, 23, 59, 0, 0))
+            .withFormat("J")
+            .isFormattedTo("1903782");
+    }
+
+    public void testCentury() {
+        assertThat(date(2001, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("21");
+
+        assertThat(date(2000, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("20");
+
+        assertThat(date(1, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("01");
+
+        assertThat(date(0, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("-01");
+
+        assertThat(date(-1, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("-01");
+
+        assertThat(date(-101, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("-02");
+
+        assertThat(date(-2000, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("-21");
+
+        assertThat(date(-2001, 1, 1, UTC))
+            .withFormat("CC")
+            .isFormattedTo("-21");
+    }
+
+    public void testAmPmOfDay() {
+        var zoneId = ZoneId.of("America/Sao_Paulo");
+        var dateTime = dateTime(2019, 9, 3, 18, 10, 37, 123456789);
+
+        assertThat(dateTime(2034, 9, 3, 9, 10, 37, 123456789))
+            .withFormat("am a.m. AM A.M.")
+            .withZoneId(zoneId)
+            .isFormattedTo("am a.m. AM A.M.");
+        assertThat(dateTime(2034, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("am a.m. AM A.M.")
+            .withZoneId(zoneId)
+            .isFormattedTo("pm p.m. PM P.M.");
+
+        assertThat(dateTime)
+            .withFormat("'arr:' h:m am")
+            .withZoneId(zoneId)
+            .isFormattedTo("arr: 3:10 pm");
+    }
+
+    public void testDate() {
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 123456789))
+            .withFormat("YYYY-MM-dd")
+            .withZoneId("Etc/GMT-10")
+            .isFormattedTo("2019-09-04");
+    }
+
+    public void testWithNulls() {
+        assertThat(randomDatetimeLiteral())
+            .withFormat(NULL)
+            .withZoneId(randomZone())
+            .isNull();
+        assertThat(randomDatetimeLiteral())
+            .withFormat(l(""))
+            .withZoneId(randomZone())
+            .isNull();
+        assertThat(NULL)
+            .withFormat(randomStringLiteral())
+            .withZoneId(randomZone())
+            .isNull();
+    }
+
+    public void testFormatInvalidInputs() {
+        assertThat(l("foo"))
+            .withFormat(randomStringLiteral())
+            .withZoneId(randomZone())
+            .throwsWithMessage(SqlIllegalArgumentException.class, "A date/datetime/time is required; received [foo]");
+        assertThat(randomDatetimeLiteral())
+            .withFormat(l(5))
+            .withZoneId(randomZone())
+            .throwsWithMessage(SqlIllegalArgumentException.class, "A string is required; received [5]");
+        assertThat(dateTime(2019, 9, 3, 18, 10, 37, 0))
+            .withFormat("invalid")
+            .withZoneId(randomZone())
+            .throwsWithMessage(SqlIllegalArgumentException.class, "Invalid pattern [invalid] is received for formatting date/time [2019-09-03T18:10:37Z]; Unknown pattern letter: i");
+        assertThat(time(18, 10, 37, 123000000))
+            .withFormat("MM/dd")
+            .withZoneId(randomZone())
+            .throwsWithMessage(SqlIllegalArgumentException.class, "Invalid pattern [MM/dd] is received for formatting date/time [18:10:37.123Z]; Unsupported field: MonthOfYear");
+    }
+
+    private ToCharAssert assertThat(ZonedDateTime zonedDateTime) {
+        return assertThat(l(zonedDateTime));
+    }
+
+    private ToCharAssert assertThat(OffsetTime offsetTime) {
+        return assertThat(l(offsetTime, TIME));
+    }
+
+    private ToCharAssert assertThat(Literal literal) {
+        return new ToCharAssert(literal);
+    }
+
+    static class ToCharAssert {
+
+        private final Literal time;
+        private Literal format;
+        private ZoneId zoneId = UTC;
+
+        public ToCharAssert(Literal time) {
+            this.time = time;
+        }
+
+        ToCharAssert withFormat(Literal format) {
+            this.format = format;
+            return this;
+        }
+
+        ToCharAssert withFormat(String format) {
+            this.format = l(format);
+            return this;
+        }
+
+        ToCharAssert withZoneId(ZoneId zoneId) {
+            this.zoneId = zoneId;
+            return this;
+        }
+
+        ToCharAssert withZoneId(String zoneId) {
+            this.zoneId = ZoneId.of(zoneId);
+            return this;
+        }
+
+        void isFormattedTo(String expectedFormat) {
+            assertEquals(expectedFormat, execute());
+        }
+
+        void isNull() {
+            assertNull(execute());
+        }
+
+        void throwsWithMessage(Class<? extends Throwable> exceptionClass, String expectedMessage) {
+            var ex = expectThrows(exceptionClass, this::execute);
+            assertEquals(expectedMessage, ex.getMessage());
+        }
+
+        private Object execute() {
+            return new ToChar(Source.EMPTY, time, format, zoneId)
+                .makePipe()
+                .asProcessor()
+                .process(null);
+        }
+    }
+}


### PR DESCRIPTION
Implement to_char according to the PostgreSQL spec: https://www.postgresql.org/docs/9.1/functions-formatting.html by translating to the java.time patterns used in DATETIME_FORMAT.
Follows: #54832 
