### PR TITLE
Make agg test less confusing (backport of #63952)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -846,7 +846,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
     }
 
     @After
-    private void cleanupReleasables() {
+    public void cleanupReleasables() {
         Releasables.close(releasables);
         releasables.clear();
     }


### PR DESCRIPTION
We have an `@After` annotated method in `AggregatorTestCase` that cleans
up releasibles. But it was `private`! Confusingly, it seemed to be
working! I'm not sure why. This makes it public which is a little more
sensible.
