### PR TITLE
Correct system index names in Kibana module

### DIFF
--- a/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
+++ b/modules/kibana/src/javaRestTest/java/org/elasticsearch/kibana/KibanaSystemIndexIT.java
@@ -47,9 +47,10 @@ public class KibanaSystemIndexIT extends ESRestTestCase {
     public static Iterable<Object[]> data() {
         return Arrays.asList(
             new Object[] { ".kibana" },
-            new Object[] { ".kibana-1" },
-            new Object[] { ".reporting" },
-            new Object[] { ".apm-agent-configuration" }
+            new Object[] { ".kibana_1" },
+            new Object[] { ".reporting-1" },
+            new Object[] { ".apm-agent-configuration" },
+            new Object[] { ".apm-custom-link" }
         );
     }
 

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -60,18 +60,20 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.unmodifiableList;
+
 public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     public static final Setting<List<String>> KIBANA_INDEX_NAMES_SETTING = Setting.listSetting(
         "kibana.system_indices",
-        Collections.unmodifiableList(Arrays.asList(".kibana*", ".reporting", ".apm-agent-configuration")),
+        unmodifiableList(Arrays.asList(".kibana", ".kibana_*", ".reporting-*", ".apm-agent-configuration", ".apm-custom-link")),
         Function.identity(),
         Property.NodeScope
     );
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        return Collections.unmodifiableList(
+        return unmodifiableList(
             KIBANA_INDEX_NAMES_SETTING.get(settings)
                 .stream()
                 .map(pattern -> new SystemIndexDescriptor(pattern, "System index used by kibana"))
@@ -90,7 +92,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         // TODO need to figure out what subset of system indices Kibana should have access to via these APIs
-        return Collections.unmodifiableList(
+        return unmodifiableList(
             Arrays.asList(
                 // Based on https://github.com/elastic/kibana/issues/49764
                 // apis needed to perform migrations... ideally these will go away
@@ -146,7 +148,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
         @Override
         public List<Route> routes() {
-            return Collections.unmodifiableList(
+            return unmodifiableList(
                 super.routes().stream()
                     .map(route -> new Route(route.getMethod(), "/_kibana" + route.getPath()))
                     .collect(Collectors.toList())

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -40,12 +40,19 @@ public class KibanaPluginTests extends ESTestCase {
                 .stream()
                 .map(SystemIndexDescriptor::getIndexPattern)
                 .collect(Collectors.toList()),
-            contains(".kibana*", ".reporting", ".apm-agent-configuration")
+            contains(".kibana", ".kibana_*", ".reporting-*", ".apm-agent-configuration", ".apm-custom-link")
         );
-        final List<String> names = Collections.unmodifiableList(Arrays.asList("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(6)));
+        final List<String> names = Collections.unmodifiableList(Arrays.asList("." + randomAlphaOfLength(4), "." + randomAlphaOfLength(5)));
         final List<String> namesFromDescriptors = new KibanaPlugin().getSystemIndexDescriptors(
             Settings.builder().putList(KibanaPlugin.KIBANA_INDEX_NAMES_SETTING.getKey(), names).build()
         ).stream().map(SystemIndexDescriptor::getIndexPattern).collect(Collectors.toList());
         assertThat(namesFromDescriptors, is(names));
+
+        assertThat(
+            new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY)
+                .stream()
+                .anyMatch(systemIndexDescriptor -> systemIndexDescriptor.matchesIndexPattern(".kibana-event-log-7-1")),
+            is(false)
+        );
     }
 }


### PR DESCRIPTION
This commit updates the list of system index names to be complete and
correct for Kibana and APM. The pattern `.kibana*` is too inclusive for
system indices and actually includes the
`.kibana-event-log-${version}-${int}` pattern for the Kibana event log,
which should only be hidden and not a system index. Additionally, the
`.apm-custom-link` index was not included in the list of system
indices. Finally, the reporting pattern has been updated to match that
of the permissions given to the kibana_system role.

Backport of #63950