### PR TITLE
Add visitor pattern to the triangle tree (#63333)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -203,6 +203,30 @@ public class GeometryTestUtils {
         return geometry.apply(hasAlt);
     }
 
+    public static Geometry randomGeometryWithoutCircle(int level, boolean hasAlt) {
+        @SuppressWarnings("unchecked") Function<Boolean, Geometry> geometry = ESTestCase.randomFrom(
+            GeometryTestUtils::randomPoint,
+            GeometryTestUtils::randomMultiPoint,
+            GeometryTestUtils::randomLine,
+            GeometryTestUtils::randomMultiLine,
+            GeometryTestUtils::randomPolygon,
+            GeometryTestUtils::randomMultiPolygon,
+            hasAlt ? GeometryTestUtils::randomPoint : (b) -> randomRectangle(),
+            level < 3 ? (b) ->
+                randomGeometryWithoutCircleCollection(level + 1, hasAlt) : GeometryTestUtils::randomPoint // don't build too deep
+        );
+        return geometry.apply(hasAlt);
+    }
+
+    private static Geometry randomGeometryWithoutCircleCollection(int level, boolean hasAlt) {
+        int size = ESTestCase.randomIntBetween(1, 10);
+        List<Geometry> shapes = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            shapes.add(randomGeometryWithoutCircle(level, hasAlt));
+        }
+        return new GeometryCollection<>(shapes);
+    }
+
     /**
      * Extracts all vertices of the supplied geometry
      */

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CoordinateEncoder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CoordinateEncoder.java
@@ -10,9 +10,19 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
  * Interface for classes that help encode double-valued spatial coordinates x/y to
  * their integer-encoded serialized form and decode them back
  */
