### PR TITLE
Don't Generate an Index Setting History UUID unless it's Supported

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -24,10 +24,6 @@ setup:
 ---
 "Create a snapshot and then restore it":
 
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/64152"
-
   - do:
       snapshot.create:
         repository: test_repo_restore_1


### PR DESCRIPTION
In 7.x we can't just by default generate this setting as it might not be
supported by data nodes (was only introduced in 7.9 in https://github.com/elastic/elasticsearch/pull/56930) that are assigned shards for an older version in mixed version clusters.

Closes #64152

