### PR TITLE
[DOCS] Note that the wildcard field supports the null_value parameter

### DIFF
--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -58,6 +58,11 @@ The following parameters are accepted by `wildcard` fields:
 
 [horizontal]
 
+<<null-value,`null_value`>>::
+
+    Accepts a string value which is substituted for any explicit `null`
+    values.  Defaults to `null`, which means the field is treated as missing.
+
 <<ignore-above,`ignore_above`>>::
 
     Do not index any string longer than this value.  Defaults to `2147483647`


### PR DESCRIPTION
I was doing some testing on an Elastic Cloud instance running 7.9.2, and discovered that the value of the `null_value` parameter is stored, but it's not documented. I copied the definition of the parameter from [keyword.asciidoc](https://github.com/elastic/elasticsearch/blob/7dd08c6292cfa740a33fef77ed82363d3cb26b6c/docs/reference/mapping/types/keyword.asciidoc).

Example:

```
PUT /test-wildcard-null-value
{
  "mappings": {
    "properties": {
      "name": {
        "type": "wildcard",
        "null_value": "mynilvalue"
      }
    }
  }
}

GET /test-wildcard-null-value/_mapping
```

This was added in https://github.com/elastic/elasticsearch/issues/55701