### PR TITLE
Drop parse from boolean runtime fields (backport of #63761)

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
+++ b/x-pack/plugin/runtime-fields/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/runtimefields/rest/CoreTestsWithRuntimeFieldsIT.java
@@ -200,7 +200,7 @@ public class CoreTestsWithRuntimeFieldsIT extends ESClientYamlSuiteTestCase {
 
     private static final Map<String, String> PAINLESS_TO_EMIT = org.elasticsearch.common.collect.Map.of(
         BooleanFieldMapper.CONTENT_TYPE,
-        "emit(parse(value));",
+        "emit(Boolean.parseBoolean(value.toString()));",
         DateFieldMapper.CONTENT_TYPE,
         "emit(parse(value.toString()));",
         NumberType.DOUBLE.typeName(),

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanFieldScript.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
@@ -75,10 +74,6 @@ public abstract class BooleanFieldScript extends AbstractFieldScript {
         } else {
             falses++;
         }
-    }
-
-    public static boolean parse(Object str) {
-        return Booleans.parseBoolean(str.toString());
     }
 
     public static class Emit {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
@@ -61,6 +61,10 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
         }
     }
 
+    /**
+     * Temporary parse method that takes into account the date format. We'll
+     * remove this when we have "native" source parsing fields.
+     */
     public static class Parse {
         private final DateFieldScript script;
 

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/boolean_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/boolean_whitelist.txt
@@ -15,7 +15,5 @@ class org.elasticsearch.xpack.runtimefields.mapper.BooleanFieldScript$Factory @n
 static_import {
     # The `emit` callback to collect values for the field
     void emit(org.elasticsearch.xpack.runtimefields.mapper.BooleanFieldScript, boolean) bound_to org.elasticsearch.xpack.runtimefields.mapper.BooleanFieldScript$Emit
-    # Parse a value from the source to a boolean
-    boolean parse(def) from_class org.elasticsearch.xpack.runtimefields.mapper.BooleanFieldScript
 }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -70,7 +70,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
     @Override
     public void testDocValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"true\"]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true]}"))));
             iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"foo\": [true, false]}"))));
             List<Long> results = new ArrayList<>();
             try (DirectoryReader reader = iw.getReader()) {
@@ -487,7 +487,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
                                     @Override
                                     public void execute() {
                                         for (Object foo : (List<?>) getSource().get("foo")) {
-                                            emit(parse(foo));
+                                            emit((Boolean) foo);
                                         }
                                     }
                                 };


### PR DESCRIPTION
Folks can just use the standard jvm method `Boolean.parseBoolean`.
\