### PR TITLE
Search - clean up case sensitivity option in term-based queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/issues/63893" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -41,9 +41,9 @@ provided `<field>`.
 (Optional, string) Method used to rewrite the query. For valid values and more
 information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
-`case_insensitive`::
-(Optional, boolean) allows ASCII case insensitive matching of the
-value with the indexed field values when set to true. Setting to false is disallowed.
+`case_sensitivity`::
+(Optional, string) allows ASCII case insensitive matching of the
+value with the indexed field values when set to "insensitive". Default value is "field_default".
 
 [[prefix-query-notes]]
 ==== Notes

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -68,9 +68,9 @@ provided. To improve performance, avoid using wildcard patterns, such as `.*` or
 valid values and more information, see <<regexp-optional-operators, Regular
 expression syntax>>.
 
-`case_insensitive`::
-(Optional, boolean) allows case insensitive matching of the regular expression
-value with the indexed field values when set to true. Setting to false is disallowed.
+`case_sensitivity`::
+(Optional, string) allows case insensitive matching of the regular expression
+value with the indexed field values when set to "insensitive". Default is "field_default".
 
 `max_determinized_states`::
 +

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -62,9 +62,9 @@ Boost values are relative to the default value of `1.0`. A boost value between
 `0` and `1.0` decreases the relevance score. A value greater than `1.0`
 increases the relevance score.
 
-`case_insensitive`::
-(Optional, boolean) allows ASCII case insensitive matching of the
-value with the indexed field values when set to true. Setting to false is disallowed.
+`case_sensitivity`::
+(Optional, string) allows ASCII case insensitive matching of the
+value with the indexed field values when set to "insensitive". Default value is "field_default".
 
 [[term-query-notes]]
 ==== Notes

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -69,9 +69,9 @@ increases the relevance score.
 (Optional, string) Method used to rewrite the query. For valid values and more information, see the
 <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
-`case_insensitive`::
-(Optional, boolean) allows case insensitive matching of the
-pattern with the indexed field values when set to true. Setting to false is disallowed.
+`case_sensitivity`::
+(Optional, string) allows case insensitive matching of the
+pattern with the indexed field values when set to "insensitive". Default value is "field_default".
 
 [[wildcard-query-notes]]
 ==== Notes

