### PR TITLE
[7.10] Backport PR #53207

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
@@ -14,8 +14,8 @@
           ],
           "parts":{
             "name":{
-              "type":"string",
-              "description":"Role name"
+              "type":"list",
+              "description":"A comma-separated list of role names"
             }
           }
         },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
@@ -14,8 +14,8 @@
           ],
           "parts":{
             "name":{
-              "type":"string",
-              "description":"Role-Mapping name"
+              "type":"list",
+              "description":"A comma-separated list of role-mapping names"
             }
           }
         },


### PR DESCRIPTION
This PR backport PR #53207 to 7.10 branch. This is a fix for YAML spec `api/security.get_role.json` and `api/security.get_role_mapping.json` in xpack. 
/cc @elastic/clients-team 