### PR TITLE
[DOCS] Expands DFA evaluation API docs with the default set of metrics

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -85,10 +85,12 @@ outputs the probability that each document is an outlier.
 
 `metrics`::
   (Optional, object) Specifies the metrics that are used for the evaluation. If 
-  no metrics are specified, the following are returned by default: `auc_roc` 
-  (`include_curve`: false), `precision` (`at`: [0.25, 0.5, 0.75]), `recall` 
-  (`at`: [0.25, 0.5, 0.75]), `confusion_matrix` (`at`: [0.25, 0.5, 0.75]).
-  Available metrics:
+  no metrics are specified, the following are returned by default: 
+  
+  * `auc_roc` (`include_curve`: false), 
+  * `precision` (`at`: [0.25, 0.5, 0.75]), 
+  * `recall` (`at`: [0.25, 0.5, 0.75]), 
+  * `confusion_matrix` (`at`: [0.25, 0.5, 0.75]).
   
   `auc_roc`:::
     (Optional, object) The AUC ROC (area under the curve of the receiver 
@@ -128,8 +130,11 @@ which outputs a prediction of values.
   (Optional, object) Specifies the metrics that are used for the evaluation. For 
   more information on `mse`, `msle`, and `huber`, consult 
   https://github.com/elastic/examples/tree/master/Machine%20Learning/Regression%20Loss%20Functions[the Jupyter notebook on regression loss functions].
-  If no metrics are specified, the following are returned by default: `mse`, 
-  `r_squared`, and `huber` (`delta`: 1.0). Available metrics:
+  If no metrics are specified, the following are returned by default: 
+  
+  * `mse`, 
+  * `r_squared`,
+  * `huber` (`delta`: 1.0). 
 
   `mse`:::
     (Optional, object) Average squared difference between the predicted values 
@@ -184,9 +189,12 @@ belongs.
 
 `metrics`::
   (Optional, object) Specifies the metrics that are used for the evaluation. If 
-  no metrics are specificed, the following are returned by default: `accuracy`, 
-  `multiclass_confusion_matrix`, `precision`, and `recall`.
-  Available metrics:
+  no metrics are specificed, the following are returned by default: 
+  
+  * `accuracy`, 
+  * `multiclass_confusion_matrix`, 
+  * `precision`, 
+  * `recall`.
 
   `accuracy`:::
     (Optional, object) Accuracy of predictions (per-class and overall).

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -86,8 +86,8 @@ outputs the probability that each document is an outlier.
 `metrics`::
   (Optional, object) Specifies the metrics that are used for the evaluation. If 
   no metrics are specified, the following are returned by default: `auc_roc` 
-  (`include_curve`: false), `precision`, `recall`, `confusion_matrix` – the 
-  latter three are calculated at 0.25, 0.5, and 0.75 thresholds.
+  (`include_curve`: false), `precision` (`at`: [0.25, 0.5, 0.75]), `recall` 
+  (`at`: [0.25, 0.5, 0.75]), `confusion_matrix` (`at`: [0.25, 0.5, 0.75]).
   Available metrics:
   
   `auc_roc`:::

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -84,7 +84,10 @@ outputs the probability that each document is an outlier.
   contains the results of the analysis.
 
 `metrics`::
-  (Optional, object) Specifies the metrics that are used for the evaluation. 
+  (Optional, object) Specifies the metrics that are used for the evaluation. If 
+  no metrics are specified, the following are returned by default: `auc_roc` 
+  (`include_curve`: false), `precision`, `recall`, `confusion_matrix` – the 
+  latter three are calculated at 0.25, 0.5, and 0.75 thresholds.
   Available metrics:
   
   `auc_roc`:::
@@ -125,7 +128,8 @@ which outputs a prediction of values.
   (Optional, object) Specifies the metrics that are used for the evaluation. For 
   more information on `mse`, `msle`, and `huber`, consult 
   https://github.com/elastic/examples/tree/master/Machine%20Learning/Regression%20Loss%20Functions[the Jupyter notebook on regression loss functions].
-  Available metrics:
+  If no metrics are specified, the following are returned by default: `mse`, 
+  `r_squared`, and `huber` (`delta`: 1.0). Available metrics:
 
   `mse`:::
     (Optional, object) Average squared difference between the predicted values 
@@ -179,7 +183,9 @@ belongs.
   This field must be defined as `nested` in the mappings.
 
 `metrics`::
-  (Optional, object) Specifies the metrics that are used for the evaluation.
+  (Optional, object) Specifies the metrics that are used for the evaluation. If 
+  no metrics are specificed, the following are returned by default: `accuracy`, 
+  `multiclass_confusion_matrix`, `precision`, and `recall`.
   Available metrics:
 
   `accuracy`:::


### PR DESCRIPTION
## Overview

This PR expands the DFA evaluation API docs with the default set of metrics if `metrics` is not specified in the API call.

### Preview

[DFA eval API](https://elasticsearch_63971.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html#ml-evaluate-dfanalytics-resources)