### PR TITLE
Improve interface for multivalue aggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.zip.DataFormatException;
 
 abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggregation.MultiValue {
@@ -39,6 +40,8 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
     protected final double[] keys;
     protected final DoubleHistogram state;
     protected final boolean keyed;
+
+    private List<String> keysAsStrings;
 
     AbstractInternalHDRPercentiles(String name, double[] keys, DoubleHistogram state, boolean keyed, DocValueFormat format,
             Map<String, Object> metadata) {
@@ -84,6 +87,15 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
     @Override
     public double value(String name) {
         return value(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 
     public DocValueFormat formatter() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -41,8 +41,6 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
     protected final DoubleHistogram state;
     protected final boolean keyed;
 
-    private List<String> keysAsStrings;
-
     AbstractInternalHDRPercentiles(String name, double[] keys, DoubleHistogram state, boolean keyed, DocValueFormat format,
             Map<String, Object> metadata) {
         super(name, metadata);
@@ -91,11 +89,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
     }
 
     public DocValueFormat formatter() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -38,8 +38,6 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     protected final TDigestState state;
     final boolean keyed;
 
-    private List<String> keysAsStrings;
-
     AbstractInternalTDigestPercentiles(String name, double[] keys, TDigestState state, boolean keyed, DocValueFormat formatter,
             Map<String, Object> metadata) {
         super(name, metadata);
@@ -75,11 +73,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
     }
 
     public abstract double value(double key);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -30,12 +30,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetricsAggregation.MultiValue {
 
     protected final double[] keys;
     protected final TDigestState state;
     final boolean keyed;
+
+    private List<String> keysAsStrings;
 
     AbstractInternalTDigestPercentiles(String name, double[] keys, TDigestState state, boolean keyed, DocValueFormat formatter,
             Map<String, Object> metadata) {
@@ -68,6 +71,15 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     @Override
     public double value(String name) {
         return value(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 
     public abstract double value(double key);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InternalStats extends InternalNumericMetricsAggregation.MultiValue implements Stats {
     enum Metrics {
@@ -38,6 +40,8 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
             return Metrics.valueOf(name);
         }
     }
+
+    public static List<String> metricNames = Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toList());
 
     protected final long count;
     protected final double min;
@@ -141,6 +145,11 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
             default:
                 throw new IllegalArgumentException("Unknown value [" + name + "] in common stats aggregation");
         }
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return metricNames;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
@@ -33,8 +33,22 @@ public interface NumericMetricsAggregation extends Aggregation {
 
     interface MultiValue extends NumericMetricsAggregation {
 
+        /**
+         * Return an iterable over all value names this multi value aggregation provides.
+         *
+         * The iterable might be created on the fly, if you need to call this multiple times, please
+         * cache the result in a variable on caller side..
+         *
+         * @return iterable over all value names
+         */
         Iterable<String> valueNames();
 
+        /**
+         * Return the result of 1 value by name
+         *
+         * @param name of the value
+         * @return the value
+         */
         double value(String name);
 
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
@@ -32,5 +32,10 @@ public interface NumericMetricsAggregation extends Aggregation {
     }
 
     interface MultiValue extends NumericMetricsAggregation {
+
+        Iterable<String> valueNames();
+
+        double value(String name);
+
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
@@ -23,12 +23,9 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentiles {
-
-    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -64,10 +61,6 @@ public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentil
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
@@ -23,8 +23,12 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentiles {
+
+    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -51,5 +55,19 @@ public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentil
         ParsedHDRPercentiles aggregation = PARSER.parse(parser, null);
         aggregation.setName(name);
         return aggregation;
+    }
+
+    @Override
+    public double value(String name) {
+        return percentile(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
@@ -19,7 +19,12 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 abstract class ParsedPercentileRanks extends ParsedPercentiles implements PercentileRanks {
+
+    private List<String> keysAsStrings;
 
     @Override
     public double percent(double value) {
@@ -29,5 +34,19 @@ abstract class ParsedPercentileRanks extends ParsedPercentiles implements Percen
     @Override
     public String percentAsString(double value) {
         return getPercentileAsString(value);
+    }
+
+    @Override
+    public double value(String name) {
+        return percent(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
@@ -19,12 +19,9 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 abstract class ParsedPercentileRanks extends ParsedPercentiles implements PercentileRanks {
-
-    private List<String> keysAsStrings;
 
     @Override
     public double percent(double value) {
@@ -43,10 +40,6 @@ abstract class ParsedPercentileRanks extends ParsedPercentiles implements Percen
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
@@ -26,10 +26,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalStats.Fields;
+import org.elasticsearch.search.aggregations.metrics.InternalStats.Metrics;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.search.aggregations.metrics.InternalStats.metricNames;
 
 public class ParsedStats extends ParsedAggregation implements Stats {
 
@@ -84,6 +87,25 @@ public class ParsedStats extends ParsedAggregation implements Stats {
     @Override
     public String getSumAsString() {
         return valueAsString.getOrDefault(Fields.SUM_AS_STRING, Double.toString(sum));
+    }
+
+    @Override
+    public double value(String name) {
+        Metrics metrics = Metrics.valueOf(name);
+        switch (metrics) {
+            case min: return min;
+            case max: return max;
+            case avg: return avg;
+            case count: return count;
+            case sum: return sum;
+            default:
+                throw new IllegalArgumentException("Unknown value [" + name + "] in common stats aggregation");
+        }
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return metricNames;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
@@ -23,8 +23,12 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ParsedTDigestPercentiles extends ParsedPercentiles implements Percentiles {
+
+    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -39,6 +43,20 @@ public class ParsedTDigestPercentiles extends ParsedPercentiles implements Perce
     @Override
     public String percentileAsString(double percent) {
         return getPercentileAsString(percent);
+    }
+
+    @Override
+    public double value(String name) {
+        return percentile(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 
     private static final ObjectParser<ParsedTDigestPercentiles, Void> PARSER =

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
@@ -23,12 +23,9 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class ParsedTDigestPercentiles extends ParsedPercentiles implements Percentiles {
-
-    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -52,11 +49,7 @@ public class ParsedTDigestPercentiles extends ParsedPercentiles implements Perce
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }
 
     private static final ObjectParser<ParsedTDigestPercentiles, Void> PARSER =

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -41,7 +41,6 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
     private double[] percentiles;
     private double[] percents;
     private boolean keyed = true;
-    private List<String> keysAsStrings;
 
     private final transient Map<Double, Double> percentileLookups = new HashMap<>();
 
@@ -122,11 +121,7 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = Arrays.stream(percents).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return Arrays.stream(percents).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -24,8 +24,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMax;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 
 import java.io.IOException;
@@ -35,11 +35,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class InternalPercentilesBucket extends InternalNumericMetricsAggregation.MultiValue implements PercentilesBucket {
     private double[] percentiles;
     private double[] percents;
     private boolean keyed = true;
+    private List<String> keysAsStrings;
+
     private final transient Map<Double, Double> percentileLookups = new HashMap<>();
 
     InternalPercentilesBucket(String name, double[] percents, double[] percentiles, boolean keyed,
@@ -115,6 +118,15 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
     @Override
     public double value(String name) {
         return percentile(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = Arrays.stream(percents).mapToObj(d -> String.valueOf(d)).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
@@ -26,13 +26,10 @@ import org.elasticsearch.search.aggregations.metrics.ParsedPercentiles;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 public class ParsedPercentilesBucket extends ParsedPercentiles implements Percentiles {
-
-    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -67,11 +64,7 @@ public class ParsedPercentilesBucket extends ParsedPercentiles implements Percen
 
     @Override
     public Iterable<String> valueNames() {
-        if (keysAsStrings == null) {
-            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
-        }
-
-        return keysAsStrings;
+        return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
@@ -26,9 +26,13 @@ import org.elasticsearch.search.aggregations.metrics.ParsedPercentiles;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 public class ParsedPercentilesBucket extends ParsedPercentiles implements Percentiles {
+
+    private List<String> keysAsStrings;
 
     @Override
     public String getType() {
@@ -54,6 +58,20 @@ public class ParsedPercentilesBucket extends ParsedPercentiles implements Percen
         } else {
             return Double.toString(value);
         }
+    }
+
+    @Override
+    public double value(String name) {
+        return percentile(Double.parseDouble(name));
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        if (keysAsStrings == null) {
+            keysAsStrings = percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
+        }
+
+        return keysAsStrings;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
@@ -69,13 +69,22 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
                 createTestInstance("test", emptyMap(), false, randomNumericDocValueFormat(), percents, values);
 
         Iterator<Percentile> iterator = aggregation.iterator();
+        Iterator<String> nameIterator = aggregation.valueNames().iterator();
         for (double percent : percents) {
             assertTrue(iterator.hasNext());
+            assertTrue(nameIterator.hasNext());
 
             Percentile percentile = iterator.next();
+            String percentileName = nameIterator.next();
+
+            assertEquals(percent, Double.valueOf(percentileName), 0.0d);
             assertEquals(percent, percentile.getPercent(), 0.0d);
+
             assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
+            assertEquals(aggregation.value(String.valueOf(percent)), percentile.getValue(), 0.0d);
         }
+        assertFalse(iterator.hasNext());
+        assertFalse(nameIterator.hasNext());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
@@ -32,6 +32,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.Collections.emptyMap;
 
 public class InternalStatsTests extends InternalAggregationTestCase<InternalStats> {
 
@@ -247,6 +251,18 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
             "  \"avg\" : null,\n" +
             "  \"sum\" : 0.0\n" +
             "}", Strings.toString(builder));
+    }
+
+    public void testIterator() {
+        InternalStats aggregation = createTestInstance("test", emptyMap());
+        List<String> names = StreamSupport.stream(aggregation.valueNames().spliterator(), false).collect(Collectors.toList());
+
+        assertEquals(5, names.size());
+        assertTrue(names.contains("min"));
+        assertTrue(names.contains("max"));
+        assertTrue(names.contains("count"));
+        assertTrue(names.contains("avg"));
+        assertTrue(names.contains("sum"));
     }
 }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
@@ -97,12 +97,21 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
         final double[] percents =  new double[]{ 0.50, 0.25, 0.01, 0.99, 0.60 };
         InternalPercentilesBucket aggregation = createTestInstance("test", Collections.emptyMap(), percents, randomBoolean());
         Iterator<Percentile> iterator = aggregation.iterator();
+        Iterator<String> nameIterator = aggregation.valueNames().iterator();
         for (double percent : percents) {
             assertTrue(iterator.hasNext());
+            assertTrue(nameIterator.hasNext());
+
             Percentile percentile = iterator.next();
+            String percentileName = nameIterator.next();
+
             assertEquals(percent, percentile.getPercent(), 0.0d);
+            assertEquals(percent, Double.valueOf(percentileName), 0.0d);
+
             assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
         }
+        assertFalse(iterator.hasNext());
+        assertFalse(nameIterator.hasNext());
     }
 
     public void testErrorOnDifferentArgumentSize() {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValue implements Boxplot {
 
@@ -68,6 +70,8 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             }
         }
     }
+
+    public static List<String> metricNames = Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toList());
 
     private final TDigestState state;
 
@@ -150,6 +154,11 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
     @Override
     public double value(String name) {
         return Metrics.resolve(name).value(this);
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return metricNames;
     }
 
     // for testing only

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -71,7 +71,9 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
         }
     }
 
-    public static List<String> metricNames = Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toList());
+    public static List<String> metricNames = Stream.of(Metrics.values())
+        .map(m -> m.name().toLowerCase(Locale.ROOT))
+        .collect(Collectors.toList());
 
     private final TDigestState state;
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -173,6 +173,11 @@ public class InternalTopMetrics extends InternalNumericMetricsAggregation.MultiV
         return topMetrics.get(0).metricValues.get(index).numberValue().doubleValue();
     }
 
+    @Override
+    public Iterable<String> valueNames() {
+        return metricNames;
+    }
+
     SortOrder getSortOrder() {
         return sortOrder;
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -24,6 +24,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.Collections.emptyMap;
 
 public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBoxplot> {
 
@@ -106,5 +110,17 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
             }
         ));
         return extendedNamedXContents;
+    }
+
+    public void testIterator() {
+        InternalBoxplot aggregation = createTestInstance("test", emptyMap());
+        List<String> names = StreamSupport.stream(aggregation.valueNames().spliterator(), false).collect(Collectors.toList());
+
+        assertEquals(5, names.size());
+        assertTrue(names.contains("min"));
+        assertTrue(names.contains("max"));
+        assertTrue(names.contains("q1"));
+        assertTrue(names.contains("q2"));
+        assertTrue(names.contains("q3"));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
@@ -49,4 +49,9 @@ class TestMultiValueAggregation extends InternalNumericMetricsAggregation.MultiV
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return values.keySet();
+    }
 }


### PR DESCRIPTION
Multi value aggregations (percentiles, top_metrics, stats, boxplot,...) are hard to integrate with. They all implement `NumericMetricsAggregation.MultiValue`, however that's an empty interface.

This PR is a follow up of a discussion about adding top_metrics to transform, see https://github.com/elastic/elasticsearch/issues/52236#issuecomment-707028708 to read more about the use case and the challenges.

To follow up on the discussion, I implemented the proposed interface from @nik9000: 

```
    interface MultiValue extends NumericMetricsAggregation {

        Iterable<String> valueNames();

        double value(String name);
    }
```
(https://github.com/elastic/elasticsearch/issues/52236#issuecomment-707160441)

Adding those 2 methods forces the implementation of it in several classes, this is what this PR is mainly about.

Before jumping on the details of the implementation, lets 1st focus on the interface and see if we agree on it.

~For the implementation I decided for an on-demand caching pattern.~ Names are created on the fly if they are dynamic.