### PR TITLE
Simplify CacheFile acquire and release Methods (#64139)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -39,21 +39,18 @@ public class CacheFileTests extends ESTestCase {
         assertThat("Cache file is not acquired: file does not exist", Files.exists(file), is(false));
 
         final TestEvictionListener listener = new TestEvictionListener();
-        boolean acquired = cacheFile.acquire(listener);
-        assertThat("Cache file has been acquired", acquired, is(true));
+        cacheFile.acquire(listener);
         assertThat("Cache file has been acquired: file should exists", Files.exists(file), is(true));
         assertThat("Cache file has been acquired: channel should exists", cacheFile.getChannel(), notNullValue());
         assertThat("Cache file has been acquired: channel is open", cacheFile.getChannel().isOpen(), is(true));
         assertThat("Cache file has been acquired: eviction listener is not executed", listener.isCalled(), is(false));
 
-        boolean released = cacheFile.release(listener);
-        assertThat("Cache file has been released", released, is(true));
+        cacheFile.release(listener);
         assertThat("Cache file has been released: eviction listener is not executed", listener.isCalled(), is(false));
         assertThat("Cache file has been released: channel does not exist", cacheFile.getChannel(), nullValue());
         assertThat("Cache file is not evicted: file still exists after release", Files.exists(file), is(true));
 
-        acquired = cacheFile.acquire(listener);
-        assertThat("Cache file is acquired again", acquired, is(true));
+        cacheFile.acquire(listener);
 
         FileChannel fileChannel = cacheFile.getChannel();
         assertThat("Channel should exists", fileChannel, notNullValue());
@@ -68,8 +65,7 @@ public class CacheFileTests extends ESTestCase {
         assertThat("Cache file is evicted but not fully released: channel is open", cacheFile.getChannel().isOpen(), is(true));
         assertThat("Channel didn't change after eviction", cacheFile.getChannel(), sameInstance(fileChannel));
 
-        released = cacheFile.release(listener);
-        assertTrue("Cache file is fully released", released);
+        cacheFile.release(listener);
         assertThat("Cache file evicted and fully released: channel does not exist", cacheFile.getChannel(), nullValue());
         assertThat("Cache file has been deleted", Files.exists(file), is(false));
     }
@@ -83,14 +79,12 @@ public class CacheFileTests extends ESTestCase {
 
         if (randomBoolean()) {
             final TestEvictionListener listener = new TestEvictionListener();
-            boolean acquired = cacheFile.acquire(listener);
-            assertTrue("Cache file is acquired", acquired);
+            cacheFile.acquire(listener);
 
             assertThat(cacheFile.getChannel(), notNullValue());
             assertThat(Files.exists(file), is(true));
 
-            boolean released = cacheFile.release(listener);
-            assertTrue("Cache file is released", released);
+            cacheFile.release(listener);
         }
 
         cacheFile.startEviction();
@@ -105,7 +99,7 @@ public class CacheFileTests extends ESTestCase {
         final List<TestEvictionListener> acquiredListeners = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 20); i++) {
             TestEvictionListener listener = new TestEvictionListener();
-            assertTrue(cacheFile.acquire(listener));
+            cacheFile.acquire(listener);
             assertThat(cacheFile.getChannel(), notNullValue());
             acquiredListeners.add(listener);
         }
@@ -135,7 +129,7 @@ public class CacheFileTests extends ESTestCase {
         final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file);
 
         final TestEvictionListener evictionListener = new TestEvictionListener();
-        assertTrue(cacheFile.acquire(evictionListener));
+        cacheFile.acquire(evictionListener);
         final long length = cacheFile.getLength();
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(
             builder().put(NODE_NAME_SETTING.getKey(), getTestName()).build(),


### PR DESCRIPTION
Follow up to #63911 making these methods either work out
or throw an already closed exception and resulting possible simplifications.

backport of #64139 