### PR TITLE
Composite aggregation must check live docs when the index is sorted

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -42,6 +42,7 @@ import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.comparators.LongComparator;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.RoaringDocIdSet;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.index.IndexSortConfig;
@@ -367,8 +368,11 @@ final class CompositeAggregator extends BucketsAggregator {
             final LeafBucketCollector inner = queue.getLeafCollector(ctx,
                 getFirstPassCollector(docIdSetBuilder, indexSortPrefix.getSort().length));
             inner.setScorer(scorer);
+            final Bits liveDocs = ctx.reader().getLiveDocs();
             while (docIt.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                inner.collect(docIt.docID());
+                if (liveDocs == null || liveDocs.get(docIt.docID())) {
+                    inner.collect(docIt.docID());
+                }
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -2254,22 +2254,24 @@ public class CompositeAggregatorTests  extends AggregatorTestCase {
                 Document document = new Document();
                 int id = 0;
                 for (Map<String, List<Object>> fields : dataset) {
+                    document.clear();
                     addToDocument(id, document, fields);
                     indexWriter.addDocument(document);
-                    if (randomBoolean()) {
-                        document.clear();
-                        indexWriter.deleteDocuments(new Term("id", Integer.toString(id)));
-                        id++;
-                        addToDocument(id, document, fields);
-                        indexWriter.addDocument(document);
-                    }
-                    document.clear();
                     id++;
                 }
                 if (rarely()) {
                     indexWriter.forceMerge(1);
                 }
-
+                if (dataset.size() > 0) {
+                    int numDeletes = randomIntBetween(1, 25);
+                    for (int i = 0; i < numDeletes; i++) {
+                        id = randomIntBetween(0, dataset.size() - 1);
+                        indexWriter.deleteDocuments(new Term("id", Integer.toString(id)));
+                        document.clear();
+                        addToDocument(id, document, dataset.get(id));
+                        indexWriter.addDocument(document);
+                    }
+                }
             }
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = new IndexSearcher(indexReader);


### PR DESCRIPTION
This change ensures that the live docs are checked in the composite aggregator
when the index is sorted.