### PR TITLE
Fix testG1GOptionsForSmallHeapWhenTuningSet

### DIFF
--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -136,17 +136,19 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
         }
     }
 
-    @Ignore(value = "https://github.com/elastic/elasticsearch/issues/63828")
+    //@Ignore(value = "https://github.com/elastic/elasticsearch/issues/63828")
     public void testG1GOptionsForSmallHeapWhenTuningSet() throws InterruptedException, IOException {
         List<String> jvmErgonomics = JvmErgonomics.choose(
             Arrays.asList("-Xms6g", "-Xmx6g", "-XX:+UseG1GC", "-XX:InitiatingHeapOccupancyPercent=45")
         );
-        assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
         assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:InitiatingHeapOccupancyPercent="))));
+
         if (JavaVersion.majorVersion(JavaVersion.CURRENT) >= 10) {
             assertThat(jvmErgonomics, hasItem("-XX:G1ReservePercent=15"));
+            assertThat(jvmErgonomics, hasItem("-XX:G1HeapRegionSize=4m"));
         } else {
             assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1ReservePercent="))));
+            assertThat(jvmErgonomics, everyItem(not(startsWith("-XX:G1HeapRegionSize="))));
         }
     }
 

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.tools.launchers;
 
 import org.elasticsearch.tools.java_version_checker.JavaVersion;
-import org.junit.Ignore;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -136,7 +136,6 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
         }
     }
 
-    //@Ignore(value = "https://github.com/elastic/elasticsearch/issues/63828")
     public void testG1GOptionsForSmallHeapWhenTuningSet() throws InterruptedException, IOException {
         List<String> jvmErgonomics = JvmErgonomics.choose(
             Arrays.asList("-Xms6g", "-Xmx6g", "-XX:+UseG1GC", "-XX:InitiatingHeapOccupancyPercent=45")


### PR DESCRIPTION
Add correct assert for JDK 10+.

Closes: https://github.com/elastic/elasticsearch/issues/63828