-interface CoordinateEncoder {
+public interface CoordinateEncoder {
+
+    CoordinateEncoder GEO = new GeoShapeCoordinateEncoder();
+
+    /** encode X value */
     int encodeX(double x);
+
+    /** encode Y value */
     int encodeY(double y);
+
+    /** decode X value */
     double decodeX(int x);
+
+    /** decode Y value */
     double decodeY(int y);
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeCoordinateEncoder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeCoordinateEncoder.java
@@ -8,8 +8,7 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
 
-public final class GeoShapeCoordinateEncoder implements CoordinateEncoder {
-    public static final GeoShapeCoordinateEncoder INSTANCE = new GeoShapeCoordinateEncoder();
+final class GeoShapeCoordinateEncoder implements CoordinateEncoder {
 
     @Override
     public int encodeX(double x) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * A reusable Geometry doc value reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
+ * {@link GeometryDocValueWriter}.
+ *
+ *
+ * -----------------------------------------
+ * |   The binary format of the tree       |
+ * -----------------------------------------
+ * -----------------------------------------  --
+ * |    centroid-x-coord (4 bytes)         |    |
+ * -----------------------------------------    |
+ * |    centroid-y-coord (4 bytes)         |    |
+ * -----------------------------------------    |
+ * |    DimensionalShapeType (1 byte)      |    | Centroid-related header
+ * -----------------------------------------    |
+ * |  Sum of weights (VLong 1-8 bytes)     |    |
+ * -----------------------------------------  --
+ * |         Extent (var-encoding)         |
+ * -----------------------------------------
+ * |         Triangle Tree                 |
+ * -----------------------------------------
+ * -----------------------------------------
+ */
+public class GeometryDocValueReader {
+    private final ByteArrayDataInput input;
+    private final Extent extent;
+    private int treeOffset;
+    private int docValueOffset;
+
+    public GeometryDocValueReader() {
+        this.extent = new Extent();
+        this.input = new ByteArrayDataInput();
+    }
+
+    /**
+     * reset the geometry.
+     */
+    public void reset(BytesRef bytesRef) {
+        this.input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        docValueOffset = bytesRef.offset;
+        treeOffset = 0;
+    }
+
+    /**
+     * returns the {@link Extent} of this geometry.
+     */
+    protected Extent getExtent() {
+        if (treeOffset == 0) {
+            getSumCentroidWeight(); // skip CENTROID_HEADER + var-long sum-weight
+            Extent.readFromCompressed(input, extent);
+            treeOffset = input.getPosition();
+        } else {
+            input.setPosition(treeOffset);
+        }
+        return extent;
+    }
+
+    /**
+     * returns the encoded X coordinate of the centroid.
+     */
+    protected int getCentroidX() {
+        input.setPosition(docValueOffset + 0);
+        return input.readInt();
+    }
+
+    /**
+     * returns the encoded Y coordinate of the centroid.
+     */
+    protected int getCentroidY() {
+        input.setPosition(docValueOffset + 4);
+        return input.readInt();
+    }
+
+    protected DimensionalShapeType getDimensionalShapeType() {
+        input.setPosition(docValueOffset + 8);
+        return DimensionalShapeType.readFrom(input);
+    }
+
+    protected double getSumCentroidWeight() {
+        input.setPosition(docValueOffset + 9);
+        return Double.longBitsToDouble(input.readVLong());
+    }
+
+    /**
+     * Visit the triangle tree with the provided visitor
+     */
+    protected void visit(TriangleTreeReader.Visitor visitor) {
+        Extent extent = getExtent();
+        int thisMaxX = extent.maxX();
+        int thisMinX = extent.minX();
+        int thisMaxY = extent.maxY();
+        int thisMinY = extent.minY();
+        if(visitor.push(thisMinX, thisMinY, thisMaxX, thisMaxY)) {
+            TriangleTreeReader.visit(input, visitor, thisMaxX, thisMaxY);
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This is a tree-writer that serializes a list of {@link ShapeField.DecodedTriangle} as an interval tree
+ * into a byte array.
+ */
+public class GeometryDocValueWriter {
+
+    private final TriangleTreeWriter treeWriter;
+    private final CoordinateEncoder coordinateEncoder;
+    private final CentroidCalculator centroidCalculator;
+
+    public GeometryDocValueWriter(List<ShapeField.DecodedTriangle> triangles, CoordinateEncoder coordinateEncoder,
+                                  CentroidCalculator centroidCalculator) {
+        this.coordinateEncoder = coordinateEncoder;
+        this.centroidCalculator = centroidCalculator;
+        this.treeWriter = new TriangleTreeWriter(triangles);
+    }
+
+    /*** Serialize the interval tree in the provided data output */
+    public void writeTo(ByteBuffersDataOutput out) throws IOException {
+        out.writeInt(coordinateEncoder.encodeX(centroidCalculator.getX()));
+        out.writeInt(coordinateEncoder.encodeY(centroidCalculator.getY()));
+        centroidCalculator.getDimensionalShapeType().writeTo(out);
+        out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
+        treeWriter.writeTo(out);
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonShapeDVAtomicShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonShapeDVAtomicShapeFieldData.java
@@ -47,7 +47,7 @@ final class LatLonShapeDVAtomicShapeFieldData extends AbstractAtomicGeoShapeShap
     public MultiGeoShapeValues getGeoShapeValues() {
         try {
             final BinaryDocValues binaryValues = DocValues.getBinary(reader, fieldName);
-            final TriangleTreeReader reader = new TriangleTreeReader(GeoShapeCoordinateEncoder.INSTANCE);
+            final GeometryDocValueReader reader = new GeometryDocValueReader();
             final MultiGeoShapeValues.GeoShapeValue geoShapeValue = new MultiGeoShapeValues.GeoShapeValue(reader);
             return new MultiGeoShapeValues() {
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import static org.apache.lucene.geo.GeoUtils.orient;
+
+/**
+ * A reusable tree reader visitor for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
+ * {@link TriangleTreeWriter}.
+ *
+ * This class supports checking bounding box relations against a serialized triangle tree. Note that this differ
+ * from Rectangle2D lucene implementation because it excludes north and east boundary intersections with tiles
+ * from intersection consideration for consistent tiling definition of shapes on the boundaries of tiles
+ *
+ */
+class Tile2DVisitor implements TriangleTreeReader.Visitor {
+
+    private GeoRelation relation;
+    private int minX;
+    private int maxX;
+    private int minY;
+    private int maxY;
+
+    Tile2DVisitor() {
+    }
+
+    public void reset(int minX, int minY, int maxX, int maxY) {
+        this.minX = minX;
+        this.maxX = maxX;
+        this.minY = minY;
+        this.maxY = maxY;
+        relation = GeoRelation.QUERY_DISJOINT;
+    }
+
+    /**
+     * return the computed relation.
+     */
+    public GeoRelation relation() {
+        return relation;
+    }
+
+    @Override
+    public void visitPoint(int x, int y) {
+        if (contains(x, y)) {
+            relation = GeoRelation.QUERY_CROSSES;
+        }
+    }
+
+    @Override
+    public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
+        if (intersectsLine(aX, aY, bX, bY)) {
+            relation = GeoRelation.QUERY_CROSSES;
+        }
+    }
+
+    @Override
+    public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
+        boolean ab = (metadata & 1 << 4) == 1 << 4;
+        boolean bc = (metadata & 1 << 5) == 1 << 5;
+        boolean ca = (metadata & 1 << 6) == 1 << 6;
+        GeoRelation relation = relateTriangle(aX, aY, ab, bX, bY, bc, cX, cY, ca);
+        if (relation != GeoRelation.QUERY_DISJOINT) {
+            this.relation = relation;
+        }
+    }
+
+    @Override
+    public boolean push() {
+        return relation != GeoRelation.QUERY_CROSSES;
+    }
+
+    @Override
+    public boolean pushX(int minX) {
+        return this.maxX >= minX;
+    }
+
+    @Override
+    public boolean pushY(int minY) {
+        return this.maxY >= minY;
+    }
+
+    @Override
+    public boolean push(int maxX, int maxY) {
+        return this.minY <= maxY && this.minX <= maxX;
+    }
+
+    @Override
+    public boolean push(int minX, int minY, int maxX, int maxY) {
+        // exclude north and east boundary intersections with tiles from intersection consideration
+        // for consistent tiling definition of shapes on the boundaries of tiles
+        if (minX >= this.maxX || maxX < this.minX || minY > this.maxY || maxY <= this.minY) {
+            // shapes are disjoint
+            relation = GeoRelation.QUERY_DISJOINT;
+            return false;
+        }
+        if (this.minX <= minX && this.maxX >= maxX && this.minY <= minY && this.maxY >= maxY) {
+            // the rectangle fully contains the shape
+            relation = GeoRelation.QUERY_CROSSES;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the rectangle contains the provided point
+     **/
+    public boolean contains(int x, int y) {
+        return (x <= minX || x > maxX || y < minY || y >= maxY) == false;
+    }
+
+    /**
+     * Checks if the rectangle intersects the provided triangle
+     **/
+    private boolean intersectsLine(int aX, int aY, int bX, int bY) {
+        // 1. query contains any triangle points
+        if (contains(aX, aY) || contains(bX, bY)) {
+            return true;
+        }
+
+        // compute bounding box of triangle
+        int tMinX = StrictMath.min(aX, bX);
+        int tMaxX = StrictMath.max(aX, bX);
+        int tMinY = StrictMath.min(aY, bY);
+        int tMaxY = StrictMath.max(aY, bY);
+
+        // 2. check bounding boxes are disjoint
+        if (tMaxX <= minX || tMinX > maxX || tMinY > maxY || tMaxY <= minY) {
+            return false;
+        }
+
+        // 4. last ditch effort: check crossings
+        if (edgeIntersectsQuery(aX, aY, bX, bY)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the rectangle intersects the provided triangle
+     **/
+    private GeoRelation relateTriangle(int aX, int aY, boolean ab, int bX, int bY, boolean bc, int cX, int cY, boolean ca) {
+        // compute bounding box of triangle
+        int tMinX = StrictMath.min(StrictMath.min(aX, bX), cX);
+        int tMaxX = StrictMath.max(StrictMath.max(aX, bX), cX);
+        int tMinY = StrictMath.min(StrictMath.min(aY, bY), cY);
+        int tMaxY = StrictMath.max(StrictMath.max(aY, bY), cY);
+
+        // 1. check bounding boxes are disjoint, where north and east boundaries are not considered as crossing
+        if (tMaxX <= minX || tMinX > maxX || tMinY > maxY || tMaxY <= minY) {
+            return GeoRelation.QUERY_DISJOINT;
+        }
+
+        // 2. query contains any triangle points
+        if (contains(aX, aY) || contains(bX, bY) || contains(cX, cY)) {
+            return GeoRelation.QUERY_CROSSES;
+        }
+
+        boolean within = false;
+        if (edgeIntersectsQuery(aX, aY, bX, bY)) {
+            if (ab) {
+                return GeoRelation.QUERY_CROSSES;
+            }
+            within = true;
+        }
+
+        // right
+        if (edgeIntersectsQuery(bX, bY, cX, cY)) {
+            if (bc) {
+                return GeoRelation.QUERY_CROSSES;
+            }
+            within = true;
+        }
+
+        if (edgeIntersectsQuery(cX, cY, aX, aY)) {
+            if (ca) {
+                return GeoRelation.QUERY_CROSSES;
+            }
+            within = true;
+        }
+
+        if (within || pointInTriangle(tMinX, tMaxX, tMinY, tMaxY, minX, minY, aX, aY, bX, bY, cX, cY)) {
+            return GeoRelation.QUERY_INSIDE;
+        }
+
+        return GeoRelation.QUERY_DISJOINT;
+    }
+
+    /**
+     * returns true if the edge (defined by (ax, ay) (bx, by)) intersects the query
+     */
+    private boolean edgeIntersectsQuery(int ax, int ay, int bx, int by) {
+        // shortcut: check bboxes of edges are disjoint
+        if (boxesAreDisjoint(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by),
+            minX, maxX, minY, maxY)) {
+            return false;
+        }
+
+        // top
+        if (orient(ax, ay, bx, by, minX, maxY) * orient(ax, ay, bx, by, maxX, maxY) <= 0 &&
+            orient(minX, maxY, maxX, maxY, ax, ay) * orient(minX, maxY, maxX, maxY, bx, by) <= 0) {
+            return true;
+        }
+
+        // right
+        if (orient(ax, ay, bx, by, maxX, maxY) * orient(ax, ay, bx, by, maxX, minY) <= 0 &&
+            orient(maxX, maxY, maxX, minY, ax, ay) * orient(maxX, maxY, maxX, minY, bx, by) <= 0) {
+            return true;
+        }
+
+        // bottom
+        if (orient(ax, ay, bx, by, maxX, minY) * orient(ax, ay, bx, by, minX, minY) <= 0 &&
+            orient(maxX, minY, minX, minY, ax, ay) * orient(maxX, minY, minX, minY, bx, by) <= 0) {
+            return true;
+        }
+
+        // left
+        if (orient(ax, ay, bx, by, minX, minY) * orient(ax, ay, bx, by, minX, maxY) <= 0 &&
+            orient(minX, minY, minX, maxY, ax, ay) * orient(minX, minY, minX, maxY, bx, by) <= 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Compute whether the given x, y point is in a triangle; uses the winding order method
+     */
+    private static boolean pointInTriangle(double minX, double maxX, double minY, double maxY, double x, double y,
+                                           double aX, double aY, double bX, double bY, double cX, double cY) {
+        //check the bounding box because if the triangle is degenerated, e.g points and lines, we need to filter out
+        //coplanar points that are not part of the triangle.
+        if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
+            int a = orient(x, y, aX, aY, bX, bY);
+            int b = orient(x, y, bX, bY, cX, cY);
+            if (a == 0 || b == 0 || a < 0 == b < 0) {
+                int c = orient(x, y, cX, cY, aX, aY);
+                return c == 0 || (c < 0 == (b < 0 || a < 0));
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * utility method to check if two boxes are disjoint
+     */
+    private static boolean boxesAreDisjoint(final int aMinX, final int aMaxX, final int aMinY, final int aMaxY,
+                                            final int bMinX, final int bMaxX, final int bMinY, final int bMaxY) {
+        return (aMaxX < bMinX || aMinX > bMaxX || aMaxY < bMinY || aMinY > bMaxY);
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
@@ -7,412 +7,140 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.util.BytesRef;
-
-import java.io.IOException;
-
-import static org.apache.lucene.geo.GeoUtils.orient;
 
 /**
- * A tree reusable reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
+ * A tree reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
  * {@link TriangleTreeWriter}.
  *
- * This class supports checking bounding box
- * relations against the serialized triangle tree.
+ * The tree structure is navigated using a {@link Visitor}.
  *
- * -----------------------------------------
- * |   The binary format of the tree       |
- * -----------------------------------------
- * -----------------------------------------  --
- * |    centroid-x-coord (4 bytes)         |    |
- * -----------------------------------------    |
- * |    centroid-y-coord (4 bytes)         |    |
- * -----------------------------------------    |
- * |    DimensionalShapeType (1 byte)      |    | Centroid-related header
- * -----------------------------------------    |
- * |  Sum of weights (VLong 1-8 bytes)     |    |
- * -----------------------------------------  --
- * |         Extent (var-encoding)         |
- * -----------------------------------------
- * |         Triangle Tree                 |
- * -----------------------------------------
- * -----------------------------------------
  */
-public class TriangleTreeReader {
-    private final ByteArrayDataInput input;
-    private final CoordinateEncoder coordinateEncoder;
-    private final Tile2D tile2D;
-    private final Extent extent;
-    private int treeOffset;
-    private int docValueOffset;
+class TriangleTreeReader {
 
-    public TriangleTreeReader(CoordinateEncoder coordinateEncoder) {
-        this.coordinateEncoder = coordinateEncoder;
-        this.tile2D = new Tile2D();
-        this.extent = new Extent();
-        this.input = new ByteArrayDataInput();
-    }
-
-    public void reset(BytesRef bytesRef) throws IOException {
-        this.input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-        docValueOffset = bytesRef.offset;
-        treeOffset = 0;
+    private TriangleTreeReader() {
     }
 
     /**
-     * returns the bounding box of the geometry in the format [minX, maxX, minY, maxY].
+     * Visit the Triangle tree using the {@link Visitor} provided.
      */
-    public Extent getExtent() {
-        if (treeOffset == 0) {
-            getSumCentroidWeight(); // skip CENTROID_HEADER + var-long sum-weight
-            Extent.readFromCompressed(input, extent);
-            treeOffset = input.getPosition();
-        } else {
-            input.setPosition(treeOffset);
-        }
-        return extent;
+    public static void visit(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor, int thisMaxX, int thisMaxY) {
+        visit(input, visitor, true, thisMaxX, thisMaxY, true);
     }
 
-    /**
-     * returns the X coordinate of the centroid.
-     */
-    public double getCentroidX() {
-        input.setPosition(docValueOffset + 0);
-        return coordinateEncoder.decodeX(input.readInt());
-    }
-
-    /**
-     * returns the Y coordinate of the centroid.
-     */
-    public double getCentroidY() {
-        input.setPosition(docValueOffset + 4);
-        return coordinateEncoder.decodeY(input.readInt());
-    }
-
-    public DimensionalShapeType getDimensionalShapeType() {
-        input.setPosition(docValueOffset + 8);
-        return DimensionalShapeType.readFrom(input);
-    }
-
-    public double getSumCentroidWeight() {
-        input.setPosition(docValueOffset + 9);
-        return Double.longBitsToDouble(input.readVLong());
-    }
-
-    /**
-     * Compute the relation with the provided bounding box. If the result is CELL_INSIDE_QUERY
-     * then the bounding box is within the shape.
-     */
-    public GeoRelation relateTile(int minX, int minY, int maxX, int maxY) {
-        Extent extent = getExtent();
-        int thisMaxX = extent.maxX();
-        int thisMinX = extent.minX();
-        int thisMaxY = extent.maxY();
-        int thisMinY = extent.minY();
-
-        // exclude north and east boundary intersections with tiles from intersection consideration
-        // for consistent tiling definition of shapes on the boundaries of tiles
-        if ((thisMinX >= maxX || thisMaxX < minX || thisMinY > maxY || thisMaxY <= minY)) {
-            // shapes are disjoint
-            return GeoRelation.QUERY_DISJOINT;
-        }
-        if (minX <= thisMinX && maxX >= thisMaxX && minY <= thisMinY && maxY >= thisMaxY) {
-            // the rectangle fully contains the shape
-            return GeoRelation.QUERY_CROSSES;
-        }
-        // quick checks failed, need to traverse the tree
-        GeoRelation rel = GeoRelation.QUERY_DISJOINT;
-        tile2D.setValues(minX, maxX, minY, maxY);
+    private static boolean visit(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor,
+                                 boolean splitX, int thisMaxX, int thisMaxY, boolean isRoot) {
         byte metadata = input.readByte();
+        int thisMinX;
+        int thisMinY;
         if ((metadata & 1 << 2) == 1 << 2) { // component in this node is a point
             int x = Math.toIntExact(thisMaxX - input.readVLong());
             int y = Math.toIntExact(thisMaxY - input.readVLong());
-            if (tile2D.contains(x, y)) {
-                return GeoRelation.QUERY_CROSSES;
+            visitor.visitPoint(x, y);
+            if (visitor.push() == false) {
+                return false;
             }
             thisMinX = x;
-        } else if ((metadata & 1 << 3) == 1 << 3) {  // component in this node is a line
+            thisMinY = y;
+        } else if ((metadata & 1 << 3) == 1 << 3) { // component in this node is a line
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
             int bY = Math.toIntExact(thisMaxY - input.readVLong());
-            if (tile2D.intersectsLine(aX, aY, bX, bY)) {
-                return GeoRelation.QUERY_CROSSES;
+            visitor.visitLine(aX, aY, bX, bY, metadata);
+            if (visitor.push() == false) {
+                return false;
             }
             thisMinX = aX;
-        } else {  // component in this node is a triangle
+            thisMinY = Math.min(aY, bY);
+        } else { // component in this node is a triangle
             int aX = Math.toIntExact(thisMaxX - input.readVLong());
             int aY = Math.toIntExact(thisMaxY - input.readVLong());
             int bX = Math.toIntExact(thisMaxX - input.readVLong());
             int bY = Math.toIntExact(thisMaxY - input.readVLong());
             int cX = Math.toIntExact(thisMaxX - input.readVLong());
             int cY = Math.toIntExact(thisMaxY - input.readVLong());
-            boolean ab = (metadata & 1 << 4) == 1 << 4;
-            boolean bc = (metadata & 1 << 5) == 1 << 5;
-            boolean ca = (metadata & 1 << 6) == 1 << 6;
-            rel = tile2D.relateTriangle(aX, aY, ab, bX, bY, bc, cX, cY, ca);
-            if (rel == GeoRelation.QUERY_CROSSES) {
-                return GeoRelation.QUERY_CROSSES;
+            visitor.visitTriangle(aX, aY, bX, bY, cX, cY, metadata);
+            if (visitor.push() == false) {
+                return false;
             }
             thisMinX = aX;
+            thisMinY = Math.min(Math.min(aY, bY), cY);
         }
         if ((metadata & 1 << 0) == 1 << 0) { // left != null
-            GeoRelation left = relateTile(tile2D, false, thisMaxX, thisMaxY);
-            if (left == GeoRelation.QUERY_CROSSES) {
-                return GeoRelation.QUERY_CROSSES;
-            } else if (left == GeoRelation.QUERY_INSIDE) {
-                rel = left;
+            if (pushLeft(input, visitor, thisMaxX, thisMaxY, splitX) == false) {
+                return false;
             }
         }
         if ((metadata & 1 << 1) == 1 << 1) { // right != null
-            if (tile2D.maxX >= thisMinX) {
-                GeoRelation right = relateTile(tile2D, false, thisMaxX, thisMaxY);
-                if (right == GeoRelation.QUERY_CROSSES) {
-                    return GeoRelation.QUERY_CROSSES;
-                } else if (right == GeoRelation.QUERY_INSIDE) {
-                    rel = right;
-                }
+            // root node does not have a size
+            int rightSize = isRoot ? 0 : input.readVInt();
+            if (pushRight(input, visitor, thisMaxX, thisMaxY, thisMinX, thisMinY, splitX, rightSize) == false) {
+                return false;
             }
         }
-
-        return rel;
+        return visitor.push();
     }
 
-    private GeoRelation relateTile(Tile2D tile2D, boolean splitX, int parentMaxX, int parentMaxY) {
-        int thisMaxX = Math.toIntExact(parentMaxX - input.readVLong());
-        int thisMaxY = Math.toIntExact(parentMaxY - input.readVLong());
-        GeoRelation rel = GeoRelation.QUERY_DISJOINT;
+    private static boolean pushLeft(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor,
+                                    int thisMaxX, int thisMaxY, boolean splitX) {
+        int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
+        int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
-        if (tile2D.minY <= thisMaxY && tile2D.minX <= thisMaxX) {
-            byte metadata = input.readByte();
-            int thisMinX;
-            int thisMinY;
-            if ((metadata & 1 << 2) == 1 << 2) { // component in this node is a point
-                int x = Math.toIntExact(thisMaxX - input.readVLong());
-                int y = Math.toIntExact(thisMaxY - input.readVLong());
-                if (tile2D.contains(x, y)) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                thisMinX = x;
-                thisMinY = y;
-            } else if ((metadata & 1 << 3) == 1 << 3) { // component in this node is a line
-                int aX = Math.toIntExact(thisMaxX - input.readVLong());
-                int aY = Math.toIntExact(thisMaxY - input.readVLong());
-                int bX = Math.toIntExact(thisMaxX - input.readVLong());
-                int bY = Math.toIntExact(thisMaxY - input.readVLong());
-                if (tile2D.intersectsLine(aX, aY, bX, bY)) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                thisMinX = aX;
-                thisMinY = Math.min(aY, bY);
-            } else { // component in this node is a triangle
-                int aX = Math.toIntExact(thisMaxX - input.readVLong());
-                int aY = Math.toIntExact(thisMaxY - input.readVLong());
-                int bX = Math.toIntExact(thisMaxX - input.readVLong());
-                int bY = Math.toIntExact(thisMaxY - input.readVLong());
-                int cX = Math.toIntExact(thisMaxX - input.readVLong());
-                int cY = Math.toIntExact(thisMaxY - input.readVLong());
-                boolean ab = (metadata & 1 << 4) == 1 << 4;
-                boolean bc = (metadata & 1 << 5) == 1 << 5;
-                boolean ca = (metadata & 1 << 6) == 1 << 6;
-                rel = tile2D.relateTriangle(aX, aY, ab, bX, bY, bc, cX, cY, ca);
-                if (rel == GeoRelation.QUERY_CROSSES) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                thisMinX = aX;
-                thisMinY = Math.min(Math.min(aY, bY), cY);
-            }
-            if ((metadata & 1 << 0) == 1 << 0) { // left != null
-                GeoRelation left = relateTile(tile2D, !splitX, thisMaxX, thisMaxY);
-                if (left == GeoRelation.QUERY_CROSSES) {
-                    return GeoRelation.QUERY_CROSSES;
-                } else if (left == GeoRelation.QUERY_INSIDE) {
-                    rel = left;
-                }
-            }
-            if ((metadata & 1 << 1) == 1 << 1) { // right != null
-                int rightSize = input.readVInt();
-                if ((splitX == false && tile2D.maxY >= thisMinY) || (splitX && tile2D.maxX >= thisMinX)) {
-                    GeoRelation right = relateTile(tile2D, !splitX, thisMaxX, thisMaxY);
-                    if (right == GeoRelation.QUERY_CROSSES) {
-                        return GeoRelation.QUERY_CROSSES;
-                    } else if (right == GeoRelation.QUERY_INSIDE) {
-                        rel = right;
-                    }
-                } else {
-                    input.skipBytes(rightSize);
-                }
-            }
+        if (visitor.push(nextMaxX, nextMaxY)) {
+            return visit(input, visitor, !splitX, nextMaxX, nextMaxY, false);
         } else {
             input.skipBytes(size);
+            return visitor.push();
         }
-        return rel;
     }
 
-    private static class Tile2D {
-
-        protected int minX;
-        protected int maxX;
-        protected int minY;
-        protected int maxY;
-
-        Tile2D() {
-        }
-
-        private void setValues(int minX, int maxX, int minY, int maxY) {
-            this.minX = minX;
-            this.maxX = maxX;
-            this.minY = minY;
-            this.maxY = maxY;
-        }
-
-        /**
-         * Checks if the rectangle contains the provided point
-         **/
-        public boolean contains(int x, int y) {
-            return (x <= minX || x > maxX || y < minY || y >= maxY) == false;
-        }
-
-        /**
-         * Checks if the rectangle intersects the provided triangle
-         **/
-        private boolean intersectsLine(int aX, int aY, int bX, int bY) {
-            // 1. query contains any triangle points
-            if (contains(aX, aY) || contains(bX, bY)) {
-                return true;
-            }
-
-            // compute bounding box of triangle
-            int tMinX = StrictMath.min(aX, bX);
-            int tMaxX = StrictMath.max(aX, bX);
-            int tMinY = StrictMath.min(aY, bY);
-            int tMaxY = StrictMath.max(aY, bY);
-
-            // 2. check bounding boxes are disjoint
-            if (tMaxX <= minX || tMinX > maxX || tMinY > maxY || tMaxY <= minY) {
-                return false;
-            }
-
-            // 4. last ditch effort: check crossings
-            if (edgeIntersectsQuery(aX, aY, bX, bY)) {
-                return true;
-            }
-            return false;
-        }
-
-        /**
-         * Checks if the rectangle intersects the provided triangle
-         **/
-        private GeoRelation relateTriangle(int aX, int aY, boolean ab, int bX, int bY, boolean bc, int cX, int cY, boolean ca) {
-            // compute bounding box of triangle
-            int tMinX = StrictMath.min(StrictMath.min(aX, bX), cX);
-            int tMaxX = StrictMath.max(StrictMath.max(aX, bX), cX);
-            int tMinY = StrictMath.min(StrictMath.min(aY, bY), cY);
-            int tMaxY = StrictMath.max(StrictMath.max(aY, bY), cY);
-
-            // 1. check bounding boxes are disjoint, where north and east boundaries are not considered as crossing
-            if (tMaxX <= minX || tMinX > maxX || tMinY > maxY || tMaxY <= minY) {
-                return GeoRelation.QUERY_DISJOINT;
-            }
-
-            // 2. query contains any triangle points
-            if (contains(aX, aY) || contains(bX, bY) || contains(cX, cY)) {
-                return GeoRelation.QUERY_CROSSES;
-            }
-
-            boolean within = false;
-            if (edgeIntersectsQuery(aX, aY, bX, bY)) {
-                if (ab) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                within = true;
-            }
-
-            // right
-            if (edgeIntersectsQuery(bX, bY, cX, cY)) {
-                if (bc) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                within = true;
-            }
-
-            if (edgeIntersectsQuery(cX, cY, aX, aY)) {
-                if (ca) {
-                    return GeoRelation.QUERY_CROSSES;
-                }
-                within = true;
-            }
-
-            if (within || pointInTriangle(tMinX, tMaxX, tMinY, tMaxY, minX, minY, aX, aY, bX, bY, cX, cY)) {
-                return GeoRelation.QUERY_INSIDE;
-            }
-
-            return GeoRelation.QUERY_DISJOINT;
-        }
-
-        /**
-         * returns true if the edge (defined by (ax, ay) (bx, by)) intersects the query
-         */
-        private boolean edgeIntersectsQuery(int ax, int ay, int bx, int by) {
-            // shortcut: check bboxes of edges are disjoint
-            if (boxesAreDisjoint(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by),
-                minX, maxX, minY, maxY)) {
-                return false;
-            }
-
-            // top
-            if (orient(ax, ay, bx, by, minX, maxY) * orient(ax, ay, bx, by, maxX, maxY) <= 0 &&
-                orient(minX, maxY, maxX, maxY, ax, ay) * orient(minX, maxY, maxX, maxY, bx, by) <= 0) {
-                return true;
-            }
-
-            // right
-            if (orient(ax, ay, bx, by, maxX, maxY) * orient(ax, ay, bx, by, maxX, minY) <= 0 &&
-                orient(maxX, maxY, maxX, minY, ax, ay) * orient(maxX, maxY, maxX, minY, bx, by) <= 0) {
-                return true;
-            }
-
-            // bottom
-            if (orient(ax, ay, bx, by, maxX, minY) * orient(ax, ay, bx, by, minX, minY) <= 0 &&
-                orient(maxX, minY, minX, minY, ax, ay) * orient(maxX, minY, minX, minY, bx, by) <= 0) {
-                return true;
-            }
-
-            // left
-            if (orient(ax, ay, bx, by, minX, minY) * orient(ax, ay, bx, by, minX, maxY) <= 0 &&
-                orient(minX, minY, minX, maxY, ax, ay) * orient(minX, minY, minX, maxY, bx, by) <= 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        /**
-         * Compute whether the given x, y point is in a triangle; uses the winding order method
-         */
-        private static boolean pointInTriangle(double minX, double maxX, double minY, double maxY, double x, double y,
-                                               double aX, double aY, double bX, double bY, double cX, double cY) {
-            //check the bounding box because if the triangle is degenerated, e.g points and lines, we need to filter out
-            //coplanar points that are not part of the triangle.
-            if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
-                int a = orient(x, y, aX, aY, bX, bY);
-                int b = orient(x, y, bX, bY, cX, cY);
-                if (a == 0 || b == 0 || a < 0 == b < 0) {
-                    int c = orient(x, y, cX, cY, aX, aY);
-                    return c == 0 || (c < 0 == (b < 0 || a < 0));
-                }
-                return false;
+    private static boolean pushRight(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor, int thisMaxX,
+                                     int thisMaxY, int thisMinX, int thisMinY, boolean splitX, int rightSize) {
+        if ((splitX == false && visitor.pushY(thisMinY)) || (splitX && visitor.pushX(thisMinX))) {
+            int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
+            int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
+            int size = input.readVInt();
+            if (visitor.push(nextMaxX, nextMaxY)) {
+                return visit(input, visitor, !splitX, nextMaxX, nextMaxY, false);
             } else {
-                return false;
+                input.skipBytes(size);
             }
+        } else {
+            input.skipBytes(rightSize);
         }
+        return visitor.push();
+    }
 
-        /**
-         * utility method to check if two boxes are disjoint
-         */
-        private static boolean boxesAreDisjoint(final int aMinX, final int aMaxX, final int aMinY, final int aMaxY,
-                                                final int bMinX, final int bMaxX, final int bMinY, final int bMaxY) {
-            return (aMaxX < bMinX || aMinX > bMaxX || aMaxY < bMinY || aMinY > bMaxY);
-        }
+    /** Visitor for triangle interval tree */
+   interface Visitor {
+
+        /** visit a node point. */
+        void visitPoint(int x, int y);
+
+        /** visit a node line. */
+        void visitLine(int aX, int aY, int bX, int bY, byte metadata);
+
+        /** visit a node triangle. */
+        void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata);
+
+        /** Should the visitor keep visiting the tree. Called after visiting a node or skipping
+         * a tree branch, if the return value is {@code false}, no more nodes will be visited. */
+        boolean push();
+
+        /** Should the visitor visit nodes that have bounds greater or equal
+         * than the {@code minX} provided. */
+        boolean pushX(int minX);
+
+        /** Should the visitor visit nodes that have bounds greater or equal
+         * than the {@code minY} provided. */
+        boolean pushY(int minY);
+
+        /** Should the visitor visit nodes that have bounds lower or equal than the
+         * {@code maxX} and {@code minX} provided. */
+        boolean push(int maxX, int maxY);
+
+        /** Should the visitor visit the tree given the bounding box of the tree. Called before
+         * visiting the tree. */
+        boolean push(int minX, int minY, int maxX, int maxY);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/BinaryGeoShapeDocValuesField.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/BinaryGeoShapeDocValuesField.java
@@ -12,8 +12,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.index.mapper.CustomDocValuesField;
 import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
-import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeCoordinateEncoder;
-import org.elasticsearch.xpack.spatial.index.fielddata.TriangleTreeWriter;
+import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueWriter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,8 +40,8 @@ public class BinaryGeoShapeDocValuesField extends CustomDocValuesField {
     @Override
     public BytesRef binaryValue() {
         try {
-            final TriangleTreeWriter writer = new TriangleTreeWriter(triangles, GeoShapeCoordinateEncoder.INSTANCE, centroidCalculator);
-            ByteBuffersDataOutput output = new ByteBuffersDataOutput();
+            final GeometryDocValueWriter writer = new GeometryDocValueWriter(triangles, CoordinateEncoder.GEO, centroidCalculator);
+            final ByteBuffersDataOutput output = new ByteBuffersDataOutput();
             writer.writeTo(output);
             return new BytesRef(output.toArrayCopy(), 0, Math.toIntExact(output.size()));
         } catch (IOException e) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeCoordinateEncoderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeCoordinateEncoderTests.java
@@ -8,9 +8,7 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeCoordinateEncoder;
 
-import static org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeCoordinateEncoder.INSTANCE;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -22,16 +20,16 @@ public class GeoShapeCoordinateEncoderTests extends ESTestCase {
         double randomInvalidLon = randomFrom(randomDoubleBetween(-1000, -180.01, true),
             randomDoubleBetween(180.01, 1000, true));
 
-        assertThat(INSTANCE.encodeX(Double.POSITIVE_INFINITY), equalTo(Integer.MAX_VALUE));
-        assertThat(INSTANCE.encodeX(Double.NEGATIVE_INFINITY), equalTo(Integer.MIN_VALUE));
-        int encodedLon = INSTANCE.encodeX(randomLon);
+        assertThat(CoordinateEncoder.GEO.encodeX(Double.POSITIVE_INFINITY), equalTo(Integer.MAX_VALUE));
+        assertThat(CoordinateEncoder.GEO.encodeX(Double.NEGATIVE_INFINITY), equalTo(Integer.MIN_VALUE));
+        int encodedLon = CoordinateEncoder.GEO.encodeX(randomLon);
         assertThat(encodedLon, equalTo(GeoEncodingUtils.encodeLongitude(randomLon)));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> GeoShapeCoordinateEncoder.INSTANCE.encodeX(randomInvalidLon));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> CoordinateEncoder.GEO.encodeX(randomInvalidLon));
         assertThat(e.getMessage(), endsWith("must be between -180.0 and 180.0"));
 
-        assertThat(INSTANCE.decodeX(encodedLon), closeTo(randomLon, 0.0001));
-        assertThat(INSTANCE.decodeX(Integer.MAX_VALUE), closeTo(180, 0.00001));
-        assertThat(INSTANCE.decodeX(Integer.MIN_VALUE), closeTo(-180, 0.00001));
+        assertThat(CoordinateEncoder.GEO.decodeX(encodedLon), closeTo(randomLon, 0.0001));
+        assertThat(CoordinateEncoder.GEO.decodeX(Integer.MAX_VALUE), closeTo(180, 0.00001));
+        assertThat(CoordinateEncoder.GEO.decodeX(Integer.MIN_VALUE), closeTo(-180, 0.00001));
     }
 
     public void testLatitude() {
@@ -39,15 +37,15 @@ public class GeoShapeCoordinateEncoderTests extends ESTestCase {
         double randomInvalidLat = randomFrom(randomDoubleBetween(-1000, -90.01, true),
             randomDoubleBetween(90.01, 1000, true));
 
-        assertThat(INSTANCE.encodeY(Double.POSITIVE_INFINITY), equalTo(Integer.MAX_VALUE));
-        assertThat(INSTANCE.encodeY(Double.NEGATIVE_INFINITY), equalTo(Integer.MIN_VALUE));
-        int encodedLat = INSTANCE.encodeY(randomLat);
+        assertThat(CoordinateEncoder.GEO.encodeY(Double.POSITIVE_INFINITY), equalTo(Integer.MAX_VALUE));
+        assertThat(CoordinateEncoder.GEO.encodeY(Double.NEGATIVE_INFINITY), equalTo(Integer.MIN_VALUE));
+        int encodedLat = CoordinateEncoder.GEO.encodeY(randomLat);
         assertThat(encodedLat, equalTo(GeoEncodingUtils.encodeLatitude(randomLat)));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> GeoShapeCoordinateEncoder.INSTANCE.encodeY(randomInvalidLat));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> CoordinateEncoder.GEO.encodeY(randomInvalidLat));
         assertThat(e.getMessage(), endsWith("must be between -90.0 and 90.0"));
 
-        assertThat(INSTANCE.decodeY(encodedLat), closeTo(randomLat, 0.0001));
-        assertThat(INSTANCE.decodeY(Integer.MAX_VALUE), closeTo(90, 0.00001));
-        assertThat(INSTANCE.decodeY(Integer.MIN_VALUE), closeTo(-90, 0.00001));
+        assertThat(CoordinateEncoder.GEO.decodeY(encodedLat), closeTo(randomLat, 0.0001));
+        assertThat(CoordinateEncoder.GEO.decodeY(Integer.MAX_VALUE), closeTo(90, 0.00001));
+        assertThat(CoordinateEncoder.GEO.decodeY(Integer.MIN_VALUE), closeTo(-90, 0.00001));
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.apache.lucene.geo.LatLonGeometry;
+import org.elasticsearch.common.geo.GeoShapeUtils;
+import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.GeometryVisitor;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.geo.GeometryTestUtils.randomLine;
+import static org.elasticsearch.geo.GeometryTestUtils.randomMultiLine;
+import static org.elasticsearch.geo.GeometryTestUtils.randomMultiPoint;
+import static org.elasticsearch.geo.GeometryTestUtils.randomMultiPolygon;
+import static org.elasticsearch.geo.GeometryTestUtils.randomPoint;
+import static org.elasticsearch.geo.GeometryTestUtils.randomPolygon;
+import static org.hamcrest.Matchers.equalTo;
+
+public class GeometryDocValueTests extends ESTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testDimensionalShapeType() throws IOException {
+        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
+        assertDimensionalShapeType(randomPoint(false), DimensionalShapeType.POINT);
+        assertDimensionalShapeType(randomMultiPoint(false), DimensionalShapeType.POINT);
+        assertDimensionalShapeType(randomLine(false), DimensionalShapeType.LINE);
+        assertDimensionalShapeType(randomMultiLine(false), DimensionalShapeType.LINE);
+        Geometry randoPoly = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
+            try {
+                Geometry newGeo = indexer.prepareForIndexing(g);
+                return newGeo.type() != ShapeType.POLYGON;
+            } catch (Exception e) {
+                return true;
+            }
+        }, () -> randomPolygon(false)));
+        Geometry randoMultiPoly = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
+            try {
+                Geometry newGeo = indexer.prepareForIndexing(g);
+                return newGeo.type() != ShapeType.MULTIPOLYGON;
+            } catch (Exception e) {
+                return true;
+            }
+        }, () -> randomMultiPolygon(false)));
+        assertDimensionalShapeType(randoPoly, DimensionalShapeType.POLYGON);
+        assertDimensionalShapeType(randoMultiPoly, DimensionalShapeType.POLYGON);
+        assertDimensionalShapeType(randomFrom(
+            new GeometryCollection<>(List.of(randomPoint(false))),
+            new GeometryCollection<>(List.of(randomMultiPoint(false))),
+            new GeometryCollection<>(Collections.singletonList(
+                new GeometryCollection<>(List.of(randomPoint(false), randomMultiPoint(false))))))
+            , DimensionalShapeType.POINT);
+        assertDimensionalShapeType(randomFrom(
+            new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))),
+            new GeometryCollection<>(List.of(randomMultiPoint(false), randomMultiLine(false))),
+            new GeometryCollection<>(Collections.singletonList(
+                new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))))))
+            , DimensionalShapeType.LINE);
+        assertDimensionalShapeType(randomFrom(
+            new GeometryCollection<>(List.of(randomPoint(false), indexer.prepareForIndexing(randomLine(false)), randoPoly)),
+            new GeometryCollection<>(List.of(randomMultiPoint(false), randoMultiPoly)),
+            new GeometryCollection<>(Collections.singletonList(
+                new GeometryCollection<>(List.of(indexer.prepareForIndexing(randomLine(false)),
+                    indexer.prepareForIndexing(randoPoly))))))
+            , DimensionalShapeType.POLYGON);
+    }
+
+    public void testRectangleShape() throws IOException {
+        for (int i = 0; i < 1000; i++) {
+            int minX = randomIntBetween(-40, -1);
+            int maxX = randomIntBetween(1, 40);
+            int minY = randomIntBetween(-40, -1);
+            int maxY = randomIntBetween(1, 40);
+            Geometry rectangle = new Rectangle(minX, maxX, maxY, minY);
+            GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(rectangle, CoordinateEncoder.GEO);
+
+            Extent expectedExtent  = getExtentFromBox(minX, minY, maxX, maxY);
+            assertThat(expectedExtent, equalTo(reader.getExtent()));
+            // centroid is calculated using original double values but then loses precision as it is serialized as an integer
+            int encodedCentroidX = CoordinateEncoder.GEO.encodeX(((double) minX + maxX) / 2);
+            int encodedCentroidY = CoordinateEncoder.GEO.encodeY(((double) minY + maxY) / 2);
+            assertEquals(encodedCentroidX, reader.getCentroidX());
+            assertEquals(encodedCentroidY, reader.getCentroidY());
+        }
+    }
+
+    private static Extent getExtentFromBox(double bottomLeftX, double bottomLeftY, double topRightX, double topRightY) {
+        return Extent.fromPoints(CoordinateEncoder.GEO.encodeX(bottomLeftX),
+            CoordinateEncoder.GEO.encodeY(bottomLeftY),
+            CoordinateEncoder.GEO.encodeX(topRightX),
+            CoordinateEncoder.GEO.encodeY(topRightY));
+
+    }
+
+    private static void assertDimensionalShapeType(Geometry geometry, DimensionalShapeType expected) throws IOException {
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        assertThat(reader.getDimensionalShapeType(), equalTo(expected));
+    }
+
+    private static LatLonGeometry[] toLuceneGeometry(Geometry geometry) {
+        List<LatLonGeometry> luceneGeometries = new ArrayList<>();
+        geometry.visit(new GeometryVisitor<Void, RuntimeException>() {
+            @Override
+            public Void visit(Circle circle)  {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Void visit(GeometryCollection<?> collection)  {
+                for (Geometry g : collection) {
+                    g.visit(this);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(Line line)  {
+                luceneGeometries.add(GeoShapeUtils.toLuceneLine(line));
+                return null;
+            }
+
+            @Override
+            public Void visit(LinearRing ring)  {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Void visit(MultiLine multiLine) {
+                for(Line line : multiLine) {
+                    visit(line);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(MultiPoint multiPoint) {
+                for(Point point : multiPoint) {
+                    visit(point);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(MultiPolygon multiPolygon)  {
+                for(Polygon polygon : multiPolygon) {
+                    visit(polygon);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(Point point)  {
+                luceneGeometries.add(GeoShapeUtils.toLucenePoint(point));
+                return null;
+            }
+
+            @Override
+            public Void visit(Polygon polygon) {
+                luceneGeometries.add(GeoShapeUtils.toLucenePolygon(polygon));
+                return null;
+            }
+
+            @Override
+            public Void visit(Rectangle rectangle) {
+                luceneGeometries.add(GeoShapeUtils.toLuceneRectangle(rectangle));
+                return null;
+            }
+        });
+        return luceneGeometries.toArray(new LatLonGeometry[luceneGeometries.size()]);
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -66,22 +67,22 @@ public class GeometryDocValueTests extends ESTestCase {
         assertDimensionalShapeType(randoPoly, DimensionalShapeType.POLYGON);
         assertDimensionalShapeType(randoMultiPoly, DimensionalShapeType.POLYGON);
         assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false))),
-            new GeometryCollection<>(List.of(randomMultiPoint(false))),
+            new GeometryCollection<>(Arrays.asList(randomPoint(false))),
+            new GeometryCollection<>(Arrays.asList(randomMultiPoint(false))),
             new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(randomPoint(false), randomMultiPoint(false))))))
+                new GeometryCollection<>(Arrays.asList(randomPoint(false), randomMultiPoint(false))))))
             , DimensionalShapeType.POINT);
         assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))),
-            new GeometryCollection<>(List.of(randomMultiPoint(false), randomMultiLine(false))),
+            new GeometryCollection<>(Arrays.asList(randomPoint(false), randomLine(false))),
+            new GeometryCollection<>(Arrays.asList(randomMultiPoint(false), randomMultiLine(false))),
             new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))))))
+                new GeometryCollection<>(Arrays.asList(randomPoint(false), randomLine(false))))))
             , DimensionalShapeType.LINE);
         assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false), indexer.prepareForIndexing(randomLine(false)), randoPoly)),
-            new GeometryCollection<>(List.of(randomMultiPoint(false), randoMultiPoly)),
+            new GeometryCollection<>(Arrays.asList(randomPoint(false), indexer.prepareForIndexing(randomLine(false)), randoPoly)),
+            new GeometryCollection<>(Arrays.asList(randomMultiPoint(false), randoMultiPoly)),
             new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(indexer.prepareForIndexing(randomLine(false)),
+                new GeometryCollection<>(Arrays.asList(indexer.prepareForIndexing(randomLine(false)),
                     indexer.prepareForIndexing(randoPoly))))))
             , DimensionalShapeType.POLYGON);
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.GeometryVisitor;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.geo.GeometryTestUtils.randomMultiLine;
+import static org.elasticsearch.geo.GeometryTestUtils.randomMultiPolygon;
+import static org.elasticsearch.geo.GeometryTestUtils.randomPoint;
+import static org.hamcrest.Matchers.equalTo;
+
+public class Tile2DVisitorTests extends ESTestCase {
+
+    public void testPacManPolygon() throws Exception {
+        // pacman
+        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10, 0};
+        double[] py = {0, -5, -9, -10, -9, 0, 9, 10, 9, 5, 0};
+
+        // test cell crossing poly
+        Polygon pacMan = new Polygon(new LinearRing(py, px), Collections.emptyList());
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(pacMan, TestCoordinateEncoder.INSTANCE);
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
+        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(-5, -6, 2, -2));
+    }
+
+    // adapted from org.apache.lucene.geo.TestPolygon2D#testMultiPolygon
+    public void testPolygonWithHole() throws Exception {
+        Polygon polyWithHole = new Polygon(new LinearRing(new double[]{-50, 50, 50, -50, -50}, new double[]{-50, -50, 50, 50, -50}),
+            Collections.singletonList(new LinearRing(new double[]{-10, 10, 10, -10, -10}, new double[]{-10, -10, 10, 10, -10})));
+
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
+
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(6, -6, 6, -6)); // in the hole
+        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(25, -25, 25, -25)); // on the mainland
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(51, 51, 52, 52)); // outside of mainland
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-60, -60, 60, 60)); // enclosing us completely
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(49, 49, 51, 51)); // overlapping the mainland
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(9, 9, 11, 11)); // overlapping the hole
+    }
+
+    public void testCombPolygon() throws Exception {
+        double[] px = {0, 10, 10, 20, 20, 30, 30, 40, 40, 50, 50, 0, 0};
+        double[] py = {0, 0, 20, 20, 0, 0, 20, 20, 0, 0, 30, 30, 0};
+
+        double[] hx = {21, 21, 29, 29, 21};
+        double[] hy = {1, 20, 20, 1, 1};
+
+        Polygon polyWithHole = new Polygon(new LinearRing(px, py), Collections.singletonList(new LinearRing(hx, hy)));
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
+        // test cell crossing poly
+        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(5, 10, 5, 10));
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(15, 10, 15, 10));
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(25, 10, 25, 10));
+    }
+
+    public void testPacManClosedLineString() throws Exception {
+        // pacman
+        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10, 0};
+        double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5, 0};
+
+        // test cell crossing poly
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(-5, -6, 2, -2));
+    }
+
+    public void testPacManLineString() throws Exception {
+        // pacman
+        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10};
+        double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5};
+
+        // test cell crossing poly
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
+        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(-5, -6, 2, -2));
+    }
+
+    public void testPacManPoints() throws Exception {
+        // pacman
+        List<Point> points = Arrays.asList(
+            new Point(0, 0),
+            new Point(5, 10),
+            new Point(9, 10),
+            new Point(10, 0),
+            new Point(9, -8),
+            new Point(0, -10),
+            new Point(-9, -8),
+            new Point(-10, 0),
+            new Point(-9, 10),
+            new Point(-5, 10)
+        );
+
+
+        // candidate intersects cell
+        int xMin = 0;
+        int xMax = 11;
+        int yMin = -10;
+        int yMax = 9;
+
+        // test cell crossing poly
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new MultiPoint(points), CoordinateEncoder.GEO);
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(xMin, yMin, xMax, yMax));
+    }
+
+    public void testRandomMultiLineIntersections() throws IOException {
+        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
+        MultiLine geometry = randomMultiLine(false);
+        geometry = (MultiLine) indexer.prepareForIndexing(geometry);
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        Extent readerExtent = reader.getExtent();
+
+        for (Line line : geometry) {
+            Extent lineExtent = GeoTestUtils.GeometryDocValueReader(line, CoordinateEncoder.GEO).getExtent();
+            if (lineExtent.minX() != Integer.MIN_VALUE && lineExtent.maxX() != Integer.MAX_VALUE
+                && lineExtent.minY() != Integer.MIN_VALUE && lineExtent.maxY() != Integer.MAX_VALUE) {
+                assertRelation(GeoRelation.QUERY_CROSSES, reader, Extent.fromPoints(lineExtent.minX() - 1, lineExtent.minY() - 1,
+                    lineExtent.maxX() + 1, lineExtent.maxY() + 1));
+            }
+        }
+
+        // extent that fully encloses the MultiLine
+        assertRelation(GeoRelation.QUERY_CROSSES, reader, reader.getExtent());
+        if (readerExtent.minX() != Integer.MIN_VALUE && readerExtent.maxX() != Integer.MAX_VALUE
+            && readerExtent.minY() != Integer.MIN_VALUE && readerExtent.maxY() != Integer.MAX_VALUE) {
+            assertRelation(GeoRelation.QUERY_CROSSES, reader, Extent.fromPoints(readerExtent.minX() - 1, readerExtent.minY() - 1,
+                readerExtent.maxX() + 1, readerExtent.maxY() + 1));
+        }
+
+    }
+
+    public void testRandomPolygonIntersection() throws IOException {
+        int testPointCount = randomIntBetween(50, 100);
+        Point[] testPoints = new Point[testPointCount];
+        double extentSize = randomDoubleBetween(1, 10, true);
+        boolean[] intersects = new boolean[testPointCount];
+        for (int i = 0; i < testPoints.length; i++) {
+            testPoints[i] = randomPoint(false);
+        }
+
+        Geometry geometry = randomMultiPolygon(false);
+        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
+        Geometry preparedGeometry = indexer.prepareForIndexing(geometry);
+
+        for (int i = 0; i < testPointCount; i++) {
+            int cur = i;
+            intersects[cur] = fold(preparedGeometry, false, (g, s) -> s || intersects(g, testPoints[cur], extentSize));
+        }
+
+        for (int i = 0; i < testPointCount; i++) {
+            assertEquals(intersects[i], intersects(preparedGeometry, testPoints[i], extentSize));
+        }
+    }
+
+    private Extent bufferedExtentFromGeoPoint(double x, double y, double extentSize) {
+        int xMin = CoordinateEncoder.GEO.encodeX(Math.max(x - extentSize, -180.0));
+        int xMax = CoordinateEncoder.GEO.encodeX(Math.min(x + extentSize, 180.0));
+        int yMin = CoordinateEncoder.GEO.encodeY(Math.max(y - extentSize, -90));
+        int yMax = CoordinateEncoder.GEO.encodeY(Math.min(y + extentSize, 90));
+        return Extent.fromPoints(xMin, yMin, xMax, yMax);
+    }
+
+    private static Extent getExtentFromBox(double bottomLeftX, double bottomLeftY, double topRightX, double topRightY) {
+        return Extent.fromPoints(CoordinateEncoder.GEO.encodeX(bottomLeftX),
+            CoordinateEncoder.GEO.encodeY(bottomLeftY),
+            CoordinateEncoder.GEO.encodeX(topRightX),
+            CoordinateEncoder.GEO.encodeY(topRightY));
+
+    }
+
+    private boolean intersects(Geometry g, Point p, double extentSize) throws IOException {
+
+        Extent bufferBounds = bufferedExtentFromGeoPoint(p.getX(), p.getY(), extentSize);
+        Tile2DVisitor tile2DVisitor = new Tile2DVisitor();
+        tile2DVisitor.reset(bufferBounds.minX(), bufferBounds.minY(), bufferBounds.maxX(), bufferBounds.maxY());
+        GeoTestUtils.GeometryDocValueReader(g, CoordinateEncoder.GEO).visit(tile2DVisitor);
+        return tile2DVisitor.relation() == GeoRelation.QUERY_CROSSES || tile2DVisitor.relation() == GeoRelation.QUERY_INSIDE;
+    }
+
+
+    /**
+     * Preforms left fold operation on all primitive geometries (points, lines polygons, circles and rectangles).
+     * All collection geometries are iterated depth first.
+     */
+    public static <R, E extends Exception> R fold(Geometry geometry, R state, CheckedBiFunction<Geometry, R, R, E> operation) throws E {
+        return geometry.visit(new GeometryVisitor<R, E>() {
+            @Override
+            public R visit(Circle circle) throws E {
+                return operation.apply(geometry, state);
+            }
+
+            @Override
+            public R visit(GeometryCollection<?> collection) throws E {
+                R ret = state;
+                for (Geometry g : collection) {
+                    ret = fold(g, ret, operation);
+                }
+                return ret;
+            }
+
+            @Override
+            public R visit(Line line) throws E {
+                return operation.apply(line, state);
+            }
+
+            @Override
+            public R visit(LinearRing ring) throws E {
+                return operation.apply(ring, state);
+            }
+
+            @Override
+            public R visit(MultiLine multiLine) throws E {
+                return visit((GeometryCollection<?>) multiLine);
+            }
+
+            @Override
+            public R visit(MultiPoint multiPoint) throws E {
+                return visit((GeometryCollection<?>) multiPoint);            }
+
+            @Override
+            public R visit(MultiPolygon multiPolygon) throws E {
+                return visit((GeometryCollection<?>) multiPolygon);
+            }
+
+            @Override
+            public R visit(Point point) throws E {
+                return operation.apply(point, state);
+            }
+
+            @Override
+            public R visit(Polygon polygon) throws E {
+                return operation.apply(polygon, state);
+            }
+
+            @Override
+            public R visit(Rectangle rectangle) throws E {
+                return operation.apply(rectangle, state);
+            }
+        });
+    }
+
+    static void assertRelation(GeoRelation expectedRelation, GeometryDocValueReader reader, Extent extent) {
+        Tile2DVisitor tile2DVisitor = new Tile2DVisitor();
+        tile2DVisitor.reset(extent.minX(), extent.minY(), extent.maxX(), extent.maxY());
+        reader.visit(tile2DVisitor);
+        assertThat(expectedRelation, equalTo(tile2DVisitor.relation()));
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
@@ -6,431 +6,69 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.elasticsearch.common.collect.List;
 import org.apache.lucene.document.ShapeField;
-import org.apache.lucene.store.ByteBuffersDataOutput;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.geo.GeometryTestUtils;
-import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.geometry.GeometryCollection;
-import org.elasticsearch.geometry.GeometryVisitor;
-import org.elasticsearch.geometry.Line;
-import org.elasticsearch.geometry.LinearRing;
-import org.elasticsearch.geometry.MultiLine;
-import org.elasticsearch.geometry.MultiPoint;
-import org.elasticsearch.geometry.MultiPolygon;
-import org.elasticsearch.geometry.Point;
-import org.elasticsearch.geometry.Polygon;
-import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.geometry.ShapeType;
-import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.function.Function;
 
-import static org.elasticsearch.geo.GeometryTestUtils.randomLine;
-import static org.elasticsearch.geo.GeometryTestUtils.randomMultiLine;
-import static org.elasticsearch.geo.GeometryTestUtils.randomMultiPoint;
-import static org.elasticsearch.geo.GeometryTestUtils.randomMultiPolygon;
-import static org.elasticsearch.geo.GeometryTestUtils.randomPoint;
-import static org.elasticsearch.geo.GeometryTestUtils.randomPolygon;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TriangleTreeTests extends ESTestCase {
 
-    @SuppressWarnings("unchecked")
-    public void testDimensionalShapeType() throws IOException {
-        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
-        assertDimensionalShapeType(randomPoint(false), DimensionalShapeType.POINT);
-        assertDimensionalShapeType(randomMultiPoint(false), DimensionalShapeType.POINT);
-        assertDimensionalShapeType(randomLine(false), DimensionalShapeType.LINE);
-        assertDimensionalShapeType(randomMultiLine(false), DimensionalShapeType.LINE);
-        Geometry randoPoly = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
-            try {
-                Geometry newGeo = indexer.prepareForIndexing(g);
-                return newGeo.type() != ShapeType.POLYGON;
-            } catch (Exception e) {
-                return true;
-            }
-        }, () -> randomPolygon(false)));
-        Geometry randoMultiPoly = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
-            try {
-                Geometry newGeo = indexer.prepareForIndexing(g);
-                return newGeo.type() != ShapeType.MULTIPOLYGON;
-            } catch (Exception e) {
-                return true;
-            }
-        }, () -> randomMultiPolygon(false)));
-        assertDimensionalShapeType(randoPoly, DimensionalShapeType.POLYGON);
-        assertDimensionalShapeType(randoMultiPoly, DimensionalShapeType.POLYGON);
-        assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false))),
-            new GeometryCollection<>(List.of(randomMultiPoint(false))),
-            new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(randomPoint(false), randomMultiPoint(false))))))
-            , DimensionalShapeType.POINT);
-        assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))),
-            new GeometryCollection<>(List.of(randomMultiPoint(false), randomMultiLine(false))),
-            new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(randomPoint(false), randomLine(false))))))
-            , DimensionalShapeType.LINE);
-        assertDimensionalShapeType(randomFrom(
-            new GeometryCollection<>(List.of(randomPoint(false), indexer.prepareForIndexing(randomLine(false)), randoPoly)),
-            new GeometryCollection<>(List.of(randomMultiPoint(false), randoMultiPoly)),
-            new GeometryCollection<>(Collections.singletonList(
-                new GeometryCollection<>(List.of(indexer.prepareForIndexing(randomLine(false)),
-                    indexer.prepareForIndexing(randoPoly))))))
-            , DimensionalShapeType.POLYGON);
-    }
-
-
-    public void testRectangleShape() throws IOException {
-        for (int i = 0; i < 1000; i++) {
-            int minX = randomIntBetween(-40, -1);
-            int maxX = randomIntBetween(1, 40);
-            int minY = randomIntBetween(-40, -1);
-            int maxY = randomIntBetween(1, 40);
-            Geometry rectangle = new Rectangle(minX, maxX, maxY, minY);
-            TriangleTreeReader reader = triangleTreeReader(rectangle, GeoShapeCoordinateEncoder.INSTANCE);
-
-            Extent expectedExtent  = getExtentFromBox(minX, minY, maxX, maxY);
-            assertThat(expectedExtent, equalTo(reader.getExtent()));
-            // centroid is calculated using original double values but then loses precision as it is serialized as an integer
-            int encodedCentroidX = GeoShapeCoordinateEncoder.INSTANCE.encodeX(((double) minX + maxX) / 2);
-            int encodedCentroidY = GeoShapeCoordinateEncoder.INSTANCE.encodeY(((double) minY + maxY) / 2);
-            assertEquals(GeoShapeCoordinateEncoder.INSTANCE.decodeX(encodedCentroidX), reader.getCentroidX(), 0.0000001);
-            assertEquals(GeoShapeCoordinateEncoder.INSTANCE.decodeY(encodedCentroidY), reader.getCentroidY(), 0.0000001);
-
-            // box-query touches bottom-left corner
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(minX - randomIntBetween(1, 180 + minX),
-                minY - randomIntBetween(1, 90 + minY), minX, minY));
-            // box-query touches bottom-right corner
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(maxX, minY - randomIntBetween(1, 90 + minY),
-                maxX + randomIntBetween(1, 180 - maxX), minY));
-            // box-query touches top-right corner
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(maxX, maxY, maxX + randomIntBetween(1, 180 - maxX),
-                maxY + randomIntBetween(1, 90 - maxY)));
-            // box-query touches top-left corner
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(minX - randomIntBetween(1, 180 + minX), maxY, minX,
-                maxY + randomIntBetween(1, 90 - maxY)));
-
-            // box-query fully-enclosed inside rectangle
-            assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(3 * (minX + maxX) / 4, 3 * (minY + maxY) / 4,
-                3 * (maxX + minX) / 4, 3 * (maxY + minY) / 4));
-            // box-query fully-contains poly
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(minX - randomIntBetween(1, 180 + minX),
-                minY - randomIntBetween(1, 90 + minY), maxX + randomIntBetween(1, 180 - maxX),
-                maxY + randomIntBetween(1, 90 - maxY)));
-            // box-query half-in-half-out-right
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(3 * (minX + maxX) / 4, 3 * (minY + maxY) / 4,
-                maxX + randomIntBetween(1, 90 - maxY), 3 * (maxY + minY) / 4));
-            // box-query half-in-half-out-left
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(minX - randomIntBetween(1, 180 + minX),
-                3 * (minY + maxY) / 4, 3 * (maxX + minX) / 4, 3 * (maxY + minY) / 4));
-            // box-query half-in-half-out-top
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(3 * (minX + maxX) / 4, 3 * (minY + maxY) / 4,
-                maxX + randomIntBetween(1, 180 - maxX), maxY + randomIntBetween(1, 90 - maxY)));
-            // box-query half-in-half-out-bottom
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(3 * (minX + maxX) / 4,
-                minY - randomIntBetween(1, 90 + minY), maxX + randomIntBetween(1, 180 - maxX),
-                3 * (maxY + minY) / 4));
-
-            // box-query outside to the right
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(maxX + randomIntBetween(1, 180 - maxX), minY,
-                maxX + randomIntBetween(1, 180 - maxX), maxY));
-            // box-query outside to the left
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(maxX - randomIntBetween(1, 180 - maxX), minY,
-                minX - randomIntBetween(1, 180 + minX), maxY));
-            // box-query outside to the top
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(minX, maxY + randomIntBetween(1, 90 - maxY), maxX,
-                maxY + randomIntBetween(1, 90 - maxY)));
-            // box-query outside to the bottom
-            assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(minX, minY - randomIntBetween(1, 90 + minY), maxX,
-                minY - randomIntBetween(1, 90 + minY)));
-        }
-    }
-
-    public void testPacManPolygon() throws Exception {
-        // pacman
-        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10, 0};
-        double[] py = {0, -5, -9, -10, -9, 0, 9, 10, 9, 5, 0};
-
-        // test cell crossing poly
-        Polygon pacMan = new Polygon(new LinearRing(py, px), Collections.emptyList());
-        TriangleTreeReader reader = triangleTreeReader(pacMan, TestCoordinateEncoder.INSTANCE);
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
-        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(-5, -6, 2, -2));
-    }
-
-    // adapted from org.apache.lucene.geo.TestPolygon2D#testMultiPolygon
-    public void testPolygonWithHole() throws Exception {
-        Polygon polyWithHole = new Polygon(new LinearRing(new double[]{-50, 50, 50, -50, -50}, new double[]{-50, -50, 50, 50, -50}),
-            Collections.singletonList(new LinearRing(new double[]{-10, 10, 10, -10, -10}, new double[]{-10, -10, 10, 10, -10})));
-
-        TriangleTreeReader reader = triangleTreeReader(polyWithHole, GeoShapeCoordinateEncoder.INSTANCE);
-
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(6, -6, 6, -6)); // in the hole
-        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(25, -25, 25, -25)); // on the mainland
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(51, 51, 52, 52)); // outside of mainland
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-60, -60, 60, 60)); // enclosing us completely
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(49, 49, 51, 51)); // overlapping the mainland
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(9, 9, 11, 11)); // overlapping the hole
-    }
-
-    public void testCombPolygon() throws Exception {
-        double[] px = {0, 10, 10, 20, 20, 30, 30, 40, 40, 50, 50, 0, 0};
-        double[] py = {0, 0, 20, 20, 0, 0, 20, 20, 0, 0, 30, 30, 0};
-
-        double[] hx = {21, 21, 29, 29, 21};
-        double[] hy = {1, 20, 20, 1, 1};
-
-        Polygon polyWithHole = new Polygon(new LinearRing(px, py), Collections.singletonList(new LinearRing(hx, hy)));
-        TriangleTreeReader reader = triangleTreeReader(polyWithHole, GeoShapeCoordinateEncoder.INSTANCE);
-        // test cell crossing poly
-        assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(5, 10, 5, 10));
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(15, 10, 15, 10));
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(25, 10, 25, 10));
-    }
-
-    public void testPacManClosedLineString() throws Exception {
-        // pacman
-        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10, 0};
-        double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5, 0};
-
-        // test cell crossing poly
-        TriangleTreeReader reader = triangleTreeReader(new Line(px, py), GeoShapeCoordinateEncoder.INSTANCE);
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(-5, -6, 2, -2));
-    }
-
-    public void testPacManLineString() throws Exception {
-        // pacman
-        double[] px = {0, 10, 10, 0, -8, -10, -8, 0, 10, 10};
-        double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5};
-
-        // test cell crossing poly
-        TriangleTreeReader reader = triangleTreeReader(new Line(px, py), GeoShapeCoordinateEncoder.INSTANCE);
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
-        assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(-5, -6, 2, -2));
-    }
-
-    public void testPacManPoints() throws Exception {
-        // pacman
-        java.util.List<Point> points = Arrays.asList(
-            new Point(0, 0),
-            new Point(5, 10),
-            new Point(9, 10),
-            new Point(10, 0),
-            new Point(9, -8),
-            new Point(0, -10),
-            new Point(-9, -8),
-            new Point(-10, 0),
-            new Point(-9, 10),
-            new Point(-5, 10)
-        );
-
-
-        // candidate intersects cell
-        int xMin = 0;
-        int xMax = 11;
-        int yMin = -10;
-        int yMax = 9;
-
-        // test cell crossing poly
-        TriangleTreeReader reader = triangleTreeReader(new MultiPoint(points), GeoShapeCoordinateEncoder.INSTANCE);
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(xMin, yMin, xMax, yMax));
-    }
-
-    public void testRandomMultiLineIntersections() throws IOException {
-        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
-        MultiLine geometry = randomMultiLine(false);
-        geometry = (MultiLine) indexer.prepareForIndexing(geometry);
-        TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
-        Extent readerExtent = reader.getExtent();
-
-        for (Line line : geometry) {
-            Extent lineExtent = triangleTreeReader(line, GeoShapeCoordinateEncoder.INSTANCE).getExtent();
-            if (lineExtent.minX() != Integer.MIN_VALUE && lineExtent.maxX() != Integer.MAX_VALUE
-                && lineExtent.minY() != Integer.MIN_VALUE && lineExtent.maxY() != Integer.MAX_VALUE) {
-                assertRelation(GeoRelation.QUERY_CROSSES, reader, Extent.fromPoints(lineExtent.minX() - 1, lineExtent.minY() - 1,
-                    lineExtent.maxX() + 1, lineExtent.maxY() + 1));
-            }
-        }
-
-        // extent that fully encloses the MultiLine
-        assertRelation(GeoRelation.QUERY_CROSSES, reader, reader.getExtent());
-        if (readerExtent.minX() != Integer.MIN_VALUE && readerExtent.maxX() != Integer.MAX_VALUE
-            && readerExtent.minY() != Integer.MIN_VALUE && readerExtent.maxY() != Integer.MAX_VALUE) {
-            assertRelation(GeoRelation.QUERY_CROSSES, reader, Extent.fromPoints(readerExtent.minX() - 1, readerExtent.minY() - 1,
-                readerExtent.maxX() + 1, readerExtent.maxY() + 1));
-        }
-
-    }
-
-    public void testRandomPolygonIntersection() throws IOException {
-        int testPointCount = randomIntBetween(50, 100);
-        Point[] testPoints = new Point[testPointCount];
-        double extentSize = randomDoubleBetween(1, 10, true);
-        boolean[] intersects = new boolean[testPointCount];
-        for (int i = 0; i < testPoints.length; i++) {
-            testPoints[i] = randomPoint(false);
-        }
-
-        Geometry geometry = randomMultiPolygon(false);
-        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
-        Geometry preparedGeometry = indexer.prepareForIndexing(geometry);
-
-        for (int i = 0; i < testPointCount; i++) {
-            int cur = i;
-            intersects[cur] = fold(preparedGeometry, false, (g, s) -> s || intersects(g, testPoints[cur], extentSize));
-        }
-
-        for (int i = 0; i < testPointCount; i++) {
-            assertEquals(intersects[i], intersects(preparedGeometry, testPoints[i], extentSize));
-        }
-    }
-
-    private Extent bufferedExtentFromGeoPoint(double x, double y, double extentSize) {
-        int xMin = GeoShapeCoordinateEncoder.INSTANCE.encodeX(Math.max(x - extentSize, -180.0));
-        int xMax = GeoShapeCoordinateEncoder.INSTANCE.encodeX(Math.min(x + extentSize, 180.0));
-        int yMin = GeoShapeCoordinateEncoder.INSTANCE.encodeY(Math.max(y - extentSize, -90));
-        int yMax = GeoShapeCoordinateEncoder.INSTANCE.encodeY(Math.min(y + extentSize, 90));
-        return Extent.fromPoints(xMin, yMin, xMax, yMax);
-    }
-
-    private static Extent getExtentFromBox(double bottomLeftX, double bottomLeftY, double topRightX, double topRightY) {
-        return Extent.fromPoints(GeoShapeCoordinateEncoder.INSTANCE.encodeX(bottomLeftX),
-            GeoShapeCoordinateEncoder.INSTANCE.encodeY(bottomLeftY),
-            GeoShapeCoordinateEncoder.INSTANCE.encodeX(topRightX),
-            GeoShapeCoordinateEncoder.INSTANCE.encodeY(topRightY));
-
-    }
-
-    private boolean intersects(Geometry g, Point p, double extentSize) throws IOException {
-
-        Extent bufferBounds = bufferedExtentFromGeoPoint(p.getX(), p.getY(), extentSize);
-        GeoRelation relation = triangleTreeReader(g, GeoShapeCoordinateEncoder.INSTANCE)
-            .relateTile(bufferBounds.minX(), bufferBounds.minY(), bufferBounds.maxX(), bufferBounds.maxY());
-        return relation == GeoRelation.QUERY_CROSSES || relation == GeoRelation.QUERY_INSIDE;
-    }
-
-    private static Geometry randomGeometryTreeGeometry() {
-        return randomGeometryTreeGeometry(0);
-    }
-
-    private static Geometry randomGeometryTreeGeometry(int level) {
-        @SuppressWarnings("unchecked") Function<Boolean, Geometry> geometry = ESTestCase.randomFrom(
-            GeometryTestUtils::randomLine,
-            GeometryTestUtils::randomPoint,
-            GeometryTestUtils::randomPolygon,
-            GeometryTestUtils::randomMultiLine,
-            GeometryTestUtils::randomMultiPoint,
-            level < 3 ? (b) -> randomGeometryTreeCollection(level + 1) : GeometryTestUtils::randomPoint // don't build too deep
-        );
-        return geometry.apply(false);
-    }
-
-    private static Geometry randomGeometryTreeCollection(int level) {
-        int size = ESTestCase.randomIntBetween(1, 10);
-        java.util.List<Geometry> shapes = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            shapes.add(randomGeometryTreeGeometry(level));
-        }
-        return new GeometryCollection<>(shapes);
-    }
-
-    private static void assertDimensionalShapeType(Geometry geometry, DimensionalShapeType expected) throws IOException {
-        TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
-        assertThat(reader.getDimensionalShapeType(), equalTo(expected));
-    }
-
-    /**
-     * Preforms left fold operation on all primitive geometries (points, lines polygons, circles and rectangles).
-     * All collection geometries are iterated depth first.
-     */
-    public static <R, E extends Exception> R fold(Geometry geometry, R state, CheckedBiFunction<Geometry, R, R, E> operation) throws E {
-        return geometry.visit(new GeometryVisitor<R, E>() {
-            @Override
-            public R visit(Circle circle) throws E {
-                return operation.apply(geometry, state);
-            }
-
-            @Override
-            public R visit(GeometryCollection<?> collection) throws E {
-                R ret = state;
-                for (Geometry g : collection) {
-                    ret = fold(g, ret, operation);
-                }
-                return ret;
-            }
-
-            @Override
-            public R visit(Line line) throws E {
-                return operation.apply(line, state);
-            }
-
-            @Override
-            public R visit(LinearRing ring) throws E {
-                return operation.apply(ring, state);
-            }
-
-            @Override
-            public R visit(MultiLine multiLine) throws E {
-                return visit((GeometryCollection<?>) multiLine);
-            }
-
-            @Override
-            public R visit(MultiPoint multiPoint) throws E {
-                return visit((GeometryCollection<?>) multiPoint);            }
-
-            @Override
-            public R visit(MultiPolygon multiPolygon) throws E {
-                return visit((GeometryCollection<?>) multiPolygon);
-            }
-
-            @Override
-            public R visit(Point point) throws E {
-                return operation.apply(point, state);
-            }
-
-            @Override
-            public R visit(Polygon polygon) throws E {
-                return operation.apply(polygon, state);
-            }
-
-            @Override
-            public R visit(Rectangle rectangle) throws E {
-                return operation.apply(rectangle, state);
-            }
-        });
-    }
-
-    static void assertRelation(GeoRelation expectedRelation, TriangleTreeReader reader, Extent extent) throws IOException {
-        GeoRelation actualRelation = reader.relateTile(extent.minX(), extent.minY(), extent.maxX(), extent.maxY());
-        assertThat(actualRelation, equalTo(expectedRelation));
-    }
-
-    static TriangleTreeReader triangleTreeReader(Geometry geometry, CoordinateEncoder encoder) throws IOException {
+    public void testVisitAllTriangles() throws IOException {
+        Geometry geometry = GeometryTestUtils.randomGeometryWithoutCircle(randomIntBetween(1, 10), false);
         ShapeField.DecodedTriangle[] triangles = GeoTestUtils.toDecodedTriangles(geometry);
-        TriangleTreeWriter writer = new TriangleTreeWriter(Arrays.asList(triangles), encoder, new CentroidCalculator(geometry));
-        ByteBuffersDataOutput output = new ByteBuffersDataOutput();
-        writer.writeTo(output);
-        TriangleTreeReader reader = new TriangleTreeReader(encoder);
-        reader.reset(new BytesRef(output.toArrayCopy(), 0, Math.toIntExact(output.size())));
-        return reader;
+        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, TestCoordinateEncoder.INSTANCE);
+        TriangleCounterVisitor visitor = new TriangleCounterVisitor();
+        reader.visit(visitor);
+        assertThat(triangles.length, equalTo(visitor.counter));
+    }
+
+    private static class TriangleCounterVisitor implements TriangleTreeReader.Visitor  {
+
+        int counter;
+
+        @Override
+        public void visitPoint(int x, int y) {
+            counter++;
+        }
+
+        @Override
+        public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
+            counter++;
+        }
+
+        @Override
+        public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
+            counter++;
+        }
+
+        @Override
+        public boolean push() {
+            return true;
+        }
+
+        @Override
+        public boolean pushX(int minX) {
+            return true;
+        }
+
+        @Override
+        public boolean pushY(int minY) {
+            return true;
+        }
+
+        @Override
+        public boolean push(int maxX, int maxY) {
+            return true;
+        }
+
+        @Override
+        public boolean push(int minX, int minY, int maxX, int maxY) {
+            return true;
+        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -27,10 +27,10 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueReader;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeCoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
-import org.elasticsearch.xpack.spatial.index.fielddata.TriangleTreeReader;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import static org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils.
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.encodeDecodeLat;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.encodeDecodeLon;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.randomBBox;
-import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.triangleTreeReader;
+import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.GeometryDocValueReader;
 import static org.hamcrest.Matchers.equalTo;
 
 public class GeoGridTilerTests extends ESTestCase {
@@ -63,9 +63,8 @@ public class GeoGridTilerTests extends ESTestCase {
         Rectangle tile = GeoTileUtils.toBoundingBox(1309, 3166, 13);
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
-        TriangleTreeReader reader = triangleTreeReader(shapeRectangle, GeoShapeCoordinateEncoder.INSTANCE);
-        MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
-
+        GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
+        MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
         // test shape within tile bounds
         {
             GeoShapeCellValues values = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
@@ -116,7 +115,7 @@ public class GeoGridTilerTests extends ESTestCase {
                 }
             }, () -> boxToGeo(randomBBox())));
 
-            TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
+            GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
             GeoBoundingBox geoBoundingBox = randomBBox();
             MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues cellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
@@ -143,7 +142,7 @@ public class GeoGridTilerTests extends ESTestCase {
                 }
             }, () -> boxToGeo(randomBBox())));
 
