### PR TITLE
[7.10] [DOCS] Remove 7.9.2 coming tags (#62872)

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.9.2]]
 == {es} version 7.9.2
 
-coming[7.9.2]
-
 Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 
 [[deprecation-7.9.2]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Remove 7.9.2 coming tags (#62872)