### PR TITLE
Cache Expensive Index Stats in TransportClusterStatsAction (#63943)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -52,7 +52,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
     /**
      * Create {@link AnalysisStats} from the given cluster state.
      */
-    public static AnalysisStats of(ClusterState state) {
+    public static AnalysisStats of(Metadata metadata) {
         final Map<String, IndexFeatureStats> usedCharFilterTypes = new HashMap<>();
         final Map<String, IndexFeatureStats> usedTokenizerTypes = new HashMap<>();
         final Map<String, IndexFeatureStats> usedTokenFilterTypes = new HashMap<>();
@@ -62,7 +62,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         final Map<String, IndexFeatureStats> usedBuiltInTokenFilters = new HashMap<>();
         final Map<String, IndexFeatureStats> usedBuiltInAnalyzers = new HashMap<>();
 
-        for (IndexMetadata indexMetadata : state.metadata()) {
+        for (IndexMetadata indexMetadata : metadata) {
             Set<String> indexAnalyzers = new HashSet<>();
             MappingMetadata mappingMetadata = indexMetadata.mapping();
             if (mappingMetadata != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -23,7 +23,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -70,12 +69,13 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
                                 ClusterName clusterName,
                                 List<ClusterStatsNodeResponse> nodes,
                                 List<FailedNodeException> failures,
-                                ClusterState state) {
+                                MappingStats mappingStats,
+                                AnalysisStats analysisStats) {
         super(clusterName, nodes, failures);
         this.clusterUUID = clusterUUID;
         this.timestamp = timestamp;
         nodesStats = new ClusterStatsNodes(nodes);
-        indicesStats = new ClusterStatsIndices(nodes, MappingStats.of(state), AnalysisStats.of(state));
+        indicesStats = new ClusterStatsIndices(nodes, mappingStats, analysisStats);
         ClusterHealthStatus status = null;
         for (ClusterStatsNodeResponse response : nodes) {
             // only the master node populates the status

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -49,9 +49,9 @@ public final class MappingStats implements ToXContentFragment, Writeable {
     /**
      * Create {@link MappingStats} from the given cluster state.
      */
-    public static MappingStats of(ClusterState state) {
+    public static MappingStats of(Metadata metadata) {
         Map<String, IndexFeatureStats> fieldTypes = new HashMap<>();
-        for (IndexMetadata indexMetadata : state.metadata()) {
+        for (IndexMetadata indexMetadata : metadata) {
             Set<String> indexFieldTypes = new HashSet<>();
             MappingMetadata mappingMetadata = indexMetadata.mapping();
             if (mappingMetadata != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -32,6 +34,7 @@ import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterStateHealth;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -54,6 +57,8 @@ import java.util.List;
 public class TransportClusterStatsAction extends TransportNodesAction<ClusterStatsRequest, ClusterStatsResponse,
         TransportClusterStatsAction.ClusterStatsNodeRequest, ClusterStatsNodeResponse> {
 
+    private static final Logger logger = LogManager.getLogger(TransportClusterStatsAction.class);
+
     private static final CommonStatsFlags SHARD_STATS_FLAGS = new CommonStatsFlags(CommonStatsFlags.Flag.Docs, CommonStatsFlags.Flag.Store,
         CommonStatsFlags.Flag.FieldData, CommonStatsFlags.Flag.QueryCache,
         CommonStatsFlags.Flag.Completion, CommonStatsFlags.Flag.Segments);
@@ -61,6 +66,12 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     private final NodeService nodeService;
     private final IndicesService indicesService;
 
+    // guards #mappingStats, #analysisStats and #metaVersion
+    private final Object statsMutex = new Object();
+
+    private MappingStats mappingStats;
+    private AnalysisStats analysisStats;
+    private long metaVersion = -1L;
 
     @Inject
     public TransportClusterStatsAction(ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
@@ -76,14 +87,43 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
                                                List<ClusterStatsNodeResponse> responses, List<FailedNodeException> failures) {
         assert Transports.assertNotTransportThread("Constructor of ClusterStatsResponse runs expensive computations on mappings found in" +
                 " the cluster state that are too slow for a transport thread");
-        ClusterState state = clusterService.state();
+        final ClusterState state = clusterService.state();
+        final Metadata metadata = state.metadata();
+        MappingStats currentMappingStats = null;
+        AnalysisStats currentAnalysisStats = null;
+        // check if we already served a stats request for the current metadata version and have the stats cached
+        synchronized (statsMutex) {
+            if (metadata.version() == metaVersion) {
+                logger.trace("Found cached mapping and analysis stats for metadata version [{}]", metadata.version());
+                currentMappingStats = this.mappingStats;
+                currentAnalysisStats = this.analysisStats;
+            }
+        }
+        if (currentMappingStats == null) {
+            // we didn't find any cached stats so we recompute them outside the mutex since the computation might be expensive for larger
+            // cluster states
+            logger.trace("Computing mapping and analysis stats for metadata version [{}]", metadata.version());
+            currentMappingStats = MappingStats.of(metadata);
+            currentAnalysisStats = AnalysisStats.of(metadata);
+            synchronized (statsMutex) {
+                // cache the computed stats unless they became outdated because of a concurrent cluster state update and a concurrent
+                // stats request has already cached a newer version
+                if (metadata.version() > metaVersion) {
+                    logger.trace("Caching mapping and analysis stats for metadata version [{}]", metadata.version());
+                    metaVersion = metadata.version();
+                    this.mappingStats = currentMappingStats;
+                    this.analysisStats = currentAnalysisStats;
+                }
+            }
+        }
         return new ClusterStatsResponse(
             System.currentTimeMillis(),
             state.metadata().clusterUUID(),
             clusterService.getClusterName(),
             responses,
             failures,
-            state);
+            currentMappingStats,
+            currentAnalysisStats);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -10,8 +10,10 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.stats.AnalysisStats;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsNodeResponse;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.elasticsearch.action.admin.cluster.stats.MappingStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -322,12 +324,14 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
         when(mockNodeResponse.nodeStats()).thenReturn(mockNodeStats);
         when(mockNodeResponse.shardsStats()).thenReturn(new ShardStats[]{mockShardStats});
 
+        final Metadata metadata = clusterState.metadata();
         final ClusterStatsResponse clusterStats = new ClusterStatsResponse(1451606400000L,
                                                                             "_cluster",
                                                                             clusterName,
                                                                             singletonList(mockNodeResponse),
                                                                             emptyList(),
-                                                                            clusterState);
+                                                                            MappingStats.of(metadata),
+                                                                            AnalysisStats.of(metadata));
 
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
 


### PR DESCRIPTION
Follow up to #62753, which moved this expensive method off of the transport threads.
Often times monitoring will hit this endpoint every few seconds while the metadata
will likely change at a much slower interval.
Given that in practice the computation of the stats might take up to a minute for large
cluster states, caching them on a best-effort basis seems like a reasonable improvement.

backport of #63943 