### PR TITLE
Compute polygon orientation using signed area

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
@@ -154,7 +154,8 @@ public class GeoPolygonDecomposer {
         }
         if (signedArea == 0) {
             // Points are collinear or self-intersection
-            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
+            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0." +
+                " Points are collinear or polygon self-intersects.");
         }
         boolean orientation = signedArea < 0;
 

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.lucene.geo.GeoUtils.orient;
 import static org.elasticsearch.common.geo.GeoUtils.normalizeLat;
 import static org.elasticsearch.common.geo.GeoUtils.normalizeLon;
 
@@ -190,45 +189,17 @@ public class GeoPolygonDecomposer {
      * @return whether the points are clockwise (true) or anticlockwise (false)
      */
     private static boolean getOrientation(Point[] points, int offset, int length) {
-        // calculate the direction of the points: find the southernmost point
-        // and check its neighbors orientation.
-
-        final int top = top(points, offset, length);
-        final int prev = (top + length - 1) % length;
-        final int next = (top + 1) % length;
-
-        final int determinantSign = orient(
-            points[offset + prev].getX(), points[offset + prev].getY(),
-            points[offset + top].getX(), points[offset + top].getY(),
-            points[offset + next].getX(), points[offset + next].getY());
-
-        if (determinantSign == 0) {
-            // Points are collinear, but `top` is not in the middle if so, so the edges either side of `top` are intersecting.
-            throw new InvalidShapeException("Cannot determine orientation: edges adjacent to ("
-                + points[offset + top].getX() + "," + points[offset + top].getY() + ") coincide");
+        // calculate the signed area of the points:
+        double determinantSign = 0;
+        for (int i = offset; i < offset + length; i++ ) {
+            determinantSign += points[i].getX() * points[i + 1].getY() - points[i].getY() * points[i + 1].getX();
         }
-
+        if (determinantSign == 0) {
+            // Points are collinear or self-intersection
+            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
+        }
         return determinantSign < 0;
     }
-
-    /**
-     * @return the (offset) index of the point that is furthest west amongst
-     * those points that are the furthest south in the set.
-     */
-    private static int top(Point[] points, int offset, int length) {
-        int top = 0; // we start at 1 here since top points to 0
-        for (int i = 1; i < length; i++) {
-            if (points[offset + i].getY() < points[offset + top].getY()) {
-                top = i;
-            } else if (points[offset + i].getY() == points[offset + top].getY()) {
-                if (points[offset + i].getX() < points[offset + top].getX()) {
-                    top = i;
-                }
-            }
-        }
-        return top;
-    }
-
 
     private static double[] range(Point[] points, int offset, int length) {
         double minX = points[0].getX();

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
@@ -144,17 +144,27 @@ public class GeoPolygonDecomposer {
      */
     private static Edge[] ring(int component, boolean direction, boolean handedness,
                         Point[] points, int offset, Edge[] edges, int toffset, int length, final AtomicBoolean translated) {
-
-        boolean orientation = getOrientation(points, offset, length);
+        double signedArea = 0;
+        double minX = Double.POSITIVE_INFINITY;
+        double maxX = Double.NEGATIVE_INFINITY;
+        for (int i = offset; i < offset + length; i++) {
+            signedArea += points[i].getX() * points[i + 1].getY() - points[i].getY() * points[i + 1].getX();
+            minX = Math.min(minX, points[i].getX());
+            maxX = Math.max(maxX, points[i].getX());
+        }
+        if (signedArea == 0) {
+            // Points are collinear or self-intersection
+            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
+        }
+        boolean orientation = signedArea < 0;
 
         // OGC requires shell as ccw (Right-Handedness) and holes as cw (Left-Handedness)
         // since GeoJSON doesn't specify (and doesn't need to) GEO core will assume OGC standards
         // thus if orientation is computed as cw, the logic will translate points across dateline
         // and convert to a right handed system
 
-        // compute the bounding box and calculate range
-        double[] range = range(points, offset, length);
-        final double rng = range[1] - range[0];
+        // calculate range
+        final double rng = maxX - minX;
         // translate the points if the following is true
         //   1.  shell orientation is cw and range is greater than a hemisphere (180 degrees) but not spanning 2 hemispheres
         //       (translation would result in a collapsed poly)
@@ -183,46 +193,6 @@ public class GeoPolygonDecomposer {
                 points[i] = new Point(points[i].getX() + 2 * DATELINE, points[i].getY());
             }
         }
-    }
-
-    /**
-     * @return whether the points are clockwise (true) or anticlockwise (false)
-     */
-    private static boolean getOrientation(Point[] points, int offset, int length) {
-        // calculate the signed area of the points:
-        double determinantSign = 0;
-        for (int i = offset; i < offset + length; i++ ) {
-            determinantSign += points[i].getX() * points[i + 1].getY() - points[i].getY() * points[i + 1].getX();
-        }
-        if (determinantSign == 0) {
-            // Points are collinear or self-intersection
-            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
-        }
-        return determinantSign < 0;
-    }
-
-    private static double[] range(Point[] points, int offset, int length) {
-        double minX = points[0].getX();
-        double maxX = minX;
-        double minY = points[0].getY();
-        double maxY = minY;
-        // compute the bounding coordinates (@todo: cleanup brute force)
-        for (int i = 1; i < length; ++i) {
-            Point point = points[offset + i];
-            if (point.getX() < minX) {
-                minX = point.getX();
-            }
-            if (point.getX() > maxX) {
-                maxX = point.getX();
-            }
-            if (point.getY() < minY) {
-                minY = point.getY();
-            }
-            if (point.getY() > maxY) {
-                maxY = point.getY();
-            }
-        }
-        return new double[]{minX, maxX, minY, maxY};
     }
 
     private static int merge(Edge[] intersections, int offset, int length, Edge[] holes, int numHoles) {

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
@@ -676,17 +676,27 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.elasticsearch.
      */
     private static Edge[] ring(int component, boolean direction, boolean handedness,
                                  Coordinate[] points, int offset, Edge[] edges, int toffset, int length, final AtomicBoolean translated) {
-
-        boolean orientation = getOrientation(points, offset, length);
+        double signedArea = 0;
+        double minX = Double.POSITIVE_INFINITY;
+        double maxX = Double.NEGATIVE_INFINITY;
+        for (int i = offset; i < offset + length; i++) {
+            signedArea += points[i].x * points[i + 1].y - points[i].y * points[i + 1].x;
+            minX = Math.min(minX, points[i].x);
+            maxX = Math.max(maxX, points[i].x);
+        }
+        if (signedArea == 0) {
+            // Points are collinear or self-intersection
+            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
+        }
+        boolean orientation = signedArea < 0;
 
         // OGC requires shell as ccw (Right-Handedness) and holes as cw (Left-Handedness)
         // since GeoJSON doesn't specify (and doesn't need to) GEO core will assume OGC standards
         // thus if orientation is computed as cw, the logic will translate points across dateline
         // and convert to a right handed system
 
-        // compute the bounding box and calculate range
-        double[] range = range(points, offset, length);
-        final double rng = range[1] - range[0];
+        // calculate range
+        final double rng = maxX - minX;
         // translate the points if the following is true
         //   1.  shell orientation is cw and range is greater than a hemisphere (180 degrees) but not spanning 2 hemispheres
         //       (translation would result in a collapsed poly)
@@ -704,47 +714,6 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.elasticsearch.
             }
         }
         return concat(component, direction ^ orientation, points, offset, edges, toffset, length);
-    }
-
-    /**
-     * @return whether the points are clockwise (true) or anticlockwise (false)
-     */
-    private static boolean getOrientation(Coordinate[] points, int offset, int length) {
-        // calculate the signed area of the points:
-        double determinantSign = 0;
-        for (int i = offset; i < offset + length; i++) {
-            determinantSign += points[i].x * points[i + 1].y - points[i].y * points[i + 1].x;
-        }
-
-        if (determinantSign == 0) {
-            // Points are collinear
-            throw new InvalidShapeException("Cannot determine orientation: signed area equal to 0");
-        }
-
-        return determinantSign < 0;
-    }
-
-    private static double[] range(Coordinate[] points, int offset, int length) {
-        double minX = points[0].x;
-        double maxX = points[0].x;
-        double minY = points[0].y;
-        double maxY = points[0].y;
-        // compute the bounding coordinates (@todo: cleanup brute force)
-        for (int i = 1; i < length; ++i) {
-            if (points[offset + i].x < minX) {
-                minX = points[offset + i].x;
-            }
-            if (points[offset + i].x > maxX) {
-                maxX = points[offset + i].x;
-            }
-            if (points[offset + i].y < minY) {
-                minY = points[offset + i].y;
-            }
-            if (points[offset + i].y > maxY) {
-                maxY = points[offset + i].y;
-            }
-        }
-        return new double[] {minX, maxX, minY, maxY};
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
@@ -370,6 +370,19 @@ public class GeometryIndexerTests extends ESTestCase {
         assertThat(e.getMessage(), not(containsString("NaN")));
     }
 
+    public void testCrossingDateline() {
+        Polygon polygon = new Polygon(new LinearRing(
+            new double[]{170, -170, -170, 170, 170}, new double[]{-10, -10, 10, 10, -10}
+        ));
+        Geometry geometry = indexer.prepareForIndexing(polygon);
+        assertTrue(geometry instanceof MultiPolygon);
+        polygon = new Polygon(new LinearRing(
+            new double[]{180, -170, -170, 170, 180}, new double[]{-10, -5, 15, -15, -10}
+        ));
+        geometry = indexer.prepareForIndexing(polygon);
+        assertTrue(geometry instanceof MultiPolygon);
+    }
+
     private XContentBuilder polygon(Boolean orientation, double... val) throws IOException {
         XContentBuilder pointGeoJson = XContentFactory.jsonBuilder().startObject();
         {

--- a/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -248,7 +248,7 @@ public class ShapeBuilderTests extends ESTestCase {
                     .coordinate(-40.0, -50.0)
                     .coordinate(40.0, -50.0).close());
         Exception e = expectThrows(InvalidShapeException.class, () -> newPolygon.buildS4J());
-        assertThat(e.getMessage(), containsString("Self-intersection at or near point (0.0"));
+        assertThat(e.getMessage(), containsString("Cannot determine orientation: signed area equal to 0"));
     }
 
     /** note: only supported by S4J at the moment */


### PR DESCRIPTION
We currently relay in the  southernmost point of a polygon ring to compute the orientation of the polygon. This might lead to wrong results if the point neighbours cross the dateline. This commit changes the computation by using the signed area of the polygon ring.

closes #26286