### PR TITLE
Fix Expected Exception Check in BlobstoreCacheService (#63474)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
@@ -251,10 +251,13 @@ public class BlobStoreCacheService {
     }
 
     private static boolean isExpectedCacheGetException(Exception e) {
-        return TransportActions.isShardNotAvailableException(e)
+        if (TransportActions.isShardNotAvailableException(e)
             || e instanceof ConnectTransportException
-            || e instanceof ClusterBlockException
-            || ExceptionsHelper.unwrapCause(e) instanceof NodeClosedException;
+            || e instanceof ClusterBlockException) {
+            return true;
+        }
+        final Throwable cause = ExceptionsHelper.unwrapCause(e);
+        return cause instanceof NodeClosedException || cause instanceof ConnectTransportException;
     }
 
     public void putAsync(String repository, String name, String path, long offset, BytesReference content, ActionListener<Void> listener) {


### PR DESCRIPTION
The `NodeNotConnectedException` exception can be nested as well in the
fairly unlikley case of the disconnect occuring between the connected check
and actually sending the request in the transport service.

Closes #63233

backport of #63474 