### PR TITLE
Modify unsigned_long tests for broader ranges

### DIFF
--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
@@ -249,20 +249,14 @@ public class UnsignedLongTests extends ESIntegTestCase {
             SearchResponse response = client().prepareSearch("idx")
                 .setSize(0)
                 .addAggregation(
-                    range("ul_range").field("ul_field")
-                        .addUnboundedTo(9.0E18)
-                        .addRange(9.0E18, 1.8E19 )
-                        .addUnboundedFrom(1.8E19 )
+                    range("ul_range").field("ul_field").addUnboundedTo(9.0E18).addRange(9.0E18, 1.8E19).addUnboundedFrom(1.8E19)
                 )
                 .get();
             assertSearchResponse(response);
             Range range = response.getAggregations().get("ul_range");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
-            String[] expectedBucketKeys = {
-                "*-9.0E18",
-                "9.0E18-1.8E19",
-                "1.8E19-*" };
+            String[] expectedBucketKeys = { "*-9.0E18", "9.0E18-1.8E19", "1.8E19-*" };
             int i = 0;
             for (Range.Bucket bucket : range.getBuckets()) {
                 assertEquals(expectedBucketDocCounts[i], bucket.getDocCount());
@@ -307,10 +301,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
             .setQuery(new RangeQueryBuilder("ul_field").from("9.0E18").to("1.8E19").includeUpper(false))
             .get();
         assertThat(response.getHits().getTotalHits().value, equalTo(3L));
-        response = client().prepareSearch("idx")
-            .setSize(0)
-            .setQuery(new RangeQueryBuilder("ul_field").from("1.8E19"))
-            .get();
+        response = client().prepareSearch("idx").setSize(0).setQuery(new RangeQueryBuilder("ul_field").from("1.8E19")).get();
         assertThat(response.getHits().getTotalHits().value, equalTo(4L));
     }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -38,6 +39,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.SuiteScopeTestCase
 
@@ -227,13 +229,13 @@ public class UnsignedLongTests extends ESIntegTestCase {
         {
             SearchResponse response = client().prepareSearch("idx")
                 .setSize(0)
-                .addAggregation(histogram("ul_histo").field("ul_field").interval(9.223372036854776E18).minDocCount(0))
+                .addAggregation(histogram("ul_histo").field("ul_field").interval(9E18).minDocCount(0))
                 .get();
             assertSearchResponse(response);
             Histogram histo = response.getAggregations().get("ul_histo");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
-            double[] expectedBucketKeys = { 0, 9.223372036854776E18, 1.8446744073709552E19 };
+            double[] expectedBucketKeys = { 0, 9.0E18, 1.8E19 };
             int i = 0;
             for (Histogram.Bucket bucket : histo.getBuckets()) {
                 assertEquals(expectedBucketDocCounts[i], bucket.getDocCount());
@@ -248,9 +250,9 @@ public class UnsignedLongTests extends ESIntegTestCase {
                 .setSize(0)
                 .addAggregation(
                     range("ul_range").field("ul_field")
-                        .addUnboundedTo(9.223372036854776E18)
-                        .addRange(9.223372036854776E18, 1.8446744073709552E19)
-                        .addUnboundedFrom(1.8446744073709552E19)
+                        .addUnboundedTo(9.0E18)
+                        .addRange(9.0E18, 1.8E19 )
+                        .addUnboundedFrom(1.8E19 )
                 )
                 .get();
             assertSearchResponse(response);
@@ -258,9 +260,9 @@ public class UnsignedLongTests extends ESIntegTestCase {
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
             String[] expectedBucketKeys = {
-                "*-9.223372036854776E18",
-                "9.223372036854776E18-1.8446744073709552E19",
-                "1.8446744073709552E19-*" };
+                "*-9.0E18",
+                "9.0E18-1.8E19",
+                "1.8E19-*" };
             int i = 0;
             for (Range.Bucket bucket : range.getBuckets()) {
                 assertEquals(expectedBucketDocCounts[i], bucket.getDocCount());
@@ -292,5 +294,23 @@ public class UnsignedLongTests extends ESIntegTestCase {
             exception.getCause().getMessage(),
             "Can't do sort across indices, as a field has [unsigned_long] type in one index, and different type in another index!"
         );
+    }
+
+    public void testRangeQuery() {
+        SearchResponse response = client().prepareSearch("idx")
+            .setSize(0)
+            .setQuery(new RangeQueryBuilder("ul_field").to("9.0E18").includeUpper(false))
+            .get();
+        assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+        response = client().prepareSearch("idx")
+            .setSize(0)
+            .setQuery(new RangeQueryBuilder("ul_field").from("9.0E18").to("1.8E19").includeUpper(false))
+            .get();
+        assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+        response = client().prepareSearch("idx")
+            .setSize(0)
+            .setQuery(new RangeQueryBuilder("ul_field").from("1.8E19"))
+            .get();
+        assertThat(response.getHits().getTotalHits().value, equalTo(4L));
     }
 }


### PR DESCRIPTION
UnsignedLongTests for the range agg was  using very specific intervals
that double type can not distinguish due to lack of precision:

9.223372036854776000E18 == 9.223372036854775807E18 returns true

If we add the corresponding range query test, it will return different
number of hits than the range agg, as range query unlike range agg
doesn't convert valued to double type, and hence more precise.

This patch make broader ranges for the range agg test (so values
converted to doubles don't loose precision), and hence corresponding
range query will return the same number of hits.

Relates to #60050