### PR TITLE
Remove QueryShardContext#getMapperService (#63998)

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -67,9 +67,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -538,9 +536,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
 
         final List<ParsedDocument> docs = new ArrayList<>();
-        final DocumentMapper docMapper;
-        final MapperService mapperService = context.getMapperService();
-        String type = mapperService.documentMapper().type();
+        String type = context.getType();
         if (documentType != null) {
             deprecationLogger.deprecate("percolate_with_document_type", DOCUMENT_TYPE_DEPRECATION_MESSAGE);
             if (documentType.equals(type) == false) {
@@ -548,13 +544,13 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                     "] is not equal to the actual type [" + type + "]");
             }
         }
-        docMapper = mapperService.documentMapper(type);
         for (BytesReference document : documents) {
-            docs.add(docMapper.parse(new SourceToParse(context.index().getName(), type, "_temp_id", document, documentXContentType)));
+            docs.add(context.parseDocument(type,
+                new SourceToParse(context.index().getName(), type, "_temp_id", document, documentXContentType)));
         }
 
-        FieldNameAnalyzer fieldNameAnalyzer = (FieldNameAnalyzer)docMapper.mappers().indexAnalyzer();
-        // Need to this custom impl because FieldNameAnalyzer is strict and the percolator sometimes isn't when
+        FieldNameAnalyzer fieldNameAnalyzer = context.getFieldNameIndexAnalyzer();
+        // We need this custom analyzer because FieldNameAnalyzer is strict and the percolator sometimes isn't when
         // 'index.percolator.map_unmapped_fields_as_string' is enabled:
         Analyzer analyzer = new DelegatingAnalyzerWrapper(Analyzer.PER_FIELD_REUSE_STRATEGY) {
             @Override
@@ -570,9 +566,9 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         final IndexSearcher docSearcher;
         final boolean excludeNestedDocuments;
         if (docs.size() > 1 || docs.get(0).docs().size() > 1) {
-            assert docs.size() != 1 || docMapper.hasNestedObjects();
+            assert docs.size() != 1 || context.hasNested();
             docSearcher = createMultiDocumentSearcher(analyzer, docs);
-            excludeNestedDocuments = docMapper.hasNestedObjects() && docs.stream()
+            excludeNestedDocuments = context.hasNested() && docs.stream()
                     .map(ParsedDocument::docs)
                     .mapToInt(List::size)
                     .anyMatch(size -> size > 1);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -149,7 +149,7 @@ public final class MappingLookup implements Iterable<Mapper> {
      * A smart analyzer used for indexing that takes into account specific analyzers configured
      * per {@link FieldMapper}.
      */
-    public Analyzer indexAnalyzer() {
+    public FieldNameAnalyzer indexAnalyzer() {
         return this.indexAnalyzer;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -169,19 +169,14 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
                 fieldName = field;
             }
             if (context.isFieldMapped(fieldName) == false) {
-                if (context.getMapperService().documentMapper() == null) {
+                if (context.hasMappings() == false) {
                     // no mappings: the index is empty anyway
                     return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
                 }
                 throw new IllegalArgumentException("Field [" + field + "] is not mapped on [" + context.index() +
-                        "] and cannot be used as a source of random numbers.");
+                    "] and cannot be used as a source of random numbers.");
             }
-            int seed;
-            if (this.seed == null) {
-                seed = hash(context.nowInMillis());
-            } else {
-                seed = this.seed;
-            }
+            int seed = this.seed == null ? hash(context.nowInMillis()) : this.seed;
             return new RandomScoreFunction(seed, salt, context.getForField(context.getFieldType(fieldName)));
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -122,7 +122,7 @@ public final class DocumentPermissions {
                 failIfQueryUsesClient(queryBuilder, queryShardContext);
                 Query roleQuery = queryShardContext.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
-                if (queryShardContext.getMapperService().hasNested()) {
+                if (queryShardContext.hasNested()) {
                     NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::isFieldMapped);
                     if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)


### PR DESCRIPTION
We have been removing usages of getMapperService with the purpose of removing the method at some point. This is so we don't have to expose the entire MapperService to all of the users of QueryShardContext, but rather only specific methods so we can better control its usages, especially around resolving field types.

This commit removes the last few usages and adds the missing methods to QueryShardContext. They all revolve around retrieving DocumentMapper from MapperService, yet we can expose specific methods without even exposing DocumentMapper, which would also cause issues.

