### PR TITLE
Fix test fixture dependencies in eclipse (7.x backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
 import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 
 plugins {
   id 'lifecycle-base'
@@ -337,6 +338,17 @@ allprojects {
       classpath.entries.findAll { it instanceof SourceFolder }.each { folder ->
         i++;
         folder.output = "build-eclipse/" + i
+      }
+
+      // Starting with Gradle 6.7 test dependencies are not exposed by eclipse
+      // projects by default. This breaks project dependencies using the `java-test-fixtures` plugin
+      // or dependencies on other projects manually declared testArtifacts configurations
+      // This issue is tracked in gradle issue tracker.
+      // See https://github.com/gradle/gradle/issues/14932 for further details
+      classpath.entries.findAll {
+        it instanceof ProjectDependency
+      }.each {
+        it.entryAttributes.remove('without_test_code')
       }
     }
   }


### PR DESCRIPTION
backports #63979 to 7.x branch