### PR TITLE
[ML] refactor to use ByteSizeValue#of... helpers

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -41,11 +40,11 @@ public class ForecastJobAction extends ActionType<ForecastJobAction.Response> {
         public static final ParseField EXPIRES_IN = new ParseField("expires_in");
         public static final ParseField MAX_MODEL_MEMORY = new ParseField("max_model_memory");
 
-        public static final ByteSizeValue FORECAST_LOCAL_STORAGE_LIMIT = new ByteSizeValue(500, ByteSizeUnit.MB);
+        public static final ByteSizeValue FORECAST_LOCAL_STORAGE_LIMIT = ByteSizeValue.ofMb(500);
 
         // Max allowed duration: 10 years
         private static final TimeValue MAX_DURATION = TimeValue.parseTimeValue("3650d", "");
-        private static final long MIN_MODEL_MEMORY = new ByteSizeValue(1, ByteSizeUnit.MB).getBytes();
+        private static final long MIN_MODEL_MEMORY = ByteSizeValue.ofMb(1).getBytes();
 
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
@@ -181,7 +180,7 @@ public class ForecastJobAction extends ActionType<ForecastJobAction.Response> {
                 builder.field(EXPIRES_IN.getPreferredName(), expiresIn.getStringRep());
             }
             if (maxModelMemory != null) {
-                builder.field(MAX_MODEL_MEMORY.getPreferredName(), new ByteSizeValue(maxModelMemory).getStringRep());
+                builder.field(MAX_MODEL_MEMORY.getPreferredName(), ByteSizeValue.ofBytes(maxModelMemory).getStringRep());
             }
             builder.endObject();
             return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -41,13 +40,13 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
 
     public static final String TYPE = "data_frame_analytics_config";
 
-    public static final ByteSizeValue DEFAULT_MODEL_MEMORY_LIMIT = new ByteSizeValue(1, ByteSizeUnit.GB);
-    public static final ByteSizeValue MIN_MODEL_MEMORY_LIMIT = new ByteSizeValue(1, ByteSizeUnit.KB);
+    public static final ByteSizeValue DEFAULT_MODEL_MEMORY_LIMIT = ByteSizeValue.ofGb(1);
+    public static final ByteSizeValue MIN_MODEL_MEMORY_LIMIT = ByteSizeValue.ofKb(1);
     /**
      * This includes the overhead of thread stacks and data structures that the program might use that
      * are not instrumented.  But it does NOT include the memory used by loading the executable code.
      */
-    public static final ByteSizeValue PROCESS_MEMORY_OVERHEAD = new ByteSizeValue(5, ByteSizeUnit.MB);
+    public static final ByteSizeValue PROCESS_MEMORY_OVERHEAD = ByteSizeValue.ofMb(5);
 
     public static final ParseField ID = new ParseField("id");
     public static final ParseField DESCRIPTION = new ParseField("description");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -41,7 +40,7 @@ public final class InferenceToXContentCompressor {
     // Either 10% of the configured JVM heap, or 1 GB, which ever is smaller
     private static final long MAX_INFLATED_BYTES = Math.min(
         (long)((0.10) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
-        new ByteSizeValue(1, ByteSizeUnit.GB).getBytes());
+        ByteSizeValue.ofGb(1).getBytes());
 
     private InferenceToXContentCompressor() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -313,7 +313,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             builder.humanReadableField(
                 ESTIMATED_HEAP_MEMORY_USAGE_BYTES.getPreferredName(),
                 ESTIMATED_HEAP_MEMORY_USAGE_HUMAN,
-                new ByteSizeValue(estimatedHeapMemory));
+                ByteSizeValue.ofBytes(estimatedHeapMemory));
             builder.field(ESTIMATED_OPERATIONS.getPreferredName(), estimatedOperations);
             builder.field(LICENSE_LEVEL.getPreferredName(), licenseLevel.description());
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisLimits.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisLimits.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -142,7 +141,7 @@ public class AnalysisLimits implements ToXContentObject, Writeable {
 
         if (maxModelMemoryIsSet && modelMemoryLimit > maxModelMemoryLimit.getMb()) {
             throw ExceptionsHelper.badRequestException(Messages.getMessage(Messages.JOB_CONFIG_MODEL_MEMORY_LIMIT_GREATER_THAN_MAX,
-                    new ByteSizeValue(modelMemoryLimit, ByteSizeUnit.MB),
+                    ByteSizeValue.ofMb(modelMemoryLimit),
                     maxModelMemoryLimit));
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -99,7 +98,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
      * and the <code>normalize</code> process is not instrumented at all.)  But this overhead does NOT
      * include the memory used by loading the executable code.
      */
-    public static final ByteSizeValue PROCESS_MEMORY_OVERHEAD = new ByteSizeValue(10, ByteSizeUnit.MB);
+    public static final ByteSizeValue PROCESS_MEMORY_OVERHEAD = ByteSizeValue.ofMb(10);
 
     public static final long DEFAULT_MODEL_SNAPSHOT_RETENTION_DAYS = 10;
     public static final long DEFAULT_DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS = 1;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -785,7 +784,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder(
             buildAnalytics(jobId, sourceIndex, destIndex, null, new Classification(NESTED_FIELD)))
-            .setModelMemoryLimit(new ByteSizeValue(1, ByteSizeUnit.KB))
+            .setModelMemoryLimit(ByteSizeValue.ofKb(1))
             .build();
         putAnalytics(config);
         // Shouldn't throw

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.core.ml.action.DeleteForecastAction;
@@ -534,7 +533,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         String forecastId = forecast(job.getId(),
             TimeValue.timeValueHours(1),
             TimeValue.ZERO,
-            new ByteSizeValue(50, ByteSizeUnit.MB).getBytes());
+            ByteSizeValue.ofMb(50).getBytes());
 
         waitForecastToFinish(job.getId(), forecastId);
         closeJob(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
@@ -506,7 +505,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         }
 
         String id = "test_model_memory_limit_lower_than_estimated_memory_usage";
-        ByteSizeValue modelMemoryLimit = new ByteSizeValue(1, ByteSizeUnit.MB);
+        ByteSizeValue modelMemoryLimit = ByteSizeValue.ofMb(1);
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder()
             .setId(id)
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null))
@@ -543,7 +542,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         String id = "test_lazy_assign_model_memory_limit_too_high";
         // Assuming a 1TB job will never fit on the test machine - increase this when machines get really big!
