### PR TITLE
Heap Size MUST be set to the same min and max

### DIFF
--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -7,8 +7,9 @@ to ensure that Elasticsearch has enough heap available.
 
 Elasticsearch will assign the entire heap specified in
 <<jvm-options,jvm.options>> via the `Xms` (minimum heap size) and `Xmx` (maximum
-heap size) settings. You should set these two settings to be equal to each
-other.
+heap size) settings. You must set these two settings to be equal to each other
+for a multi-node cluster. You should set these settings to be equal in all
+environments.
 
 The value for these settings depends on the amount of RAM available on your
 server:

--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -7,9 +7,7 @@ to ensure that Elasticsearch has enough heap available.
 
 Elasticsearch will assign the entire heap specified in
 <<jvm-options,jvm.options>> via the `Xms` (minimum heap size) and `Xmx` (maximum
-heap size) settings. You must set these two settings to be equal to each other
-for a multi-node cluster. You should set these settings to be equal in all
-environments.
+heap size) settings. These two settings must be equal to each other.
 
 The value for these settings depends on the amount of RAM available on your
 server:


### PR DESCRIPTION
https://discuss.elastic.co/t/memory-xmx-and-xms-should-be-the-same-how-severely-should-we-heed-this-recommendation/252737

It sounds like there are some use-cases for non-production usage where you wouldn't? Or developers of Elasticsearch itself might not? But in production multi-node, it's basically that you "must".

We observed that in a single-node environment, you might happen to work around the bootstrap check.

Can we get a backport to the 6.x docs also? They look different from the 7.x docs, which makes people think that the "should" recommendation is different, when in fact it hasn't changed.
