### PR TITLE
[7.x] Add value_count mode to rate agg (#63687)

### DIFF
--- a/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
@@ -93,8 +93,8 @@ be automatically calculated by multiplying monthly rate by 12.
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
 Instead of counting the number of documents, it is also possible to calculate a sum of all values of the fields in the documents in each
-bucket. The following request will group all sales records into monthly bucket and than calculate the total monthly sales and convert them
-into average daily sales.
+bucket or the number of values in each bucket. The following request will group all sales records into monthly bucket and than calculate
+the total monthly sales and convert them into average daily sales.
 
 [source,console]
 --------------------------------------------------
@@ -164,6 +164,84 @@ The response will contain the average daily sale prices for each month.
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
+By adding the `mode` parameter with the value `value_count`, we can change the calculation from `sum` to the number of values of the field:
+
+[source,console]
+--------------------------------------------------
+GET sales/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_date": {
+      "date_histogram": {
+        "field": "date",
+        "calendar_interval": "month"  <1>
+      },
+      "aggs": {
+        "avg_number_of_sales_per_year": {
+          "rate": {
+            "field": "price", <2>
+            "unit": "year",  <3>
+            "mode": "value_count" <4>
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[setup:sales]
+<1> Histogram is grouped by month.
+<2> Calculate number of of all sale prices
+<3> Convert to annual counts
+<4> Changing the mode to value count
+
+The response will contain the average daily sale prices for each month.
+
+[source,console-result]
+--------------------------------------------------
+{
+  ...
+  "aggregations" : {
+    "by_date" : {
+      "buckets" : [
+        {
+          "key_as_string" : "2015/01/01 00:00:00",
+          "key" : 1420070400000,
+          "doc_count" : 3,
+          "avg_number_of_sales_per_year" : {
+            "value" : 36.0
+          }
+        },
+        {
+          "key_as_string" : "2015/02/01 00:00:00",
+          "key" : 1422748800000,
+          "doc_count" : 2,
+          "avg_number_of_sales_per_year" : {
+            "value" : 24.0
+          }
+        },
+        {
+          "key_as_string" : "2015/03/01 00:00:00",
+          "key" : 1425168000000,
+          "doc_count" : 2,
+          "avg_number_of_sales_per_year" : {
+            "value" : 24.0
+          }
+        }
+      ]
+    }
+  }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
+
+By default `sum` mode is used.
+
+`"mode": "sum"`:: calculate the sum of all values field
+`"mode": "value_count"`:: use the number of values in the field
+
+The `mode` parameter can only be used with fields and scripts.
 
 ==== Relationship between bucket sizes and rate
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
@@ -26,6 +26,7 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
     protected final ValuesSource valuesSource;
     private final DocValueFormat format;
     private final Rounding.DateTimeUnit rateUnit;
+    protected final RateMode rateMode;
     private final SizedBucketAggregator sizedBucketAggregator;
 
     protected DoubleArray sums;
@@ -35,6 +36,7 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
         String name,
         ValuesSourceConfig valuesSourceConfig,
         Rounding.DateTimeUnit rateUnit,
+        RateMode rateMode,
         SearchContext context,
         Aggregator parent,
         Map<String, Object> metadata
@@ -45,8 +47,12 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
         if (valuesSource != null) {
             sums = context.bigArrays().newDoubleArray(1, true);
             compensations = context.bigArrays().newDoubleArray(1, true);
+            if (rateMode == null) {
+                rateMode = RateMode.SUM;
+            }
         }
         this.rateUnit = rateUnit;
+        this.rateMode = rateMode;
         this.sizedBucketAggregator = findSizedBucketAncestor();
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
@@ -5,6 +5,11 @@
  */
 package org.elasticsearch.xpack.analytics.rate;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,13 +29,10 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Objects;
-
 public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource, RateAggregationBuilder> {
     public static final String NAME = "rate";
     public static final ParseField UNIT_FIELD = new ParseField("unit");
+    public static final ParseField MODE_FIELD = new ParseField("mode");
     public static final ValuesSourceRegistry.RegistryKey<RateAggregatorSupplier> REGISTRY_KEY = new ValuesSourceRegistry.RegistryKey<>(
         NAME,
         RateAggregatorSupplier.class
@@ -40,9 +42,11 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
     static {
         ValuesSourceAggregationBuilder.declareFields(PARSER, true, true, false, false);
         PARSER.declareString(RateAggregationBuilder::rateUnit, UNIT_FIELD);
+        PARSER.declareString(RateAggregationBuilder::rateMode, MODE_FIELD);
     }
 
     Rounding.DateTimeUnit rateUnit;
+    RateMode rateMode;
 
     public static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         RateAggregatorFactory.registerAggregators(builder);
@@ -58,6 +62,8 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
         Map<String, Object> metadata
     ) {
         super(clone, factoriesBuilder, metadata);
+        this.rateUnit = clone.rateUnit;
+        this.rateMode = clone.rateMode;
     }
 
     @Override
@@ -76,6 +82,11 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
         } else {
             rateUnit = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
+            if (in.readBoolean()) {
+                rateMode = in.readEnum(RateMode.class);
+            }
+        }
     }
 
     @Override
@@ -89,6 +100,14 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
             out.writeByte(rateUnit.getId());
         } else {
             out.writeByte((byte) 0);
+        }
+        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
+            if (rateMode != null) {
+                out.writeBoolean(true);
+                out.writeEnum(rateMode);
+            } else {
+                out.writeBoolean(false);
+            }
         }
     }
 
@@ -104,13 +123,21 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder
     ) throws IOException {
-        return new RateAggregatorFactory(name, config, rateUnit, context, parent, subFactoriesBuilder, metadata);
+        if (field() == null && script() == null) {
+            if (rateMode != null) {
+                throw new IllegalArgumentException("The mode parameter is only supported with field or script");
+            }
+        }
+        return new RateAggregatorFactory(name, config, rateUnit, rateMode, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         if (rateUnit != null) {
             builder.field(UNIT_FIELD.getPreferredName(), rateUnit.shortName());
+        }
+        if (rateMode != null) {
+            builder.field(MODE_FIELD.getPreferredName(), rateMode.value());
         }
         return builder;
     }
@@ -129,6 +156,15 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
         return this;
     }
 
