### PR TITLE
Don't Generate an Index Setting History UUID unless it's Supported (#64164)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -24,10 +24,6 @@ setup:
 ---
 "Create a snapshot and then restore it":
 
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/64152"
-
   - do:
       snapshot.create:
         repository: test_repo_restore_1


### PR DESCRIPTION
In 7.x we can't just by default generate this setting as it might not be
supported by data nodes that are assigned shards for an older version in mixed version
clusters.

Closes #64152

backport of #64164 