### PR TITLE
[7.9] [DOCS] Clarifies destination index mappings for Transforms. (#63794)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -155,7 +155,11 @@ The destination for the {transform}.
 end::dest[]
 
 tag::dest-index[]
-The _destination index_ for the {transform}.
+The _destination index_ for the {transform}. The mappings of the destination 
+index are deduced based on the source fields when possible. If alternate 
+mappings are required, use the 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html[Create index API] 
+prior to starting the {transform}.
 end::dest-index[]
 
 tag::dest-pipeline[]

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -56,11 +56,18 @@ or <<search-aggregations-pipeline-bucket-script-aggregation,`bucket_scripts`>>,
 <<dynamic-mapping,dynamic mappings>> will be used. In some instances the 
 deduced mappings may be incompatible with the actual data. For example, numeric 
 overflows might occur or dynamically mapped fields might contain both numbers 
-and strings. Please check {es} logs if you think this may have occurred. As a 
-workaround, you may define custom mappings prior to starting the 
-{transform}. For example, 
-<<indices-create-index,create a custom destination index>> or 
-<<indices-templates,define an index template>>.
+and strings. Please check {es} logs if you think this may have occurred. 
+
+You can view the deduced mappings by using the 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html[Preview transform API].
+See the `generated_dest_index` object in the API response.
+
+If it's required, you may define custom mappings prior to starting the 
+{transform} by creating a custom destination index using the 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html[Create index API].
+As deduced mappings cannot be overwritten by an index template, use the Create 
+index API to define custom mappings. The index templates only apply to fields 
+derived from scripts that use dynamic mappings. 
 
 [discrete]
 [[transform-batch-limitations]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Clarifies destination index mappings for Transforms. (#63794)