### PR TITLE
[DOCS] Add tips for num_top_classes classification parameter

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -143,8 +143,8 @@ a large number of categories, there could be a significant effect on the size of
 --
 NOTE: To use the
 {ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[AUC ROC evaluation method],
-`num_top_classes` must be set to `-1` or a value greater than the total number
-of categories.
+`num_top_classes` must be set to `-1` or a value greater than or equal to the
+total number of categories.
 
 --
 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -136,9 +136,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 `num_top_classes`::::
 (Optional, integer)
 Defines the number of categories for which the predicted probabilities are
-reported. It must be non-negative or -1 (which denotes all categories). If it is
-greater than the total number of categories, the API reports all category
-probabilities. Defaults to 2.
+reported. It must be non-negative or -1. If it is -1 or greater than the total
+number of categories, all category probabilities are reported and your
+destination index increases in size accordingly. If it is 0, no probabilities
+are reported and you cannot use the
+<<ml-dfanalytics-class-aucroc,AUC ROC evaluation method>>. Defaults to 2.
 
 `num_top_feature_importance_values`::::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -140,7 +140,8 @@ reported. It must be non-negative or -1. If it is -1 or greater than the total
 number of categories, all category probabilities are reported and your
 destination index increases in size accordingly. If it is 0, no probabilities
 are reported and you cannot use the
-<<ml-dfanalytics-class-aucroc,AUC ROC evaluation method>>. Defaults to 2.
+{ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[AUC ROC evaluation method].
+Defaults to 2.
 
 `num_top_feature_importance_values`::::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -137,11 +137,16 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 (Optional, integer)
 Defines the number of categories for which the predicted probabilities are
 reported. It must be non-negative or -1. If it is -1 or greater than the total
-number of categories, all category probabilities are reported and your
-destination index increases in size accordingly. If it is 0, no probabilities
-are reported and you cannot use the
-{ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[AUC ROC evaluation method].
-Defaults to 2.
+number of categories, probabilities are reported for all categories; if you have
+a large number of categories, there could be a significant effect on the size of your destination index. Defaults to 2. 
++
+--
+NOTE: To use the
+{ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[AUC ROC evaluation method],
+`num_top_classes` must be set to `-1` or a value greater than the total number
+of categories.
+
+--
 
 `num_top_feature_importance_values`::::
 (Optional, integer)


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/80003

This PR adds more information to the [create data frame analytics job API](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html) about the impact of setting `num_top_classes` to 0 or -1.

### Preview

https://elasticsearch_63781.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html