### PR TITLE
make sure AggregationTest creates reduced aggregations.

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -296,7 +296,7 @@ public class AggregationsTests extends ESTestCase {
                     singleBucketAggTestCase.subAggregationsSupplier = () -> InternalAggregations.EMPTY;
                 }
             }
-            aggs.add(testCase.createTestInstance());
+            aggs.add(testCase.createTestInstanceForXContent());
         }
         return InternalAggregations.from(aggs);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -91,7 +91,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
     }
 
     private List<Object> randomAggregations() {
-        return randomList(1, randomBoolean() ? 1 : 5, this::randomAggregation);
+        return randomList(randomBoolean() ? 1 : 5, this::randomAggregation);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -160,7 +160,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
     }
 
     @Override
-    protected InternalScriptedMetric createTestInstanceForXContent() {
+    public InternalScriptedMetric createTestInstanceForXContent() {
         InternalScriptedMetric aggregation = createTestInstance();
         return (InternalScriptedMetric) aggregation.reduce(
             singletonList(aggregation),

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -91,7 +91,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
     }
 
     private List<Object> randomAggregations() {
-        return randomList(randomBoolean() ? 1 : 5, this::randomAggregation);
+        return randomList(1, randomBoolean() ? 1 : 5, this::randomAggregation);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -436,7 +436,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         return createUnmappedInstance(name, metadata);
     }
 
-    protected T createTestInstanceForXContent() {
+    public T createTestInstanceForXContent() {
         return createTestInstance();
     }
 


### PR DESCRIPTION
The test calls ` InternalAggregationTestCase#createTestInstanceForXContent()`  instead  of `InternalAggregationTestCase#createTestInstance()`.  The method needs to become public. 

Fixes #63925