### PR TITLE
Remove Expression specific alias tests (#64065)

### DIFF
--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
@@ -60,8 +60,7 @@ public class ExpressionFieldScriptTests extends ESTestCase {
         when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
-        lookup = new SearchLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null,
-            (ignored, lookup) -> fieldData, null);
+        lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData, null);
     }
 
     private FieldScript.LeafFactory compile(String expression) {
@@ -85,14 +84,6 @@ public class ExpressionFieldScriptTests extends ESTestCase {
 
     public void testFieldAccess() throws IOException {
         FieldScript script = compile("doc['field'].value").newInstance(null);
-        script.setDocument(1);
-
-        Object result = script.execute();
-        assertThat(result, equalTo(2.718));
-    }
-
-    public void testFieldAccessWithFieldAlias() throws IOException {
-        FieldScript script = compile("doc['alias'].value").newInstance(null);
         script.setDocument(1);
 
         Object result = script.execute();

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
@@ -59,8 +59,7 @@ public class ExpressionNumberSortScriptTests extends ESTestCase {
         when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
-        lookup = new SearchLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null,
-            (ignored, lookup) -> fieldData, null);
+        lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData, null);
     }
 
     private NumberSortScript.LeafFactory compile(String expression) {
@@ -85,14 +84,6 @@ public class ExpressionNumberSortScriptTests extends ESTestCase {
 
     public void testFieldAccess() throws IOException {
         NumberSortScript script = compile("doc['field'].value").newInstance(null);
-        script.setDocument(1);
-
-        double result = script.execute();
-        assertEquals(2.718, result, 0.0);
-    }
-
-    public void testFieldAccessWithFieldAlias() throws IOException {
-        NumberSortScript script = compile("doc['alias'].value").newInstance(null);
         script.setDocument(1);
 
         double result = script.execute();

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
@@ -59,8 +59,7 @@ public class ExpressionTermsSetQueryTests extends ESTestCase {
         when(fieldData.load(anyObject())).thenReturn(atomicFieldData);
 
         service = new ExpressionScriptEngine();
-        lookup = new SearchLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null,
-            (ignored, lookup) -> fieldData, null);
+        lookup = new SearchLookup(field -> field.equals("field") ? fieldType : null, (ignored, lookup) -> fieldData, null);
     }
 
     private TermsSetQueryScript.LeafFactory compile(String expression) {
@@ -85,14 +84,6 @@ public class ExpressionTermsSetQueryTests extends ESTestCase {
 
     public void testFieldAccess() throws IOException {
         TermsSetQueryScript script = compile("doc['field'].value").newInstance(null);
-        script.setDocument(1);
-
-        double result = script.execute().doubleValue();
-        assertEquals(2.718, result, 0.0);
-    }
-
-    public void testFieldAccessWithFieldAlias() throws IOException {
-        TermsSetQueryScript script = compile("doc['alias'].value").newInstance(null);
         script.setDocument(1);
 
         double result = script.execute().doubleValue();

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -47,8 +47,11 @@ public class LeafDocLookupTests extends ESTestCase {
         docValues = mock(ScriptDocValues.class);
         IndexFieldData<?> fieldData = createFieldData(docValues);
 
-        docLookup = new LeafDocLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null,
-            ignored -> fieldData, new String[] { "type" }, null);
+        docLookup = new LeafDocLookup(
+            field -> field.equals("field") || field.equals("alias") || field.equals("_type") ? fieldType : null,
+            ignored -> fieldData,
+            new String[]{"type"},
+            null);
     }
 
     public void testBasicLookup() {

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -45,18 +44,11 @@ public class LeafDocLookupTests extends ESTestCase {
         when(fieldType.name()).thenReturn("field");
         when(fieldType.valueForDisplay(anyObject())).then(returnsFirstArg());
 
-        MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fieldType("_type")).thenReturn(fieldType);
-        when(mapperService.fieldType("field")).thenReturn(fieldType);
-        when(mapperService.fieldType("alias")).thenReturn(fieldType);
-
         docValues = mock(ScriptDocValues.class);
         IndexFieldData<?> fieldData = createFieldData(docValues);
 
-        docLookup = new LeafDocLookup(mapperService::fieldType,
-            ignored -> fieldData,
-            new String[] { "type" },
-            null);
+        docLookup = new LeafDocLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null,
+            ignored -> fieldData, new String[] { "type" }, null);
     }
 
     public void testBasicLookup() {


### PR DESCRIPTION
Backport of #64065

There is no longer a reason to have specific unit tests for looking up field aliases in Expression, especially as the field type lookup function is mocked. Such tests can be removed.

Also, there was a leftover usage of a mocked MapperService to feed a LeafDocLookup which is also removed.

