### PR TITLE
Return the same point in time in search response

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -544,6 +544,8 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     boolean buildPointInTimeFromSearchResults() {
+        // TODO: Until we implement the retry mechanism for point in times (i.e., replace an unavailable shard with an equivalent copy),
+        // we can simply return the point in time of the search request.
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -260,7 +260,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     }
 
                     @Override
-                    boolean includeSearchContextInResponse() {
+                    boolean buildPointInTimeFromSearchResults() {
                         return includeSearchContext;
                     }
                 };

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/search/PointInTimeIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/search/PointInTimeIT.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -131,7 +132,7 @@ public class PointInTimeIT extends ESIntegTestCase {
             assertNoFailures(resp);
             assertHitCount(resp, numDocs);
             assertNotNull(resp.pointInTimeId());
-            pitId = resp.pointInTimeId();
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
             int moreDocs = randomIntBetween(10, 50);
             for (int i = 0; i < moreDocs; i++) {
                 String id = "more-" + i;
@@ -147,7 +148,7 @@ public class PointInTimeIT extends ESIntegTestCase {
             assertNoFailures(resp);
             assertHitCount(resp, numDocs);
             assertNotNull(resp.pointInTimeId());
-            pitId = resp.pointInTimeId();
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
         } finally {
             closePointInTime(pitId);
         }
@@ -170,10 +171,7 @@ public class PointInTimeIT extends ESIntegTestCase {
                 .get();
             assertNoFailures(resp);
             assertHitCount(resp, numDocs);
-            assertNotNull(resp.pointInTimeId());
-            if (randomBoolean()) {
-                pitId = resp.pointInTimeId();
-            }
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
             final Set<String> dataNodes = StreamSupport.stream(clusterService().state().nodes().getDataNodes().spliterator(), false)
                 .map(e -> e.value.getId()).collect(Collectors.toSet());
             final List<String> excludedNodes = randomSubsetOf(2, dataNodes);
@@ -192,10 +190,7 @@ public class PointInTimeIT extends ESIntegTestCase {
                 .get();
             assertNoFailures(resp);
             assertHitCount(resp, numDocs);
-            assertNotNull(resp.pointInTimeId());
-            if (randomBoolean()) {
-                pitId = resp.pointInTimeId();
-            }
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
             assertBusy(() -> {
                 final Set<String> assignedNodes = clusterService().state().routingTable().allShards().stream()
                     .filter(shr -> shr.index().getName().equals("test") && shr.assignedToNode())
@@ -209,10 +204,7 @@ public class PointInTimeIT extends ESIntegTestCase {
                 .get();
             assertNoFailures(resp);
             assertHitCount(resp, numDocs);
-            assertNotNull(resp.pointInTimeId());
-            if (randomBoolean()) {
-                pitId = resp.pointInTimeId();
-            }
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
         } finally {
             closePointInTime(pitId);
         }
@@ -327,6 +319,54 @@ public class PointInTimeIT extends ESIntegTestCase {
                     }
                 }
             }
+        } finally {
+            closePointInTime(pitId);
+        }
+    }
+
+    public void testPartialResults() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        final List<String> dataNodes =
+            StreamSupport.stream(internalCluster().clusterService().state().nodes().getDataNodes().spliterator(), false)
+            .map(e -> e.value.getName())
+            .collect(Collectors.toList());
+        final String assignedNodeForIndex1 = randomFrom(dataNodes);
+
+        createIndex("test-1", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.routing.allocation.include._name", assignedNodeForIndex1)
+            .build());
+        createIndex("test-2", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.routing.allocation.exclude._name", assignedNodeForIndex1)
+            .build());
+
+        int numDocs1 = randomIntBetween(10, 50);
+        for (int i = 0; i < numDocs1; i++) {
+            client().prepareIndex(randomFrom("test-1")).setId(Integer.toString(i)).setSource("value", i).get();
+        }
+        int numDocs2 = randomIntBetween(10, 50);
+        for (int i = 0; i < numDocs2; i++) {
+            client().prepareIndex(randomFrom("test-2")).setId(Integer.toString(i)).setSource("value", i).get();
+        }
+        refresh();
+        String pitId = openPointInTime(new String[]{"test-*"}, TimeValue.timeValueMinutes(2));
+        try {
+            SearchResponse resp = client().prepareSearch()
+                .setPreference(null)
+                .setPointInTime(new PointInTimeBuilder(pitId))
+                .get();
+            assertNoFailures(resp);
+            assertHitCount(resp, numDocs1 + numDocs2);
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
+
+            internalCluster().restartNode(assignedNodeForIndex1);
+            resp = client().prepareSearch()
+                .setPreference(null)
+                .setAllowPartialSearchResults(true)
+                .setPointInTime(new PointInTimeBuilder(pitId))
+                .get();
+            assertFailures(resp);
+            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertHitCount(resp, numDocs2);
         } finally {
             closePointInTime(pitId);
         }


### PR DESCRIPTION
With this change, we will always return the same point in time in a search response as its input until we implement the retry mechanism for the point in times.