-        ByteSizeValue modelMemoryLimit = new ByteSizeValue(1, ByteSizeUnit.TB);
+        ByteSizeValue modelMemoryLimit = ByteSizeValue.ofTb(1);
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder()
             .setId(id)
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null))

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -66,7 +65,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(4);
         ensureStableCluster(4);
 
-        Job.Builder job = createJob("fail-over-basics-job", new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob("fail-over-basics-job", ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
         ensureYellow(); // at least the primary shards of the indices a job uses should be started
@@ -209,7 +208,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         ensureStableCluster(3);
 
         String jobId = "dedicated-ml-node-job";
-        Job.Builder job = createJob(jobId, new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
 
@@ -287,7 +286,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         ensureYellow(); // at least the primary shards of the indices a job uses should be started
         int numJobs = numMlNodes * 10;
         for (int i = 0; i < numJobs; i++) {
-            Job.Builder job = createJob(Integer.toString(i), new ByteSizeValue(2, ByteSizeUnit.MB));
+            Job.Builder job = createJob(Integer.toString(i), ByteSizeValue.ofMb(2));
             PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
             client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
 
@@ -426,7 +425,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         String jobId = "test-lazy-stop";
         String datafeedId = jobId + "-datafeed";
         // Assume the test machine won't have space to assign a 2TB job
-        Job.Builder job = createJob(jobId, new ByteSizeValue(2, ByteSizeUnit.TB), true);
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofTb(2), true);
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -205,7 +204,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
 
             DataFrameAnalyticsConfigUpdate configUpdate =
                 new DataFrameAnalyticsConfigUpdate.Builder(configId)
-                    .setModelMemoryLimit(new ByteSizeValue(1024))
+                    .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
                     .build();
 
             blockingCall(
@@ -220,7 +219,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
                 is(equalTo(
                     new DataFrameAnalyticsConfig.Builder(initialConfig)
                         .setDescription("description-1")
-                        .setModelMemoryLimit(new ByteSizeValue(1024))
+                        .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
                         .build())));
         }
         {   // Noop update
@@ -241,7 +240,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
                 is(equalTo(
                     new DataFrameAnalyticsConfig.Builder(initialConfig)
                         .setDescription("description-1")
-                        .setModelMemoryLimit(new ByteSizeValue(1024))
+                        .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
                         .build())));
         }
         {   // Update that changes both description and model memory limit
@@ -251,7 +250,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
             DataFrameAnalyticsConfigUpdate configUpdate =
                 new DataFrameAnalyticsConfigUpdate.Builder(configId)
                     .setDescription("description-2")
-                    .setModelMemoryLimit(new ByteSizeValue(2048))
+                    .setModelMemoryLimit(ByteSizeValue.ofBytes(2048))
                     .build();
 
             blockingCall(
@@ -266,7 +265,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
                 is(equalTo(
                     new DataFrameAnalyticsConfig.Builder(initialConfig)
                         .setDescription("description-2")
-                        .setModelMemoryLimit(new ByteSizeValue(2048))
+                        .setModelMemoryLimit(ByteSizeValue.ofBytes(2048))
                         .build())));
         }
         {  // Update that applies security headers
@@ -289,7 +288,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
                 is(equalTo(
                     new DataFrameAnalyticsConfig.Builder(initialConfig)
                         .setDescription("description-2")
-                        .setModelMemoryLimit(new ByteSizeValue(2048))
+                        .setModelMemoryLimit(ByteSizeValue.ofBytes(2048))
                         .setHeaders(securityHeaders)
                         .build())));
         }
@@ -332,7 +331,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
 
             DataFrameAnalyticsConfigUpdate configUpdate =
                 new DataFrameAnalyticsConfigUpdate.Builder(configId)
-                    .setModelMemoryLimit(new ByteSizeValue(2048, ByteSizeUnit.MB))
+                    .setModelMemoryLimit(ByteSizeValue.ofMb(2048))
                     .build();
 
             ClusterState clusterState = clusterStateWithRunningAnalyticsTask(configId, DataFrameAnalyticsState.ANALYZING);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -153,7 +153,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
         blockingCall(actionListener -> jobConfigProvider.updateJob
-                (jobId, jobUpdate, new ByteSizeValue(32), actionListener), updateJobResponseHolder, exceptionHolder);
+                (jobId, jobUpdate, ByteSizeValue.ofBytes(32), actionListener), updateJobResponseHolder, exceptionHolder);
         assertNull(exceptionHolder.get());
         assertEquals("This job has been updated", updateJobResponseHolder.get().getDescription());
 
@@ -210,7 +210,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
                 .build();
 
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
-        blockingCall(actionListener -> jobConfigProvider.updateJob(jobId, invalidUpdate, new ByteSizeValue(32),
+        blockingCall(actionListener -> jobConfigProvider.updateJob(jobId, invalidUpdate, ByteSizeValue.ofBytes(32),
             actionListener), updateJobResponseHolder, exceptionHolder);
         assertNull(updateJobResponseHolder.get());
         assertNotNull(exceptionHolder.get());
@@ -235,7 +235,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
         // update with the no-op validator
         blockingCall(actionListener -> jobConfigProvider.updateJobWithValidation(
-            jobId, jobUpdate, new ByteSizeValue(32), validator, actionListener), updateJobResponseHolder, exceptionHolder);
+            jobId, jobUpdate, ByteSizeValue.ofBytes(32), validator, actionListener), updateJobResponseHolder, exceptionHolder);
 
         assertNull(exceptionHolder.get());
         assertNotNull(updateJobResponseHolder.get());
@@ -247,7 +247,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         updateJobResponseHolder.set(null);
         // Update with a validator that errors
