### PR TITLE
Fix plugin installation in Docker container as non-default user

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -207,7 +207,7 @@ RUN tar zxf /opt/elasticsearch.tar.gz --strip-components=1
 # Configure the distribution for Docker
 RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
 RUN mkdir -p config config/jvm.options.d data logs
-RUN chmod 0775 config config/jvm.options.d data logs
+RUN chmod 0775 config config/jvm.options.d data logs plugins
 COPY config/elasticsearch.yml config/log4j2.properties config/
 RUN chmod 0660 config/elasticsearch.yml config/log4j2.properties
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -526,9 +526,9 @@ public class Docker {
         final String homeDir = passwdResult.stdout.trim().split(":")[5];
         assertThat(homeDir, equalTo("/usr/share/elasticsearch"));
 
-        Stream.of(es.home, es.data, es.logs, es.config).forEach(dir -> assertPermissionsAndOwnership(dir, p775));
+        Stream.of(es.home, es.data, es.logs, es.config, es.plugins).forEach(dir -> assertPermissionsAndOwnership(dir, p775));
 
-        Stream.of(es.plugins, es.modules).forEach(dir -> assertPermissionsAndOwnership(dir, p755));
+        Stream.of(es.modules).forEach(dir -> assertPermissionsAndOwnership(dir, p755));
 
         Stream.of("elasticsearch.keystore", "elasticsearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertPermissionsAndOwnership(es.config(configFile), p660));


### PR DESCRIPTION
It turns out that default `$ES_HOME/plugins` directory is not group-writable which prevents from plugin installation when running as [non-default user](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user) (non-default here meaning `UID != 1000`):
```
przemyslaw@serenity elasticsearch % docker run -i -t --user 1337:0 elasticsearch:test bash -c " > plugins/my-plugin"
bash: plugins/my-plugin: Permission denied
```

With my patch:
```
docker run -i -t --user 1337:0 elasticsearch:test bash -c "
  wget https://snapshots.elastic.co/8.0.0-1b1e3d9e/downloads/elasticsearch-plugins/mapper-size/mapper-size-8.0.0-SNAPSHOT.zip \
  && ./bin/elasticsearch-plugin install file:///usr/share/elasticsearch/mapper-size-8.0.0-SNAPSHOT.zip"


Connecting to snapshots.elastic.co (151.101.38.217:443)
wget: note: TLS certificate validation not implemented
saving to 'mapper-size-8.0.0-SNAPSHOT.zip'
mapper-size-8.0.0-SN 100% |*********************************************************************************************************************************************************************| 13817  0:00:00 ETA
'mapper-size-8.0.0-SNAPSHOT.zip' saved
-> Installing file:///usr/share/elasticsearch/mapper-size-8.0.0-SNAPSHOT.zip
-> Downloading file:///usr/share/elasticsearch/mapper-size-8.0.0-SNAPSHOT.zip
[=================================================] 100%??
-> Installed mapper-size
```