### PR TITLE
[ML] Change docs test mute comment

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -92,7 +92,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 --------------------------------------------------
 POST _ml/anomaly_detectors/low_request_rate/_close
 --------------------------------------------------
-// TEST[skip:sometimes fails due to https://github.com/elastic/elasticsearch/pull/48583#issuecomment-552991325]
+// TEST[skip:Kibana sample data]
 
 When the job is closed, you receive the following results:
 


### PR DESCRIPTION
The original comment mentioned issue #48583, but issue #48941
is specifically open for this mute.  However, this is
inappropriate, as the underlying reason the test cannot be
unmuted is the same as for all the other tests skipped with the
comment "Kibana sample data": issues #51572, #51576 and #51678.

Closes #48941