### PR TITLE
Fix Broken Clone Snapshot CS Update (#64116)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -558,7 +558,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public TimeValue timeout() {
-                initializingClones.remove(snapshot);
                 return request.masterNodeTimeout();
             }
         }, "clone_snapshot [" + request.source() + "][" + snapshotName + ']', listener::onFailure);


### PR DESCRIPTION
We must not remove the snapshot from the initializing set
in the `timeout` getter. This was a plain oversight/mistake
and went unnoticed. It can lead to the removal of a valid
snapshot clone from the cluster state in rare circumstances
(e.g. when a node concurrently joins the cluster or a routing
change happens as it did in the linked test failure).

Closes #64115

backport of #64116 