### PR TITLE
[DOCS] Fix `ignore_unavailable` param in get index and get alias APIs

### DIFF
--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -50,7 +50,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `all`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, requests that include a missing index in the `<index>` argument
+return an error. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -46,7 +46,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-defaults]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, requests that target a missing index return an error. Defaults to
+`false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 


### PR DESCRIPTION
Previously, the definitions statd `ignore_unavailable` also affected closed indices. This also clarifies the get index alias API definition to indicate `ignore_unavailable` only targets the `<index>` request parameter.

Closes #63607