### PR TITLE
[ML] Extract dependent variable's mapping correctly in case of a multi-field

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -52,7 +52,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
     private final Map<String, Map<String, FieldCapabilities>> responseMap;
     private final List<FieldCapabilitiesIndexResponse> indexResponses;
 
-    FieldCapabilitiesResponse(String[] indices, Map<String, Map<String, FieldCapabilities>> responseMap) {
+    public FieldCapabilitiesResponse(String[] indices, Map<String, Map<String, FieldCapabilities>> responseMap) {
         this(indices, responseMap, Collections.emptyList());
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Randomness;
@@ -14,7 +16,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -373,28 +374,19 @@ public class Classification implements DataFrameAnalysis {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(Map<String, Object> mappingsProperties, String resultsFieldName) {
+    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
-        Object dependentVariableMapping = extractMapping(dependentVariable, mappingsProperties);
-        if ((dependentVariableMapping instanceof Map) == false) {
+        Map<String, FieldCapabilities> dependentVariableFieldCaps = fieldCapabilitiesResponse.getField(dependentVariable);
+        if (dependentVariableFieldCaps == null || dependentVariableFieldCaps.isEmpty()) {
             return additionalProperties;
         }
-        Map<String, Object> dependentVariableMappingAsMap = (Map) dependentVariableMapping;
-        // If the source field is an alias, fetch the concrete field that the alias points to.
-        if (FieldAliasMapper.CONTENT_TYPE.equals(dependentVariableMappingAsMap.get("type"))) {
-            String path = (String) dependentVariableMappingAsMap.get(FieldAliasMapper.Names.PATH);
-            dependentVariableMapping = extractMapping(path, mappingsProperties);
-        }
-        // We may have updated the value of {@code dependentVariableMapping} in the "if" block above.
-        // Hence, we need to check the "instanceof" condition again.
-        if ((dependentVariableMapping instanceof Map) == false) {
-            return additionalProperties;
-        }
-        additionalProperties.put(resultsFieldName + "." + predictionFieldName, dependentVariableMapping);
+        Object dependentVariableMappingType = dependentVariableFieldCaps.values().iterator().next().getType();
+        additionalProperties.put(
+            resultsFieldName + "." + predictionFieldName, Collections.singletonMap("type", dependentVariableMappingType));
 
         Map<String, Object> topClassesProperties = new HashMap<>();
-        topClassesProperties.put("class_name", dependentVariableMapping);
+        topClassesProperties.put("class_name", Collections.singletonMap("type", dependentVariableMappingType));
         topClassesProperties.put("class_probability", Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
 
         Map<String, Object> topClassesMapping = new HashMap<>();
@@ -403,40 +395,6 @@ public class Classification implements DataFrameAnalysis {
 
         additionalProperties.put(resultsFieldName + ".top_classes", topClassesMapping);
         return additionalProperties;
-    }
-
-    // Visible for testing
-    static Object extractMapping(String path, Map<String, Object> mappingsProperties) {
-        if (path.isEmpty()) {
-            return mappingsProperties;
-        }
-        Object current = mappingsProperties;
-        Map<String, Object> currentAsMap = mappingsProperties;
-        String[] pathParts = path.split("\\.");
-        for (int i = 0; i < pathParts.length; ++i) {
-            if (current == null) {
-                return null;
-            }
-            String pathPart = pathParts[i];
-            if (currentAsMap.containsKey(pathPart) == false) {
-                return null;
-            }
-            current = currentAsMap.get(pathPart);
-            if (i == pathParts.length - 1) {
-                break;
-            }
-            currentAsMap = (Map<String, Object>) current;
-            if (currentAsMap.containsKey("properties")) {
-                current = currentAsMap.get("properties");
-                currentAsMap = (Map<String, Object>) current;
-            } else if (currentAsMap.containsKey("fields")) {
-                current = currentAsMap.get("fields");
-                currentAsMap = (Map<String, Object>) current;
-            } else {
-                return null;
-            }
-        }
-        return current;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -46,11 +47,11 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
     /**
      * Returns fields for which the mappings should be either predefined or copied from source index to destination index.
      *
-     * @param mappingsProperties mappings.properties portion of the index mappings
      * @param resultsFieldName name of the results field under which all the results are stored
+     * @param fieldCapabilitiesResponse field capabilities fetched for this analysis' required fields
      * @return {@link Map} containing fields for which the mappings should be handled explicitly
      */
-    Map<String, Object> getExplicitlyMappedFields(Map<String, Object> mappingsProperties, String resultsFieldName);
+    Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse);
 
     /**
      * @return {@code true} if this analysis supports data frame rows with missing values

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -245,7 +246,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(Map<String, Object> mappingsProperties, String resultsFieldName) {
+    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".outlier_score",
             Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Randomness;
@@ -284,7 +285,7 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(Map<String, Object> mappingsProperties, String resultsFieldName) {
+    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
         // Prediction field should be always mapped as "double" rather than "float" in order to increase precision in case of

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -108,7 +108,7 @@ public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<Outl
     }
 
     public void testGetExplicitlyMappedFields() {
-        Map<String, Object> mappedFields = createTestInstance().getExplicitlyMappedFields(null, "test");
+        Map<String, Object> mappedFields = createTestInstance().getExplicitlyMappedFields("test", null);
         assertThat(mappedFields.size(), equalTo(2));
         assertThat(mappedFields, hasKey("test.outlier_score"));
         assertThat(mappedFields.get("test.outlier_score"),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -322,7 +322,7 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
     }
 
     public void testGetExplicitlyMappedFields() {
-        Map<String, Object> explicitlyMappedFields = new Regression("foo").getExplicitlyMappedFields(null, "results");
+        Map<String, Object> explicitlyMappedFields = new Regression("foo").getExplicitlyMappedFields("results", null);
         assertThat(explicitlyMappedFields, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
         assertThat(explicitlyMappedFields, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -460,6 +460,11 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertThat(e.getMessage(), startsWith("field [text-field] of type [text] is non-aggregatable"));
     }
 
+    public void testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsTextAndKeyword() throws Exception {
+        testWithOnlyTrainingRowsAndTrainingPercentIsFifty(
+            "classification_training_percent_is_50_text_and_keyword", TEXT_FIELD + ".keyword", KEYWORD_FIELD_VALUES, "keyword");
+    }
+
     public void testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsBoolean() throws Exception {
         testWithOnlyTrainingRowsAndTrainingPercentIsFifty(
             "classification_training_percent_is_50_boolean", BOOLEAN_FIELD, BOOLEAN_FIELD_VALUES, "boolean");
@@ -832,7 +837,12 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             "          \"type\": \"integer\"\n" +
             "        }," +
             "        \""+ TEXT_FIELD + "\": {\n" +
-            "          \"type\": \"text\"\n" +
+            "          \"type\": \"text\",\n" +
+            "          \"fields\": {" +
+            "            \"keyword\": {" +
+            "              \"type\": \"keyword\"\n" +
+            "            }" +
+            "          }" +
             "        }," +
             "        \""+ KEYWORD_FIELD + "\": {\n" +
             "          \"type\": \"keyword\"\n" +

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -355,8 +355,16 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
         if (getFieldValue(mappings, "properties", "ml", "properties", "top_classes") != null) {
             assertThat(
                 mappings.toString(),
+                getFieldValue(mappings, "properties", "ml", "properties", "top_classes", "type"),
+                equalTo("nested"));
+            assertThat(
+                mappings.toString(),
                 getFieldValue(mappings, "properties", "ml", "properties", "top_classes", "properties", "class_name", "type"),
                 equalTo(expectedType));
+            assertThat(
+                mappings.toString(),
+                getFieldValue(mappings, "properties", "ml", "properties", "top_classes", "properties", "class_probability", "type"),
+                equalTo("double"));
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -19,6 +19,9 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
@@ -31,12 +34,14 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.RequiredField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -105,9 +110,37 @@ public final class DestinationIndex {
     private static void prepareCreateIndexRequest(Client client, Clock clock, DataFrameAnalyticsConfig config,
                                                   ActionListener<CreateIndexRequest> listener) {
         AtomicReference<Settings> settingsHolder = new AtomicReference<>();
+        AtomicReference<MappingMetadata> mappingsHolder = new AtomicReference<>();
+
+        ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesListener = ActionListener.wrap(
+            fieldCapabilitiesResponse -> {
+                listener.onResponse(
+                    createIndexRequest(clock, config, settingsHolder.get(), mappingsHolder.get(), fieldCapabilitiesResponse));
+            },
+            listener::onFailure
+        );
 
         ActionListener<MappingMetadata> mappingsListener = ActionListener.wrap(
-            mappings -> listener.onResponse(createIndexRequest(clock, config, settingsHolder.get(), mappings)),
+            mappings -> {
+                mappingsHolder.set(mappings);
+
+                List<RequiredField> requiredFields = config.getAnalysis().getRequiredFields();
+                if (requiredFields.isEmpty()) {
+                    fieldCapabilitiesListener.onResponse(null);
+                    return;
+                }
+                FieldCapabilitiesRequest fieldCapabilitiesRequest =
+                    new FieldCapabilitiesRequest()
+                        .indices(config.getSource().getIndex())
+                        .fields(requiredFields.stream().map(RequiredField::getName).toArray(String[]::new));
+                ClientHelper.executeWithHeadersAsync(
+                    config.getHeaders(),
+                    ML_ORIGIN,
+                    client,
+                    FieldCapabilitiesAction.INSTANCE,
+                    fieldCapabilitiesRequest,
+                    fieldCapabilitiesListener);
+            },
             listener::onFailure
         );
 
@@ -133,13 +166,16 @@ public final class DestinationIndex {
             config.getHeaders(), ML_ORIGIN, client, GetSettingsAction.INSTANCE, getSettingsRequest, getSettingsResponseListener);
     }
 
-    private static CreateIndexRequest createIndexRequest(Clock clock, DataFrameAnalyticsConfig config, Settings settings,
-                                                         MappingMetadata mappings) {
+    private static CreateIndexRequest createIndexRequest(Clock clock,
+                                                         DataFrameAnalyticsConfig config,
+                                                         Settings settings,
+                                                         MappingMetadata mappings,
+                                                         FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         String destinationIndex = config.getDest().getIndex();
         Map<String, Object> mappingsAsMap = mappings.sourceAsMap();
         Map<String, Object> properties = getOrPutDefault(mappingsAsMap, PROPERTIES, HashMap::new);
         checkResultsFieldIsNotPresentInProperties(config, properties);
-        properties.putAll(createAdditionalMappings(config, Collections.unmodifiableMap(properties)));
+        properties.putAll(createAdditionalMappings(config, Collections.unmodifiableMap(properties), fieldCapabilitiesResponse));
         Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
         metadata.putAll(createMetadata(config.getId(), clock, Version.CURRENT));
         return new CreateIndexRequest(destinationIndex, settings).mapping(mappingsAsMap);
@@ -173,10 +209,14 @@ public final class DestinationIndex {
         return maxValue;
     }
 
-    private static Map<String, Object> createAdditionalMappings(DataFrameAnalyticsConfig config, Map<String, Object> mappingsProperties) {
+    private static Map<String, Object> createAdditionalMappings(DataFrameAnalyticsConfig config,
+                                                                Map<String, Object> mappingsProperties,
+                                                                FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> properties = new HashMap<>();
         properties.put(INCREMENTAL_ID, Map.of("type", NumberFieldMapper.NumberType.LONG.typeName()));
-        properties.putAll(config.getAnalysis().getExplicitlyMappedFields(mappingsProperties, config.getDest().getResultsField()));
+        properties.putAll(
+            config.getAnalysis().getExplicitlyMappedFields(
+                config.getDest().getResultsField(), fieldCapabilitiesResponse));
         return properties;
     }
 
@@ -201,7 +241,9 @@ public final class DestinationIndex {
     }
 
     @SuppressWarnings("unchecked")
-    public static void updateMappingsToDestIndex(Client client, DataFrameAnalyticsConfig config, GetIndexResponse getIndexResponse,
+    public static void updateMappingsToDestIndex(Client client,
+                                                 DataFrameAnalyticsConfig config,
+                                                 GetIndexResponse getIndexResponse,
                                                  ActionListener<AcknowledgedResponse> listener) {
         // We have validated the destination index should match a single index
         assert getIndexResponse.indices().length == 1;
@@ -214,16 +256,40 @@ public final class DestinationIndex {
         // Verify that the results field does not exist in the dest index
         checkResultsFieldIsNotPresentInProperties(config, destPropertiesAsMap);
 
-        // Determine mappings to be added to the destination index
-        Map<String, Object> addedMappings =
-            Map.of(PROPERTIES, createAdditionalMappings(config, Collections.unmodifiableMap(destPropertiesAsMap)));
+        ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesListener = ActionListener.wrap(
+            fieldCapabilitiesResponse -> {
+                // Determine mappings to be added to the destination index
+                Map<String, Object> addedMappings =
+                    Map.of(
+                        PROPERTIES,
+                        createAdditionalMappings(config, Collections.unmodifiableMap(destPropertiesAsMap), fieldCapabilitiesResponse));
 
-        // Add the mappings to the destination index
-        PutMappingRequest putMappingRequest =
-            new PutMappingRequest(getIndexResponse.indices())
-                .source(addedMappings);
+                // Add the mappings to the destination index
+                PutMappingRequest putMappingRequest =
+                    new PutMappingRequest(getIndexResponse.indices())
+                        .source(addedMappings);
+                ClientHelper.executeWithHeadersAsync(
+                    config.getHeaders(), ML_ORIGIN, client, PutMappingAction.INSTANCE, putMappingRequest, listener);
+            },
+            listener::onFailure
+        );
+
+        List<RequiredField> requiredFields = config.getAnalysis().getRequiredFields();
+        if (requiredFields.isEmpty()) {
+            fieldCapabilitiesListener.onResponse(null);
+            return;
+        }
+        FieldCapabilitiesRequest fieldCapabilitiesRequest =
+            new FieldCapabilitiesRequest()
+                .indices(config.getSource().getIndex())
+                .fields(requiredFields.stream().map(RequiredField::getName).toArray(String[]::new));
         ClientHelper.executeWithHeadersAsync(
-            config.getHeaders(), ML_ORIGIN, client, PutMappingAction.INSTANCE, putMappingRequest, listener);
+            config.getHeaders(),
+            ML_ORIGIN,
+            client,
+            FieldCapabilitiesAction.INSTANCE,
+            fieldCapabilitiesRequest,
+            fieldCapabilitiesListener);
     }
 
     private static void checkResultsFieldIsNotPresentInProperties(DataFrameAnalyticsConfig config, Map<String, Object> properties) {


### PR DESCRIPTION
This PR fixes the way dependent variable's mapping is fetched in case of a multi-field.

Closes https://github.com/elastic/machine-learning-qa/issues/868