### PR TITLE
[DOCS] Fix cache setting name in 7.9 migration docs

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -59,8 +59,8 @@ set per-context.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of the `script.cache.max_size`
-setting. You may use `script.context.$CONTEXT.context_max_size` for the particular context.
-For example, for the `ingest` context, use `script.context.ingest.context_max_size`.
+setting. You may use `script.context.$CONTEXT.cache_max_size` for the particular context.
+For example, for the `ingest` context, use `script.context.ingest.cache_max_size`.
 
 ====
 


### PR DESCRIPTION
The setting name is script.context.$CONTEXT.cache_max_size rather than
script.context.$CONTEXT.context_max_size.
