### PR TITLE
SimilarityService to not require the entire MapperService

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -172,7 +172,7 @@ public class QueryShardContext extends QueryRewriteContext {
     }
 
     public Similarity getSearchSimilarity() {
-        return similarityService != null ? similarityService.similarity(mapperService) : null;
+        return similarityService != null ? similarityService.similarity(mapperService::fieldType) : null;
     }
 
     public List<String> defaultFields() {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2716,7 +2716,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return new EngineConfig(shardId,
                 threadPool, indexSettings, warmer, store, indexSettings.getMergePolicy(),
                 mapperService != null ? mapperService.indexAnalyzer() : null,
-                similarityService.similarity(mapperService), codecService, shardEventListener,
+                similarityService.similarity(mapperService == null ? null : mapperService::fieldType), codecService, shardEventListener,
                 indexCache != null ? indexCache.query() : null, cachingPolicy, translogConfig,
                 IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()),
                 List.of(refreshListeners, refreshPendingLocationListener),


### PR DESCRIPTION
SimilarityService currently requires the whole MapperService, which it passes through to PerFieldSimilarity. The only functionality needed is looking up a field type based on a field name.

With this commit, SimilarityService requires a Function<String,MappedFieldType> rather than the whole MapperService. This helps clarifying the dependency between MapperService and similarities.