### PR TITLE
[7.10] [DOCS] Fix cache setting name in 7.9 migration docs (#64063)

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -59,8 +59,8 @@ set per-context.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of the `script.cache.max_size`
-setting. You may use `script.context.$CONTEXT.context_max_size` for the particular context.
-For example, for the `ingest` context, use `script.context.ingest.context_max_size`.
+setting. You may use `script.context.$CONTEXT.cache_max_size` for the particular context.
+For example, for the `ingest` context, use `script.context.ingest.cache_max_size`.
 
 ====
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix cache setting name in 7.9 migration docs (#64063)