### PR TITLE
Search - fixed Nullpointer in significant text agg when field does not exist

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -432,6 +432,9 @@ buildRestTests.setups['news'] = '''
                   type: keyword
                 content:
                   type: text
+                  copy_to: custom_all
+                custom_all:
+                  type: text
   - do:
         bulk:
           index: news

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -81,9 +81,11 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
                                                 Map<String, Object> metadata) throws IOException {
         super(name, context, parent, subFactoriesBuilder, metadata);
 
-        // Note that if the field is unmapped (its field type is null), we don't fail,
-        // and just use the given field name as a placeholder.
         this.fieldType = context.getFieldType(fieldName);
+        if (fieldType == null ) {
+            throw new IllegalArgumentException("Field [" + fieldName + "] does not exist, SignificantText " +
+                "requires an analyzed field");
+        }        
         if (fieldType != null && fieldType.indexAnalyzer() == null) {
             throw new IllegalArgumentException("Field [" + fieldType.name() + "] has no analyzer, but SignificantText " +
                 "requires an analyzed field");

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantText;
+import static org.hamcrest.Matchers.equalTo;
 
 public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
@@ -144,6 +145,37 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    
+    public void testMissingField() throws IOException {
+        TextFieldType textFieldType = new TextFieldType("text");
+        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
+
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100);
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+            indexDocuments(w);
+
+            SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "this_field_does_not_exist")
+                .filterDuplicateText(true);
+            if(randomBoolean()){
+                sigAgg.sourceFieldNames(Arrays.asList(new String [] {"json_only_field"}));
+            }
+            SamplerAggregationBuilder aggBuilder = new SamplerAggregationBuilder("sampler")
+                    .subAggregation(sigAgg);
+
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () ->  searchAndReduce(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType));
+                assertThat(e.getMessage(), equalTo("Field [this_field_does_not_exist] does not exist, SignificantText "
+                    + "requires an analyzed field"));
+            }
+        }
+    }
+    
     public void testFieldAlias() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));


### PR DESCRIPTION
Backport (#64144)

Fixed Nullpointer in significant text agg - added test
Closes #64045