--- a/server/src/main/java/org/elasticsearch/index/query/CaseSensitivityMode.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CaseSensitivityMode.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+
+import java.io.IOException;
+
+/** Case sensitivity matching mode for term-based queries */
+public enum CaseSensitivityMode implements Writeable {
+
+    /**
+     * use the field's setting for handling matching 
+     */
+    FIELD_DEFAULT(new ParseField("field_default")),
+
+    /**
+     * case insensitive matching
+     */
+    INSENSITIVE(new ParseField("insensitive"));
+
+    public static final ParseField KEY = new ParseField("case_sensitivity");
+
+    private final ParseField parseField;
+
+    CaseSensitivityMode(ParseField parseField) {
+        this.parseField = parseField;
+    }
+
+    public ParseField parseField() {
+        return parseField;
+    }
+
+    public static CaseSensitivityMode parse(String value, DeprecationHandler deprecationHandler) {
+        CaseSensitivityMode[] modes = CaseSensitivityMode.values();
+        for (CaseSensitivityMode mode : modes) {
+            if (mode.parseField.match(value, deprecationHandler)) {
+                return mode;
+            }
+        }
+        throw new ElasticsearchParseException("no [{}] found for value [{}]", KEY.getPreferredName(), value);
+    }
+
+    public static CaseSensitivityMode readFromStream(StreamInput in) throws IOException {
+        return in.readEnum(CaseSensitivityMode.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeEnum(this);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -74,7 +74,7 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         assertThat(query, Matchers.anyOf(instanceOf(PrefixQuery.class), instanceOf(MatchNoDocsQuery.class),
             instanceOf(AutomatonQuery.class)));
         if (context.getFieldType(queryBuilder.fieldName()) != null
-            && queryBuilder.caseInsensitive() == false) { // The field is mapped and case sensitive
+            && queryBuilder.caseSensitivityMode() != CaseSensitivityMode.INSENSITIVE) { // The field is mapped and case sensitive
             PrefixQuery prefixQuery = (PrefixQuery) query;
 
             String expectedFieldName = expectedFieldName(queryBuilder.fieldName());

--- a/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -47,7 +47,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
             query.flags(flags.toArray(new RegexpFlag[flags.size()]));
         }
         if (randomBoolean()) {
-            query.caseInsensitive(true);
+            query.caseSensitivityMode(CaseSensitivityMode.INSENSITIVE);
         }
         if (randomBoolean()) {
             query.maxDeterminizedStates(randomInt(50000));
@@ -104,7 +104,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
                 "    \"name.first\" : {\n" +
                 "      \"value\" : \"s.*y\",\n" +
                 "      \"flags_value\" : 7,\n" +
-                "      \"case_insensitive\" : true,\n" +
+                "      \"case_sensitivity\" : \"insensitive\",\n" +
                 "      \"max_determinized_states\" : 20000,\n" +
                 "      \"boost\" : 1.0\n" +
                 "    }\n" +
@@ -152,17 +152,4 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
         assertEquals("[regexp] query doesn't support multiple fields, found [user1] and [user2]", e.getMessage());
     }
 
-    public void testParseFailsWithCaseSensitive() throws IOException {
-        String json =
-                "{\n" +
-                "    \"regexp\": {\n" +
-                "      \"user1\": {\n" +
-                "        \"value\": \"k.*y\",\n" +
-                "        \"case_insensitive\": false\n" +
-                "      },\n" +
-                "    }\n" +
-                "}";
-        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
-        assertEquals("[regexp] query does not support [case_insensitive] = false", e.getMessage());
-   }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -97,16 +97,17 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
         assertThat(query, either(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class)).or(instanceOf(MatchNoDocsQuery.class))
             .or(instanceOf(AutomatonQuery.class)));
         MappedFieldType mapper = context.getFieldType(queryBuilder.fieldName());
+        boolean insensitive = queryBuilder.caseSensitivityMode() == CaseSensitivityMode.INSENSITIVE;
         if (query instanceof TermQuery) {
             TermQuery termQuery = (TermQuery) query;
 
             String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
             assertThat(termQuery.getTerm().field(), equalTo(expectedFieldName));
 
-            Term term = ((TermQuery) termQuery(mapper, queryBuilder.value(), queryBuilder.caseInsensitive())).getTerm();
+            Term term = ((TermQuery) termQuery(mapper, queryBuilder.value(), insensitive)).getTerm();
             assertThat(termQuery.getTerm(), equalTo(term));
         } else if (mapper != null) {
-            assertEquals(query, termQuery(mapper, queryBuilder.value(), queryBuilder.caseInsensitive()));
+            assertEquals(query, termQuery(mapper, queryBuilder.value(), insensitive));
         } else {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         }
@@ -135,7 +136,7 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
                 "  \"term\" : {\n" +
                 "    \"exact_value\" : {\n" +
                 "      \"value\" : \"Quick Foxes!\",\n" +
-                "      \"case_insensitive\" : true,\n" +
+                "      \"case_sensitivity\" : \"insensitive\",\n" +
                 "      \"boost\" : 1.0\n" +
                 "    }\n" +
                 "  }\n" +

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -73,7 +73,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
 
         if (expectedFieldName.equals(TEXT_FIELD_NAME)) {
-            if (queryBuilder.caseInsensitive()) {
+            if (queryBuilder.caseSensitivityMode() == CaseSensitivityMode.INSENSITIVE) {
                 assertThat(query, instanceOf(AutomatonQuery.class));
             } else {
                 assertThat(query, instanceOf(WildcardQuery.class));
@@ -110,7 +110,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
     public void testFromJson() throws IOException {
         String json = "{    \"wildcard\" : { \"user\" : { \"wildcard\" : \"ki*y\","
-            + " \"case_insensitive\" : true,\n"
+            + " \"case_sensitivity\" : \"insensitive\",\n" 
             + " \"boost\" : 2.0"
             + " } }}";
         WildcardQueryBuilder parsed = (WildcardQueryBuilder) parseQuery(json);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/TermQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/TermQuery.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ql.querydsl.query;
 
+import org.elasticsearch.index.query.CaseSensitivityMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -45,8 +46,10 @@ public class TermQuery extends LeafQuery {
     @Override
     public QueryBuilder asBuilder() {
         TermQueryBuilder qb = termQuery(term, value);
-        // ES does not allow case_insensitive to be set to "false", it should be either "true" or not specified
-        return caseInsensitive == false ? qb : qb.caseInsensitive(caseInsensitive);
+        if (caseInsensitive) {
+            qb.caseSensitivityMode(CaseSensitivityMode.INSENSITIVE);
+        }
+        return qb;
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/WildcardQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/WildcardQuery.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ql.querydsl.query;
 
+import org.elasticsearch.index.query.CaseSensitivityMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -44,8 +45,10 @@ public class WildcardQuery extends LeafQuery {
     @Override
     public QueryBuilder asBuilder() {
         WildcardQueryBuilder wb = wildcardQuery(field, query);
-        // ES does not allow case_insensitive to be set to "false", it should be either "true" or not specified
-        return caseInsensitive == false ? wb : wb.caseInsensitive(caseInsensitive);
+        if (caseInsensitive) {
+            wb.caseSensitivityMode(CaseSensitivityMode.INSENSITIVE);
+        }
+        return wb;
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -118,7 +118,7 @@ setup:
           track_total_hits: true
           query:
             regexp:
-              my_wildcard: {value: ".*Worl.*", case_insensitive: true}
+              my_wildcard: {value: ".*Worl.*", case_sensitivity: "insensitive"}
 
 
   - match: {hits.total.value: 3}


### PR DESCRIPTION
Case sensitivity options are an uncomfortable fit with a boolean setting - changing to enum.
Closes #63893
