### PR TITLE
[Transform] improve bucket key normalization

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GeoTileGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GeoTileGroupSource.java
@@ -8,26 +8,16 @@ package org.elasticsearch.xpack.core.transform.transforms.pivot;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoBoundingBox;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.PolygonBuilder;
-import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -148,32 +138,4 @@ public class GeoTileGroupSource extends SingleGroupSource {
         return GeoShapeFieldMapper.CONTENT_TYPE;
     }
 
-    @Override
-    public Object transformBucketKey(Object key) {
-        assert key instanceof String;
-        Rectangle rectangle = GeoTileUtils.toBoundingBox(key.toString());
-        final Map<String, Object> geoShape = new HashMap<>();
-        geoShape.put(ShapeParser.FIELD_TYPE.getPreferredName(), PolygonBuilder.TYPE.shapeName());
-        geoShape.put(
-            ShapeParser.FIELD_COORDINATES.getPreferredName(),
-            Collections.singletonList(
-                Arrays.asList(
-                    new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() },
-                    new Double[] { rectangle.getMinLon(), rectangle.getMinLat() },
-                    new Double[] { rectangle.getMinLon(), rectangle.getMaxLat() },
-                    new Double[] { rectangle.getMaxLon(), rectangle.getMaxLat() },
-                    new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() }
-                )
-            )
-        );
-        return geoShape;
-    }
-
-    private GeoBoundingBoxQueryBuilder toGeoQuery(Rectangle rectangle) {
-        return QueryBuilders.geoBoundingBoxQuery(field)
-            .setCorners(
-                new GeoPoint(rectangle.getMaxLat(), rectangle.getMinLon()),
-                new GeoPoint(rectangle.getMinLat(), rectangle.getMaxLon())
-            );
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/SingleGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/SingleGroupSource.java
@@ -187,13 +187,4 @@ public abstract class SingleGroupSource implements Writeable, ToXContentObject {
         return null;
     }
 
-    /**
-     * This will transform a composite aggregation bucket key into the desired format for indexing.
-     *
-     * @param key The bucket key for this group source
-     * @return the transformed bucket key for indexing
-     */
-    public Object transformBucketKey(Object key) {
-        return key;
-    }
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -510,7 +510,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         // we expect 3 documents as there shall be 5 unique star values and we are bucketing every 2 starting at 0
         Map<String, Object> indexStats = getAsMap(transformIndex + "/_stats");
         assertEquals(3, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
-        assertOnePivotValue(transformIndex + "/_search?q=every_2:0.0", 1.0);
+        assertOnePivotValue(transformIndex + "/_search?q=every_2:0", 1.0);
     }
 
     public void testContinuousPivotHistogram() throws Exception {
@@ -556,15 +556,15 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         Map<String, Object> indexStats = getAsMap(transformIndex + "/_stats");
         assertEquals(3, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
 
-        Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=every_2:0.0");
+        Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=every_2:0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19));
 
-        searchResult = getAsMap(transformIndex + "/_search?q=every_2:2.0");
+        searchResult = getAsMap(transformIndex + "/_search?q=every_2:2");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
-        searchResult = getAsMap(transformIndex + "/_search?q=every_2:4.0");
+        searchResult = getAsMap(transformIndex + "/_search?q=every_2:4");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
@@ -608,18 +608,20 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         indexStats = getAsMap(transformIndex + "/_stats");
         assertEquals(3, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
 
-        searchResult = getAsMap(transformIndex + "/_search?q=every_2:0.0");
+        searchResult = getAsMap(transformIndex + "/_search?q=every_2:0");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(19));
 
-        searchResult = getAsMap(transformIndex + "/_search?q=every_2:2.0");
+        searchResult = getAsMap(transformIndex + "/_search?q=every_2:2");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(30));
 
-        searchResult = getAsMap(transformIndex + "/_search?q=every_2:4.0");
+        searchResult = getAsMap(transformIndex + "/_search?q=every_2:4");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         assertThat(((List<?>) XContentMapValues.extractValue("hits.hits._source.user_dc", searchResult)).get(0), equalTo(27));
 
+        deleteTransform(transformId);
+        deleteIndex(indexName);
     }
 
     public void testBiggerPivot() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -185,7 +185,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
                     .field("type", "keyword")
                     .endObject()
                     .startObject("stars")
