### PR TITLE
[7.9] [DOCS] Fix `ignore_unavailable` param in get index and get alias APIs (#64075)

### DIFF
--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -50,7 +50,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `all`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, requests that include a missing index in the `<index>` argument
+return an error. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -53,7 +53,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-defaults]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-type-name]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+`ignore_unavailable`::
+(Optional, boolean)
+If `false`, requests that target a missing index return an error. Defaults to
+`false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fix `ignore_unavailable` param in get index and get alias APIs (#64075)