### PR TITLE
[7.x] Mute SearchableSnapshotDirectoryTests testClearCache (#64137)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -652,6 +652,7 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/64136")
     public void testClearCache() throws Exception {
         try (CacheService cacheService = TestUtils.createDefaultCacheService()) {
             cacheService.start();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mute SearchableSnapshotDirectoryTests testClearCache (#64137)