### PR TITLE
Refactor searcher wrapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Sort;
@@ -34,7 +33,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
@@ -117,7 +115,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final ShardStoreDeleter shardStoreDeleter;
     private final IndexStorePlugin.DirectoryFactory directoryFactory;
     private final IndexStorePlugin.RecoveryStateFactory recoveryStateFactory;
-    private final CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper;
+    private final ReaderWrapperFactory readerWrapper;
     private final IndexCache indexCache;
     private final MapperService mapperService;
     private final NamedXContentRegistry xContentRegistry;
@@ -168,7 +166,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             QueryCache queryCache,
             IndexStorePlugin.DirectoryFactory directoryFactory,
             IndexEventListener eventListener,
-            Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> wrapperFactory,
+            Function<IndexService, ReaderWrapperFactory> wrapperFactory,
             MapperRegistry mapperRegistry,
             IndicesFieldDataCache indicesFieldDataCache,
             List<SearchOperationListener> searchOperationListeners,
@@ -816,7 +814,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         return engineFactory;
     }
 
-    final CheckedFunction<DirectoryReader, DirectoryReader, IOException> getReaderWrapper() {
+    final ReaderWrapperFactory getReaderWrapper() {
         return readerWrapper;
     } // pkg private for testing
 

--- a/server/src/main/java/org/elasticsearch/index/ReaderWrapperFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/ReaderWrapperFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface ReaderWrapperFactory {
+    /**
+     * Returns the reader wrapper for the given shardId if exists.
+     * The caller must apply wrapping on the same thread that created the wrapper instance.
+     */
+    @Nullable
+    CheckedFunction<DirectoryReader, DirectoryReader, IOException> getWrapper(ShardId shardId);
+}

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -598,9 +598,10 @@ public class IndexModuleTests extends ESTestCase {
         }
     }
 
-    public static final class Wrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
+
+    public static final class Wrapper implements ReaderWrapperFactory {
         @Override
-        public DirectoryReader apply(DirectoryReader reader) {
+        public CheckedFunction<DirectoryReader, DirectoryReader, IOException> getWrapper(ShardId shardId) {
             return null;
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -389,7 +389,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                     similarityService,
                     engineFactory,
                     indexEventListener,
-                    readerWrapperFactory,
+                    readerWrapperFactory != null ? readerWrapperFactory : randomReaderWrapper(),
                     threadPool,
                     BigArrays.NON_RECYCLING_INSTANCE,
                     warmer,
@@ -879,5 +879,13 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 }
             }
         };
