### PR TITLE
Use asterisk instead of empty string to clear all cached entries

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -195,7 +195,7 @@ teardown:
 
   - do:
       security.clear_api_key_cache:
-        ids: ""
+        ids: "*"
 
   - match: { _nodes.failed: 0 }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
@@ -338,5 +338,5 @@ teardown:
 
   - do:
       security.clear_cached_privileges:
-        application: ""
+        application: "*"
   - match: { _nodes.failed: 0 }


### PR DESCRIPTION
The officially supported way to clearing all entries from a cache is to use wildcard of either `*` or `_all`. Though empty string has the same effect, it was never intended. Therefore the tests should not use empty string. This PR changes them to use `*`.

Resolves: #63885 