### PR TITLE
[7.9] [DOCS] Fix role template snippet (#63774)

### DIFF
--- a/x-pack/docs/en/security/authorization/role-templates.asciidoc
+++ b/x-pack/docs/en/security/authorization/role-templates.asciidoc
@@ -81,9 +81,7 @@ POST /_security/role/example3
       "privileges" : [ "read" ],
       "query" : {
         "template" : {
-          "source" : {
-            "terms" : { "group.statuses" : "{{#toJson}}_user.metadata.statuses{{/toJson}}" }
-          }
+          "source" : "{ \"terms\": { \"group.statuses\": {{#toJson}}_user.metadata.statuses{{/toJson}} }}"
         }
       }
     }


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fix role template snippet (#63774)