### PR TITLE
Search - fixed Nullpointer in significant text agg when field does not exist

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -436,6 +436,9 @@ buildRestTests.setups['news'] = '''
                   type: keyword
                 content:
                   type: text
+                  copy_to: custom_all
+                custom_all:
+                  type: text
   - do:
         bulk:
           index: news

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -81,9 +81,11 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
                                                 Map<String, Object> metadata) throws IOException {
         super(name, context, parent, subFactoriesBuilder, metadata);
 
-        // Note that if the field is unmapped (its field type is null), we don't fail,
-        // and just use the given field name as a placeholder.
         this.fieldType = context.getFieldType(fieldName);
+        if (fieldType == null ) {
+            throw new IllegalArgumentException("Field [" + fieldName + "] does not exist, SignificantText " +
+                "requires an analyzed field");
+        }        
         if (fieldType != null && fieldType.indexAnalyzer() == null) {
             throw new IllegalArgumentException("Field [" + fieldType.name() + "] has no analyzer, but SignificantText " +
                 "requires an analyzed field");

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -31,7 +31,6 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
@@ -43,13 +42,11 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
 import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
-import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
@@ -159,7 +156,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             indexDocuments(w);
 
-            SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "this_field_does_not_exist").filterDuplicateText(true);
+            SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "this_field_does_not_exist")
+                .filterDuplicateText(true);
             if(randomBoolean()){
                 sigAgg.sourceFieldNames(Arrays.asList(new String [] {"json_only_field"}));
             }
@@ -172,7 +170,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 
                 IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                     () ->  searchAndReduce(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType));
-                assertThat(e.getMessage(), equalTo("Field [this_field_does_not_exist] does not exist, SignificantText requires an analyzed field"));
+                assertThat(e.getMessage(), equalTo("Field [this_field_does_not_exist] does not exist, SignificantText "
+                    + "requires an analyzed field"));
             }
         }
     }


### PR DESCRIPTION
Constructor now rejects null field type. Added test
Closes #64045 