### PR TITLE
[DOCS] Add grant API key to Java HLRC

### DIFF
--- a/docs/java-rest/high-level/security/grant-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/grant-api-key.asciidoc
@@ -23,25 +23,22 @@ descriptors to define permissions, and an optional expiration for the
 generated API key. If expiration is not provided, by default the API keys do not
 expire.
 
-////
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 
 include::../execution.asciidoc[]
-////
 
 [id="{upid}-{api}-response"]
 ==== Grant API key response
 
 The returned +{response}+ contains an ID, API key, name for the API key, and
 optional expiration.
-////
+
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> The API key that can be used to authenticate to Elasticsearch.
 <2> Expiration details, if the API keys expire.
-////

--- a/docs/java-rest/high-level/security/grant-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/grant-api-key.asciidoc
@@ -1,7 +1,7 @@
 --
 :api: grant-api-key
 :request: GrantApiKeyRequest
-:response: GrantApiKeyResponse
+:response: CreateApiKeyResponse
 --
 [role="xpack"]
 [id="{upid}-{api}"]

--- a/docs/java-rest/high-level/security/grant-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/grant-api-key.asciidoc
@@ -1,0 +1,47 @@
+--
+:api: grant-api-key
+:request: GrantApiKeyRequest
+:response: GrantApiKeyResponse
+--
+[role="xpack"]
+[id="{upid}-{api}"]
+=== Grant API key API
+
+Creates an API key on behalf of another user.
+
+[id="{upid}-{api}-request"]
+==== Grant API key request
+
+This API is similar to <<java-rest-high-security-create-api-key>>, however it
+creates the API key for a user that is different than the user that runs the API.
+
+A +{request}+ contains authentication credentials for the user on whose behalf
+the API key will be created, a grant type (which indicates whether the
+credentials are an access token or a user ID and password), and API key details.
+The API key details include a name for the API key, an optional list of role 
+descriptors to define permissions, and an optional expiration for the
+generated API key. If expiration is not provided, by default the API keys do not
+expire.
+
+////
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+
+include::../execution.asciidoc[]
+////
+
+[id="{upid}-{api}-response"]
+==== Grant API key response
+
+The returned +{response}+ contains an ID, API key, name for the API key, and
+optional expiration.
+////
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> The API key that can be used to authenticate to Elasticsearch.
+<2> Expiration details, if the API keys expire.
+////

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -523,6 +523,7 @@ include::security/create-token.asciidoc[]
 include::security/invalidate-token.asciidoc[]
 include::security/put-privileges.asciidoc[]
 include::security/create-api-key.asciidoc[]
+include::security/grant-api-key.asciidoc[]
 include::security/get-api-key.asciidoc[]
 include::security/invalidate-api-key.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/63449 and https://github.com/elastic/elasticsearch/pull/68190

This PR adds the grant API key API to the Java REST client docs, based on https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-security-create-api-key.html

### Preview

https://elasticsearch_63783.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-security-grant-api-key.html