-        blockingCall(actionListener -> jobConfigProvider.updateJobWithValidation(jobId, jobUpdate, new ByteSizeValue(32),
+        blockingCall(actionListener -> jobConfigProvider.updateJobWithValidation(jobId, jobUpdate, ByteSizeValue.ofBytes(32),
                 validatorWithAnError, actionListener),
                 updateJobResponseHolder, exceptionHolder);
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -88,7 +87,7 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
 
         enableIndexBlock(UNRELATED_INDEX, IndexMetadata.SETTING_READ_ONLY);
 
-        Job.Builder job = createJob("delete-aliases-test-job", new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob("delete-aliases-test-job", ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
 
@@ -111,7 +110,7 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
         ensureStableCluster(1);
         String jobIdDedicated = "delete-test-job-dedicated";
 
-        Job.Builder job = createJob(jobIdDedicated, new ByteSizeValue(2, ByteSizeUnit.MB)).setResultsIndexName(jobIdDedicated);
+        Job.Builder job = createJob(jobIdDedicated, ByteSizeValue.ofMb(2)).setResultsIndexName(jobIdDedicated);
         client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId())).actionGet();
         String dedicatedIndex = job.build().getInitialResultsIndexName();
@@ -119,7 +118,7 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
         createBuckets(jobIdDedicated, 1, 10);
 
         String jobIdShared = "delete-test-job-shared";
-        job = createJob(jobIdShared, new ByteSizeValue(2, ByteSizeUnit.MB));
+        job = createJob(jobIdShared, ByteSizeValue.ofMb(2));
         client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId())).actionGet();
         awaitJobOpenedAndAssigned(job.getId(), null);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -367,10 +366,10 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
         // Open 4 small jobs.  Since there is only 1 node in the cluster they'll have to go on that node.
 
-        setupJobWithoutDatafeed("small1", new ByteSizeValue(2, ByteSizeUnit.MB));
-        setupJobWithoutDatafeed("small2", new ByteSizeValue(2, ByteSizeUnit.MB));
-        setupJobWithoutDatafeed("small3", new ByteSizeValue(2, ByteSizeUnit.MB));
-        setupJobWithoutDatafeed("small4", new ByteSizeValue(2, ByteSizeUnit.MB));
+        setupJobWithoutDatafeed("small1", ByteSizeValue.ofMb(2));
+        setupJobWithoutDatafeed("small2", ByteSizeValue.ofMb(2));
+        setupJobWithoutDatafeed("small3", ByteSizeValue.ofMb(2));
+        setupJobWithoutDatafeed("small4", ByteSizeValue.ofMb(2));
 
         // Expand the cluster to 3 nodes.  The 4 small jobs will stay on the
         // same node because we don't rebalance jobs that are happily running.
@@ -384,7 +383,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
         // Open a big job.  This should go on a different node to the 4 small ones.
 
-        setupJobWithoutDatafeed("big1", new ByteSizeValue(500, ByteSizeUnit.MB));
+        setupJobWithoutDatafeed("big1", ByteSizeValue.ofMb(500));
 
         // Stop the current master node - this should be the one with the 4 small jobs on.
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.integration;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
@@ -42,7 +41,7 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(5);
         ensureStableCluster(5);
 
-        Job.Builder job = createJob("relocation-job", new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob("relocation-job", ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequ
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.transport.TransportService;
@@ -33,7 +32,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         startMlCluster(1, 1);
 
         // create and open first job, which succeeds:
-        Job.Builder job = createJob("close-failed-job-1", new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob("close-failed-job-1", ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).get();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId())).get();
@@ -44,7 +43,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         });
 
         // create and try to open second job, which fails:
-        job = createJob("close-failed-job-2", new ByteSizeValue(2, ByteSizeUnit.MB));
+        job = createJob("close-failed-job-2", ByteSizeValue.ofMb(2));
         putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).get();
         expectThrows(ElasticsearchStatusException.class,
@@ -86,7 +85,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
             .get()
             .isAcknowledged());
         // create and open first job, which succeeds:
-        Job.Builder job = createJob("lazy-node-validation-job-1", new ByteSizeValue(2, ByteSizeUnit.MB));
+        Job.Builder job = createJob("lazy-node-validation-job-1", ByteSizeValue.ofMb(2));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).get();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId())).get();
@@ -98,7 +97,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         });
 
         // create and try to open second job, which succeeds due to lazy node number:
-        job = createJob("lazy-node-validation-job-2", new ByteSizeValue(2, ByteSizeUnit.MB));
+        job = createJob("lazy-node-validation-job-2", ByteSizeValue.ofMb(2));
         putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).get();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId())).get(); // Should return while job is opening
