### PR TITLE
[ML] Pass job config in JSON file to autodetect

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
@@ -177,13 +177,20 @@ public class AutodetectBuilder {
     public void build() throws IOException, InterruptedException {
 
         List<String> command = buildAutodetectCommand();
+
+        // While it may appear that the JSON formatted job config file contains data that
+        // is duplicated in the existing limits, modelPlot and field config files, over time
+        // the C++ backend will retrieve all its required configuration data from the new
+        // JSON config file and the old-style configuration files will be removed.
+        buildJobConfig(command);
+
+        // Per the comment above, these three lines will eventually be removed once migration
+        // to the new JSON formatted configuration file has been completed.
         buildLimits(command);
         buildModelPlotConfig(command);
-
-        buildQuantiles(command);
         buildFieldConfig(command);
 
-        buildJobConfig(command);
+        buildQuantiles(command);
 
         processPipes.addArgs(command);
         controller.startProcess(command);
@@ -362,7 +369,7 @@ public class AutodetectBuilder {
         Path configFile = Files.createTempFile(env.tmpFile(), "config", JSON_EXTENSION);
         filesToDelete.add(configFile);
         try (OutputStreamWriter osw = new OutputStreamWriter(Files.newOutputStream(configFile),StandardCharsets.UTF_8);
-             XContentBuilder jsonBuilder = JsonXContent.contentBuilder()) {
+            XContentBuilder jsonBuilder = JsonXContent.contentBuilder()) {
 
             job.toXContent(jsonBuilder, ToXContent.EMPTY_PARAMS);
             osw.write(Strings.toString(jsonBuilder));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
@@ -19,14 +19,19 @@ import org.elasticsearch.xpack.core.ml.job.config.PerPartitionCategorizationConf
 import org.elasticsearch.xpack.ml.process.NativeController;
 import org.elasticsearch.xpack.ml.process.ProcessPipes;
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class AutodetectBuilderTests extends ESTestCase {
 
@@ -36,11 +41,14 @@ public class AutodetectBuilderTests extends ESTestCase {
     private Settings settings;
     private NativeController nativeController;
     private ProcessPipes processPipes;
+    private ArgumentCaptor<List<String>> commandCaptor;
 
+    @SuppressWarnings("unchecked")
     @Before
     public void setUpTests() {
         logger = mock(Logger.class);
-        filesToDelete = Collections.emptyList();
+        filesToDelete = new ArrayList<>();
+        commandCaptor = ArgumentCaptor.forClass((Class)List.class);
         settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         env = TestEnvironment.newEnvironment(settings);
         nativeController = mock(NativeController.class);
@@ -125,5 +133,20 @@ public class AutodetectBuilderTests extends ESTestCase {
 
     private AutodetectBuilder autodetectBuilder(Job job) {
         return new AutodetectBuilder(job, filesToDelete, logger, env, settings, nativeController, processPipes);
+    }
+
+    public void testBuildAutodetect() throws Exception {
+        Job.Builder job = buildJobBuilder("unit-test-job");
+
+        autodetectBuilder(job.build()).build();
+
+        assertThat(filesToDelete, hasSize(3));
+
+        verify(nativeController).startProcess(commandCaptor.capture());
+        verifyNoMoreInteractions(nativeController);
+
+        List<String> command = commandCaptor.getValue();
+        String commandString = command.toString();
+        assertTrue(commandString.contains(" --config="));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
@@ -27,8 +27,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -146,7 +148,6 @@ public class AutodetectBuilderTests extends ESTestCase {
         verifyNoMoreInteractions(nativeController);
 
         List<String> command = commandCaptor.getValue();
-        String commandString = command.toString();
-        assertTrue(commandString.contains(" --config="));
+        assertThat(command, hasItem(matchesPattern("--config=.*\\.json")));
     }
 }


### PR DESCRIPTION
Write job config in the form of a JSON formatted file and pass its
location to autodetect as an additional command line option. This will
ultimately allow all relevant job config to be read from the JSON config
file and hence reduce the number of command line arguments for
autodetect.

Relates to https://github.com/elastic/ml-cpp/issues/1253