### PR TITLE
Fix license header for RestRequestFilter

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestRequestFilter.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequestFilter.java
@@ -17,11 +17,6 @@
  * under the License.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;


### PR DESCRIPTION
A duplicate license was inadvertently introduced in #63507