@@ -136,7 +135,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
     private void verifyMaxNumberOfJobsLimit(int numNodes, int maxNumberOfJobsPerNode, boolean testDynamicChange) throws Exception {
         startMlCluster(numNodes, testDynamicChange ? 1 : maxNumberOfJobsPerNode);
         long maxMlMemoryPerNode = calculateMaxMlMemory();
-        ByteSizeValue jobModelMemoryLimit = new ByteSizeValue(2, ByteSizeUnit.MB);
+        ByteSizeValue jobModelMemoryLimit = ByteSizeValue.ofMb(2);
         long memoryFootprintPerJob = jobModelMemoryLimit.getBytes() + Job.PROCESS_MEMORY_OVERHEAD.getBytes();
         long maxJobsPerNodeDueToMemoryLimit = maxMlMemoryPerNode / memoryFootprintPerJob;
         int clusterWideMaxNumberOfJobs = numNodes * maxNumberOfJobsPerNode;

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/UnusedStatsRemoverIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/UnusedStatsRemoverIT.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -63,7 +62,7 @@ public class UnusedStatsRemoverIT extends BaseMlIntegTestCase {
 
         PutDataFrameAnalyticsAction.Request request = new PutDataFrameAnalyticsAction.Request(new DataFrameAnalyticsConfig.Builder()
             .setId("analytics-with-stats")
-            .setModelMemoryLimit(new ByteSizeValue(1, ByteSizeUnit.GB))
+            .setModelMemoryLimit(ByteSizeValue.ofGb(1))
             .setSource(new DataFrameAnalyticsSource(new String[]{"foo"}, null, null))
             .setDest(new DataFrameAnalyticsDest("bar", null))
             .setAnalysis(new Regression("prediction"))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.settings.SettingsModule;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -413,7 +412,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
      * ML job to run on a given node will do this, and then subsequent ML jobs on the same node will reuse the
      * same already-loaded code.
      */
-    public static final ByteSizeValue NATIVE_EXECUTABLE_CODE_OVERHEAD = new ByteSizeValue(30, ByteSizeUnit.MB);
+    public static final ByteSizeValue NATIVE_EXECUTABLE_CODE_OVERHEAD = ByteSizeValue.ofMb(30);
     // Values higher than 100% are allowed to accommodate use cases where swapping has been determined to be acceptable.
     // Anomaly detector jobs only use their full model memory during background persistence, and this is deliberately
     // staggered, so with large numbers of jobs few will generally be persisting state at the same time.
@@ -442,7 +441,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
 
     // Undocumented setting for integration test purposes
     public static final Setting<ByteSizeValue> MIN_DISK_SPACE_OFF_HEAP =
-        Setting.byteSizeSetting("xpack.ml.min_disk_space_off_heap", new ByteSizeValue(5, ByteSizeUnit.GB), Setting.Property.NodeScope);
+        Setting.byteSizeSetting("xpack.ml.min_disk_space_off_heap", ByteSizeValue.ofGb(5), Setting.Property.NodeScope);
 
     // Requests per second throttling for the nightly maintenance task
     public static final Setting<Float> NIGHTLY_MAINTENANCE_REQUESTS_PER_SECOND =

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -35,9 +34,9 @@ import java.util.Set;
 public class TransportEstimateModelMemoryAction
     extends HandledTransportAction<EstimateModelMemoryAction.Request, EstimateModelMemoryAction.Response> {
 
-    static final ByteSizeValue BASIC_REQUIREMENT = new ByteSizeValue(10, ByteSizeUnit.MB);
-    static final long BYTES_PER_INFLUENCER_VALUE = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
-    private static final long BYTES_IN_MB = new ByteSizeValue(1, ByteSizeUnit.MB).getBytes();
+    static final ByteSizeValue BASIC_REQUIREMENT = ByteSizeValue.ofMb(10);
+    static final long BYTES_PER_INFLUENCER_VALUE = ByteSizeValue.ofKb(10).getBytes();
+    private static final long BYTES_IN_MB = ByteSizeValue.ofMb(1).getBytes();
 
     @Inject
     public TransportEstimateModelMemoryAction(TransportService transportService,
@@ -87,11 +86,11 @@ public class TransportEstimateModelMemoryAction
             case NON_ZERO_COUNT:
             case LOW_NON_ZERO_COUNT:
             case HIGH_NON_ZERO_COUNT:
-                answer = new ByteSizeValue(32, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(32).getBytes();
                 break;
             case RARE:
             case FREQ_RARE:
-                answer = new ByteSizeValue(2, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(2).getBytes();
                 break;
             case INFO_CONTENT:
             case LOW_INFO_CONTENT:
@@ -114,23 +113,23 @@ public class TransportEstimateModelMemoryAction
             case VARP:
             case LOW_VARP:
             case HIGH_VARP:
-                answer = new ByteSizeValue(48, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(48).getBytes();
                 break;
             case METRIC:
                 // metric analyses mean, min and max simultaneously, and uses about 2.5 times the memory of one of these
-                answer = new ByteSizeValue(120, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(120).getBytes();
                 break;
             case MEDIAN:
             case LOW_MEDIAN:
             case HIGH_MEDIAN:
-                answer = new ByteSizeValue(64, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(64).getBytes();
                 break;
             case TIME_OF_DAY:
             case TIME_OF_WEEK:
-                answer = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(10).getBytes();
                 break;
             case LAT_LONG:
-                answer = new ByteSizeValue(64, ByteSizeUnit.KB).getBytes();
+                answer = ByteSizeValue.ofKb(64).getBytes();
                 break;
             default:
                 assert false : "unhandled detector function: " + detector.getFunction().getFullName();
@@ -174,7 +173,7 @@ public class TransportEstimateModelMemoryAction
             // length of all the distinct values of the function field concatenated in the bucket.
             // However, that would be very expensive and complex for the caller to calculate so
             // we just allow a fixed amount.
-            answer = addNonNegativeLongsWithMaxValueCap(answer, new ByteSizeValue(5, ByteSizeUnit.MB).getBytes());
+            answer = addNonNegativeLongsWithMaxValueCap(answer, ByteSizeValue.ofMb(5).getBytes());
         }
 
         return answer;
@@ -216,7 +215,7 @@ public class TransportEstimateModelMemoryAction
 
         // 5MB is a pretty conservative estimate of the memory requirement for categorization.
         // Often it is considerably less, but it's very hard to predict from simple statistics.
-        return new ByteSizeValue(5 * relevantPartitionFieldCardinalityEstimate, ByteSizeUnit.MB).getBytes();
+        return ByteSizeValue.ofMb(5 * relevantPartitionFieldCardinalityEstimate).getBytes();
     }
 
     static long cardinalityEstimate(String description, String fieldName, Map<String, Long> suppliedCardinailityEstimates,
@@ -235,7 +234,7 @@ public class TransportEstimateModelMemoryAction
 
     static ByteSizeValue roundUpToNextMb(long bytes) {
         assert bytes >= 0 : "negative bytes " + bytes;
-        return new ByteSizeValue(addNonNegativeLongsWithMaxValueCap(bytes, BYTES_IN_MB - 1) / BYTES_IN_MB, ByteSizeUnit.MB);
+        return ByteSizeValue.ofMb(addNonNegativeLongsWithMaxValueCap(bytes, BYTES_IN_MB - 1) / BYTES_IN_MB);
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -145,7 +144,7 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
         long jobLimitMegaBytes = job.getAnalysisLimits() == null || job.getAnalysisLimits().getModelMemoryLimit() == null ?
             AnalysisLimits.PRE_6_1_DEFAULT_MODEL_MEMORY_LIMIT_MB :
             job.getAnalysisLimits().getModelMemoryLimit();
-        long allowedMax = (long)(new ByteSizeValue(jobLimitMegaBytes, ByteSizeUnit.MB).getBytes() * 0.40);
+        long allowedMax = (long)(ByteSizeValue.ofMb(jobLimitMegaBytes).getBytes() * 0.40);
         long adjustedMax = Math.min(requestedLimit, allowedMax - 1);
         if (adjustedMax != requestedLimit) {
             String msg = "requested forecast memory limit [" +

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.tasks.Task;
@@ -98,7 +97,7 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
     }
 
     private ByteSizeValue defaultModelMemoryLimit() {
-        ByteSizeValue defaultLimit = new ByteSizeValue(AnalysisLimits.DEFAULT_MODEL_MEMORY_LIMIT_MB, ByteSizeUnit.MB);
+        ByteSizeValue defaultLimit = ByteSizeValue.ofMb(AnalysisLimits.DEFAULT_MODEL_MEMORY_LIMIT_MB);
         ByteSizeValue maxModelMemoryLimit = clusterService.getClusterSettings().get(MachineLearningField.MAX_MODEL_MEMORY_LIMIT);
         if (maxModelMemoryLimit != null && maxModelMemoryLimit.getBytes() > 0
                 && maxModelMemoryLimit.getBytes() < defaultLimit.getBytes()) {
@@ -141,7 +140,7 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
 
         maxMlMemory -= Math.max(Job.PROCESS_MEMORY_OVERHEAD.getBytes(), DataFrameAnalyticsConfig.PROCESS_MEMORY_OVERHEAD.getBytes());
         maxMlMemory -= MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes();
-        return new ByteSizeValue(Math.max(0L, maxMlMemory) / 1024 / 1024, ByteSizeUnit.MB);
+        return ByteSizeValue.ofMb(Math.max(0L, maxMlMemory) / 1024 / 1024);
     }
 
     private Map<String, Object> limits() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -75,7 +74,7 @@ public class MemoryUsageEstimationProcessManager {
                 dataSummary.cols,
                 // For memory estimation the model memory limit here should be set high enough not to trigger an error when C++ code
                 // compares the limit to the result of estimation.
-                new ByteSizeValue(1, ByteSizeUnit.PB),
+                ByteSizeValue.ofPb(1),
                 1,
                 "",
                 categoricalFields,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -425,9 +425,9 @@ public class ModelLoadingService implements ClusterStateListener {
                     "model cache entry evicted." +
                         "current cache [{}] current max [{}] model size [{}]. " +
                         "If this is undesired, consider updating setting [{}] or [{}].",
-                    new ByteSizeValue(localModelCache.weight()).getStringRep(),
+                    ByteSizeValue.ofBytes(localModelCache.weight()).getStringRep(),
                     maxCacheSize.getStringRep(),
-                    new ByteSizeValue(notification.getValue().model.ramBytesUsed()).getStringRep(),
+                    ByteSizeValue.ofBytes(notification.getValue().model.ramBytesUsed()).getStringRep(),
                     INFERENCE_MODEL_CACHE_SIZE.getKey(),
                     INFERENCE_MODEL_CACHE_TTL.getKey());
                 auditIfNecessary(notification.getKey(), msg);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -465,12 +464,12 @@ public class JobManager {
             }
             jobResultsProvider.modelSizeStats(job.getId(), modelSizeStats -> {
                 if (modelSizeStats != null) {
-                    ByteSizeValue modelSize = new ByteSizeValue(modelSizeStats.getModelBytes(), ByteSizeUnit.BYTES);
+                    ByteSizeValue modelSize = ByteSizeValue.ofBytes(modelSizeStats.getModelBytes());
                     if (newModelMemoryLimit < modelSize.getMb()) {
                         listener.onFailure(ExceptionsHelper.badRequestException(
                                 Messages.getMessage(Messages.JOB_CONFIG_UPDATE_ANALYSIS_LIMITS_MODEL_MEMORY_LIMIT_CANNOT_BE_DECREASED,
-                                        new ByteSizeValue(modelSize.getMb(), ByteSizeUnit.MB),
-                                        new ByteSizeValue(newModelMemoryLimit, ByteSizeUnit.MB))));
+                                        ByteSizeValue.ofMb(modelSize.getMb()),
+                                        ByteSizeValue.ofMb(newModelMemoryLimit))));
                         return;
                     }
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
@@ -407,11 +406,11 @@ public class AutodetectResultProcessor {
             } else if (memoryStatus == ModelSizeStats.MemoryStatus.HARD_LIMIT) {
                 if (modelSizeStats.getModelBytesMemoryLimit() == null || modelSizeStats.getModelBytesExceeded() == null) {
                     auditor.error(jobId, Messages.getMessage(Messages.JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT_PRE_7_2,
-                        new ByteSizeValue(modelSizeStats.getModelBytes(), ByteSizeUnit.BYTES).toString()));
+                        ByteSizeValue.ofBytes(modelSizeStats.getModelBytes()).toString()));
                 } else {
                     auditor.error(jobId, Messages.getMessage(Messages.JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT,
-                        new ByteSizeValue(modelSizeStats.getModelBytesMemoryLimit(), ByteSizeUnit.BYTES).toString(),
-                        new ByteSizeValue(modelSizeStats.getModelBytesExceeded(), ByteSizeUnit.BYTES).toString()));
+                        ByteSizeValue.ofBytes(modelSizeStats.getModelBytesMemoryLimit()).toString(),
+                        ByteSizeValue.ofBytes(modelSizeStats.getModelBytesExceeded()).toString()));
                 }
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
@@ -426,7 +426,7 @@ public class MlMemoryTracker implements LocalNodeMasterListener {
             if (memoryLimitMb == null) {
                 memoryLimitMb = AnalysisLimits.PRE_6_1_DEFAULT_MODEL_MEMORY_LIMIT_MB;
             }
-            Long memoryRequirementBytes = ByteSizeUnit.MB.toBytes(memoryLimitMb) + Job.PROCESS_MEMORY_OVERHEAD.getBytes();
+            Long memoryRequirementBytes = ByteSizeValue.ofMb(memoryLimitMb).getBytes() + Job.PROCESS_MEMORY_OVERHEAD.getBytes();
             memoryRequirementByAnomalyDetectorJob.put(jobId, memoryRequirementBytes);
             listener.onResponse(memoryRequirementBytes);
         }, e -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
@@ -342,7 +342,7 @@ public class RestCatJobsAction extends AbstractCatAction {
             DataCounts dataCounts = job.getDataCounts();
             table.addCell(dataCounts.getProcessedRecordCount());
             table.addCell(dataCounts.getProcessedFieldCount());
-            table.addCell(new ByteSizeValue(dataCounts.getInputBytes()));
+            table.addCell(ByteSizeValue.ofBytes(dataCounts.getInputBytes()));
             table.addCell(dataCounts.getInputRecordCount());
             table.addCell(dataCounts.getInputFieldCount());
             table.addCell(dataCounts.getInvalidDateCount());
@@ -358,14 +358,14 @@ public class RestCatJobsAction extends AbstractCatAction {
             table.addCell(dataCounts.getLatestSparseBucketTimeStamp());
 
             ModelSizeStats modelSizeStats = job.getModelSizeStats();
-            table.addCell(modelSizeStats == null ? null : new ByteSizeValue(modelSizeStats.getModelBytes()));
+            table.addCell(modelSizeStats == null ? null : ByteSizeValue.ofBytes(modelSizeStats.getModelBytes()));
             table.addCell(modelSizeStats == null ? null : modelSizeStats.getMemoryStatus().toString());
             table.addCell(modelSizeStats == null || modelSizeStats.getModelBytesExceeded() == null ?
                 null :
-                new ByteSizeValue(modelSizeStats.getModelBytesExceeded()));
+                ByteSizeValue.ofBytes(modelSizeStats.getModelBytesExceeded()));
             table.addCell(modelSizeStats == null || modelSizeStats.getModelBytesMemoryLimit() == null ?
                 null :
-                new ByteSizeValue(modelSizeStats.getModelBytesMemoryLimit()));
+                ByteSizeValue.ofBytes(modelSizeStats.getModelBytesMemoryLimit()));
             table.addCell(modelSizeStats == null ? null : modelSizeStats.getTotalByFieldCount());
             table.addCell(modelSizeStats == null ? null : modelSizeStats.getTotalOverFieldCount());
             table.addCell(modelSizeStats == null ? null : modelSizeStats.getTotalPartitionFieldCount());
@@ -383,10 +383,10 @@ public class RestCatJobsAction extends AbstractCatAction {
             ForecastStats forecastStats = job.getForecastStats();
             boolean missingForecastStats = forecastStats == null || forecastStats.getTotal() <= 0L;
             table.addCell(forecastStats == null ? null : forecastStats.getTotal());
-            table.addCell(missingForecastStats ? null : new ByteSizeValue((long)forecastStats.getMemoryStats().getMin()));
-            table.addCell(missingForecastStats ? null : new ByteSizeValue((long)forecastStats.getMemoryStats().getMax()));
-            table.addCell(missingForecastStats ? null : new ByteSizeValue(Math.round(forecastStats.getMemoryStats().getAvg())));
-            table.addCell(missingForecastStats ? null : new ByteSizeValue((long)forecastStats.getMemoryStats().getTotal()));
+            table.addCell(missingForecastStats ? null : ByteSizeValue.ofBytes((long)forecastStats.getMemoryStats().getMin()));
+            table.addCell(missingForecastStats ? null : ByteSizeValue.ofBytes((long)forecastStats.getMemoryStats().getMax()));
+            table.addCell(missingForecastStats ? null : ByteSizeValue.ofBytes(Math.round(forecastStats.getMemoryStats().getAvg())));
+            table.addCell(missingForecastStats ? null : ByteSizeValue.ofBytes((long)forecastStats.getMemoryStats().getTotal()));
             table.addCell(missingForecastStats ? null : forecastStats.getRecordStats().getMin());
             table.addCell(missingForecastStats ? null : forecastStats.getRecordStats().getMax());
             table.addCell(missingForecastStats ? null : forecastStats.getRecordStats().getAvg());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
@@ -240,7 +240,7 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
             // Trained Model Info
             table.addCell(config.getModelId());
             table.addCell(config.getCreatedBy());
-            table.addCell(new ByteSizeValue(config.getEstimatedHeapMemory()));
+            table.addCell(ByteSizeValue.ofBytes(config.getEstimatedHeapMemory()));
             table.addCell(config.getEstimatedOperations());
             table.addCell(config.getLicenseLevel());
             table.addCell(config.getCreateTime());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -40,7 +40,7 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
 
         // Disable native ML autodetect_process as the c++ controller won't be available
         newSettings.put(MachineLearningField.AUTODETECT_PROCESS.getKey(), false);
-        newSettings.put(MachineLearningField.MAX_MODEL_MEMORY_LIMIT.getKey(), new ByteSizeValue(1024));
+        newSettings.put(MachineLearningField.MAX_MODEL_MEMORY_LIMIT.getKey(), ByteSizeValue.ofBytes(1024));
         newSettings.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         // Disable security otherwise delete-by-query action fails to get authorized
         newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -113,21 +112,21 @@ public class TransportEstimateModelMemoryActionTests extends ESTestCase {
     public void testRoundUpToNextMb() {
 
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(0),
-            equalTo(new ByteSizeValue(0, ByteSizeUnit.BYTES)));
+            equalTo(ByteSizeValue.ofBytes(0)));
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(1),
-            equalTo(new ByteSizeValue(1, ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(1)));
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(randomIntBetween(1, 1024 * 1024)),
-            equalTo(new ByteSizeValue(1, ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(1)));
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(1024 * 1024),
-            equalTo(new ByteSizeValue(1, ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(1)));
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(1024 * 1024 + 1),
-            equalTo(new ByteSizeValue(2, ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(2)));
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(2 * 1024 * 1024),
-            equalTo(new ByteSizeValue(2, ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(2)));
         // We don't round up at the extremes, to ensure that the resulting value can be represented as bytes in a long
         // (At such extreme scale it won't be possible to actually run the analysis, so ease of use trumps precision)
         assertThat(TransportEstimateModelMemoryAction.roundUpToNextMb(Long.MAX_VALUE - randomIntBetween(0, 1000000)),
-            equalTo(new ByteSizeValue(Long.MAX_VALUE / new ByteSizeValue(1, ByteSizeUnit.MB).getBytes() , ByteSizeUnit.MB)));
+            equalTo(ByteSizeValue.ofMb(Long.MAX_VALUE / ByteSizeValue.ofMb(1).getBytes() )));
     }
 
     public void testReducedCardinality() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportForecastJobActionRequestTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportForecastJobActionRequestTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -69,18 +68,18 @@ public class TransportForecastJobActionRequestTests extends ESTestCase {
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(jobBuilder.build(), null, auditor), is(nullValue()));
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(
                 jobBuilder.build(),
-                new ByteSizeValue(20, ByteSizeUnit.MB).getBytes(),
+                ByteSizeValue.ofMb(20).getBytes(),
                 auditor),
-                equalTo(new ByteSizeValue(20, ByteSizeUnit.MB).getBytes()));
+                equalTo(ByteSizeValue.ofMb(20).getBytes()));
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(
                 jobBuilder.build(),
-                new ByteSizeValue(499, ByteSizeUnit.MB).getBytes(),
+                ByteSizeValue.ofMb(499).getBytes(),
                 auditor),
-                equalTo(new ByteSizeValue(499, ByteSizeUnit.MB).getBytes()));
+                equalTo(ByteSizeValue.ofMb(499).getBytes()));
         }
 
         {
-            long limit = new ByteSizeValue(100, ByteSizeUnit.MB).getBytes();
+            long limit = ByteSizeValue.ofMb(100).getBytes();
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(
                 jobBuilder.setAnalysisLimits(new AnalysisLimits(1L)).build(),
                 limit,
@@ -98,14 +97,14 @@ public class TransportForecastJobActionRequestTests extends ESTestCase {
         }
 
         {
-            long limit = new ByteSizeValue(200, ByteSizeUnit.MB).getBytes();
+            long limit = ByteSizeValue.ofMb(200).getBytes();
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(jobBuilder.build(), limit, auditor), equalTo(limit));
             // gets adjusted down due to job analysis limits
             assertThat(TransportForecastJobAction.getAdjustedMemoryLimit(
                 jobBuilder.setAnalysisLimits(new AnalysisLimits(200L, null)).build(),
                 limit,
                 auditor),
-                equalTo(new ByteSizeValue(80, ByteSizeUnit.MB).getBytes() - 1L));
+                equalTo(ByteSizeValue.ofMb(80).getBytes() - 1L));
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessConfigTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessConfigTests.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.ml.dataframe.process;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -48,7 +47,7 @@ public class AnalyticsProcessConfigTests extends ESTestCase {
         jobId = randomAlphaOfLength(10);
         rows = randomNonNegativeLong();
         cols = randomIntBetween(1, 42000);
-        memoryLimit = new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES);
+        memoryLimit = ByteSizeValue.ofBytes(randomNonNegativeLong());
         threads = randomIntBetween(1, 8);
         resultsField = randomAlphaOfLength(10);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResultTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.dataframe.process.results;
 
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
@@ -19,8 +18,8 @@ public class MemoryUsageEstimationResultTests extends AbstractXContentTestCase<M
 
     public static MemoryUsageEstimationResult createRandomResult() {
         return new MemoryUsageEstimationResult(
-            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null,
-            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null);
+            randomBoolean() ? ByteSizeValue.ofBytes(randomNonNegativeLong()) : null,
+            randomBoolean() ? ByteSizeValue.ofBytes(randomNonNegativeLong()) : null);
     }
 
     @Override
@@ -46,15 +45,15 @@ public class MemoryUsageEstimationResultTests extends AbstractXContentTestCase<M
 
     public void testConstructor_SmallValues() {
         MemoryUsageEstimationResult result =
-            new MemoryUsageEstimationResult(new ByteSizeValue(120, ByteSizeUnit.KB), new ByteSizeValue(30, ByteSizeUnit.KB));
-        assertThat(result.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(120, ByteSizeUnit.KB)));
-        assertThat(result.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(30, ByteSizeUnit.KB)));
+            new MemoryUsageEstimationResult(ByteSizeValue.ofKb(120), ByteSizeValue.ofKb(30));
+        assertThat(result.getExpectedMemoryWithoutDisk(), equalTo(ByteSizeValue.ofKb(120)));
+        assertThat(result.getExpectedMemoryWithDisk(), equalTo(ByteSizeValue.ofKb(30)));
     }
 
     public void testConstructor() {
         MemoryUsageEstimationResult result =
-            new MemoryUsageEstimationResult(new ByteSizeValue(20, ByteSizeUnit.MB), new ByteSizeValue(10, ByteSizeUnit.MB));
-        assertThat(result.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(20, ByteSizeUnit.MB)));
-        assertThat(result.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(10, ByteSizeUnit.MB)));
+            new MemoryUsageEstimationResult(ByteSizeValue.ofMb(20), ByteSizeValue.ofMb(10));
+        assertThat(result.getExpectedMemoryWithoutDisk(), equalTo(ByteSizeValue.ofMb(20)));
+        assertThat(result.getExpectedMemoryWithDisk(), equalTo(ByteSizeValue.ofMb(10)));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -175,7 +175,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             threadPool,
             clusterService,
             trainedModelStatsService,
