### PR TITLE
[7.10][DOCS] Adds ML related release highlights to What's new.

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -70,7 +70,7 @@ considered to be part of all tiers.
 
 {ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[Area under the curve of receiver operating characteristic (AUC ROC)] 
 is an evaluation metric that has been available for {oldetection} since 7.3 and 
-now is available for {classification} analysis as well. It represents the 
+now is available for {classification} analysis. AUC ROC represents the 
 performance of the {classification} process at different predicted probability 
 thresholds. The true positive rate for a specific class is compared against the 
 rate of all the other classes combined at the different threshold levels to 
@@ -84,8 +84,8 @@ create the curve.
 Feature processors enable you to extract process features from document fields. 
 You can use these features in model training and model deployment. Custom 
 feature processors provide a mechanism to create features that can be used at 
-search and ingest time and they don’t take up space in the index. Furthermore, 
-this process more tightly couples feature generation with the resulting model. 
+search and ingest time and they don’t take up space in the index.
+This process more tightly couples feature generation with the resulting model. 
 The result is simplified model management as both the features and the model can 
 easily follow the same life cycle.
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -63,6 +63,33 @@ the `data_hot` tier automatically, while standalone indices will be allocated to
 the `data_content` tier automatically. Nodes with the pre-existing `data` role are 
 considered to be part of all tiers.
 
+
+[discrete]
+[[auc-roc-eval-class]]
+=== AUC ROC evaluation metrics for classification analysis
+
+{ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[Area under the curve of receiver operating characteristic (AUC ROC)] 
+is an evaluation metric that has been available for {oldetection} since 7.3 and 
+now is available for {classification} analysis as well. It represents the 
+performance of the {classification} process at different predicted probability 
+thresholds. The true positive rate for a specific class is compared against the 
+rate of all the other classes combined at the different threshold levels to 
+create the curve.
+
+
+[discrete]
+[[custom-feature-processor-dfa]]
+=== Custom feature processors in {dfanalytics}
+
+Feature processors enable you to extract process features from document fields. 
+You can use these features in model training and model deployment. Custom 
+feature processors provide a mechanism to create features that can be used at 
+search and ingest time and they don’t take up space in the index. Furthermore, 
+this process more tightly couples feature generation with the resulting model. 
+The result is simplified model management as both the features and the model can 
+easily follow the same life cycle.
+
+
 [discrete]
 [[points-in-time-for-search]]
 === Points in time (PITs) for search


### PR DESCRIPTION
## Overview

This PR expands the `What's new in 7.10` section with the ML related release highlights.

### Preview

[What's new in 7.10](https://elasticsearch_63934.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.10/release-highlights.html#auc-roc-eval-class)