### PR TITLE
Remove two redundant DocumentMapper methods (#63922)

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -553,7 +553,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             docs.add(docMapper.parse(new SourceToParse(context.index().getName(), type, "_temp_id", document, documentXContentType)));
         }
 
-        FieldNameAnalyzer fieldNameAnalyzer = (FieldNameAnalyzer) docMapper.mappers().indexAnalyzer();
+        FieldNameAnalyzer fieldNameAnalyzer = (FieldNameAnalyzer)docMapper.mappers().indexAnalyzer();
         // Need to this custom impl because FieldNameAnalyzer is strict and the percolator sometimes isn't when
         // 'index.percolator.map_unmapped_fields_as_string' is enabled:
         Analyzer analyzer = new DelegatingAnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {

--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -241,7 +241,7 @@ public final class BitsetFilterCache extends AbstractIndexComponent
             if (docMapper != null) {
                 if (docMapper.hasNestedObjects()) {
                     hasNested = true;
-                    for (ObjectMapper objectMapper : docMapper.objectMappers().values()) {
+                    for (ObjectMapper objectMapper : docMapper.mappers().objectMappers().values()) {
                         if (objectMapper.nested().isNested()) {
                             ObjectMapper parentObjectMapper = objectMapper.getParentObjectMapper(mapperService);
                             if (parentObjectMapper != null && parentObjectMapper.nested().isNested()) {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -207,7 +207,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             for (String field : storedFields) {
                 Mapper fieldMapper = docMapper.mappers().getMapper(field);
                 if (fieldMapper == null) {
-                    if (docMapper.objectMappers().get(field) != null) {
+                    if (docMapper.mappers().objectMappers().get(field) != null) {
                         // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
                         throw new IllegalArgumentException("field [" + field + "] isn't a leaf field");
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -207,14 +207,6 @@ public class DocumentMapper implements ToXContentFragment {
         return this.fieldMappers;
     }
 
-    public FieldTypeLookup fieldTypes() {
-        return mappers().fieldTypes();
-    }
-
-    public Map<String, ObjectMapper> objectMappers() {
-        return mappers().objectMappers();
-    }
-
     public ParsedDocument parse(SourceToParse source) throws MapperParsingException {
         return documentParser.parseDocument(source, mapping.metadataMappers, this);
     }
@@ -239,7 +231,7 @@ public class DocumentMapper implements ToXContentFragment {
      */
     public ObjectMapper findNestedObjectMapper(int nestedDocId, SearchContext sc, LeafReaderContext context) throws IOException {
         ObjectMapper nestedObjectMapper = null;
-        for (ObjectMapper objectMapper : objectMappers().values()) {
+        for (ObjectMapper objectMapper : mappers().objectMappers().values()) {
             if (!objectMapper.nested().isNested()) {
                 continue;
             }
@@ -304,7 +296,7 @@ public class DocumentMapper implements ToXContentFragment {
             ", mapping=" + mapping +
             ", documentParser=" + documentParser +
             ", fieldMappers=" + fieldMappers +
-            ", objectMappers=" + objectMappers() +
+            ", objectMappers=" + mappers().objectMappers() +
             ", hasNestedObjects=" + hasNestedObjects() +
             ", deleteTombstoneMetadataFieldMappers=" + Arrays.toString(deleteTombstoneMetadataFieldMappers) +
             ", noopTombstoneMetadataFieldMappers=" + Arrays.toString(noopTombstoneMetadataFieldMappers) +

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -337,7 +337,7 @@ final class DocumentParser {
             // only prefix with parent mapper if the parent mapper isn't the root (which has a fake name)
             updateParentName = lastParent.name() + '.' + nameParts[i];
         }
-        ObjectMapper updateParent = docMapper.objectMappers().get(updateParentName);
+        ObjectMapper updateParent = docMapper.mappers().objectMappers().get(updateParentName);
         assert updateParent != null : updateParentName + " doesn't exist";
         return createUpdate(updateParent, nameParts, i + 1, newMapper);
     }
@@ -838,7 +838,7 @@ final class DocumentParser {
                     "Could not dynamically add mapping for field [{}]. Existing mapping for [{}] must be of type object but found [{}].",
                     null, String.join(".", paths), currentPath, existingFieldMapper.typeName());
         }
-        mapper = context.docMapper().objectMappers().get(currentPath);
+        mapper = context.docMapper().mappers().objectMappers().get(currentPath);
             if (mapper == null) {
                 // One mapping is missing, check if we are allowed to create a dynamic one.
                 ObjectMapper.Dynamic dynamic = dynamicOrDefault(parent, context);
@@ -883,7 +883,7 @@ final class DocumentParser {
                 break;
             }
             String parentName = parentMapper.name().substring(0, lastDotNdx);
-            parentMapper = context.docMapper().objectMappers().get(parentName);
+            parentMapper = context.docMapper().mappers().objectMappers().get(parentName);
             if (parentMapper == null) {
                 // If parentMapper is ever null, it means the parent of the current mapper was dynamically created.
                 // But in order to be created dynamically, the dynamic setting of that parent was necessarily true

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -94,7 +94,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
          * if a shard was moved to a different node or for administrative
          * purposes.
          */
-        MAPPING_RECOVERY;
+        MAPPING_RECOVERY
     }
 
     public static final String DEFAULT_MAPPING = "_default_";
@@ -611,8 +611,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             String type = mapper == null ? null : mapper.type();
             return new TypeFieldMapper.TypeFieldType(type);
         }
-
-        return this.mapper == null ? null : this.mapper.fieldTypes().get(fullName);
+        return this.mapper == null ? null : this.mapper.mappers().fieldTypes().get(fullName);
     }
 
     /**
@@ -624,7 +623,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             // no wildcards
             return Collections.singleton(pattern);
         }
-        return this.mapper == null ? Collections.emptySet() : this.mapper.fieldTypes().simpleMatchToFullName(pattern);
+        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().simpleMatchToFullName(pattern);
     }
 
     /**
@@ -632,18 +631,18 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      * the 'source path' for a multi-field is the path to its parent field.
      */
     public Set<String> sourcePath(String fullName) {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.fieldTypes().sourcePaths(fullName);
+        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().sourcePaths(fullName);
     }
 
     /**
      * Returns all mapped field types.
      */
     public Iterable<MappedFieldType> fieldTypes() {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.fieldTypes();
+        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes();
     }
 
     public ObjectMapper getObjectMapper(String name) {
-        return this.mapper == null ? null : this.mapper.objectMappers().get(name);
+        return this.mapper == null ? null : this.mapper.mappers().objectMappers().get(name);
     }
 
     public Analyzer indexAnalyzer() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
@@ -28,7 +28,7 @@ public class DocumentMapperParserTests extends MapperServiceTestCase {
         }));
         assertNotNull(docMapper.mappers().getMapper("foo.bar"));
         assertNotNull(docMapper.mappers().getMapper("foo.baz"));
-        assertNotNull(docMapper.objectMappers().get("foo"));
+        assertNotNull(docMapper.mappers().objectMappers().get("foo"));
     }
 
     public void testFieldNameWithDeepDots() throws Exception {
@@ -46,7 +46,7 @@ public class DocumentMapperParserTests extends MapperServiceTestCase {
         }));
         assertNotNull(docMapper.mappers().getMapper("foo.bar"));
         assertNotNull(docMapper.mappers().getMapper("foo.baz.deep.field"));
-        assertNotNull(docMapper.objectMappers().get("foo"));
+        assertNotNull(docMapper.mappers().objectMappers().get("foo"));
     }
 
     public void testFieldNameWithDotsConflict() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -318,7 +318,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         MapperService mapperService = createMapperService(
             fieldMapping(b -> b.field("type", "keyword").field("similarity", "boolean"))
         );
-        MappedFieldType ft = mapperService.documentMapper().fieldTypes().get("field");
+        MappedFieldType ft = mapperService.documentMapper().mappers().fieldTypes().get("field");
         assertEquals("boolean", ft.getTextSearchInfo().getSimilarity().name());
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -93,7 +93,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
 
         ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "1", BytesReference
@@ -145,11 +145,11 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested1Mapper.nested().isIncludeInRoot(), equalTo(false));
-        ObjectMapper nested2Mapper = docMapper.objectMappers().get("nested1.nested2");
+        ObjectMapper nested2Mapper = docMapper.mappers().objectMappers().get("nested1.nested2");
         assertThat(nested2Mapper.nested().isNested(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
@@ -206,11 +206,11 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested1Mapper.nested().isIncludeInRoot(), equalTo(false));
-        ObjectMapper nested2Mapper = docMapper.objectMappers().get("nested1.nested2");
+        ObjectMapper nested2Mapper = docMapper.mappers().objectMappers().get("nested1.nested2");
         assertThat(nested2Mapper.nested().isNested(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
@@ -269,11 +269,11 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.nested().isIncludeInParent(), equalTo(true));
         assertThat(nested1Mapper.nested().isIncludeInRoot(), equalTo(false));
-        ObjectMapper nested2Mapper = docMapper.objectMappers().get("nested1.nested2");
+        ObjectMapper nested2Mapper = docMapper.mappers().objectMappers().get("nested1.nested2");
         assertThat(nested2Mapper.nested().isNested(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
@@ -330,11 +330,11 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested1Mapper.nested().isIncludeInRoot(), equalTo(false));
-        ObjectMapper nested2Mapper = docMapper.objectMappers().get("nested1.nested2");
+        ObjectMapper nested2Mapper = docMapper.mappers().objectMappers().get("nested1.nested2");
         assertThat(nested2Mapper.nested().isNested(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(true));
@@ -524,7 +524,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
             .parse("type", new CompressedXContent(mapping));
 
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
-        ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+        ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.dynamic(), equalTo(Dynamic.STRICT));
 
@@ -779,7 +779,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
                     .mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
 
             assertThat(docMapper.hasNestedObjects(), equalTo(true));
-            ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
+            ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
             assertThat(nested1Mapper.nested().isNested(), equalTo(true));
 
             ParsedDocument doc = docMapper.parse(new SourceToParse("test", "type", "1",

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -204,7 +204,7 @@ public class ObjectMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         mapper = mapperService.merge("type", new CompressedXContent(update), MergeReason.INDEX_TEMPLATE);
 
-        ObjectMapper objectMapper = mapper.objectMappers().get("object");
+        ObjectMapper objectMapper = mapper.mappers().objectMappers().get("object");
         assertNotNull(objectMapper);
         assertFalse(objectMapper.isEnabled());
 
@@ -218,7 +218,7 @@ public class ObjectMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         mapper = mapperService.merge("type", new CompressedXContent(update), MergeReason.INDEX_TEMPLATE);
 
-        objectMapper = mapper.objectMappers().get("object");
+        objectMapper = mapper.mappers().objectMappers().get("object");
         assertNotNull(objectMapper);
         assertTrue(objectMapper.isEnabled());
     }


### PR DESCRIPTION
Backport of #63922

DocumentMapper exposes field types and object mappers through specific getter methods, that call the corresponding getters exposed by MappingLookup. MappingLookup is though exposed directly by DocumentMapper, hence there is no need for additional methods other than the one to retrieve the mapping lookup object.
