### PR TITLE
[DOCS] Changes experimental flag to beta in DFA related docs

### DIFF
--- a/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Delete {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Delete an existing {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Delete trained models API
 
-experimental::[]
+beta::[]
 
 Deletes a previously saved trained model.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Evaluate {dfanalytics} API
 
-experimental::[]
+beta::[]
 
 Evaluates the {dfanalytics} for an annotated index.
 The API accepts an +{request}+ object and returns an +{response}+.

--- a/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Explain {dfanalytics} API
 
-experimental::[]
+beta::[]
 
 Explains the following about a {dataframe-analytics-config}:
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} stats API
 
-experimental::[]
+beta::[]
 
 Retrieves the operational statistics of one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Retrieves one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get trained models stats API
 
-experimental::[]
+beta::[]
 
 Retrieves one or more trained model statistics.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Get trained models API
 
-experimental::[]
+beta::[]
 
 Retrieves one or more trained models.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Put {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Creates a new {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model.asciidoc
@@ -7,9 +7,7 @@
 [id="{upid}-{api}"]
 === Put trained models API
 
-experimental:[]
-
-experimental::[]
+beta::[]
 
 Creates a new trained model for inference.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Start {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Starts an existing {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Stop {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Stops a running {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
@@ -7,7 +7,7 @@
 [id="{upid}-{api}"]
 === Update {dfanalytics-jobs} API
 
-experimental::[]
+beta::[]
 
 Updates an existing {dfanalytics-job}.
 The API accepts an +{request}+ object as a request and returns an +{response}+.

--- a/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
@@ -3,7 +3,7 @@
 [[search-aggregations-pipeline-inference-bucket-aggregation]]
 === {infer-cap} Bucket Aggregation
 
-experimental::[]
+beta::[]
 
 A parent pipeline aggregation which loads a pre-trained model and performs 
 {infer} on the collated result fields from the parent bucket aggregation.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>{infer-cap}</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 Uses a pre-trained {dfanalytics} model to infer against the data that is being
 ingested in the pipeline.

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Deletes an existing {dfanalytics-job}.
 
-beta[]
+beta::[]
 
 
 [[ml-delete-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Deletes an existing {dfanalytics-job}.
 
-experimental[]
+beta[]
 
 
 [[ml-delete-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -10,7 +10,7 @@
 Deletes an existing trained {infer} model that is currently not referenced by an
 ingest pipeline.
 
-experimental[]
+beta[]
 
 
 [[ml-delete-trained-models-request]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -10,7 +10,7 @@
 Deletes an existing trained {infer} model that is currently not referenced by an
 ingest pipeline.
 
-beta[]
+beta::[]
 
 
 [[ml-delete-trained-models-request]]
@@ -67,4 +67,3 @@ The API returns the following result:
   "acknowledged" : true
 }
 ----
-

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Evaluates the {dfanalytics} for an annotated index.
 
-beta[]
+beta::[]
 
 
 [[ml-evaluate-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Evaluates the {dfanalytics} for an annotated index.
 
-experimental[]
+beta[]
 
 
 [[ml-evaluate-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Explains a {dataframe-analytics-config}.
 
-beta[]
+beta::[]
 
 
 [[ml-explain-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Explains a {dataframe-analytics-config}.
 
-experimental[]
+beta[]
 
 
 [[ml-explain-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves usage information for {dfanalytics-jobs}.
 
-experimental[]
+beta[]
 
 [[ml-get-dfanalytics-stats-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves usage information for {dfanalytics-jobs}.
 
-beta[]
+beta::[]
 
 [[ml-get-dfanalytics-stats-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves configuration information for {dfanalytics-jobs}.
 
-experimental[]
+beta[]
 
 
 [[ml-get-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves configuration information for {dfanalytics-jobs}.
 
-beta[]
+beta::[]
 
 
 [[ml-get-dfanalytics-request]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves usage information for trained models.
 
-beta[]
+beta::[]
 
 
 [[ml-get-trained-models-stats-request]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves usage information for trained models.
 
-experimental[]
+beta[]
 
 
 [[ml-get-trained-models-stats-request]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves configuration information for a trained model.
 
-experimental[]
+beta[]
 
 
 [[ml-get-trained-models-request]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -9,7 +9,7 @@
 
 Retrieves configuration information for a trained model.
 
-beta[]
+beta::[]
 
 
 [[ml-get-trained-models-request]]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Instantiates a {dfanalytics-job}.
 
-beta[]
+beta::[]
 
 [[ml-put-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Instantiates a {dfanalytics-job}.
 
-experimental[]
+beta[]
 
 [[ml-put-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -15,7 +15,7 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
          a 7.8.0 node.
 
 
-beta[]
+beta::[]
 
 
 [[ml-put-trained-models-request]]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -15,7 +15,7 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
          a 7.8.0 node.
 
 
-experimental[]
+beta[]
 
 
 [[ml-put-trained-models-request]]

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Starts a {dfanalytics-job}.
 
-beta[]
+beta::[]
 
 [[ml-start-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Starts a {dfanalytics-job}.
 
-experimental[]
+beta[]
 
 [[ml-start-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Stops one or more {dfanalytics-jobs}.
 
-beta[]
+beta::[]
 
 [[ml-stop-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -10,7 +10,7 @@
 
 Stops one or more {dfanalytics-jobs}.
 
-experimental[]
+beta[]
 
 [[ml-stop-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Updates an existing {dfanalytics-job}.
 
-experimental[]
+beta[]
 
 [[ml-update-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -9,7 +9,7 @@
 
 Updates an existing {dfanalytics-job}.
 
-beta[]
+beta::[]
 
 [[ml-update-dfanalytics-request]]
 == {api-request-title}


### PR DESCRIPTION
## Overview

This PR changes the `experimental` flag to `beta` in the DFA related documentation pages.
* Inference bucket aggregation
* Inference processor
* PUT DFA
* Start DFA
* Stop DFA
* Update DFA
* GET DFA
* GET DFA stats
* DEL DFA
* Explain DFA
* Evaluate DFA
* PUT trained models
* GET trained models
* GET trained models stats
* DEL trained models

## Preview

https://elasticsearch_63992.docs-preview.app.elstc.co/diff