+    }
+
+    protected ReaderWrapperFactory randomReaderWrapper() {
+        if (randomBoolean()) {
+            return shardId -> null;
+        } else {
+            return shardId -> reader -> reader;
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
@@ -12,8 +12,8 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedFunction;
-import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.ReaderWrapperFactory;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
@@ -36,12 +36,12 @@ import java.util.function.Function;
  * Based on the {@link ThreadContext} this class will enable field and/or document level security.
  * <p>
  * Field level security is enabled by wrapping the original {@link DirectoryReader} in a {@link FieldSubsetReader}
- * in the {@link #apply(DirectoryReader)} method.
+ * in the {@link #getWrapper(ShardId)} (DirectoryReader)} method.
  * <p>
  * Document level security is enabled by wrapping the original {@link DirectoryReader} in a {@link DocumentSubsetReader}
  * instance.
  */
-public class SecurityIndexReaderWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
+public class SecurityIndexReaderWrapper implements ReaderWrapperFactory {
     private static final Logger logger = LogManager.getLogger(SecurityIndexReaderWrapper.class);
 
     private final Function<ShardId, QueryShardContext> queryShardContextProvider;
@@ -61,40 +61,47 @@ public class SecurityIndexReaderWrapper implements CheckedFunction<DirectoryRead
     }
 
     @Override
-    public DirectoryReader apply(final DirectoryReader reader) {
+    public CheckedFunction<DirectoryReader, DirectoryReader, IOException> getWrapper(ShardId shardId) {
         if (licenseState.isSecurityEnabled() == false ||
             licenseState.checkFeature(Feature.SECURITY_DLS_FLS) == false) {
-            return reader;
+            return null;
         }
-
-        try {
-            final IndicesAccessControl indicesAccessControl = getIndicesAccessControl();
-
-            ShardId shardId = ShardUtils.extractShardId(reader);
-            if (shardId == null) {
-                throw new IllegalStateException(LoggerMessageFormat.format("couldn't extract shardId from reader [{}]", reader));
-            }
-
-            final IndicesAccessControl.IndexAccessControl permissions = indicesAccessControl.getIndexPermissions(shardId.getIndexName());
-            // No permissions have been defined for an index, so don't intercept the index reader for access control
-            if (permissions == null) {
-                return reader;
-            }
-
-            DirectoryReader wrappedReader = reader;
-            DocumentPermissions documentPermissions = permissions.getDocumentPermissions();
-            if (documentPermissions != null && documentPermissions.hasDocumentLevelPermissions()) {
-                BooleanQuery filterQuery = documentPermissions.filter(getUser(), scriptService, shardId, queryShardContextProvider);
-                if (filterQuery != null) {
-                    wrappedReader = DocumentSubsetReader.wrap(wrappedReader, bitsetCache, new ConstantScoreQuery(filterQuery));
+        final IndicesAccessControl indicesAccessControl = getIndicesAccessControl();
+        final IndicesAccessControl.IndexAccessControl permissions = indicesAccessControl.getIndexPermissions(shardId.getIndexName());
+        // No permissions have been defined for an index, so don't intercept the index reader for access control
+        if (permissions == null) {
+            return null;
+        }
+        final DocumentPermissions documentPermissions = permissions.getDocumentPermissions();
+        final boolean hasDocumentLevelPermissions = documentPermissions != null && documentPermissions.hasDocumentLevelPermissions();
+        if (hasDocumentLevelPermissions == false && permissions.getFieldPermissions().hasFieldLevelSecurity() == false) {
+            return null;
+        }
+        final Thread createThread = Thread.currentThread();
+        return reader -> {
+            try {
+                final ShardId readerShardId = ShardUtils.extractShardId(reader);
+                if (shardId.equals(readerShardId) == false) {
+                    assert false : readerShardId + " != " + shardId;
+                    throw new IllegalArgumentException("Wrapping wrong reader; expected shardId " + shardId + "; but " + readerShardId);
                 }
+                if (Thread.currentThread() != createThread) {
+                    assert false : Thread.currentThread() + " != " + createThread;
+                    throw new IllegalStateException("Wrapping reader on a different thread");
+                }
+                DirectoryReader wrappedReader = reader;
+                if (hasDocumentLevelPermissions) {
+                    BooleanQuery filterQuery = documentPermissions.filter(getUser(), scriptService, shardId, queryShardContextProvider);
+                    if (filterQuery != null) {
+                        wrappedReader = DocumentSubsetReader.wrap(wrappedReader, bitsetCache, new ConstantScoreQuery(filterQuery));
+                    }
+                }
+                return permissions.getFieldPermissions().filter(wrappedReader);
+            } catch (IOException e) {
+                logger.error("Unable to apply field level security");
+                throw ExceptionsHelper.convertToElastic(e);
             }
-
-            return permissions.getFieldPermissions().filter(wrappedReader);
-        } catch (IOException e) {
-            logger.error("Unable to apply field level security");
-            throw ExceptionsHelper.convertToElastic(e);
-        }
+        };
     }
 
     protected IndicesAccessControl getIndicesAccessControl() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -159,7 +159,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
             ParsedQuery parsedQuery = new ParsedQuery(new TermQuery(new Term("field", values[i])));
             when(queryShardContext.toQuery(new TermsQueryBuilder("field", values[i]))).thenReturn(parsedQuery);
 
-            DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
+            DirectoryReader wrappedDirectoryReader = wrapper.getWrapper(shardId).apply(directoryReader);
             IndexSearcher indexSearcher = new ContextIndexSearcher(
                     wrappedDirectoryReader, IndexSearcher.getDefaultSimilarity(), IndexSearcher.getDefaultQueryCache(),
                     IndexSearcher.getDefaultQueryCachingPolicy(), true);
@@ -267,7 +267,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         iw.close();
 
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(directory), shardId);
-        DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
+        DirectoryReader wrappedDirectoryReader = wrapper.getWrapper(shardId).apply(directoryReader);
         IndexSearcher indexSearcher = new ContextIndexSearcher(
                 wrappedDirectoryReader, IndexSearcher.getDefaultSimilarity(), IndexSearcher.getDefaultQueryCache(),
                 IndexSearcher.getDefaultQueryCachingPolicy(), true);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
@@ -37,7 +37,6 @@ import java.util.Set;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -97,7 +96,7 @@ public class SecurityIndexReaderWrapperUnitTests extends ESTestCase {
         };
 
         FieldSubsetReader.FieldSubsetDirectoryReader result =
-                (FieldSubsetReader.FieldSubsetDirectoryReader) securityIndexReaderWrapper.apply(esIn);
+                (FieldSubsetReader.FieldSubsetDirectoryReader) securityIndexReaderWrapper.getWrapper(esIn.shardId()).apply(esIn);
         assertThat(result.getFilter().run("_uid"), is(true));
         assertThat(result.getFilter().run("_id"), is(true));
         assertThat(result.getFilter().run("_version"), is(true));
@@ -118,8 +117,7 @@ public class SecurityIndexReaderWrapperUnitTests extends ESTestCase {
         when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(false);
         securityIndexReaderWrapper =
                 new SecurityIndexReaderWrapper(null, null, securityContext, licenseState, scriptService);
-        DirectoryReader reader = securityIndexReaderWrapper.apply(esIn);
-        assertThat(reader, sameInstance(esIn));
+        assertNull(securityIndexReaderWrapper.getWrapper(esIn.shardId()));
     }
 
     public void testWildcards() throws Exception {


### PR DESCRIPTION
When the reader wrapper in IndexShard is null, we can apply some optimizations. However, if security is enabled, it is always non-null, although it can be a noop (i.e., when document and field level security are disabled). This commit adds a new interface to allow the reader wrapper to become null in this case.