### PR TITLE
SimilarityService to not require the entire MapperService (#64032)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -190,7 +190,7 @@ public class QueryShardContext extends QueryRewriteContext {
     }
 
     public Similarity getSearchSimilarity() {
-        return similarityService != null ? similarityService.similarity(mapperService) : null;
+        return similarityService != null ? similarityService.similarity(mapperService::fieldType) : null;
     }
 
     public List<String> defaultFields() {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2783,7 +2783,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return new EngineConfig(shardId,
                 threadPool, indexSettings, warmer, store, indexSettings.getMergePolicy(),
                 mapperService != null ? mapperService.indexAnalyzer() : null,
-                similarityService.similarity(mapperService), codecService, shardEventListener,
+                similarityService.similarity(mapperService == null ? null : mapperService::fieldType), codecService, shardEventListener,
                 indexCache != null ? indexCache.query() : null, cachingPolicy, translogConfig,
                 IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.get(indexSettings.getSettings()),
                 Arrays.asList(refreshListeners, refreshPendingLocationListener),

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -32,6 +32,7 @@ import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.search.similarity.LegacyBM25Similarity;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -39,12 +40,12 @@ import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.ScriptService;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -159,9 +160,8 @@ public final class SimilarityService extends AbstractIndexComponent {
         }
     }
 
-    public Similarity similarity(MapperService mapperService) {
-        // TODO we can maybe factor out MapperService here entirely by introducing an interface for the lookup?
-        return (mapperService != null) ? new PerFieldSimilarity(defaultSimilarity, mapperService) :
+    public Similarity similarity(@Nullable Function<String, MappedFieldType> fieldTypeLookup) {
+        return (fieldTypeLookup != null) ? new PerFieldSimilarity(defaultSimilarity, fieldTypeLookup) :
                 defaultSimilarity;
     }
 
@@ -182,17 +182,17 @@ public final class SimilarityService extends AbstractIndexComponent {
     static class PerFieldSimilarity extends PerFieldSimilarityWrapper {
 
         private final Similarity defaultSimilarity;
-        private final MapperService mapperService;
+        private final Function<String, MappedFieldType> fieldTypeLookup;
 
-        PerFieldSimilarity(Similarity defaultSimilarity, MapperService mapperService) {
+        PerFieldSimilarity(Similarity defaultSimilarity, Function<String, MappedFieldType> fieldTypeLookup) {
             super();
             this.defaultSimilarity = defaultSimilarity;
-            this.mapperService = mapperService;
+            this.fieldTypeLookup = Objects.requireNonNull(fieldTypeLookup, "fieldTypeLookup cannot be null");
         }
 
         @Override
         public Similarity get(String name) {
-            MappedFieldType fieldType = mapperService.fieldType(name);
+            MappedFieldType fieldType = fieldTypeLookup.apply(name);
             return (fieldType != null && fieldType.getTextSearchInfo().getSimilarity() != null)
                 ? fieldType.getTextSearchInfo().getSimilarity().get() : defaultSimilarity;
         }


### PR DESCRIPTION
SimilarityService currently requires the whole MapperService, which it passes through to PerFieldSimilarity. The only functionality needed is looking up a field type based on a field name.

With this commit, SimilarityService requires a Function<String,MappedFieldType> rather than the whole MapperService. This helps clarifying the dependency between MapperService and similarities.

