### PR TITLE
Fixing typo in ilm-with-existing-indices.asciidoc

### DIFF
--- a/docs/reference/ilm/ilm-with-existing-indices.asciidoc
+++ b/docs/reference/ilm/ilm-with-existing-indices.asciidoc
@@ -4,7 +4,7 @@
 == Manage existing indices
 
 If you've been using Curator or some other mechanism to manage periodic indices,
-you have a couple options when migrating to {ilm-init}:
+you have a couple of options when migrating to {ilm-init}:
 
 * Set up your index templates to use an {ilm-init} policy to manage your new indices. 
 Once {ilm-init} is managing your current write index, you can apply an appropriate policy to your old indices.


### PR DESCRIPTION
In line 7, added a missing preposition - 'of' after the word 'couple'