### PR TITLE
Add APM configuration index to Kibana system indices

### DIFF
--- a/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
+++ b/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.kibana;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -27,6 +29,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
@@ -34,18 +37,35 @@ import static org.hamcrest.Matchers.is;
 
 public class KibanaSystemIndexIT extends ESRestTestCase {
 
+    private final String indexName;
+
+    public KibanaSystemIndexIT(@Name("indexName") String indexName) {
+        this.indexName = indexName;
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(
+            new Object[] { ".kibana" },
+            new Object[] { ".kibana-1" },
+            new Object[] { ".reporting" },
+            new Object[] { ".apm-agent-configuration" }
+        );
+    }
+
     public void testCreateIndex() throws IOException {
-        Request request = new Request("PUT", "/_kibana/.kibana-1");
+        Request request = new Request("PUT", "/_kibana/" + indexName);
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
     }
 
     public void testAliases() throws IOException {
-        Request request = new Request("PUT", "/_kibana/.kibana-1");
+        assumeFalse("In this test, .kibana is the alias name", ".kibana".equals(indexName));
+        Request request = new Request("PUT", "/_kibana/" + indexName);
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        request = new Request("PUT", "/_kibana/.kibana-1/_alias/.kibana");
+        request = new Request("PUT", "/_kibana/" + indexName + "/_alias/.kibana");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
@@ -57,22 +77,22 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
 
     public void testBulkToKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
-        request.setJsonEntity("{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
+        request.setJsonEntity("{ \"index\" : { \"_index\" : \"" + indexName + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
     }
 
     public void testRefresh() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
-        request.setJsonEntity("{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
+        request.setJsonEntity("{ \"index\" : { \"_index\" : \"" + indexName + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        request = new Request("GET", "/_kibana/.kibana/_refresh");
+        request = new Request("GET", "/_kibana/" + indexName + "/_refresh");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request getRequest = new Request("GET", "/_kibana/.kibana/_doc/1");
+        Request getRequest = new Request("GET", "/_kibana/" + indexName + "/_doc/1");
         Response getResponse = client().performRequest(getRequest);
         assertThat(getResponse.getStatusLine().getStatusCode(), is(200));
         String responseBody = EntityUtils.toString(getResponse.getEntity());
@@ -82,13 +102,13 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
 
     public void testGetFromKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
-        request.setJsonEntity("{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
+        request.setJsonEntity("{ \"index\" : { \"_index\" : \"" + indexName + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n");
         request.addParameter("refresh", "true");
 
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request getRequest = new Request("GET", "/_kibana/.kibana/_doc/1");
+        Request getRequest = new Request("GET", "/_kibana/" + indexName + "/_doc/1");
         Response getResponse = client().performRequest(getRequest);
         assertThat(getResponse.getStatusLine().getStatusCode(), is(200));
         String responseBody = EntityUtils.toString(getResponse.getEntity());
@@ -99,8 +119,12 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public void testMultiGetFromKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
         request.setJsonEntity(
-            "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
+            "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
         );
         request.addParameter("refresh", "true");
 
@@ -109,7 +133,12 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
 
         Request getRequest = new Request("GET", "/_kibana/_mget");
         getRequest.setJsonEntity(
-            "{ \"docs\" : [ { \"_index\" : \".kibana\", \"_id\" : \"1\" }, " + "{ \"_index\" : \".kibana\", \"_id\" : \"2\" } ] }\n"
+            "{ \"docs\" : [ { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" }, "
+                + "{ \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } ] }\n"
         );
         Response getResponse = client().performRequest(getRequest);
         assertThat(getResponse.getStatusLine().getStatusCode(), is(200));
@@ -123,15 +152,19 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public void testSearchFromKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
         request.setJsonEntity(
-            "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
+            "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
         );
         request.addParameter("refresh", "true");
 
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request searchRequest = new Request("GET", "/_kibana/.kibana/_search");
+        Request searchRequest = new Request("GET", "/_kibana/" + indexName + "/_search");
         searchRequest.setJsonEntity("{ \"query\" : { \"match_all\" : {} } }\n");
         Response getResponse = client().performRequest(searchRequest);
         assertThat(getResponse.getStatusLine().getStatusCode(), is(200));
@@ -145,15 +178,19 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public void testDeleteFromKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
         request.setJsonEntity(
-            "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
+            "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
         );
         request.addParameter("refresh", "true");
 
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request deleteRequest = new Request("DELETE", "/_kibana/.kibana/_doc/1");
+        Request deleteRequest = new Request("DELETE", "/_kibana/" + indexName + "/_doc/1");
         Response deleteResponse = client().performRequest(deleteRequest);
         assertThat(deleteResponse.getStatusLine().getStatusCode(), is(200));
     }
@@ -161,63 +198,67 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public void testDeleteByQueryFromKibanaIndex() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
         request.setJsonEntity(
-            "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
+            "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
         );
         request.addParameter("refresh", "true");
 
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request dbqRequest = new Request("POST", "/_kibana/.kibana/_delete_by_query");
+        Request dbqRequest = new Request("POST", "/_kibana/" + indexName + "/_delete_by_query");
         dbqRequest.setJsonEntity("{ \"query\" : { \"match_all\" : {} } }\n");
         Response dbqResponse = client().performRequest(dbqRequest);
         assertThat(dbqResponse.getStatusLine().getStatusCode(), is(200));
     }
 
     public void testUpdateIndexSettings() throws IOException {
-        Request request = new Request("PUT", "/_kibana/.kibana-1");
+        Request request = new Request("PUT", "/_kibana/" + indexName);
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        request = new Request("PUT", "/_kibana/.kibana-1/_settings");
+        request = new Request("PUT", "/_kibana/" + indexName + "/_settings");
         request.setJsonEntity("{ \"index.blocks.read_only\" : false }");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
     }
 
     public void testGetIndex() throws IOException {
-        Request request = new Request("PUT", "/_kibana/.kibana-1");
+        Request request = new Request("PUT", "/_kibana/" + indexName);
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        request = new Request("GET", "/_kibana/.kibana-1");
+        request = new Request("GET", "/_kibana/" + indexName);
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
-        assertThat(EntityUtils.toString(response.getEntity()), containsString(".kibana-1"));
+        assertThat(EntityUtils.toString(response.getEntity()), containsString(indexName));
     }
 
     public void testIndexingAndUpdatingDocs() throws IOException {
-        Request request = new Request("PUT", "/_kibana/.kibana-1/_doc/1");
+        Request request = new Request("PUT", "/_kibana/" + indexName + "/_doc/1");
         request.setJsonEntity("{ \"foo\" : \"bar\" }");
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(201));
 
-        request = new Request("PUT", "/_kibana/.kibana-1/_create/2");
+        request = new Request("PUT", "/_kibana/" + indexName + "/_create/2");
         request.setJsonEntity("{ \"foo\" : \"bar\" }");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(201));
 
-        request = new Request("POST", "/_kibana/.kibana-1/_doc");
+        request = new Request("POST", "/_kibana/" + indexName + "/_doc");
         request.setJsonEntity("{ \"foo\" : \"bar\" }");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(201));
 
-        request = new Request("GET", "/_kibana/.kibana-1/_refresh");
+        request = new Request("GET", "/_kibana/" + indexName + "/_refresh");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        request = new Request("POST", "/_kibana/.kibana-1/_update/1");
+        request = new Request("POST", "/_kibana/" + indexName + "/_update/1");
         request.setJsonEntity("{ \"doc\" : { \"foo\" : \"baz\" } }");
         response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
@@ -226,15 +267,21 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public void testScrollingDocs() throws IOException {
         Request request = new Request("POST", "/_kibana/_bulk");
         request.setJsonEntity(
-            "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
-                + "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"3\" } }\n{ \"baz\" : \"tag\" }\n"
+            "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"1\" } }\n{ \"foo\" : \"bar\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"2\" } }\n{ \"baz\" : \"tag\" }\n"
+                + "{ \"index\" : { \"_index\" : \""
+                + indexName
+                + "\", \"_id\" : \"3\" } }\n{ \"baz\" : \"tag\" }\n"
         );
         request.addParameter("refresh", "true");
         Response response = client().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(200));
 
-        Request searchRequest = new Request("GET", "/_kibana/.kibana/_search");
+        Request searchRequest = new Request("GET", "/_kibana/" + indexName + "/_search");
         searchRequest.setJsonEntity("{ \"size\" : 1,\n\"query\" : { \"match_all\" : {} } }\n");
         searchRequest.addParameter("scroll", "1m");
         response = client().performRequest(searchRequest);

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -64,7 +64,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     public static final Setting<List<String>> KIBANA_INDEX_NAMES_SETTING = Setting.listSetting(
         "kibana.system_indices",
-        Collections.unmodifiableList(Arrays.asList(".kibana*", ".reporting")),
+        Collections.unmodifiableList(Arrays.asList(".kibana*", ".reporting", ".apm-agent-configuration")),
         Function.identity(),
         Property.NodeScope
     );

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -40,7 +40,7 @@ public class KibanaPluginTests extends ESTestCase {
                 .stream()
                 .map(SystemIndexDescriptor::getIndexPattern)
                 .collect(Collectors.toList()),
-            contains(".kibana*", ".reporting")
+            contains(".kibana*", ".reporting", ".apm-agent-configuration")
         );
         final List<String> names = Collections.unmodifiableList(Arrays.asList("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(6)));
         final List<String> namesFromDescriptors = new KibanaPlugin().getSystemIndexDescriptors(


### PR DESCRIPTION
* Add APM index to Kibana system indices, making it
accessible through the _kibana endpoint and giving it the
same access privileges as the other Kibana system indices.
* Parameterize kibana system index tests by index name

Backport of #63756