### PR TITLE
Remove CloseHandle call on current process handle (noop)

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -203,10 +203,6 @@ class JNANatives {
             }
         } catch (UnsatisfiedLinkError e) {
             // this will have already been logged by Kernel32Library, no need to repeat it
-        } finally {
-            if (process != null) {
-                kernel.CloseHandle(process);
-            }
         }
     }
 


### PR DESCRIPTION
This is a simple PR to remove the call to CloseHandle on the pseudo-handle returned by GetCurrentProcess().  As documented here, this pseudo-handle is actually a constant (HANDLE)-1 rather than an actually allocated resource.  The call to CloseHandle isn't harmful but it is a pointless syscall.

https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess

I have signed the CLA.

Thanks!