### PR TITLE
Replace Function<Type, Boolean> with Predicate

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
@@ -35,17 +35,18 @@ import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.index.mapper.ObjectMapper;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /** Utility class to filter parent and children clauses when building nested
  * queries. */
 public final class NestedHelper {
 
     private final Function<String, ObjectMapper> objectMapperLookup;
-    private final Function<String, Boolean> isMappedFieldFunction;
+    private final Predicate<String> isMappedFieldPredicate;
 
-    public NestedHelper(Function<String, ObjectMapper> objectMapperLookup, Function<String, Boolean> isMappedFieldFunction) {
+    public NestedHelper(Function<String, ObjectMapper> objectMapperLookup, Predicate<String> isMappedFieldPredicate) {
         this.objectMapperLookup = objectMapperLookup;
-        this.isMappedFieldFunction = isMappedFieldFunction;
+        this.isMappedFieldPredicate = isMappedFieldPredicate;
     }
 
     /** Returns true if the given query might match nested documents. */
@@ -106,7 +107,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (isMappedFieldFunction.apply(field) == false) {
+        if (isMappedFieldPredicate.test(field) == false) {
             // field does not exist
             return false;
         }
@@ -175,7 +176,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (isMappedFieldFunction.apply(field) == false) {
+        if (isMappedFieldPredicate.test(field) == false) {
             return false;
         }
         for (String parent = parentObject(field); parent != null; parent = parentObject(parent)) {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -36,8 +36,8 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -50,7 +50,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -108,7 +108,7 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
 
 
     private void indicesThatCannotBeCreatedTestCase(Set<String> expected,
-            BulkRequest bulkRequest, Function<String, Boolean> shouldAutoCreate) {
+            BulkRequest bulkRequest, Predicate<String> shouldAutoCreate) {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
         when(state.getMetadata()).thenReturn(Metadata.EMPTY_METADATA);
@@ -139,7 +139,7 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
 
             @Override
             boolean shouldAutoCreate(String index, ClusterState state) {
-                return shouldAutoCreate.apply(index);
+                return shouldAutoCreate.test(index);
             }
 
             @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporter.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.ml.job.process.diagnostics.DataStreamDiagnostics;
 
 import java.util.Date;
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 
 /**
@@ -49,7 +49,7 @@ public class DataCountsReporter {
     private long logEvery = 1;
     private long logCount = 0;
 
-    private Function<Long, Boolean> reportingBoundaryFunction;
+    private Predicate<Long> reportingBoundaryFunction;
 
     private DataStreamDiagnostics diagnostics;
 
@@ -93,7 +93,7 @@ public class DataCountsReporter {
 
         // report at various boundaries
         long totalRecords = getInputRecordCount();
-        if (reportingBoundaryFunction.apply(totalRecords)) {
+        if (reportingBoundaryFunction.test(totalRecords)) {
             logStatus(totalRecords);
         }
 


### PR DESCRIPTION
In a few cases we use a Function that returns a Boolean, for which we could simply use a Predicate instead.