### PR TITLE
Emit a warning when an unknown geo strategy is passed in

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -149,7 +149,14 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         public static boolean parse(String name, String fieldName, Object fieldNode, DeprecatedParameters deprecatedParameters) {
             if (Names.STRATEGY.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                 checkPrefixTreeSupport(fieldName);
-                deprecatedParameters.setSpatialStrategy(SpatialStrategy.fromString(fieldNode.toString()));
+                SpatialStrategy strategy = SpatialStrategy.fromString(fieldNode.toString());
+                if (strategy == null) {
+                    DEPRECATION_LOGGER.deprecate("geo_mapper_strategy",
+                        "Unknown strategy [" + fieldNode.toString() + "], falling back to [recursive]. " +
+                            "Available strategies are [recursive,term].  In a future release, this fallback " +
+                            "will be removed and an unknown strategy will throw an error");
+                }
+                deprecatedParameters.setSpatialStrategy(strategy);
             } else if (Names.TREE.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                 checkPrefixTreeSupport(fieldName);
                 deprecatedParameters.setTree(fieldNode.toString());


### PR DESCRIPTION
Currently if you set a value other than `term` or `recursive` as the 
deprecated `strategy` parameter on a `geo_shape` field, the mapper
will silently fall back to the `recursive` strategy.  This commit changes
the parsing logic to emit a deprecation warning when this occurs,
informing the user that a) they're not getting the strategy they were
asking for, and b) this will turn into an error in the near future.