### PR TITLE
[7.x] Preserve backing index ordering for data streams (#63749)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -579,7 +579,6 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                     case DATA_STREAM:
                         IndexAbstraction.DataStream dataStream = (IndexAbstraction.DataStream) ia;
                         String[] backingIndices = dataStream.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
-                        Arrays.sort(backingIndices);
                         dataStreams.add(new ResolvedDataStream(
                             dataStream.getName(),
                             backingIndices,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexTests.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -167,6 +168,29 @@ public class ResolveIndexTests extends ESTestCase {
         validateIndices(indices, ".ds-logs-mysql-prod-000003", "logs-pgsql-test-20200102");
         validateAliases(aliases, "one-off-alias");
         validateDataStreams(dataStreams, "logs-mysql-test");
+    }
+
+    public void testResolvePreservesBackingIndexOrdering() {
+        Metadata.Builder builder = Metadata.builder();
+        String dataStreamName = "my-data-stream";
+        String[] names = {"not-in-order-2", "not-in-order-1", DataStream.getDefaultBackingIndexName(dataStreamName, 3)};
+        List<IndexMetadata> backingIndices = Arrays.stream(names).map(n -> createIndexMetadata(n, true)).collect(Collectors.toList());
+        for (IndexMetadata index : backingIndices) {
+            builder.put(index, false);
+        }
+
+        DataStream ds = new DataStream(dataStreamName, createTimestampField("@timestamp"),
+            backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()));
+        builder.put(ds);
+
+        IndicesOptions indicesOptions = IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN;
+        List<ResolvedIndex> indices = new ArrayList<>();
+        List<ResolvedAlias> aliases = new ArrayList<>();
+        List<ResolvedDataStream> dataStreams = new ArrayList<>();
+        TransportAction.resolveIndices(new String[]{"*"}, indicesOptions, builder.build(), resolver, indices, aliases, dataStreams, true);
+
+        assertThat(dataStreams.size(), equalTo(1));
+        assertThat(dataStreams.get(0).getBackingIndices(), arrayContaining(names));
     }
 
     private void validateIndices(List<ResolvedIndex> resolvedIndices, String... expectedIndices) {


### PR DESCRIPTION
The resolve index API incorrectly sorts the backing indices returned for data streams. The backing indices on a data stream are an ordered list in which the last index is always the write index so sorting them may produce incorrect results once [migration of existing indices to data streams](https://github.com/elastic/elasticsearch/issues/61046) is permitted.

Backport of #63749
