### PR TITLE
[DOCS] Fix glossary formatting

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -4,20 +4,21 @@
 
 [glossary]
 [[glossary-analysis]] analysis ::
-
++
+--
 Analysis is the process of converting <<glossary-text,full text>> to
 <<glossary-term,terms>>. Depending on which analyzer is used, these phrases:
 `FOO BAR`, `Foo-Bar`, `foo,bar` will probably all result in the
 terms `foo` and `bar`. These terms are what is actually stored in
 the index.
-+
+
 A full text query (not a <<glossary-term,term>> query) for `FoO:bAR` will
 also be analyzed to the terms `foo`,`bar` and will thus match the
 terms stored in the index.
-+
+
 It is this process of analysis (both at index time and at search time)
 that allows Elasticsearch to perform full text queries.
-+
+
 Also see <<glossary-text,text>> and <<glossary-term,term>>.
 // end::analysis-def[]
 --
@@ -70,17 +71,12 @@ The {ccs} feature enables any node to act as a federated client across
 multiple clusters. See <<modules-cross-cluster-search>>.
 
 [[glossary-data-stream]] data stream ::
-+
---
 // tag::data-stream-def[]
 A named resource used to ingest, search, and manage time series data in {es}. A
 data stream's data is stored across multiple hidden, auto-generated
 <<glossary-index,indices>>. You can automate management of these indices to more
-efficiently store large data volumes.
-
-See {ref}/data-streams.html[Data streams].
+efficiently store large data volumes. See {ref}/data-streams.html[Data streams].
 // end::data-stream-def[]
---
 
 [[glossary-delete-phase]] delete phase ::
 // tag::delete-phase-def[]
@@ -197,13 +193,11 @@ An optimized collection of JSON documents. Each document is a collection of fiel
 the key-value pairs that contain your data.
 // end::index-def-short[]
 
-An index is like a _table_ in a relational database. It has a
-<<glossary-mapping,mapping>> which contains a <<glossary-type,type>>,
-which contains the <<glossary-field,fields>> in the index.
-+
 An index is a logical namespace which maps to one or more
 <<glossary-primary-shard,primary shards>> and can have zero or more
 <<glossary-replica-shard,replica shards>>.
+// end::index-def[]
+--
 
 [[glossary-index-alias]] index alias ::
 +

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -6,6 +6,7 @@
 [[glossary-analysis]] analysis ::
 +
 --
+// tag::analysis-def[]
 Analysis is the process of converting <<glossary-text,full text>> to
 <<glossary-term,terms>>. Depending on which analyzer is used, these phrases:
 `FOO BAR`, `Foo-Bar`, `foo,bar` will probably all result in the

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -72,12 +72,17 @@ The {ccs} feature enables any node to act as a federated client across
 multiple clusters. See <<modules-cross-cluster-search>>.
 
 [[glossary-data-stream]] data stream ::
++
+--
 // tag::data-stream-def[]
 A named resource used to ingest, search, and manage time series data in {es}. A
 data stream's data is stored across multiple hidden, auto-generated
 <<glossary-index,indices>>. You can automate management of these indices to more
-efficiently store large data volumes. See {ref}/data-streams.html[Data streams].
+efficiently store large data volumes.
+
+See {ref}/data-streams.html[Data streams].
 // end::data-stream-def[]
+--
 
 [[glossary-delete-phase]] delete phase ::
 // tag::delete-phase-def[]


### PR DESCRIPTION
Fixes the glossary formatting for the `data streams` and `index` entries.