### PR TITLE
[7.10][Transform] add support for unsigned_long data type

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -554,15 +554,15 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
         Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=every_2:0.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19));
 
         searchResult = getAsMap(transformIndex + "/_search?q=every_2:2.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
         searchResult = getAsMap(transformIndex + "/_search?q=every_2:4.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
         final StringBuilder bulk = new StringBuilder();
 
@@ -606,15 +606,15 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
         searchResult = getAsMap(transformIndex + "/_search?q=every_2:0.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19));
 
         searchResult = getAsMap(transformIndex + "/_search?q=every_2:2.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(30.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(30));
 
         searchResult = getAsMap(transformIndex + "/_search?q=every_2:4.0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27.0));
+        assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -130,8 +130,8 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
             );
             assertThat(
                 "Doc count did not match, source: " + source + ", expected: " + bucket.getDocCount() + ", iteration: " + iteration,
-                XContentMapValues.extractValue("count", source),
-                equalTo(Double.valueOf(bucket.getDocCount()))
+                ((Integer) XContentMapValues.extractValue("count", source)).longValue(),
+                equalTo(bucket.getDocCount())
             );
 
             // transform should only rewrite documents that require it
@@ -146,9 +146,11 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
                     // we use a fixed_interval of `1s`, the transform runs every `1s` so it the bucket might be recalculated at the next run
                     // but
                     // should NOT be recalculated for the 2nd/3rd/... run
-                    Double.valueOf((Integer) XContentMapValues.extractValue(INGEST_RUN_FIELD, source)) - (Double) XContentMapValues
-                        .extractValue(MAX_RUN_FIELD, source),
-                    is(lessThanOrEqualTo(1.0))
+                    (Integer) XContentMapValues.extractValue(INGEST_RUN_FIELD, source) - (Integer) XContentMapValues.extractValue(
+                        MAX_RUN_FIELD,
+                        source
+                    ),
+                    is(lessThanOrEqualTo(1))
                 );
             }
         }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -310,7 +310,7 @@ public class TransformContinuousIT extends ESRestTestCase {
                     .field("type", "keyword")
                     .endObject()
                     .startObject("metric")
-                    .field("type", "integer")
+                    .field("type", randomFrom("integer", "long", "unsigned_long"))
                     .endObject()
                     .startObject("location")
                     .field("type", "geo_point")

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.xpack.transform.transforms.pivot.SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt;
 import static org.elasticsearch.xpack.transform.transforms.pivot.SchemaUtil.isNumericType;
 
 public final class AggregationResultUtils {
@@ -198,7 +199,7 @@ public final class AggregationResultUtils {
             // If the type is numeric or if the formatted string is the same as simply making the value a string,
             // gather the `value` type, otherwise utilize `getValueAsString` so we don't lose formatted outputs.
             if (isNumericType(fieldType) || aggregation.getValueAsString().equals(String.valueOf(aggregation.value()))) {
-                return aggregation.value();
+                return dropFloatingPointComponentIfTypeRequiresIt(fieldType, aggregation.value());
             } else {
                 return aggregation.getValueAsString();
             }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -654,6 +654,12 @@ public class AggregationResultUtilsTests extends ESTestCase {
             AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "string"), ""),
             equalTo("one_hundred")
         );
+
+        agg = createSingleMetricAgg("metric", 100.0, "one_hundred");
+        assertThat(
+            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "unsigned_long"), ""),
+            equalTo(100L)
+        );
     }
 
     private ScriptedMetric createScriptedMetric(Object returnValue) {
@@ -836,7 +842,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         );
         assertThat(
             AggregationResultUtils.getExtractor(agg).value(agg, asStringMap("sba2.sub1", "long", "sba2.sub2", "float"), ""),
-            equalTo(asMap("sub1", 100.0, "sub2", 33.33))
+            equalTo(asMap("sub1", 100L, "sub2", 33.33))
         );
 
         agg = createSingleBucketAgg(
@@ -848,7 +854,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         );
         assertThat(
             AggregationResultUtils.getExtractor(agg).value(agg, asStringMap("sba3.sub1", "long", "sba3.sub2", "double"), ""),
-            equalTo(asMap("sub1", 100.0, "sub2", 33.33, "sub3", 42L))
+            equalTo(asMap("sub1", 100L, "sub2", 33.33, "sub3", 42L))
         );
 
         agg = createSingleBucketAgg(
@@ -861,7 +867,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         assertThat(
             AggregationResultUtils.getExtractor(agg)
                 .value(agg, asStringMap("sba4.sub3.subsub1", "double", "sba4.sub2", "float", "sba4.sub1", "long"), ""),
-            equalTo(asMap("sub1", 100.0, "sub2", 33.33, "sub3", asMap("subsub1", 11.1)))
+            equalTo(asMap("sub1", 100L, "sub2", 33.33, "sub3", asMap("subsub1", 11.1)))
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -127,8 +127,11 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
-        long numGroupsWithoutScripts = groupConfig.getGroups().values().stream()
-            .filter(singleGroupSource -> singleGroupSource.getScriptConfig() == null).count();
+        long numGroupsWithoutScripts = groupConfig.getGroups()
+            .values()
+            .stream()
+            .filter(singleGroupSource -> singleGroupSource.getScriptConfig() == null)
+            .count();
 
         this.<Map<String, String>>assertAsync(
             listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
@@ -191,8 +194,11 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
-        long numGroupsWithoutScripts = groupConfig.getGroups().values().stream()
-            .filter(singleGroupSource -> singleGroupSource.getScriptConfig() == null).count();
+        long numGroupsWithoutScripts = groupConfig.getGroups()
+            .values()
+            .stream()
+            .filter(singleGroupSource -> singleGroupSource.getScriptConfig() == null)
+            .count();
 
         this.<Map<String, String>>assertAsync(
             listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
@@ -219,7 +225,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                     23144,
                     AggregationResultUtilsTests.createSingleMetricAgg("max_drinks_2", 45.0, "forty_five")
                 );
-                assertThat(AggregationResultUtils.getExtractor(agg).value(agg, mappings, ""), equalTo(asMap("max_drinks_2", 45.0)));
+                assertThat(AggregationResultUtils.getExtractor(agg).value(agg, mappings, ""), equalTo(asMap("max_drinks_2", 45L)));
 
                 agg = AggregationResultUtilsTests.createSingleBucketAgg(
                     "filter_3",

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -8,8 +8,11 @@ package org.elasticsearch.xpack.transform.transforms.pivot;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class SchemaUtilTests extends ESTestCase {
 
@@ -50,6 +53,20 @@ public class SchemaUtilTests extends ESTestCase {
         assertEquals("object", fieldMappings.get(".z"));
         assertFalse(fieldMappings.containsKey("."));
         assertFalse(fieldMappings.containsKey(""));
+    }
+
+    public void testConvertToIntegerTypeIfNeeded() {
+        assertEquals(33L, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("unsigned_long", 33.0));
+        assertEquals(33L, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("long", 33.0));
+        assertEquals(33.0, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("double", 33.0));
+        assertEquals(33.0, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("half_float", 33.0));
+        assertEquals(33.0, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("unknown", 33.0));
+        assertEquals(33.0, SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt(null, 33.0));
+
+        Object value = SchemaUtil.dropFloatingPointComponentIfTypeRequiresIt("unsigned_long", 1.8446744073709551615E19);
+        assertThat(value, instanceOf(BigInteger.class));
+
+        assertEquals(new BigInteger("18446744073709551615").doubleValue(), ((BigInteger) value).doubleValue(), 0.0);
     }
 
 }


### PR DESCRIPTION
add support for unsigned_long, which required a change in
writing out integer results properly, because coerce is not
supported for unsigned_long

fixes #63871
backport #63940