### PR TITLE
[DOCS] Move clone snapshot API page

### DIFF
--- a/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
+++ b/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
@@ -19,6 +19,7 @@ For more information, see <<snapshot-restore>>.
 [[snapshot-management-apis]]
 === Snapshot management APIs
 * <<create-snapshot-api,Create snapshot>>
+* <<clone-snapshot-api,Clone snapshot>>
 * <<get-snapshot-api,Get snapshot>>
 * <<get-snapshot-status-api,Get snapshot status>>
 * <<restore-snapshot-api,Restore snapshot>>
@@ -29,6 +30,7 @@ include::verify-repo-api.asciidoc[]
 include::get-repo-api.asciidoc[]
 include::delete-repo-api.asciidoc[]
 include::clean-up-repo-api.asciidoc[]
+include::clone-snapshot-api.asciidoc[]
 include::create-snapshot-api.asciidoc[]
 include::get-snapshot-api.asciidoc[]
 include::get-snapshot-status-api.asciidoc[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -107,7 +107,6 @@ understand the time requirements before proceeding.
 --
 
 include::register-repository.asciidoc[]
-include::apis/clone-snapshot-api.asciidoc[]
 include::take-snapshot.asciidoc[]
 include::restore-snapshot.asciidoc[]
 include::monitor-snapshot-restore.asciidoc[]


### PR DESCRIPTION
Moves the [clone snapshot API](https://elasticsearch_63902.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/clone-snapshot-api.html) page to nest with the other snapshot and restore API pages.

Closes #63901