-                    .field("type", "integer")
+                    .field("type", randomFrom("integer", "long", "unsigned_long"))
                     .endObject()
                     .startObject("location")
                     .field("type", "geo_point")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -185,7 +185,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
                     .field("type", "keyword")
                     .endObject()
                     .startObject("stars")
-                    .field("type", randomFrom("integer", "long", "unsigned_long"))
+                    .field("type", randomFrom("integer", "long")) // gh#64347 unsigned_long disabled
                     .endObject()
                     .startObject("location")
                     .field("type", "geo_point")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -1,0 +1,112 @@
+package org.elasticsearch.xpack.transform.integration.continuous;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.transform.transforms.DestConfig;
+import org.elasticsearch.client.transform.transforms.SourceConfig;
+import org.elasticsearch.client.transform.transforms.TransformConfig;
+import org.elasticsearch.client.transform.transforms.pivot.GroupConfig;
+import org.elasticsearch.client.transform.transforms.pivot.HistogramGroupSource;
+import org.elasticsearch.client.transform.transforms.pivot.PivotConfig;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HistogramGroupByIT extends ContinuousTestCase {
+    private static final String NAME = "continuous-histogram-pivot-test";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public TransformConfig createConfig() {
+        TransformConfig.Builder transformConfigBuilder = new TransformConfig.Builder();
+        addCommonBuilderParameters(transformConfigBuilder);
+        transformConfigBuilder.setSource(new SourceConfig(CONTINUOUS_EVENTS_SOURCE_INDEX));
+        transformConfigBuilder.setDest(new DestConfig(NAME, INGEST_PIPELINE));
+        transformConfigBuilder.setId(NAME);
+        PivotConfig.Builder pivotConfigBuilder = new PivotConfig.Builder();
+        pivotConfigBuilder.setGroups(
+            new GroupConfig.Builder().groupBy("metric", new HistogramGroupSource.Builder().setField("metric").setInterval(50.0).build())
+                .build()
+        );
+        AggregatorFactories.Builder aggregations = new AggregatorFactories.Builder();
+        addCommonAggregations(aggregations);
+
+        pivotConfigBuilder.setAggregations(aggregations);
+        transformConfigBuilder.setPivotConfig(pivotConfigBuilder.build());
+        return transformConfigBuilder.build();
+    }
+
+    @Override
+    public void testIteration(int iteration) throws IOException {
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
+        HistogramAggregationBuilder metricBuckets = new HistogramAggregationBuilder("metric").field("metric")
+            .interval(50.0)
+            .order(BucketOrder.key(true));
+        sourceBuilderSource.aggregation(metricBuckets);
+        searchRequestSource.source(sourceBuilderSource);
+        SearchResponse responseSource = search(searchRequestSource);
+
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(10000).sort("metric");
+        searchRequestDest.source(sourceBuilderDest);
+        SearchResponse responseDest = search(searchRequestDest);
+
+        List<? extends Bucket> buckets = ((Histogram) responseSource.getAggregations().get("metric")).getBuckets();
+
+        Iterator<? extends Bucket> sourceIterator = buckets.iterator();
+        Iterator<SearchHit> destIterator = responseDest.getHits().iterator();
+
+        while (sourceIterator.hasNext() && destIterator.hasNext()) {
+            Bucket bucket = sourceIterator.next();
+            SearchHit searchHit = destIterator.next();
+            Map<String, Object> source = searchHit.getSourceAsMap();
+
+            Long transformBucketKey = ((Integer) XContentMapValues.extractValue("metric", source)).longValue();
+
+            // aggs return buckets with 0 doc_count while composite aggs skip over them
+            while (bucket.getDocCount() == 0L) {
+                assertTrue(sourceIterator.hasNext());
+                bucket = sourceIterator.next();
+            }
+            long bucketKey = ((Double) bucket.getKey()).longValue();
+
+            // test correctness, the results from the aggregation and the results from the transform should be the same
+            assertThat(
+                "Buckets did not match, source: " + source + ", expected: " + bucketKey + ", iteration: " + iteration,
+                transformBucketKey,
+                equalTo(bucketKey)
+            );
+            assertThat(
+                "Doc count did not match, source: " + source + ", expected: " + bucket.getDocCount() + ", iteration: " + iteration,
+                ((Integer) XContentMapValues.extractValue("count", source)).longValue(),
+                equalTo(bucket.getDocCount())
+            );
+
+            // TODO: gh#63801 transform is not optimized for histogram it, it should only rewrite documents that require it
+        }
+
+        assertFalse(sourceIterator.hasNext());
+        assertFalse(destIterator.hasNext());
+    }
+
+}

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.integration.continuous;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.transform.transforms.DestConfig;
+import org.elasticsearch.client.transform.transforms.SourceConfig;
+import org.elasticsearch.client.transform.transforms.TransformConfig;
+import org.elasticsearch.client.transform.transforms.pivot.GroupConfig;
+import org.elasticsearch.client.transform.transforms.pivot.PivotConfig;
+import org.elasticsearch.client.transform.transforms.pivot.TermsGroupSource;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.SingleValue;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TermsOnDateGroupByIT extends ContinuousTestCase {
+
+    private static final String NAME = "continuous-terms-pivot-test";
+    private static final String MISSING_BUCKET_KEY = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
+        .format(Instant.ofEpochMilli(1262304000000L)); // 01/01/2010 should end up last when sorting
+    private final boolean missing;
+
+    public TermsOnDateGroupByIT() {
+        missing = randomBoolean();
+    }
+
+    @Override
+    public TransformConfig createConfig() {
+        TransformConfig.Builder transformConfigBuilder = new TransformConfig.Builder();
+        addCommonBuilderParameters(transformConfigBuilder);
+        transformConfigBuilder.setSource(new SourceConfig(CONTINUOUS_EVENTS_SOURCE_INDEX));
+        transformConfigBuilder.setDest(new DestConfig(NAME, INGEST_PIPELINE));
+        transformConfigBuilder.setId(NAME);
+
+        PivotConfig.Builder pivotConfigBuilder = new PivotConfig.Builder();
+        pivotConfigBuilder.setGroups(
+            new GroupConfig.Builder().groupBy(
+                "some-timestamp",
+                new TermsGroupSource.Builder().setField("some-timestamp").setMissingBucket(missing).build()
+            ).build()
+        );
+
+        AggregatorFactories.Builder aggregations = new AggregatorFactories.Builder();
+        addCommonAggregations(aggregations);
+        aggregations.addAggregator(AggregationBuilders.avg("metric.avg").field("metric"));
+
+        pivotConfigBuilder.setAggregations(aggregations);
+        transformConfigBuilder.setPivotConfig(pivotConfigBuilder.build());
+        return transformConfigBuilder.build();
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void testIteration(int iteration) throws IOException {
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
+        TermsAggregationBuilder terms = new TermsAggregationBuilder("some-timestamp").size(1000)
+            .field("some-timestamp")
+            .order(BucketOrder.key(true));
+        if (missing) {
+            // missing_bucket produces `null`, we can't use `null` in aggs, so we have to use a magic value, see gh#60043
+            terms.missing(MISSING_BUCKET_KEY);
+        }
+
+        terms.subAggregation(AggregationBuilders.avg("metric.avg").field("metric"));
+        sourceBuilderSource.aggregation(terms);
+        searchRequestSource.source(sourceBuilderSource);
+        SearchResponse responseSource = search(searchRequestSource);
+
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(1000).sort("some-timestamp");
+        searchRequestDest.source(sourceBuilderDest);
+        SearchResponse responseDest = search(searchRequestDest);
+
+        List<? extends Bucket> buckets = ((Terms) responseSource.getAggregations().get("some-timestamp")).getBuckets();
+
+        // the number of search hits should be equal to the number of buckets returned by the aggregation
+        assertThat(
+            "Number of buckets did not match, source: "
+                + responseDest.getHits().getTotalHits().value
+                + ", expected: "
+                + Long.valueOf(buckets.size())
+                + ", iteration: "
+                + iteration,
+            responseDest.getHits().getTotalHits().value,
+            equalTo(Long.valueOf(buckets.size()))
+        );
+
+        Iterator<? extends Bucket> sourceIterator = buckets.iterator();
+        Iterator<SearchHit> destIterator = responseDest.getHits().iterator();
+
+        while (sourceIterator.hasNext() && destIterator.hasNext()) {
+            Bucket bucket = sourceIterator.next();
+            SearchHit searchHit = destIterator.next();
+            Map<String, Object> source = searchHit.getSourceAsMap();
+
+            String transformBucketKey = (String) XContentMapValues.extractValue("some-timestamp", source);
+            if (transformBucketKey == null) {
+                transformBucketKey = MISSING_BUCKET_KEY;
+            }
+            // test correctness, the results from the aggregation and the results from the transform should be the same
+            assertThat(
+                "Buckets did not match, source: " + source + ", expected: " + bucket.getKeyAsString() + ", iteration: " + iteration,
+                transformBucketKey,
+                equalTo(bucket.getKeyAsString())
+            );
+            assertThat(
+                "Doc count did not match, source: " + source + ", expected: " + bucket.getDocCount() + ", iteration: " + iteration,
+                ((Integer) XContentMapValues.extractValue("count", source)).longValue(),
+                equalTo(bucket.getDocCount())
+            );
+
+            SingleValue avgAgg = (SingleValue) bucket.getAggregations().get("metric.avg");
+            assertThat(
+                "Metric aggregation did not match, source: " + source + ", expected: " + avgAgg.value() + ", iteration: " + iteration,
+                XContentMapValues.extractValue("metric.avg", source),
+                equalTo(avgAgg.value())
+            );
+
+            // test optimization, transform should only rewrite documents that require it
+            // run.ingest is set by the pipeline, run.max is set by the transform
+            // run.ingest > run.max means, the data point has been re-created/re-fed although it wasn't necessary,
+            // this is probably a bug in transform's change collection optimization
+            // run.ingest < run.max means the ingest pipeline wasn't updated, this might be a bug in put pipeline
+            assertThat(
+                "Ingest run: "
+                    + XContentMapValues.extractValue(INGEST_RUN_FIELD, source)
+                    + " did not match max run: "
+                    + XContentMapValues.extractValue(MAX_RUN_FIELD, source)
+                    + ", iteration: "
+                    + iteration
+                    + " full source: "
+                    + source,
+                XContentMapValues.extractValue(INGEST_RUN_FIELD, source),
+                equalTo(XContentMapValues.extractValue(MAX_RUN_FIELD, source))
+            );
+        }
+        assertFalse(sourceIterator.hasNext());
+        assertFalse(destIterator.hasNext());
+    }
+}

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -124,6 +124,7 @@ public class TransformContinuousIT extends ESRestTestCase {
     @Before
     public void registerTestCases() {
         addTestCaseIfNotDisabled(new TermsGroupByIT());
+        addTestCaseIfNotDisabled(new TermsOnDateGroupByIT());
         addTestCaseIfNotDisabled(new DateHistogramGroupByIT());
         addTestCaseIfNotDisabled(new DateHistogramGroupByOtherTimeFieldIT());
         addTestCaseIfNotDisabled(new HistogramGroupByIT());
@@ -176,18 +177,31 @@ public class TransformContinuousIT extends ESRestTestCase {
             }
         }
 
+        // generate date id's to group on
+        List<String> dates = new ArrayList<>();
+        dates.add(null);
+        for (int i = 0; i < 100; i++) {
+            dates.add(
+                // create a random date between 1/1/2001 and 1/1/2006
+                ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
+                    .format(Instant.ofEpochMilli(randomLongBetween(978307200000L, 1136073600000L)))
+            );
+        }
+
         putIndex(sourceIndexName, dateType, isDataStream);
         // create all transforms to test
         createTransforms();
 
         for (int run = 0; run < runs; run++) {
             Instant runDate = Instant.now();
+
             createOrUpdatePipeline(ContinuousTestCase.INGEST_RUN_FIELD, run);
 
             // shuffle the list to draw randomly from the first x entries (that way we do not update all entities in 1 run)
             Collections.shuffle(events, random());
             Collections.shuffle(metric_bucket, random());
             Collections.shuffle(locations, random());
+            Collections.shuffle(dates, random());
 
             final StringBuilder source = new StringBuilder();
             BulkRequest bulkRequest = new BulkRequest(sourceIndexName);
@@ -195,6 +209,7 @@ public class TransformContinuousIT extends ESRestTestCase {
             int numDocs = randomIntBetween(1000, 20000);
             for (int numDoc = 0; numDoc < numDocs; numDoc++) {
                 source.append("{");
+
                 String event = events.get((numDoc + randomIntBetween(0, 50)) % 50);
                 if (event != null) {
                     source.append("\"event\":\"").append(event).append("\",");
@@ -216,17 +231,22 @@ public class TransformContinuousIT extends ESRestTestCase {
                     source.append("\"location\":\"").append(randomizedLat + "," + randomizedLon).append("\",");
                 }
 
-                // simulate a different timestamp that is off from the timestamp used for sync, so it can fall into the previous bucket
-                String metric_date_string = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
-                    .format(runDate.minusSeconds(randomIntBetween(0, 5)).plusNanos(randomIntBetween(0, 999999)));
-                source.append("\"metric-timestamp\":\"").append(metric_date_string).append("\",");
+                String date = dates.get((numDoc + randomIntBetween(0, 50)) % 50);
+                if (date != null) {
+                    source.append("\"some-timestamp\":\"").append(date).append("\",");
+                }
 
-                String date_string = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
+                // simulate a different timestamp that is off from the timestamp used for sync, so it can fall into the previous bucket
+                String metricDateString = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
+                    .format(runDate.minusSeconds(randomIntBetween(0, 5)).plusNanos(randomIntBetween(0, 999999)));
+                source.append("\"metric-timestamp\":\"").append(metricDateString).append("\",");
+
+                String dateString = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
                     .format(runDate.plusNanos(randomIntBetween(0, 999999)));
 
-                source.append("\"timestamp\":\"").append(date_string).append("\",");
+                source.append("\"timestamp\":\"").append(dateString).append("\",");
                 // for data streams
-                source.append("\"@timestamp\":\"").append(date_string).append("\",");
+                source.append("\"@timestamp\":\"").append(dateString).append("\",");
                 source.append("\"run\":").append(run);
                 source.append("}");
 
@@ -326,6 +346,9 @@ public class TransformContinuousIT extends ESRestTestCase {
                     .field("type", "integer")
                     .endObject()
                     .startObject("metric-timestamp")
+                    .field("type", dateType)
+                    .endObject()
+                    .startObject("some-timestamp")
                     .field("type", dateType)
                     .endObject()
                     .endObject()

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -126,6 +126,7 @@ public class TransformContinuousIT extends ESRestTestCase {
         addTestCaseIfNotDisabled(new TermsGroupByIT());
         addTestCaseIfNotDisabled(new DateHistogramGroupByIT());
         addTestCaseIfNotDisabled(new DateHistogramGroupByOtherTimeFieldIT());
+        addTestCaseIfNotDisabled(new HistogramGroupByIT());
     }
 
     @Before

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
@@ -414,10 +413,7 @@ public final class AggregationResultUtils {
         public Object value(Object key, String type) {
             if (isNumericType(type) && key instanceof Double) {
                 return dropFloatingPointComponentIfTypeRequiresIt(type, (Double) key);
-            } else if ((DateFieldMapper.CONTENT_TYPE.equals(type) || DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(type))
-                && key instanceof Long) {
-                    return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis((Long) key);
-                }
+            }
             return key;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -410,6 +410,9 @@ public final class AggregationResultUtils {
 
         @Override
         public Object value(Object key, String type) {
+            if (isNumericType(type) && key instanceof Double) {
+                return dropFloatingPointComponentIfTypeRequiresIt(type, (Double) key);
+            }
             return key;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
@@ -99,6 +100,7 @@ public final class AggregationResultUtils {
 
             groups.getGroups().forEach((destinationFieldName, singleGroupSource) -> {
                 Object value = bucket.getKey().get(destinationFieldName);
+
                 idGen.add(destinationFieldName, value);
                 updateDocument(
                     document,
@@ -412,7 +414,10 @@ public final class AggregationResultUtils {
         public Object value(Object key, String type) {
             if (isNumericType(type) && key instanceof Double) {
                 return dropFloatingPointComponentIfTypeRequiresIt(type, (Double) key);
-            }
+            } else if ((DateFieldMapper.CONTENT_TYPE.equals(type) || DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(type))
+                && key instanceof Long) {
+                    return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis((Long) key);
+                }
             return key;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -13,12 +13,14 @@ import org.elasticsearch.common.geo.builders.LineStringBuilder;
 import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
+import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.metrics.GeoBounds;
 import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.SingleValue;
@@ -27,7 +29,9 @@ import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.ScriptedMetric;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.GeoTileGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
 import org.elasticsearch.xpack.transform.transforms.IDGenerator;
 import org.elasticsearch.xpack.transform.utils.OutputFieldNameConverter;
 
@@ -56,6 +60,15 @@ public final class AggregationResultUtils {
         tempMap.put(SingleBucketAggregation.class.getName(), new SingleBucketAggExtractor());
         tempMap.put(MultiBucketsAggregation.class.getName(), new MultiBucketsAggExtractor());
         TYPE_VALUE_EXTRACTOR_MAP = Collections.unmodifiableMap(tempMap);
+    }
+
+    private static final Map<String, BucketKeyExtractor> BUCKET_KEY_EXTRACTOR_MAP;
+    private static final BucketKeyExtractor DEFAULT_BUCKET_KEY_EXTRACTOR = new DefaultBucketKeyExtractor();
+    static {
+        Map<String, BucketKeyExtractor> tempMap = new HashMap<>();
+        tempMap.put(GeoTileGroupSource.class.getName(), new GeoTileBucketKeyExtractor());
+
+        BUCKET_KEY_EXTRACTOR_MAP = Collections.unmodifiableMap(tempMap);
     }
 
     /**
@@ -87,7 +100,11 @@ public final class AggregationResultUtils {
             groups.getGroups().forEach((destinationFieldName, singleGroupSource) -> {
                 Object value = bucket.getKey().get(destinationFieldName);
                 idGen.add(destinationFieldName, value);
-                updateDocument(document, destinationFieldName, singleGroupSource.transformBucketKey(value));
+                updateDocument(
+                    document,
+                    destinationFieldName,
+                    getBucketKeyExtractor(singleGroupSource).value(value, fieldTypeMap.get(destinationFieldName))
+                );
             });
 
             List<String> aggNames = aggregationBuilders.stream().map(AggregationBuilder::getName).collect(Collectors.toList());
@@ -108,6 +125,10 @@ public final class AggregationResultUtils {
 
             return document;
         });
+    }
+
+    static BucketKeyExtractor getBucketKeyExtractor(SingleGroupSource groupSource) {
+        return BUCKET_KEY_EXTRACTOR_MAP.getOrDefault(groupSource.getClass().getName(), DEFAULT_BUCKET_KEY_EXTRACTOR);
     }
 
     static AggValueExtractor getExtractor(Aggregation aggregation) {
@@ -180,6 +201,21 @@ public final class AggregationResultUtils {
         AggregationExtractionException(String msg, Object... args) {
             super(msg, args);
         }
+    }
+
+    /**
+     * Extract the bucket key and transform it for indexing.
+     */
+    interface BucketKeyExtractor {
+
+        /**
+         * Take the bucket key and return it in the format for the index, taking the mapped type into account.
+         *
+         * @param key The bucket key for this group source
+         * @param type the mapping type of the destination field
+         * @return the transformed bucket key for indexing
+         */
+        Object value(Object key, String type);
     }
 
     interface AggValueExtractor {
@@ -345,4 +381,37 @@ public final class AggregationResultUtils {
         }
     }
 
+    static class GeoTileBucketKeyExtractor implements BucketKeyExtractor {
+
+        @Override
+        public Object value(Object key, String type) {
+            assert key instanceof String;
+            Rectangle rectangle = GeoTileUtils.toBoundingBox(key.toString());
+            final Map<String, Object> geoShape = new HashMap<>();
+            geoShape.put(ShapeParser.FIELD_TYPE.getPreferredName(), PolygonBuilder.TYPE.shapeName());
+            geoShape.put(
+                ShapeParser.FIELD_COORDINATES.getPreferredName(),
+                Collections.singletonList(
+                    Arrays.asList(
+                        new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() },
+                        new Double[] { rectangle.getMinLon(), rectangle.getMinLat() },
+                        new Double[] { rectangle.getMinLon(), rectangle.getMaxLat() },
+                        new Double[] { rectangle.getMaxLon(), rectangle.getMaxLat() },
+                        new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() }
+                    )
+                )
+            );
+            return geoShape;
+        }
+
+    }
+
+    static class DefaultBucketKeyExtractor implements BucketKeyExtractor {
+
+        @Override
+        public Object value(Object key, String type) {
+            return key;
+        }
+
+    }
 }


### PR DESCRIPTION
re-factor bucket key normalization, depending on the source and mapped type. Remove floating point
component for numeric keys if mapped to an integer type (long, unsigned long, integer, ...)

fixes #64070

Notes:
 - the original PR converted date objects to a formatted string, this has been reverted