### PR TITLE
[7.10] [DOCS] Remove 7.9.3 coming tag (#64057)

### DIFF
--- a/docs/reference/release-notes/7.9.asciidoc
+++ b/docs/reference/release-notes/7.9.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.9.3]]
 == {es} version 7.9.3
 
-coming[7.9.3]
-
 Also see <<breaking-changes-7.9,Breaking changes in 7.9>>.
 
 [[bug-7.9.3]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Remove 7.9.3 coming tag (#64057)