### PR TITLE
Fix testStartCloneWithSuccessfulShardSnapshotPendingFinalization

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -562,7 +562,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         } finally {
             unblockNode(repoName, masterName);
         }
-        awaitNumberOfSnapshotsInProgress(1);
+        awaitNoMoreRunningOperations();
 
         awaitMasterFinishRepoOperations();
 


### PR DESCRIPTION
We have to wait for no more operations here not for `1`. This mostly worked
because the test thread would add the listener quickly enough so that it sees the
state where either the snapshot or clone but not both have already finished
but randomly the test thread would be slow and time out on a state without snaphots in it.

This failed a few times on CI lately but no issue was raised.