### PR TITLE
Simplify DocumentParser handling (#63800)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -59,6 +59,7 @@ public class DocumentMapper implements ToXContentFragment {
         private final IndexSettings indexSettings;
         private final IndexAnalyzers indexAnalyzers;
         private final DocumentMapperParser documentMapperParser;
+        private final DocumentParser documentParser;
 
         private Map<String, Object> meta;
 
@@ -66,6 +67,7 @@ public class DocumentMapper implements ToXContentFragment {
             this.indexSettings = mapperService.getIndexSettings();
             this.indexAnalyzers = mapperService.getIndexAnalyzers();
             this.documentMapperParser = mapperService.documentMapperParser();
+            this.documentParser = mapperService.documentParser();
             this.builderContext = new Mapper.BuilderContext(indexSettings.getSettings(), new ContentPath(1));
             this.rootObjectMapper = builder.build(builderContext);
             final String type = rootObjectMapper.name();
@@ -107,7 +109,7 @@ public class DocumentMapper implements ToXContentFragment {
                     rootObjectMapper,
                     metadataMappers.values().toArray(new MetadataFieldMapper[0]),
                     meta);
-            return new DocumentMapper(indexSettings, documentMapperParser, indexAnalyzers, mapping);
+            return new DocumentMapper(indexSettings, documentMapperParser, indexAnalyzers, documentParser, mapping);
         }
     }
 
@@ -126,14 +128,15 @@ public class DocumentMapper implements ToXContentFragment {
     private DocumentMapper(IndexSettings indexSettings,
                            DocumentMapperParser documentMapperParser,
                            IndexAnalyzers indexAnalyzers,
+                           DocumentParser documentParser,
                            Mapping mapping) {
         this.type = mapping.root().name();
         this.typeText = new Text(this.type);
         this.mapping = mapping;
         this.documentMapperParser = documentMapperParser;
+        this.documentParser = documentParser;
         this.indexSettings = indexSettings;
         this.indexAnalyzers = indexAnalyzers;
-        this.documentParser = new DocumentParser();
         this.fieldMappers = MappingLookup.fromMapping(this.mapping, indexAnalyzers.getDefaultIndexAnalyzer());
 
         try {
@@ -288,7 +291,7 @@ public class DocumentMapper implements ToXContentFragment {
 
     public DocumentMapper merge(Mapping mapping, MergeReason reason) {
         Mapping merged = this.mapping.merge(mapping, reason);
-        return new DocumentMapper(this.indexSettings, this.documentMapperParser, this.indexAnalyzers, merged);
+        return new DocumentMapper(this.indexSettings, this.documentMapperParser, this.indexAnalyzers, this.documentParser, merged);
     }
 
     public void validate(IndexSettings settings, boolean checkLimits) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -48,18 +48,19 @@ public class DocumentMapperParser {
     private final NamedXContentRegistry xContentRegistry;
     private final SimilarityService similarityService;
     private final Supplier<QueryShardContext> queryShardContextSupplier;
-
     private final RootObjectMapper.TypeParser rootObjectTypeParser = new RootObjectMapper.TypeParser();
-
     private final Version indexVersionCreated;
-
     private final Map<String, Mapper.TypeParser> typeParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> rootTypeParsers;
     private final ScriptService scriptService;
 
-    public DocumentMapperParser(IndexSettings indexSettings, MapperService mapperService, NamedXContentRegistry xContentRegistry,
-            SimilarityService similarityService, MapperRegistry mapperRegistry,
-            Supplier<QueryShardContext> queryShardContextSupplier, ScriptService scriptService) {
+    public DocumentMapperParser(IndexSettings indexSettings,
+                                MapperService mapperService,
+                                NamedXContentRegistry xContentRegistry,
+                                SimilarityService similarityService,
+                                MapperRegistry mapperRegistry,
+                                Supplier<QueryShardContext> queryShardContextSupplier,
+                                ScriptService scriptService) {
         this.mapperService = mapperService;
         this.xContentRegistry = xContentRegistry;
         this.similarityService = similarityService;
@@ -211,9 +212,5 @@ public class DocumentMapperParser {
             mapping = new Tuple<>(type, root);
         }
         return mapping;
-    }
-
-    NamedXContentRegistry getXContentRegistry() {
-        return xContentRegistry;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -46,6 +47,12 @@ import static org.elasticsearch.index.mapper.FieldMapper.IGNORE_MALFORMED_SETTIN
 /** A parser for documents, given mappings from a DocumentMapper */
 final class DocumentParser {
 
+    private final NamedXContentRegistry xContentRegistry;
+
+    DocumentParser(NamedXContentRegistry xContentRegistry) {
+        this.xContentRegistry = xContentRegistry;
+    }
+
     ParsedDocument parseDocument(SourceToParse source,
                                  MetadataFieldMapper[] metadataFieldsMappers,
                                  DocumentMapper docMapper) throws MapperParsingException {
@@ -55,7 +62,7 @@ final class DocumentParser {
         final ParseContext.InternalParseContext context;
         final XContentType xContentType = source.getXContentType();
 
-        try (XContentParser parser = XContentHelper.createParser(docMapper.documentMapperParser().getXContentRegistry(),
+        try (XContentParser parser = XContentHelper.createParser(xContentRegistry,
             LoggingDeprecationHandler.INSTANCE, source.source(), xContentType)) {
             context = new ParseContext.InternalParseContext(docMapper, source, parser);
             validateStart(parser);


### PR DESCRIPTION
Backport of #63800

DocumentMapperParser holds a reference to the xcontent registry, only with the purpose of being retrieved in DocumentParser#parsedDocument .

This can be greatly simplified by making DocumentParser take the registry as a constructor argument, and removing the same reference from DocumentMapperParser. This may also allow for further refactorings around how DocumentMapperParser is used. With this change it is MapperService that creates DocumentParser and exposes it so that DocumentMapper can use it.