### PR TITLE
Add no-kpi as url param to distro downloads

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -152,7 +152,8 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
                 creds.setValue("1");
             });
             repo.getAuthentication().create("header", HttpHeaderAuthentication.class);
-            repo.patternLayout(layout -> layout.artifact("/downloads/elasticsearch/[module]-[revision](-[classifier]).[ext]"));
+            String urlPath = "/downloads/elasticsearch/[module]-[revision](-[classifier]).[ext]?x-elastic-no-kpi=true";
+            repo.patternLayout(layout -> layout.artifact(urlPath));
         });
         project.getRepositories().exclusiveContent(exclusiveContentRepository -> {
             exclusiveContentRepository.filter(config -> config.includeGroup(group));


### PR DESCRIPTION
The Elastic download service currently expects a header named
`X-ELASTIC-NO-KPI` when used for internal downloads to not effect
download statistics. Due to upcoming changes in the load balancing
architecture, this flag is moving to a url parameter. This commit adds
the url param to the distro downloads, while preserving the same header
until the service is fully switched to the new architecture.