### PR TITLE
Explicitly use TLS 1.2 in Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ systemProp.org.gradle.dependency.duplicate.project.detection=false
 # Enforce the build to fail on deprecated gradle api usage
 systemProp.org.gradle.warning.mode=fail
 
-# forcing forcing to use TLS1.2 to avoid failure in vault
+# forcing to use TLS1.2 to avoid failure in vault
 # see https://github.com/hashicorp/vault/issues/8750#issuecomment-631236121
 systemProp.jdk.tls.client.protocols=TLSv1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,7 @@ systemProp.org.gradle.dependency.duplicate.project.detection=false
 
 # Enforce the build to fail on deprecated gradle api usage
 systemProp.org.gradle.warning.mode=fail
+
+# forcing forcing to use TLS1.2 to avoid failure in vault
+# see https://github.com/hashicorp/vault/issues/8750#issuecomment-631236121
+systemProp.jdk.tls.client.protocols=TLSv1.2


### PR DESCRIPTION
Should fix CI failures after vault update
See https://github.com/hashicorp/vault/issues/8750\#issuecomment-631236121