### PR TITLE
Fix CachedBlobContainerIndexInputTests Shutdown (#64181)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -943,14 +943,14 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
     }
 
     // Wait for all operations on the threadpool to complete to make sure we don't leak any reference count releasing and then shut it down
-    private static void terminateSafely(ThreadPool threadPool) throws Exception {
+    public static void terminateSafely(ThreadPool threadPool) throws Exception {
         assertBusy(() -> {
             for (ThreadPoolStats.Stats stat : threadPool.stats()) {
                 assertEquals(stat.getActive(), 0);
                 assertEquals(stat.getQueue(), 0);
             }
         });
-        assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        assertTrue(ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS));
     }
 
     private static class FaultyReadsFileSystem extends FilterFileSystemProvider {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.SearchableSnapshotDirectory;
+import org.elasticsearch.index.store.SearchableSnapshotDirectoryTests;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.store.cache.TestUtils.NoopBlobStoreCacheService;
 import org.elasticsearch.indices.recovery.RecoveryState;
@@ -44,7 +45,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import static java.util.Collections.singletonList;
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
 
-    public void testRandomReads() throws IOException {
+    public void testRandomReads() throws Exception {
         final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
         try (CacheService cacheService = createCacheService(random())) {
             cacheService.start();
@@ -155,11 +155,11 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                 }
             }
         } finally {
-            ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+            SearchableSnapshotDirectoryTests.terminateSafely(threadPool);
         }
     }
 
-    public void testThrowsEOFException() throws IOException {
+    public void testThrowsEOFException() throws Exception {
         try (CacheService cacheService = createCacheService(random())) {
             cacheService.start();
 
@@ -223,7 +223,7 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                     }
                 }
             } finally {
-                terminate(threadPool);
+                SearchableSnapshotDirectoryTests.terminateSafely(threadPool);
             }
         }
     }


### PR DESCRIPTION
Same problem as in #64100 we have to safely wait for all operations to go through to
not leak file handles potentially in this test.

backport of #64181 