-            Settings.builder().put(ModelLoadingService.INFERENCE_MODEL_CACHE_SIZE.getKey(), new ByteSizeValue(20L)).build(),
+            Settings.builder().put(ModelLoadingService.INFERENCE_MODEL_CACHE_SIZE.getKey(), ByteSizeValue.ofBytes(20L)).build(),
             "test-node",
             circuitBreaker);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/modelsize/SizeEstimatorTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/modelsize/SizeEstimatorTestCase.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.inference.modelsize;
 
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.test.AbstractXContentTestCase;
@@ -22,7 +21,7 @@ public abstract class SizeEstimatorTestCase<T extends ToXContentObject & Account
     abstract T translateObject(U originalObject);
 
     public void testRamUsageEstimationAccuracy() {
-        final long bytesEps = new ByteSizeValue(2, ByteSizeUnit.KB).getBytes();
+        final long bytesEps = ByteSizeValue.ofKb(2).getBytes();
         for (int i = 0; i < NUMBER_OF_TEST_RUNS; ++i) {
             U obj = generateTrueObject();
             T estimateObj = translateObject(obj);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeLoadDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeLoadDetectorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
@@ -37,7 +36,7 @@ import static org.mockito.Mockito.when;
 public class JobNodeLoadDetectorTests extends ESTestCase {
 
     // To simplify the logic in this class all jobs have the same memory requirement
-    private static final ByteSizeValue JOB_MEMORY_REQUIREMENT = new ByteSizeValue(10, ByteSizeUnit.MB);
+    private static final ByteSizeValue JOB_MEMORY_REQUIREMENT = ByteSizeValue.ofMb(10);
 
     private NodeLoadDetector nodeLoadDetector;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
@@ -49,7 +48,7 @@ import static org.mockito.Mockito.when;
 public class JobNodeSelectorTests extends ESTestCase {
 
     // To simplify the logic in this class all jobs have the same memory requirement
-    private static final ByteSizeValue JOB_MEMORY_REQUIREMENT = new ByteSizeValue(10, ByteSizeUnit.MB);
+    private static final ByteSizeValue JOB_MEMORY_REQUIREMENT = ByteSizeValue.ofMb(10);
 
     private MlMemoryTracker memoryTracker;
     private boolean isMemoryTrackerRecentlyRefreshed;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.shard.ShardId;
@@ -328,8 +327,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         // Now with hard_limit
         modelSizeStats = new ModelSizeStats.Builder(JOB_ID)
                 .setMemoryStatus(ModelSizeStats.MemoryStatus.HARD_LIMIT)
-                .setModelBytesMemoryLimit(new ByteSizeValue(512, ByteSizeUnit.MB).getBytes())
-                .setModelBytesExceeded(new ByteSizeValue(1, ByteSizeUnit.KB).getBytes())
+                .setModelBytesMemoryLimit(ByteSizeValue.ofMb(512).getBytes())
+                .setModelBytesExceeded(ByteSizeValue.ofKb(1).getBytes())
                 .build();
         when(result.getModelSizeStats()).thenReturn(modelSizeStats);
         processorUnderTest.processResult(result);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
@@ -10,7 +10,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -229,7 +229,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
             } else {
                 long expectedModelMemoryLimit =
                     simulateVeryOldJob ? AnalysisLimits.PRE_6_1_DEFAULT_MODEL_MEMORY_LIMIT_MB : recentJobModelMemoryLimitMb;
-                assertEquals(Long.valueOf(ByteSizeUnit.MB.toBytes(expectedModelMemoryLimit) + Job.PROCESS_MEMORY_OVERHEAD.getBytes()),
+                assertEquals(Long.valueOf(ByteSizeValue.ofMb(expectedModelMemoryLimit).getBytes() + Job.PROCESS_MEMORY_OVERHEAD.getBytes()),
                     memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId));
             }
         } else {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/NativeStorageProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/NativeStorageProviderTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.process;
 
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
@@ -33,16 +32,16 @@ public class NativeStorageProviderTests extends ESTestCase {
         Map<Path, Long> storage = new HashMap<>();
         Path tmpDir = createTempDir();
 
-        storage.put(tmpDir, new ByteSizeValue(6, ByteSizeUnit.GB).getBytes());
+        storage.put(tmpDir, ByteSizeValue.ofGb(6).getBytes());
         NativeStorageProvider storageProvider = createNativeStorageProvider(storage);
 
         Assert.assertNotNull(
-                storageProvider.tryGetLocalTmpStorage(randomAlphaOfLengthBetween(4, 10), new ByteSizeValue(100, ByteSizeUnit.BYTES)));
+                storageProvider.tryGetLocalTmpStorage(randomAlphaOfLengthBetween(4, 10), ByteSizeValue.ofBytes(100)));
         Assert.assertNull(storageProvider.tryGetLocalTmpStorage(randomAlphaOfLengthBetween(4, 10),
-                new ByteSizeValue(1024 * 1024 * 1024 + 1, ByteSizeUnit.BYTES)));
+                ByteSizeValue.ofBytes(1024 * 1024 * 1024 + 1)));
 
         String id = randomAlphaOfLengthBetween(4, 10);
-        Path path = storageProvider.tryGetLocalTmpStorage(id, new ByteSizeValue(1, ByteSizeUnit.GB));
+        Path path = storageProvider.tryGetLocalTmpStorage(id, ByteSizeValue.ofGb(1));
         Assert.assertNotNull(path);
 
         Assert.assertEquals(tmpDir.resolve("ml-local-data").resolve("tmp").resolve(id).toString(), path.toString());
@@ -54,16 +53,16 @@ public class NativeStorageProviderTests extends ESTestCase {
 
         // low disk space
         Path disk1 = tmpDir.resolve(randomAlphaOfLengthBetween(4, 10));
-        storage.put(disk1, new ByteSizeValue(1, ByteSizeUnit.GB).getBytes());
+        storage.put(disk1, ByteSizeValue.ofGb(1).getBytes());
 
         // sufficient disk space
         Path disk2 = tmpDir.resolve(randomAlphaOfLengthBetween(4, 10));
-        storage.put(disk2, new ByteSizeValue(20, ByteSizeUnit.GB).getBytes());
+        storage.put(disk2, ByteSizeValue.ofGb(20).getBytes());
 
         NativeStorageProvider storageProvider = createNativeStorageProvider(storage);
 
         String id = randomAlphaOfLengthBetween(4, 10);
-        Path path = storageProvider.tryGetLocalTmpStorage(id, new ByteSizeValue(1, ByteSizeUnit.GB));
+        Path path = storageProvider.tryGetLocalTmpStorage(id, ByteSizeValue.ofGb(1));
         Assert.assertNotNull(path);
 
         // should resolve to disk2 as disk1 is low on space
@@ -73,11 +72,11 @@ public class NativeStorageProviderTests extends ESTestCase {
     public void testTmpStorageCleanup() throws IOException {
         Map<Path, Long> storage = new HashMap<>();
         Path tmpDir = createTempDir();
-        storage.put(tmpDir, new ByteSizeValue(6, ByteSizeUnit.GB).getBytes());
+        storage.put(tmpDir, ByteSizeValue.ofGb(6).getBytes());
         NativeStorageProvider storageProvider = createNativeStorageProvider(storage);
         String id = randomAlphaOfLengthBetween(4, 10);
 
-        Path path = storageProvider.tryGetLocalTmpStorage(id, new ByteSizeValue(1, ByteSizeUnit.KB));
+        Path path = storageProvider.tryGetLocalTmpStorage(id, ByteSizeValue.ofKb(1));
 
         Assert.assertTrue(Files.exists(path));
         Path testFile = PathUtils.get(path.toString(), "testFile");
@@ -97,11 +96,11 @@ public class NativeStorageProviderTests extends ESTestCase {
     public void testTmpStorageCleanupOnStart() throws IOException {
         Map<Path, Long> storage = new HashMap<>();
         Path tmpDir = createTempDir();
-        storage.put(tmpDir, new ByteSizeValue(6, ByteSizeUnit.GB).getBytes());
+        storage.put(tmpDir, ByteSizeValue.ofGb(6).getBytes());
         NativeStorageProvider storageProvider = createNativeStorageProvider(storage);
         String id = randomAlphaOfLengthBetween(4, 10);
 
-        Path path = storageProvider.tryGetLocalTmpStorage(id, new ByteSizeValue(1, ByteSizeUnit.KB));
+        Path path = storageProvider.tryGetLocalTmpStorage(id, ByteSizeValue.ofKb(1));
 
         Assert.assertTrue(Files.exists(path));
         Path testFile = PathUtils.get(path.toString(), "testFile");
@@ -124,7 +123,7 @@ public class NativeStorageProviderTests extends ESTestCase {
         Environment environment = mock(Environment.class);
 
         when(environment.dataFiles()).thenReturn(paths.keySet().toArray(new Path[paths.size()]));
-        NativeStorageProvider storageProvider = spy(new NativeStorageProvider(environment, new ByteSizeValue(5, ByteSizeUnit.GB)));
+        NativeStorageProvider storageProvider = spy(new NativeStorageProvider(environment, ByteSizeValue.ofGb(5)));
 
         doAnswer(invocation -> {
             return paths.getOrDefault(invocation.getArguments()[0], Long.valueOf(0)).longValue();


### PR DESCRIPTION
This is a simple find/replace with regex. 

This replaces all the `new ByteSizeValue(<value>, ByteSizeUnit.<unit)` to the correct `ByteSizeValue.of...` functions.

Its a much better abstraction and removes the need to refer to `ByteSizeUnit` all together.