### PR TITLE
Remove QueryShardContext#getMapperService

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -65,9 +65,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -464,15 +462,12 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
 
         final List<ParsedDocument> docs = new ArrayList<>();
-        final DocumentMapper docMapper;
-        final MapperService mapperService = context.getMapperService();
-        docMapper = mapperService.documentMapper();
         for (BytesReference document : documents) {
-            docs.add(docMapper.parse(new SourceToParse(context.index().getName(), "_temp_id", document, documentXContentType)));
+            docs.add(context.parseDocument(new SourceToParse(context.index().getName(), "_temp_id", document, documentXContentType)));
         }
 
-        FieldNameAnalyzer fieldNameAnalyzer = (FieldNameAnalyzer)docMapper.mappers().indexAnalyzer();
-        // Need to this custom impl because FieldNameAnalyzer is strict and the percolator sometimes isn't when
+        FieldNameAnalyzer fieldNameAnalyzer = context.getFieldNameIndexAnalyzer();
+        // We need this custom analyzer because FieldNameAnalyzer is strict and the percolator sometimes isn't when
         // 'index.percolator.map_unmapped_fields_as_string' is enabled:
         Analyzer analyzer = new DelegatingAnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {
             @Override
@@ -488,9 +483,9 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         final IndexSearcher docSearcher;
         final boolean excludeNestedDocuments;
         if (docs.size() > 1 || docs.get(0).docs().size() > 1) {
-            assert docs.size() != 1 || docMapper.hasNestedObjects();
+            assert docs.size() != 1 || context.hasNested();
             docSearcher = createMultiDocumentSearcher(analyzer, docs);
-            excludeNestedDocuments = docMapper.hasNestedObjects() && docs.stream()
+            excludeNestedDocuments = context.hasNested() && docs.stream()
                     .map(ParsedDocument::docs)
                     .mapToInt(List::size)
                     .anyMatch(size -> size > 1);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -149,7 +149,7 @@ public final class MappingLookup implements Iterable<Mapper> {
      * A smart analyzer used for indexing that takes into account specific analyzers configured
      * per {@link FieldMapper}.
      */
-    public Analyzer indexAnalyzer() {
+    public FieldNameAnalyzer indexAnalyzer() {
         return this.indexAnalyzer;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -40,15 +40,20 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ObjectMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -214,6 +219,23 @@ public class QueryShardContext extends QueryRewriteContext {
     public Map<String, Query> copyNamedQueries() {
         // This might be a good use case for CopyOnWriteHashMap
         return Map.copyOf(namedQueries);
+    }
+
+    public ParsedDocument parseDocument(SourceToParse source) throws MapperParsingException {
+        return mapperService.documentMapper() == null ? null : mapperService.documentMapper().parse(source);
+    }
+
+    public FieldNameAnalyzer getFieldNameIndexAnalyzer() {
+        DocumentMapper documentMapper = mapperService.documentMapper();
+        return documentMapper == null ? null : documentMapper.mappers().indexAnalyzer();
+    }
+
+    public boolean hasNested() {
+        return mapperService.hasNested();
+    }
+
+    public boolean hasMappings() {
+        return mapperService.documentMapper() != null;
     }
 
     /**
@@ -465,13 +487,6 @@ public class QueryShardContext extends QueryRewriteContext {
      */
     public IndexSettings getIndexSettings() {
         return indexSettings;
-    }
-
-    /**
-     * Return the MapperService.
-     */
-    public MapperService getMapperService() {
-        return mapperService;
     }
 
     /** Return the current {@link IndexReader}, or {@code null} if no index reader is available,

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -163,13 +163,14 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             } else {
                 fieldName = field;
             }
-            if (context.isFieldMapped(fieldName) == false) {
-                if (context.getMapperService().documentMapper() == null) {
-                    // no mappings: the index is empty anyway
-                    return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
-                }
-                throw new IllegalArgumentException("Field [" + field + "] is not mapped on [" + context.index() +
+            if (context.hasMappings()) {
+                if (context.isFieldMapped(fieldName) == false) {
+                    throw new IllegalArgumentException("Field [" + field + "] is not mapped on [" + context.index() +
                         "] and cannot be used as a source of random numbers.");
+                }
+            } else {
+                // no mappings: the index is empty anyway
+                return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
             }
             int seed;
             if (this.seed == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -163,21 +163,15 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             } else {
                 fieldName = field;
             }
-            if (context.hasMappings()) {
-                if (context.isFieldMapped(fieldName) == false) {
-                    throw new IllegalArgumentException("Field [" + field + "] is not mapped on [" + context.index() +
-                        "] and cannot be used as a source of random numbers.");
+            if (context.isFieldMapped(fieldName) == false) {
+                if (context.hasMappings() == false) {
+                    // no mappings: the index is empty anyway
+                    return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
                 }
-            } else {
-                // no mappings: the index is empty anyway
-                return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
+                throw new IllegalArgumentException("Field [" + field + "] is not mapped on [" + context.index() +
+                    "] and cannot be used as a source of random numbers.");
             }
-            int seed;
-            if (this.seed == null) {
-                seed = hash(context.nowInMillis());
-            } else {
-                seed = this.seed;
-            }
+            int seed = this.seed == null ? hash(context.nowInMillis()) : this.seed;
             return new RandomScoreFunction(seed, salt, context.getForField(context.getFieldType(fieldName)));
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -122,7 +122,7 @@ public final class DocumentPermissions {
                 failIfQueryUsesClient(queryBuilder, queryShardContext);
                 Query roleQuery = queryShardContext.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
-                if (queryShardContext.getMapperService().hasNested()) {
+                if (queryShardContext.hasNested()) {
                     NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::isFieldMapped);
                     if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)


### PR DESCRIPTION
We have been removing usages of getMapperService with the purpose of removing the method at some point. This is so we don't have to expose the entire MapperService to all of the users of QueryShardContext, but rather only specific methods so we can better control its usages, especially around resolving field types.

This commit removes the last few usages and adds the missing methods to QueryShardContext. They all revolve around retrieving DocumentMapper from MapperService, yet we can expose specific methods without even exposing DocumentMapper, which would also cause issues.