-            TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
+            GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
             MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
@@ -176,7 +175,7 @@ public class GeoGridTilerTests extends ESTestCase {
             if (point.getX() == GeoUtils.MAX_LON || point.getY() == -LATITUDE_MASK) {
                 continue;
             }
-            TriangleTreeReader reader = triangleTreeReader(point, GeoShapeCoordinateEncoder.INSTANCE);
+            GeometryDocValueReader reader = GeometryDocValueReader(point, CoordinateEncoder.GEO);
             MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
@@ -197,7 +196,7 @@ public class GeoGridTilerTests extends ESTestCase {
 
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
-        TriangleTreeReader reader = triangleTreeReader(shapeRectangle, GeoShapeCoordinateEncoder.INSTANCE);
+        GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
         MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
 
         // test shape within tile bounds
@@ -316,7 +315,7 @@ public class GeoGridTilerTests extends ESTestCase {
         int precision = randomIntBetween(1, 4);
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
-        TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
+        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
         MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
         int recursiveCount;
@@ -346,7 +345,7 @@ public class GeoGridTilerTests extends ESTestCase {
         int precision = randomIntBetween(1, 3);
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
-        TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
+        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
         MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOHASH, NOOP_BREAKER);
         int recursiveCount;
@@ -467,7 +466,7 @@ public class GeoGridTilerTests extends ESTestCase {
     private void testCircuitBreaker(GeoGridTiler tiler) throws IOException {
         Geometry geometry = GeometryTestUtils.randomPolygon(false);
         int precision = randomIntBetween(0, 3);
-        TriangleTreeReader reader = triangleTreeReader(geometry, GeoShapeCoordinateEncoder.INSTANCE);
+        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
         MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
 
         List<Long> byteChangeHistory = new ArrayList<>();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -37,9 +37,10 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
+import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueReader;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeCoordinateEncoder;
-import org.elasticsearch.xpack.spatial.index.fielddata.TriangleTreeReader;
+import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
@@ -57,7 +58,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.randomBBox;
-import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.triangleTreeReader;
+import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.GeometryDocValueReader;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>> extends AggregatorTestCase {
@@ -187,19 +188,15 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             double y = GeoTestUtils.encodeDecodeLat(p.getY());
             Rectangle pointTile = getTile(x, y, precision);
 
-
-            TriangleTreeReader reader = triangleTreeReader(p, GeoShapeCoordinateEncoder.INSTANCE);
-            GeoRelation tileRelation = reader.relateTile(GeoShapeCoordinateEncoder.INSTANCE.encodeX(pointTile.getMinX()),
-                GeoShapeCoordinateEncoder.INSTANCE.encodeY(pointTile.getMinY()),
-                GeoShapeCoordinateEncoder.INSTANCE.encodeX(pointTile.getMaxX()),
-                GeoShapeCoordinateEncoder.INSTANCE.encodeY(pointTile.getMaxY()));
+            GeometryDocValueReader reader = GeometryDocValueReader(p, CoordinateEncoder.GEO);
+            MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+            GeoRelation tileRelation =  value.relate(pointTile);
             boolean intersectsBounds = boundsTop >= pointTile.getMinY() && boundsBottom <= pointTile.getMaxY()
                 && (boundsEastLeft <= pointTile.getMaxX() && boundsEastRight >= pointTile.getMinX()
                 || (crossesDateline && boundsWestLeft <= pointTile.getMaxX() && boundsWestRight >= pointTile.getMinX()));
             if (tileRelation != GeoRelation.QUERY_DISJOINT && intersectsBounds) {
                 numDocsWithin += 1;
             }
-
 
             points.add(p);
             docs.add(new BinaryGeoShapeDocValuesField(FIELD_NAME,


### PR DESCRIPTION
GeoShape doc values are stored as an interval tree of triangles. Currently the only implementation that uses this structure is the tile aggregation with a custom implementation. In order to add more functionality to this data structure, we should add a visitor pattern.

backport #63333