### PR TITLE
Fix build tools integTest failure after vault update

### DIFF
--- a/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/gradle.properties
+++ b/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/gradle.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# forcing to use TLS1.2 to avoid failure in vault
+# see https://github.com/hashicorp/vault/issues/8750#issuecomment-631236121
+systemProp.jdk.tls.client.protocols=TLSv1.2


### PR DESCRIPTION
This fixes the build-tools integration tests that started failing after updating vault. We need to apply the same fix as we do for our production build by enforcing TLS 1.2