### PR TITLE
Unmute SearchableSnapshotDirectoryTests (#64140)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -652,7 +652,6 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/64136")
     public void testClearCache() throws Exception {
         try (CacheService cacheService = TestUtils.createDefaultCacheService()) {
             cacheService.start();


### PR DESCRIPTION
This was already fixed in #64100

Closes #64136

backport of #64140 