+    public RateAggregationBuilder rateMode(String rateMode) {
+        return rateMode(RateMode.resolve(rateMode));
+    }
+
+    public RateAggregationBuilder rateMode(RateMode rateMode) {
+        this.rateMode = rateMode;
+        return this;
+    }
+
     static Rounding.DateTimeUnit parse(String rateUnit) {
         Rounding.DateTimeUnit parsedRate = DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(rateUnit);
         if (parsedRate == null) {
@@ -140,17 +176,7 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
     @Override
     protected ValuesSourceConfig resolveConfig(AggregationContext context) {
         if (field() == null && script() == null) {
-            return new ValuesSourceConfig(
-                CoreValuesSourceType.NUMERIC,
-                null,
-                true,
-                null,
-                null,
-                1.0,
-                null,
-                DocValueFormat.RAW,
-                context
-            );
+            return new ValuesSourceConfig(CoreValuesSourceType.NUMERIC, null, true, null, null, 1.0, null, DocValueFormat.RAW, context);
         } else {
             return super.resolveConfig(context);
         }
@@ -162,11 +188,11 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         RateAggregationBuilder that = (RateAggregationBuilder) o;
-        return rateUnit == that.rateUnit;
+        return rateUnit == that.rateUnit && rateMode == that.rateMode;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), rateUnit);
+        return Objects.hash(super.hashCode(), rateUnit, rateMode);
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorFactory.java
@@ -30,10 +30,13 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     private final Rounding.DateTimeUnit rateUnit;
 
+    private final RateMode rateMode;
+
     RateAggregatorFactory(
         String name,
         ValuesSourceConfig config,
         Rounding.DateTimeUnit rateUnit,
+        RateMode rateMode,
         AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
@@ -41,6 +44,7 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
     ) throws IOException {
         super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.rateUnit = rateUnit;
+        this.rateMode = rateMode;
     }
 
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
@@ -60,7 +64,7 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new AbstractRateAggregator(name, config, rateUnit, searchContext, parent, metadata) {
+        return new AbstractRateAggregator(name, config, rateUnit, rateMode, searchContext, parent, metadata) {
             @Override
             public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) {
                 return LeafBucketCollector.NO_OP_COLLECTOR;
@@ -77,6 +81,6 @@ class RateAggregatorFactory extends ValuesSourceAggregatorFactory {
     ) throws IOException {
         return context.getValuesSourceRegistry()
             .getAggregator(RateAggregationBuilder.REGISTRY_KEY, config)
-            .build(name, config, rateUnit, searchContext, parent, metadata);
+            .build(name, config, rateUnit, rateMode, searchContext, parent, metadata);
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorSupplier.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorSupplier.java
@@ -19,6 +19,7 @@ public interface RateAggregatorSupplier {
         String name,
         ValuesSourceConfig valuesSourceConfig,
         Rounding.DateTimeUnit rateUnit,
+        RateMode rateMode,
         SearchContext context,
         Aggregator parent,
         Map<String, Object> metadata

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateMode.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.analytics.rate;
+
+import java.util.Locale;
+
+/**
+ * Rate mode - value_count or sum
+ */
+public enum RateMode {
+    VALUE_COUNT, SUM;
+
+    public static RateMode resolve(String name) {
+        return RateMode.valueOf(name.toUpperCase(Locale.ROOT));
+    }
+
+    public String value() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilderTests.java
@@ -56,6 +56,9 @@ public class RateAggregationBuilderTests extends AbstractSerializingTestCase<Rat
             } else {
                 aggregationBuilder.script(new Script(randomAlphaOfLength(10)));
             }
+            if (randomBoolean()) {
+                aggregationBuilder.rateMode(randomFrom(RateMode.values()));
+            }
         }
         if (randomBoolean()) {
             aggregationBuilder.rateUnit(randomFrom(Rounding.DateTimeUnit.values()));


### PR DESCRIPTION
Adds a new value count mode to the rate aggregation.

Closes #63575
