### PR TITLE
Correct system index names in Kibana module

### DIFF
--- a/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
+++ b/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
@@ -48,7 +48,7 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
         return Arrays.asList(
             new Object[] { ".kibana" },
             new Object[] { ".kibana_1" },
-            new Object[] { ".reporting" },
+            new Object[] { ".reporting-1" },
             new Object[] { ".apm-agent-configuration" },
             new Object[] { ".apm-custom-link" }
         );

--- a/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
+++ b/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
@@ -47,9 +47,10 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public static Iterable<Object[]> data() {
         return Arrays.asList(
             new Object[] { ".kibana" },
-            new Object[] { ".kibana-1" },
+            new Object[] { ".kibana_1" },
             new Object[] { ".reporting" },
-            new Object[] { ".apm-agent-configuration" }
+            new Object[] { ".apm-agent-configuration" },
+            new Object[] { ".apm-custom-link" }
         );
     }
 

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -62,7 +62,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     public static final Setting<List<String>> KIBANA_INDEX_NAMES_SETTING = Setting.listSetting(
         "kibana.system_indices",
-        List.of(".kibana*", ".reporting", ".apm-agent-configuration"),
+        List.of(".kibana", ".kibana_*", ".reporting*", ".apm-agent-configuration", ".apm-custom-link"),
         Function.identity(),
         Property.NodeScope
     );

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -62,7 +62,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     public static final Setting<List<String>> KIBANA_INDEX_NAMES_SETTING = Setting.listSetting(
         "kibana.system_indices",
-        List.of(".kibana", ".kibana_*", ".reporting*", ".apm-agent-configuration", ".apm-custom-link"),
+        List.of(".kibana", ".kibana_*", ".reporting-*", ".apm-agent-configuration", ".apm-custom-link"),
         Function.identity(),
         Property.NodeScope
     );

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -38,12 +38,20 @@ public class KibanaPluginTests extends ESTestCase {
                 .stream()
                 .map(SystemIndexDescriptor::getIndexPattern)
                 .collect(Collectors.toUnmodifiableList()),
-            contains(".kibana*", ".reporting", ".apm-agent-configuration")
+            contains(".kibana", ".kibana_*", ".reporting*", ".apm-agent-configuration", ".apm-custom-link")
         );
-        final List<String> names = List.of("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(6));
+
+        final List<String> names = List.of("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(5));
         final List<String> namesFromDescriptors = new KibanaPlugin().getSystemIndexDescriptors(
             Settings.builder().putList(KibanaPlugin.KIBANA_INDEX_NAMES_SETTING.getKey(), names).build()
         ).stream().map(SystemIndexDescriptor::getIndexPattern).collect(Collectors.toUnmodifiableList());
         assertThat(namesFromDescriptors, is(names));
+
+        assertThat(
+            new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY)
+                .stream()
+                .anyMatch(systemIndexDescriptor -> systemIndexDescriptor.matchesIndexPattern(".kibana-event-log-7-1")),
+            is(false)
+        );
     }
 }

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -38,7 +38,7 @@ public class KibanaPluginTests extends ESTestCase {
                 .stream()
                 .map(SystemIndexDescriptor::getIndexPattern)
                 .collect(Collectors.toUnmodifiableList()),
-            contains(".kibana", ".kibana_*", ".reporting*", ".apm-agent-configuration", ".apm-custom-link")
+            contains(".kibana", ".kibana_*", ".reporting-*", ".apm-agent-configuration", ".apm-custom-link")
         );
 
         final List<String> names = List.of("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(5));


### PR DESCRIPTION
This commit updates the list of system index names to be complete and
correct for Kibana and APM. The pattern `.kibana*` is too inclusive for
system indices and actually includes the
`.kibana-event-log-${version}-${int}` pattern for the Kibana event log,
which should only be hidden and not a system index. Additionally, the
`.apm-custom-link` index was not included in the list of system
indices.