### PR TITLE
XPack Usage should run on MANAGEMENT threads

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -17,6 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackFeatureSet.Usage;
 import org.elasticsearch.xpack.core.common.IteratingActionListener;
@@ -69,12 +71,14 @@ public class TransportXPackUsageAction extends TransportMasterNodeAction<XPackUs
         final AtomicReferenceArray<Usage> featureSetUsages = new AtomicReferenceArray<>(featureSets.size());
         final AtomicInteger position = new AtomicInteger(0);
         final BiConsumer<XPackFeatureSet, ActionListener<List<Usage>>> consumer = (featureSet, iteratingListener) -> {
+            assert Transports.assertNotTransportThread("calculating usage can be more expensive than we allow on transport threads");
             featureSet.usage(new ActionListener<Usage>() {
                 @Override
                 public void onResponse(Usage usage) {
                     featureSetUsages.set(position.getAndIncrement(), usage);
                     // the value sent back doesn't matter since our predicate keeps iterating
-                    iteratingListener.onResponse(Collections.emptyList());
+                    ActionRunnable<?> invokeListener = ActionRunnable.supply(iteratingListener, Collections::emptyList);
+                    threadPool.executor(ThreadPool.Names.MANAGEMENT).execute(invokeListener);
                 }
 
                 @Override


### PR DESCRIPTION
XPack usage starts out on management threads, but depending on the
implementation of the usage plugin, they could end up running on
transport threads instead. Fixed to always reschedule on a management
thread.

This looks vastly different in master, where each feature usage check has it's own
transport action, correctly handling threading, therefore this only targets 7.x.