### PR TITLE
Limit blast redius of SearchContext in aggs (backport of #64068)

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.matrix.stats;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.search.MultiValueMode;
@@ -69,7 +68,6 @@ final class MatrixStatsAggregator extends MetricsAggregator {
         if (valuesSources == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final NumericDoubleValues[] values = new NumericDoubleValues[valuesSources.fieldNames().length];
         for (int i = 0; i < values.length; ++i) {
             values[i] = valuesSources.getField(i, ctx);
@@ -83,7 +81,7 @@ final class MatrixStatsAggregator extends MetricsAggregator {
             public void collect(int doc, long bucket) throws IOException {
                 // get fields
                 if (includeDocument(doc)) {
-                    stats = bigArrays.grow(stats, bucket + 1);
+                    stats = bigArrays().grow(stats, bucket + 1);
                     RunningStats stat = stats.get(bucket);
                     // add document fields to correlation stats
                     if (stat == null) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentJoinAggregator.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentJoinAggregator.java
@@ -119,7 +119,7 @@ public abstract class ParentJoinAggregator extends BucketsAggregator implements 
 
     @Override
     protected void beforeBuildingBuckets(long[] ordsToCollect) throws IOException {
-        IndexReader indexReader = context().searcher().getIndexReader();
+        IndexReader indexReader = searcher().getIndexReader();
         for (LeafReaderContext ctx : indexReader.leaves()) {
             Scorer childDocsScorer = outFilter.scorer(ctx);
             if (childDocsScorer == null) {
@@ -196,7 +196,7 @@ public abstract class ParentJoinAggregator extends BucketsAggregator implements 
         private final BitArray ordsBits;
 
         public DenseCollectionStrategy(long maxOrd, BigArrays bigArrays) {
-            ordsBits = new BitArray(maxOrd, context.bigArrays());
+            ordsBits = new BitArray(maxOrd, bigArrays());
         }
 
         @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -511,7 +511,7 @@ public class TransportSearchIT extends ESIntegTestCase {
                                                     Aggregator parent,
                                                     CardinalityUpperBound cardinality,
                                                     Map<String, Object> metadata) throws IOException {
-                    return new TestAggregator(name, parent, searchContext);
+                    return new TestAggregator(name, parent);
                 }
             };
         }
@@ -544,23 +544,16 @@ public class TransportSearchIT extends ESIntegTestCase {
     private static class TestAggregator extends Aggregator {
         private final String name;
         private final Aggregator parent;
-        private final SearchContext context;
 
-        private TestAggregator(String name, Aggregator parent, SearchContext context) {
+        private TestAggregator(String name, Aggregator parent) {
             this.name = name;
             this.parent = parent;
-            this.context = context;
         }
 
 
         @Override
         public String name() {
             return name;
-        }
-
-        @Override
-        public SearchContext context() {
-            return context;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
@@ -67,11 +66,6 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      * Return the name of this aggregator.
      */
     public abstract String name();
-
-    /**
-     * Return the {@link SearchContext} attached with this {@link Aggregator}.
-     */
-    public abstract SearchContext context();
 
     /**
      * Return the parent aggregator.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -193,7 +193,7 @@ public class AggregatorFactories {
         Aggregator[] aggregators = new Aggregator[countAggregators()];
         for (int i = 0; i < factories.length; ++i) {
             Aggregator factory = factories[i].create(searchContext, parent, cardinality);
-            Profilers profilers = factory.context().getProfilers();
+            Profilers profilers = searchContext.getProfilers();
             if (profilers != null) {
                 factory = new ProfilingAggregator(factory, profilers.getAggregationProfiler());
             }
@@ -211,7 +211,7 @@ public class AggregatorFactories {
              * *exactly* what CardinalityUpperBound.ONE *means*.  
              */
             Aggregator factory = factories[i].create(searchContext, null, CardinalityUpperBound.ONE);
-            Profilers profilers = factory.context().getProfilers();
+            Profilers profilers = searchContext.getProfilers();
             if (profilers != null) {
                 factory = new ProfilingAggregator(factory, profilers.getAggregationProfiler());
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
@@ -36,7 +37,6 @@ import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.MultiBucketCollector;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,7 +64,8 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
 
     protected List<Entry> entries = new ArrayList<>();
     protected BucketCollector collector;
-    protected final SearchContext searchContext;
+    private final Query topLevelQuery;
+    private final IndexSearcher searcher;
     protected final boolean isGlobal;
     protected LeafReaderContext context;
     protected PackedLongValues.Builder docDeltasBuilder;
@@ -75,11 +76,11 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
 
     /**
      * Sole constructor.
-     * @param context The search context
      * @param isGlobal Whether this collector visits all documents (global context)
      */
-    public BestBucketsDeferringCollector(SearchContext context, boolean isGlobal) {
-        this.searchContext = context;
+    public BestBucketsDeferringCollector(Query topLevelQuery, IndexSearcher searcher, boolean isGlobal) {
+        this.topLevelQuery = topLevelQuery;
+        this.searcher = searcher;
         this.isGlobal = isGlobal;
     }
 
@@ -162,8 +163,8 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
         boolean needsScores = scoreMode().needsScores();
         Weight weight = null;
         if (needsScores) {
-            Query query = isGlobal ? new MatchAllDocsQuery() : searchContext.query();
-            weight = searchContext.searcher().createWeight(searchContext.searcher().rewrite(query), ScoreMode.COMPLETE, 1f);
+            Query query = isGlobal ? new MatchAllDocsQuery() : topLevelQuery;
+            weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1f);
         }
 
         for (Entry entry : entries) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferableBucketAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferableBucketAggregator.java
@@ -21,8 +21,8 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.MultiBucketCollector;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -74,7 +74,7 @@ public abstract class DeferableBucketAggregator extends BucketsAggregator {
     public DeferringBucketCollector getDeferringCollector() {
         // Default impl is a collector that selects the best buckets
         // but an alternative defer policy may be based on best docs.
-        return new BestBucketsDeferringCollector(context(), descendsFromGlobalAggregator(parent()));
+        return new BestBucketsDeferringCollector(topLevelQuery(), searcher(), descendsFromGlobalAggregator(parent()));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.support.AggregationPath.PathElement;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
@@ -82,11 +81,6 @@ public abstract class DeferringBucketCollector extends BucketCollector {
         @Override
         public Aggregator parent() {
             return in.parent();
-        }
-
-        @Override
-        public SearchContext context() {
-            return in.context();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MergingBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MergingBucketsDeferringCollector.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,8 +35,8 @@ import java.util.function.LongUnaryOperator;
  * rounding interval.
  */
 public class MergingBucketsDeferringCollector extends BestBucketsDeferringCollector {
-    public MergingBucketsDeferringCollector(SearchContext context, boolean isGlobal) {
-        super(context, isGlobal);
+    public MergingBucketsDeferringCollector(Query topLevelQuery, IndexSearcher searcher, boolean isGlobal) {
+        super(topLevelQuery, searcher, isGlobal);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
@@ -56,7 +56,7 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid> extends Bucke
         this.valuesSource = valuesSource;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
-        bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -97,7 +97,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.formatter = valuesSourceConfig.format();
 
-        bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -108,7 +108,7 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
                 + "]");
         }
 
-        bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
@@ -98,7 +98,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
         private MergeBucketsPhase mergeBucketsPhase;
 
         BufferValuesPhase(int bufferLimit){
-            this.buffer = bigArrays.newDoubleArray(1);
+            this.buffer = bigArrays().newDoubleArray(1);
             this.bufferSize = 0;
             this.bufferLimit = bufferLimit;
             this.mergeBucketsPhase = null;
@@ -108,7 +108,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
         public CollectionPhase collectValue(LeafBucketCollector sub, int doc, double val) throws IOException{
             if (bufferSize < bufferLimit) {
                 // Add to the buffer i.e store the doc in a new bucket
-                buffer = bigArrays.grow(buffer, bufferSize + 1);
+                buffer = bigArrays().grow(buffer, bufferSize + 1);
                 buffer.set((long) bufferSize, val);
                 collectBucket(sub, doc, bufferSize);
                 bufferSize += 1;
@@ -234,10 +234,10 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
          */
         private void bucketBufferedDocs(final DoubleArray buffer, final int bufferSize, final int numBuckets) {
             // Allocate space for the clusters about to be created
-            clusterMins = bigArrays.newDoubleArray(1);
-            clusterMaxes = bigArrays.newDoubleArray(1);
-            clusterCentroids = bigArrays.newDoubleArray(1);
-            clusterSizes = bigArrays.newDoubleArray(1);
+            clusterMins = bigArrays().newDoubleArray(1);
+            clusterMaxes = bigArrays().newDoubleArray(1);
+            clusterCentroids = bigArrays().newDoubleArray(1);
+            clusterSizes = bigArrays().newDoubleArray(1);
             numClusters = 0;
 
             ClusterSorter sorter = new ClusterSorter(buffer, bufferSize);
@@ -313,10 +313,10 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
          */
         private void createAndAppendNewCluster(double value){
             // Ensure there is space for the cluster
-            clusterMaxes = bigArrays.grow(clusterMaxes, numClusters + 1); //  + 1 because indexing starts at 0
-            clusterMins = bigArrays.grow(clusterMins, numClusters + 1);
-            clusterCentroids = bigArrays.grow(clusterCentroids, numClusters + 1);
-            clusterSizes = bigArrays.grow(clusterSizes, numClusters + 1);
+            clusterMaxes = bigArrays().grow(clusterMaxes, numClusters + 1); //  + 1 because indexing starts at 0
+            clusterMins = bigArrays().grow(clusterMins, numClusters + 1);
+            clusterCentroids = bigArrays().grow(clusterCentroids, numClusters + 1);
+            clusterSizes = bigArrays().grow(clusterSizes, numClusters + 1);
 
             // Initialize the cluster at the end of the array
             clusterMaxes.set(numClusters, value);
@@ -438,7 +438,6 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
     private final int shardSize;
     private final int bufferLimit;
 
-    final BigArrays bigArrays;
     private CollectionPhase collector;
 
     private MergingBucketsDeferringCollector deferringCollector;
@@ -455,7 +454,6 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
         this.shardSize = shardSize;
         this.bufferLimit = initialBuffer;
 
-        bigArrays = context.bigArrays();
         collector = new BufferValuesPhase(this.bufferLimit);
 
         String scoringAgg = subAggsNeedScore();
@@ -509,7 +507,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
 
     @Override
     public DeferringBucketCollector getDeferringCollector() {
-        deferringCollector = new MergingBucketsDeferringCollector(context, descendsFromGlobalAggregator(parent()));
+        deferringCollector = new MergingBucketsDeferringCollector(topLevelQuery(), searcher(), descendsFromGlobalAggregator(parent()));
         return deferringCollector;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
@@ -78,14 +78,14 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
         DiverseDocsDeferringCollector(Consumer<Long> circuitBreakerConsumer) {
-            super(shardSize, context.bigArrays(), circuitBreakerConsumer);
+            super(shardSize, bigArrays(), circuitBreakerConsumer);
         }
 
 
         @Override
         protected TopDocsCollector<ScoreDocKey> createTopDocsCollector(int size) {
             // Make sure we do not allow size > maxDoc, to prevent accidental OOM
-            int minMaxDocsPerValue = Math.min(maxDocsPerValue, context.searcher().getIndexReader().maxDoc());
+            int minMaxDocsPerValue = Math.min(maxDocsPerValue, searcher().getIndexReader().maxDoc());
             return new ValuesDiversifiedTopDocsCollector(size, minMaxDocsPerValue);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
@@ -85,13 +85,13 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
         DiverseDocsDeferringCollector(Consumer<Long> circuitBreakerConsumer) {
-            super(shardSize, context.bigArrays(), circuitBreakerConsumer);
+            super(shardSize, bigArrays(), circuitBreakerConsumer);
         }
 
         @Override
         protected TopDocsCollector<ScoreDocKey> createTopDocsCollector(int size) {
             // Make sure we do not allow size > maxDoc, to prevent accidental OOM
-            int minMaxDocsPerValue = Math.min(maxDocsPerValue, context.searcher().getIndexReader().maxDoc());
+            int minMaxDocsPerValue = Math.min(maxDocsPerValue, searcher().getIndexReader().maxDoc());
             return new ValuesDiversifiedTopDocsCollector(size, minMaxDocsPerValue);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
@@ -72,13 +72,13 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
         DiverseDocsDeferringCollector(Consumer<Long> circuitBreakerConsumer) {
-            super(shardSize, context.bigArrays(), circuitBreakerConsumer);
+            super(shardSize, bigArrays(), circuitBreakerConsumer);
         }
 
         @Override
         protected TopDocsCollector<ScoreDocKey> createTopDocsCollector(int size) {
             // Make sure we do not allow size > maxDoc, to prevent accidental OOM
-            int minMaxDocsPerValue = Math.min(maxDocsPerValue, context.searcher().getIndexReader().maxDoc());
+            int minMaxDocsPerValue = Math.min(maxDocsPerValue, searcher().getIndexReader().maxDoc());
             return new ValuesDiversifiedTopDocsCollector(size, minMaxDocsPerValue);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
@@ -74,13 +74,13 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
         DiverseDocsDeferringCollector(Consumer<Long> circuitBreakerConsumer) {
-            super(shardSize, context.bigArrays(), circuitBreakerConsumer);
+            super(shardSize, bigArrays(), circuitBreakerConsumer);
         }
 
         @Override
         protected TopDocsCollector<ScoreDocKey> createTopDocsCollector(int size) {
             // Make sure we do not allow size > maxDoc, to prevent accidental OOM
-            int minMaxDocsPerValue = Math.min(maxDocsPerValue, context.searcher().getIndexReader().maxDoc());
+            int minMaxDocsPerValue = Math.min(maxDocsPerValue, searcher().getIndexReader().maxDoc());
             return new ValuesDiversifiedTopDocsCollector(size, minMaxDocsPerValue);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -184,7 +184,7 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
 
     @Override
     public DeferringBucketCollector getDeferringCollector() {
-        bdd = new BestDocsDeferringCollector(shardSize, context.bigArrays(), this::addRequestCircuitBreakerBytes);
+        bdd = new BestDocsDeferringCollector(shardSize, bigArrays(), this::addRequestCircuitBreakerBytes);
         return bdd;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
@@ -92,7 +92,7 @@ public abstract class AbstractRareTermsAggregator extends DeferableBucketAggrega
 
     @Override
     public DeferringBucketCollector getDeferringCollector() {
-        deferringCollector = new MergingBucketsDeferringCollector(context, descendsFromGlobalAggregator(parent()));
+        deferringCollector = new MergingBucketsDeferringCollector(topLevelQuery(), searcher(), descendsFromGlobalAggregator(parent()));
         return deferringCollector;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.apache.lucene.index.IndexReader;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -51,9 +49,7 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
 
     protected SignificantStringTerms buildEmptySignificantTermsAggregation(long subsetSize, SignificanceHeuristic significanceHeuristic) {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
-        ContextIndexSearcher searcher = context.searcher();
-        IndexReader topReader = searcher.getIndexReader();
-        int supersetSize = topReader.numDocs();
+        int supersetSize = searcher().getIndexReader().numDocs();
         return new SignificantStringTerms(name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(),
                 metadata(), format, subsetSize, supersetSize, significanceHeuristic, emptyList());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -301,7 +301,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                 mapSegmentCountsToGlobalCounts(mapping);
             }
             final SortedSetDocValues segmentOrds = valuesSource.ordinalsValues(ctx);
-            segmentDocCounts = context.bigArrays().grow(segmentDocCounts, 1 + segmentOrds.getValueCount());
+            segmentDocCounts = bigArrays().grow(segmentDocCounts, 1 + segmentOrds.getValueCount());
             assert sub == LeafBucketCollector.NO_OP_COLLECTOR;
             final SortedDocValues singleValues = DocValues.unwrapSingleton(segmentOrds);
             mapping = valuesSource.globalOrdinalsMapping(ctx);
@@ -474,7 +474,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         private final LongKeyedBucketOrds bucketOrds;
 
         private RemapGlobalOrds(CardinalityUpperBound cardinality) {
-            bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+            bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
         }
 
         @Override
@@ -778,14 +778,14 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         private final long supersetSize;
         private final SignificanceHeuristic significanceHeuristic;
 
-        private LongArray subsetSizes = context.bigArrays().newLongArray(1, true);
+        private LongArray subsetSizes = bigArrays().newLongArray(1, true);
 
         SignificantTermsResults(
             SignificanceLookup significanceLookup,
             SignificanceHeuristic significanceHeuristic,
             CardinalityUpperBound cardinality
         ) {
-            backgroundFrequencies = significanceLookup.bytesLookup(context.bigArrays(), cardinality);
+            backgroundFrequencies = significanceLookup.bytesLookup(bigArrays(), cardinality);
             supersetSize = significanceLookup.supersetSize();
             this.significanceHeuristic = significanceHeuristic;
         }
@@ -801,7 +801,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                 @Override
                 public void collect(int doc, long owningBucketOrd) throws IOException {
                     super.collect(doc, owningBucketOrd);
-                    subsetSizes = context.bigArrays().grow(subsetSizes, owningBucketOrd + 1);
+                    subsetSizes = bigArrays().grow(subsetSizes, owningBucketOrd + 1);
                     subsetSizes.increment(owningBucketOrd, 1);
                 }
             };

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
@@ -74,7 +74,7 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator {
         );
         this.valuesSource = valuesSource;
         this.filter = filter;
-        this.bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        this.bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     protected SortedNumericDocValues getValues(ValuesSource.Numeric valuesSource, LeafReaderContext ctx) throws IOException {
@@ -126,7 +126,7 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator {
         Arrays.fill(mergeMap, -1);
         long offset = 0;
         for (int owningOrdIdx = 0; owningOrdIdx < owningBucketOrds.length; owningOrdIdx++) {
-            try (LongHash bucketsInThisOwningBucketToCollect = new LongHash(1, context.bigArrays())) {
+            try (LongHash bucketsInThisOwningBucketToCollect = new LongHash(1, bigArrays())) {
                 filters[owningOrdIdx] = newFilter();
                 List<LongRareTerms.Bucket> builtBuckets = new ArrayList<>();
                 LongKeyedBucketOrds.BucketOrdsEnum collectedBuckets = bucketOrds.ordsEnum(owningBucketOrds[owningOrdIdx]);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -47,8 +47,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
 
@@ -357,7 +357,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                 return;
             }
             // we need to fill-in the blanks
-            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+            for (LeafReaderContext ctx : searcher().getTopReaderContext().leaves()) {
                 SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
                 // brute force
                 for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
@@ -447,14 +447,14 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         private final long supersetSize;
         private final SignificanceHeuristic significanceHeuristic;
 
-        private LongArray subsetSizes = context.bigArrays().newLongArray(1, true);
+        private LongArray subsetSizes = bigArrays().newLongArray(1, true);
 
         SignificantTermsResults(
             SignificanceLookup significanceLookup,
             SignificanceHeuristic significanceHeuristic,
             CardinalityUpperBound cardinality
         ) {
-            backgroundFrequencies = significanceLookup.bytesLookup(context.bigArrays(), cardinality);
+            backgroundFrequencies = significanceLookup.bytesLookup(bigArrays(), cardinality);
             supersetSize = significanceLookup.supersetSize();
             this.significanceHeuristic = significanceHeuristic;
         }
@@ -470,7 +470,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                 @Override
                 public void collect(int doc, long owningBucketOrd) throws IOException {
                     super.collect(doc, owningBucketOrd);
-                    subsetSizes = context.bigArrays().grow(subsetSizes, owningBucketOrd + 1);
+                    subsetSizes = bigArrays().grow(subsetSizes, owningBucketOrd + 1);
                     subsetSizes.increment(owningBucketOrd, 1);
                 }
             };

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
@@ -44,7 +43,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.LongKeyedBucketOrds.Bu
 import org.elasticsearch.search.aggregations.bucket.terms.SignificanceLookup.BackgroundFrequencyForLong;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -83,7 +81,7 @@ public class NumericTermsAggregator extends TermsAggregator {
         this.resultStrategy = resultStrategy.apply(this); // ResultStrategy needs a reference to the Aggregator to do its job.
         this.valuesSource = valuesSource;
         this.longFilter = longFilter;
-        bucketOrds = LongKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        bucketOrds = LongKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     @Override
@@ -307,7 +305,7 @@ public class NumericTermsAggregator extends TermsAggregator {
                 return;
             }
             // we need to fill-in the blanks
-            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+            for (LeafReaderContext ctx : searcher().getTopReaderContext().leaves()) {
                 SortedNumericDocValues values = getValues(ctx);
                 for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
                     if (values.advanceExact(docId)) {
@@ -501,10 +499,10 @@ public class NumericTermsAggregator extends TermsAggregator {
             SignificanceHeuristic significanceHeuristic,
             CardinalityUpperBound cardinality
         ) {
-            backgroundFrequencies = significanceLookup.longLookup(context.bigArrays(), cardinality);
+            backgroundFrequencies = significanceLookup.longLookup(bigArrays(), cardinality);
             supersetSize = significanceLookup.supersetSize();
             this.significanceHeuristic = significanceHeuristic;
-            subsetSizes = context.bigArrays().newLongArray(1, true);
+            subsetSizes = bigArrays().newLongArray(1, true);
         }
 
         @Override
@@ -523,7 +521,7 @@ public class NumericTermsAggregator extends TermsAggregator {
                 @Override
                 public void collect(int doc, long owningBucketOrd) throws IOException {
                     super.collect(doc, owningBucketOrd);
-                    subsetSizes = context.bigArrays().grow(subsetSizes, owningBucketOrd + 1);
+                    subsetSizes = bigArrays().grow(subsetSizes, owningBucketOrd + 1);
                     subsetSizes.increment(owningBucketOrd, 1);
                 }
             };
@@ -587,9 +585,7 @@ public class NumericTermsAggregator extends TermsAggregator {
         @Override
         SignificantLongTerms buildEmptyResult() {
             // We need to account for the significance of a miss in our global stats - provide corpus size as context
-            ContextIndexSearcher searcher = context.searcher();
-            IndexReader topReader = searcher.getIndexReader();
-            int supersetSize = topReader.numDocs();
+            int supersetSize = searcher().getIndexReader().numDocs();
             return new SignificantLongTerms(
                 name,
                 bucketCountThresholds.getRequiredSize(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
@@ -76,7 +76,7 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
         );
         this.valuesSource = valuesSource;
         this.filter = filter;
-        this.bucketOrds = BytesKeyedBucketOrds.build(context.bigArrays(), cardinality);
+        this.bucketOrds = BytesKeyedBucketOrds.build(bigArrays(), cardinality);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
         Arrays.fill(mergeMap, -1);
         long offset = 0;
         for (int owningOrdIdx = 0; owningOrdIdx < owningBucketOrds.length; owningOrdIdx++) {
-            try (BytesRefHash bucketsInThisOwningBucketToCollect = new BytesRefHash(1, context.bigArrays())) {
+            try (BytesRefHash bucketsInThisOwningBucketToCollect = new BytesRefHash(1, bigArrays())) {
                 filters[owningOrdIdx] = newFilter();
                 List<StringRareTerms.Bucket> builtBuckets = new ArrayList<>();
                 BytesKeyedBucketOrds.BucketOrdsEnum collectedBuckets = bucketOrds.ordsEnum(owningBucketOrds[owningOrdIdx]);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -73,13 +73,11 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
-
         final SortedNumericDoubleValues values = ((ValuesSource.Numeric)valuesSource).doubleValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                DoubleHistogram state = getExistingOrNewHistogram(bigArrays, bucket);
+                DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -72,12 +72,11 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = ((ValuesSource.Numeric)valuesSource).doubleValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                TDigestState state = getExistingOrNewHistogram(bigArrays, bucket);
+                TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -71,16 +71,15 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = valuesSource.doubleValues(ctx);
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
 
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays.grow(counts, bucket + 1);
-                sums = bigArrays.grow(sums, bucket + 1);
-                compensations = bigArrays.grow(compensations, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
+                sums = bigArrays().grow(sums, bucket + 1);
+                compensations = bigArrays().grow(compensations, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -116,7 +116,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             // only use ordinals if they don't increase memory usage by more than 25%
             if (ordinalsMemoryUsage < countsMemoryUsage / 4) {
                 ordinalsCollectorsUsed++;
-                return new OrdinalsCollector(counts, ordinalValues, context.bigArrays());
+                return new OrdinalsCollector(counts, ordinalValues, bigArrays());
             }
             ordinalsCollectorsOverheadTooHigh++;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -92,7 +92,6 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = valuesSource.doubleValues(ctx);
         final CompensatedSum compensatedSum = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumOfSqr = new CompensatedSum(0, 0);
@@ -103,13 +102,13 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
                 if (bucket >= counts.size()) {
                     final long from = counts.size();
                     final long overSize = BigArrays.overSize(bucket + 1);
-                    counts = bigArrays.resize(counts, overSize);
-                    sums = bigArrays.resize(sums, overSize);
-                    compensations = bigArrays.resize(compensations, overSize);
-                    mins = bigArrays.resize(mins, overSize);
-                    maxes = bigArrays.resize(maxes, overSize);
-                    sumOfSqrs = bigArrays.resize(sumOfSqrs, overSize);
-                    compensationOfSqrs = bigArrays.resize(compensationOfSqrs, overSize);
+                    counts = bigArrays().resize(counts, overSize);
+                    sums = bigArrays().resize(sums, overSize);
+                    compensations = bigArrays().resize(compensations, overSize);
+                    mins = bigArrays().resize(mins, overSize);
+                    maxes = bigArrays().resize(maxes, overSize);
+                    sumOfSqrs = bigArrays().resize(sumOfSqrs, overSize);
+                    compensationOfSqrs = bigArrays().resize(compensationOfSqrs, overSize);
                     mins.fill(from, overSize, Double.POSITIVE_INFINITY);
                     maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -63,18 +62,17 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource() : null;
         this.wrapLongitude = wrapLongitude;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            tops = bigArrays.newDoubleArray(1, false);
+            tops = bigArrays().newDoubleArray(1, false);
             tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
-            bottoms = bigArrays.newDoubleArray(1, false);
+            bottoms = bigArrays().newDoubleArray(1, false);
             bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
-            posLefts = bigArrays.newDoubleArray(1, false);
+            posLefts = bigArrays().newDoubleArray(1, false);
             posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
-            posRights = bigArrays.newDoubleArray(1, false);
+            posRights = bigArrays().newDoubleArray(1, false);
             posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
-            negLefts = bigArrays.newDoubleArray(1, false);
+            negLefts = bigArrays().newDoubleArray(1, false);
             negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
-            negRights = bigArrays.newDoubleArray(1, false);
+            negRights = bigArrays().newDoubleArray(1, false);
             negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
         }
     }
@@ -85,24 +83,23 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final MultiGeoPointValues values = valuesSource.geoPointValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= tops.size()) {
                     long from = tops.size();
-                    tops = bigArrays.grow(tops, bucket + 1);
+                    tops = bigArrays().grow(tops, bucket + 1);
                     tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
-                    bottoms = bigArrays.resize(bottoms, tops.size());
+                    bottoms = bigArrays().resize(bottoms, tops.size());
                     bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
-                    posLefts = bigArrays.resize(posLefts, tops.size());
+                    posLefts = bigArrays().resize(posLefts, tops.size());
                     posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
-                    posRights = bigArrays.resize(posRights, tops.size());
+                    posRights = bigArrays().resize(posRights, tops.size());
                     posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
-                    negLefts = bigArrays.resize(negLefts, tops.size());
+                    negLefts = bigArrays().resize(negLefts, tops.size());
                     negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
-                    negRights = bigArrays.resize(negRights, tops.size());
+                    negRights = bigArrays().resize(negRights, tops.size());
                     negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
                 }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
@@ -56,12 +55,11 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         // TODO: Stop expecting nulls here
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource() : null;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            lonSum = bigArrays.newDoubleArray(1, true);
-            lonCompensations = bigArrays.newDoubleArray(1, true);
-            latSum = bigArrays.newDoubleArray(1, true);
-            latCompensations = bigArrays.newDoubleArray(1, true);
-            counts = bigArrays.newLongArray(1, true);
+            lonSum = bigArrays().newDoubleArray(1, true);
+            lonCompensations = bigArrays().newDoubleArray(1, true);
+            latSum = bigArrays().newDoubleArray(1, true);
+            latCompensations = bigArrays().newDoubleArray(1, true);
+            counts = bigArrays().newLongArray(1, true);
         }
     }
 
@@ -70,7 +68,6 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final MultiGeoPointValues values = valuesSource.geoPointValues(ctx);
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
@@ -78,11 +75,11 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                latSum = bigArrays.grow(latSum, bucket + 1);
-                lonSum = bigArrays.grow(lonSum, bucket + 1);
-                lonCompensations = bigArrays.grow(lonCompensations, bucket + 1);
-                latCompensations = bigArrays.grow(latCompensations, bucket + 1);
-                counts = bigArrays.grow(counts, bucket + 1);
+                latSum = bigArrays().grow(latSum, bucket + 1);
+                lonSum = bigArrays().grow(lonSum, bucket + 1);
+                lonCompensations = bigArrays().grow(lonCompensations, bucket + 1);
+                latCompensations = bigArrays().grow(latCompensations, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -26,7 +26,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FutureArrays;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
@@ -105,7 +104,6 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                 throw new CollectionTerminatedException();
             }
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues allValues = valuesSource.doubleValues(ctx);
         final NumericDoubleValues values = MultiValueMode.MAX.select(allValues);
         return new LeafBucketCollectorBase(sub, allValues) {
@@ -114,7 +112,7 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= maxes.size()) {
                     long from = maxes.size();
-                    maxes = bigArrays.grow(maxes, bucket + 1);
+                    maxes = bigArrays().grow(maxes, bucket + 1);
                     maxes.fill(from, maxes.size(), Double.NEGATIVE_INFINITY);
                 }
                 if (values.advanceExact(doc)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -93,14 +92,13 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
 
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = valuesSource.doubleValues(ctx);
 
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
 
-                valueSketches = bigArrays.grow(valueSketches, bucket + 1);
+                valueSketches = bigArrays().grow(valueSketches, bucket + 1);
 
                 TDigestState valueSketch = valueSketches.get(bucket);
                 if (valueSketch == null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -25,7 +25,6 @@ import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
@@ -105,7 +104,6 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue {
                 throw new CollectionTerminatedException();
             }
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues allValues = valuesSource.doubleValues(ctx);
         final NumericDoubleValues values = MultiValueMode.MIN.select(allValues);
         return new LeafBucketCollectorBase(sub, allValues) {
@@ -114,7 +112,7 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue {
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= mins.size()) {
                     long from = mins.size();
-                    mins = bigArrays.grow(mins, bucket + 1);
+                    mins = bigArrays().grow(mins, bucket + 1);
                     mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
                 }
                 if (values.advanceExact(doc)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.script.ScriptedMetricAggContexts.MapScript;
+import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
@@ -56,6 +57,7 @@ class ScriptedMetricAggregator extends MetricsAggregator {
     private static final long BUCKET_COST_ESTIMATE = 1024 * 5;
 
     private final SearchLookup lookup;
+    private final SearchShardTarget shardTarget;
     private final Map<String, Object> aggParams;
     @Nullable
     private final ScriptedMetricAggContexts.InitScript.Factory initScriptFactory;
@@ -84,6 +86,7 @@ class ScriptedMetricAggregator extends MetricsAggregator {
     ) throws IOException {
         super(name, context, parent, metadata);
         this.lookup = lookup;
+        this.shardTarget = context.shardTarget();
         this.aggParams = aggParams;
         this.initScriptFactory = initScriptFactory;
         this.initScriptParams = initScriptParams;
@@ -120,7 +123,7 @@ class ScriptedMetricAggregator extends MetricsAggregator {
 
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
-                states = context.bigArrays().grow(states, owningBucketOrd + 1);
+                states = bigArrays().grow(states, owningBucketOrd + 1);
                 State state = states.get(owningBucketOrd);
                 if (state == null) {
                     addRequestCircuitBreakerBytes(BUCKET_COST_ESTIMATE);
@@ -176,12 +179,12 @@ class ScriptedMetricAggregator extends MetricsAggregator {
 
         State() {
             // Its possible for building the initial state to mutate the parameters as a side effect
-            Map<String, Object> aggParamsForState = ScriptedMetricAggregatorFactory.deepCopyParams(aggParams, context);
+            Map<String, Object> aggParamsForState = ScriptedMetricAggregatorFactory.deepCopyParams(aggParams, shardTarget);
             mapScriptParamsForState = ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, mapScriptParams);
             combineScriptParamsForState = ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, combineScriptParams);
             aggState = newInitialState(ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, initScriptParams));
             mapScript = mapScriptFactory.newFactory(
-                ScriptedMetricAggregatorFactory.deepCopyParams(mapScriptParamsForState, context),
+                ScriptedMetricAggregatorFactory.deepCopyParams(mapScriptParamsForState, shardTarget),
                 aggState,
                 lookup
             );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.SearchParseException;
+import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -81,7 +82,7 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
                                         Map<String, Object> metadata) throws IOException {
         Map<String, Object> aggParams = this.aggParams == null ? org.elasticsearch.common.collect.Map.of() : this.aggParams;
 
-        Script reduceScript = deepCopyScript(this.reduceScript, searchContext, aggParams);
+        Script reduceScript = deepCopyScript(this.reduceScript, searchContext.shardTarget(), aggParams);
 
         return new ScriptedMetricAggregator(
             name,
@@ -100,9 +101,9 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
         );
     }
 
-    private static Script deepCopyScript(Script script, SearchContext context, Map<String, Object> aggParams) {
+    private static Script deepCopyScript(Script script, SearchShardTarget shardTarget, Map<String, Object> aggParams) {
         if (script != null) {
-            Map<String, Object> params = mergeParams(aggParams, deepCopyParams(script.getParams(), context));
+            Map<String, Object> params = mergeParams(aggParams, deepCopyParams(script.getParams(), shardTarget));
             return new Script(script.getType(), script.getLang(), script.getIdOrCode(), params);
         } else {
             return null;
@@ -110,20 +111,20 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
     }
 
     @SuppressWarnings({ "unchecked" })
-    static <T> T deepCopyParams(T original, SearchContext context) {
+    static <T> T deepCopyParams(T original, SearchShardTarget shardTarget) {
         T clone;
         if (original instanceof Map) {
             Map<?, ?> originalMap = (Map<?, ?>) original;
             Map<Object, Object> clonedMap = new HashMap<>();
             for (Map.Entry<?, ?> e : originalMap.entrySet()) {
-                clonedMap.put(deepCopyParams(e.getKey(), context), deepCopyParams(e.getValue(), context));
+                clonedMap.put(deepCopyParams(e.getKey(), shardTarget), deepCopyParams(e.getValue(), shardTarget));
             }
             clone = (T) clonedMap;
         } else if (original instanceof List) {
             List<?> originalList = (List<?>) original;
             List<Object> clonedList = new ArrayList<>();
             for (Object o : originalList) {
-                clonedList.add(deepCopyParams(o, context));
+                clonedList.add(deepCopyParams(o, shardTarget));
             }
             clone = (T) clonedList;
         } else if (original instanceof String || original instanceof Integer || original instanceof Long || original instanceof Short
@@ -131,7 +132,7 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
             || original instanceof Boolean) {
             clone = original;
         } else {
-            throw new SearchParseException(context.shardTarget(),
+            throw new SearchParseException(shardTarget,
                 "Can only clone primitives, String, ArrayList, and HashMap. Found: " + original.getClass().getCanonicalName(), null);
         }
         return clone;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -59,13 +59,12 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
         // TODO: stop using nulls here
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            counts = bigArrays.newLongArray(1, true);
-            sums = bigArrays.newDoubleArray(1, true);
-            compensations = bigArrays.newDoubleArray(1, true);
-            mins = bigArrays.newDoubleArray(1, false);
+            counts = bigArrays().newLongArray(1, true);
+            sums = bigArrays().newDoubleArray(1, true);
+            compensations = bigArrays().newDoubleArray(1, true);
+            mins = bigArrays().newDoubleArray(1, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-            maxes = bigArrays.newDoubleArray(1, false);
+            maxes = bigArrays().newDoubleArray(1, false);
             maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         }
         this.format = valuesSourceConfig.format();
@@ -82,7 +81,6 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = valuesSource.doubleValues(ctx);
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
 
@@ -92,11 +90,11 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
                 if (bucket >= counts.size()) {
                     final long from = counts.size();
                     final long overSize = BigArrays.overSize(bucket + 1);
-                    counts = bigArrays.resize(counts, overSize);
-                    sums = bigArrays.resize(sums, overSize);
-                    compensations = bigArrays.resize(compensations, overSize);
-                    mins = bigArrays.resize(mins, overSize);
-                    maxes = bigArrays.resize(maxes, overSize);
+                    counts = bigArrays().resize(counts, overSize);
+                    sums = bigArrays().resize(sums, overSize);
+                    compensations = bigArrays().resize(compensations, overSize);
+                    mins = bigArrays().resize(mins, overSize);
+                    maxes = bigArrays().resize(maxes, overSize);
                     mins.fill(from, overSize, Double.POSITIVE_INFINITY);
                     maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -56,8 +55,8 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.format = valuesSourceConfig.format();
         if (valuesSource != null) {
-            sums = context.bigArrays().newDoubleArray(1, true);
-            compensations = context.bigArrays().newDoubleArray(1, true);
+            sums = bigArrays().newDoubleArray(1, true);
+            compensations = bigArrays().newDoubleArray(1, true);
         }
     }
 
@@ -72,14 +71,13 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues values = valuesSource.doubleValues(ctx);
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                sums = bigArrays.grow(sums, bucket + 1);
-                compensations = bigArrays.grow(compensations, bucket + 1);
+                sums = bigArrays().grow(sums, bucket + 1);
+                compensations = bigArrays().grow(compensations, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final int valuesCount = values.docValueCount();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -60,7 +59,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
         // TODO: stop expecting nulls here
         this.valuesSource = valuesSourceConfig.hasValues() ? valuesSourceConfig.getValuesSource() : null;
         if (valuesSource != null) {
-            counts = context.bigArrays().newLongArray(1, true);
+            counts = bigArrays().newLongArray(1, true);
         }
     }
 
@@ -70,7 +69,6 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
 
         if (valuesSource instanceof ValuesSource.Numeric) {
             final SortedNumericDocValues values = ((ValuesSource.Numeric)valuesSource).longValues(ctx);
@@ -78,7 +76,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    counts = bigArrays.grow(counts, bucket + 1);
+                    counts = bigArrays().grow(counts, bucket + 1);
                     if (values.advanceExact(doc)) {
                         counts.increment(bucket, values.docValueCount());
                     }
@@ -91,7 +89,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    counts = bigArrays.grow(counts, bucket + 1);
+                    counts = bigArrays().grow(counts, bucket + 1);
                     if (values.advanceExact(doc)) {
                         counts.increment(bucket, values.docValueCount());
                     }
@@ -104,7 +102,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays.grow(counts, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
                 if (values.advanceExact(doc)) {
                     counts.increment(bucket, values.docValueCount());
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -55,11 +54,10 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         this.valuesSources = valuesSources;
         this.format = format;
         if (valuesSources != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            weights = bigArrays.newDoubleArray(1, true);
-            valueSums = bigArrays.newDoubleArray(1, true);
-            valueCompensations = bigArrays.newDoubleArray(1, true);
-            weightCompensations = bigArrays.newDoubleArray(1, true);
+            weights = bigArrays().newDoubleArray(1, true);
+            valueSums = bigArrays().newDoubleArray(1, true);
+            valueCompensations = bigArrays().newDoubleArray(1, true);
+            weightCompensations = bigArrays().newDoubleArray(1, true);
         }
     }
 
@@ -74,7 +72,6 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         if (valuesSources == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues docValues = valuesSources.getField(VALUE_FIELD.getPreferredName(), ctx);
         final SortedNumericDoubleValues docWeights = valuesSources.getField(WEIGHT_FIELD.getPreferredName(), ctx);
         final CompensatedSum compensatedValueSum = new CompensatedSum(0, 0);
@@ -83,10 +80,10 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         return new LeafBucketCollectorBase(sub, docValues) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                weights = bigArrays.grow(weights, bucket + 1);
-                valueSums = bigArrays.grow(valueSums, bucket + 1);
-                valueCompensations = bigArrays.grow(valueCompensations, bucket + 1);
-                weightCompensations = bigArrays.grow(weightCompensations, bucket + 1);
+                weights = bigArrays().grow(weights, bucket + 1);
+                valueSums = bigArrays().grow(valueSums, bucket + 1);
+                valueCompensations = bigArrays().grow(valueCompensations, bucket + 1);
+                weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
 
                 if (docValues.advanceExact(doc) && docWeights.advanceExact(doc)) {
                     if (docWeights.docValueCount() > 1) {

--- a/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
@@ -25,7 +25,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.support.AggregationPath.PathElement;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.profile.Timer;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -56,11 +55,6 @@ public class ProfilingAggregator extends Aggregator {
     @Override
     public String name() {
         return delegate.name();
-    }
-
-    @Override
-    public SearchContext context() {
-        return delegate.context();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollectorTests.java
@@ -37,14 +37,11 @@ import org.apache.lucene.store.Directory;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.mockito.Mockito.when;
 
 public class BestBucketsDeferringCollectorTests extends AggregatorTestCase {
 
@@ -67,9 +64,7 @@ public class BestBucketsDeferringCollectorTests extends AggregatorTestCase {
         Query rewrittenQuery = indexSearcher.rewrite(termQuery);
         TopDocs topDocs = indexSearcher.search(termQuery, numDocs);
 
-        SearchContext searchContext = createSearchContext(indexSearcher, createIndexSettings(), rewrittenQuery, null);
-        when(searchContext.query()).thenReturn(rewrittenQuery);
-        BestBucketsDeferringCollector collector = new BestBucketsDeferringCollector(searchContext, false) {
+        BestBucketsDeferringCollector collector = new BestBucketsDeferringCollector(rewrittenQuery, indexSearcher, false) {
             @Override
             public ScoreMode scoreMode() {
                 return ScoreMode.COMPLETE;
@@ -88,7 +83,7 @@ public class BestBucketsDeferringCollectorTests extends AggregatorTestCase {
         }
 
         topDocs = indexSearcher.search(new MatchAllDocsQuery(), numDocs);
-        collector = new BestBucketsDeferringCollector(searchContext, true);
+        collector = new BestBucketsDeferringCollector(rewrittenQuery, indexSearcher, true);
         deferredCollectedDocIds = new HashSet<>();
         collector.setDeferredCollector(Collections.singleton(bla(deferredCollectedDocIds)));
         collector.preCollection();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregatorTests.java
@@ -24,24 +24,17 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
-import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-
-import static org.elasticsearch.search.aggregations.MultiBucketConsumerService.DEFAULT_MAX_BUCKETS;
 
 public class BucketsAggregatorTests extends AggregatorTestCase{
 
@@ -58,12 +51,7 @@ public class BucketsAggregatorTests extends AggregatorTestCase{
 
                 SearchContext searchContext = createSearchContext(
                     indexSearcher,
-                    createIndexSettings(),
                     null,
-                    new MultiBucketConsumerService.MultiBucketConsumer(
-                        DEFAULT_MAX_BUCKETS,
-                        new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
-                    ),
                     new NumberFieldMapper.NumberFieldType("test", NumberFieldMapper.NumberType.INTEGER)
                 );
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/MergingBucketsDeferringCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/MergingBucketsDeferringCollectorTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.when;
 
 public class MergingBucketsDeferringCollectorTests extends AggregatorTestCase {
     public void testBucketMergeNoDelete() throws Exception {
@@ -147,9 +145,7 @@ public class MergingBucketsDeferringCollectorTests extends AggregatorTestCase {
                 IndexSearcher indexSearcher = new IndexSearcher(indexReader);
 
                 Query query = new MatchAllDocsQuery();
-                SearchContext searchContext = createSearchContext(indexSearcher, createIndexSettings(), query, null);
-                when(searchContext.query()).thenReturn(query);
-                MergingBucketsDeferringCollector deferringCollector = new MergingBucketsDeferringCollector(searchContext, false);
+                MergingBucketsDeferringCollector deferringCollector = new MergingBucketsDeferringCollector(query, indexSearcher, false);
 
                 CollectingBucketCollector finalCollector = new CollectingBucketCollector();
                 deferringCollector.setDeferredCollector(Collections.singleton(finalCollector));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -94,6 +95,7 @@ import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
@@ -156,14 +158,13 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         return new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS);
     }
 
-    protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder,
-            IndexSearcher indexSearcher, MappedFieldType... fieldTypes) throws IOException {
+    protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder, SearchContext context) throws IOException {
         try {
             if (randomizeAggregatorImpl) {
                 TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = randomBoolean();
                 TermsAggregatorFactory.REMAP_GLOBAL_ORDS = randomBoolean();
             }
-            return super.createAggregator(aggregationBuilder, indexSearcher, fieldTypes);
+            return super.createAggregator(aggregationBuilder, context);
         } finally {
             TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = null;
             TermsAggregatorFactory.REMAP_GLOBAL_ORDS = null;
@@ -268,11 +269,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             .order(BucketOrder.key(true));
                         MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string");
 
-                        TermsAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                        SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+                        TermsAggregator aggregator = createAggregator(aggregationBuilder, context);
                         aggregator.preCollection();
                         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                         aggregator.postCollection();
-                        Terms result = reduce(aggregator);
+                        Terms result = reduce(aggregator, context.bigArrays());
                         assertEquals(5, result.getBuckets().size());
                         assertEquals("", result.getBuckets().get(0).getKeyAsString());
                         assertEquals(2L, result.getBuckets().get(0).getDocCount());
@@ -337,11 +339,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .size(12)
                         .order(BucketOrder.key(true));
 
-                    TermsAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+                    TermsAggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals(10, result.getBuckets().size());
                     assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -372,11 +375,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .field("sv_field")
                         .order(BucketOrder.key(true));
 
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType2);
+                    context = createSearchContext(indexSearcher, null, fieldType2);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(5, result.getBuckets().size());
                     assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -396,11 +400,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .field("mv_field")
                         .order(BucketOrder.key(true));
 
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(8, result.getBuckets().size());
                     assertEquals("val002", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -425,11 +430,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(null, "val00.+"))
                         .field("mv_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(2, result.getBuckets().size());
                     assertEquals("val010", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -442,11 +448,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(new String[]{"val000", "val010"}, null))
                         .field("mv_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(2, result.getBuckets().size());
                     assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -460,11 +467,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             "val005", "val006", "val007", "val008", "val009", "val011"}))
                         .field("mv_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(2, result.getBuckets().size());
                     assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -515,11 +523,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(new long[]{0, 5}, null))
                         .field("long_field")
                         .order(BucketOrder.key(true));
-                    TermsAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+                    TermsAggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals(2, result.getBuckets().size());
                     assertEquals(0L, result.getBuckets().get(0).getKey());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -532,11 +541,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(null, new long[]{0, 5}))
                         .field("long_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(4, result.getBuckets().size());
                     assertEquals(1L, result.getBuckets().get(0).getKey());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -555,11 +565,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(new double[]{0.0, 5.0}, null))
                         .field("double_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(2, result.getBuckets().size());
                     assertEquals(0.0, result.getBuckets().get(0).getKey());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -572,11 +583,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .includeExclude(new IncludeExclude(null, new double[]{0.0, 5.0}))
                         .field("double_field")
                         .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    context = createSearchContext(indexSearcher, null, fieldType);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals(4, result.getBuckets().size());
                     assertEquals(1.0, result.getBuckets().get(0).getKey());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -738,11 +750,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .field("field")
                         .order(bucketOrder);
 
-                    Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals(size, result.getBuckets().size());
                     for (int i = 0; i < size; i++) {
                         Map.Entry<T, Integer>  expected = expectedBuckets.get(i);
@@ -764,11 +777,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             .size(numTerms)
                             .collectMode(randomFrom(Aggregator.SubAggCollectionMode.values()))
                             .field("field"));
-                        aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType, filterFieldType);
+                        context = createSearchContext(indexSearcher, null, fieldType, filterFieldType);
+                        aggregator = createAggregator(aggregationBuilder, context);
                         aggregator.preCollection();
                         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                         aggregator.postCollection();
-                        result = ((Filter) reduce(aggregator)).getAggregations().get("_name2");
+                        result = ((Filter) reduce(aggregator, context.bigArrays())).getAggregations().get("_name2");
                         int expectedFilteredCounts = 0;
                         for (Integer count : filteredCounts.values()) {
                             if (count > 0) {
@@ -837,11 +851,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                     MappedFieldType fieldType2
                         = new NumberFieldMapper.NumberFieldType("value", NumberFieldMapper.NumberType.LONG);
-                    Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType, fieldType2);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType, fieldType2);
+                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals(size, result.getBuckets().size());
                     for (int i = 0; i < size; i++) {
                         Map.Entry<T, Long>  expected = expectedBuckets.get(i);
@@ -866,31 +881,32 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
                         .userValueTypeHint(ValueType.STRING)
                         .field("string");
-                    Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType1);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType1);
+                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals("_name", result.getName());
                     assertEquals(0, result.getBuckets().size());
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.LONG)
-                        .field("long");
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType2);
+                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.LONG).field("long");
+                    context = createSearchContext(indexSearcher, null, fieldType2);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals("_name", result.getName());
                     assertEquals(0, result.getBuckets().size());
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.DOUBLE)
-                        .field("double");
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType3);
+                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.DOUBLE).field("double");
+                    context = createSearchContext(indexSearcher, null, fieldType3);
+                    aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    result = reduce(aggregator);
+                    result = reduce(aggregator, context.bigArrays());
                     assertEquals("_name", result.getName());
                     assertEquals(0, result.getBuckets().size());
                 }
@@ -909,11 +925,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
                             .userValueTypeHint(valueTypes[i])
                             .field(fieldNames[i]);
-                        Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, (MappedFieldType) null);
+                        SearchContext context = createSearchContext(indexSearcher, null);
+                        Aggregator aggregator = createAggregator(aggregationBuilder, context);
                         aggregator.preCollection();
                         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                         aggregator.postCollection();
-                        Terms result = reduce(aggregator);
+                        Terms result = reduce(aggregator, context.bigArrays());
                         assertEquals("_name", result.getName());
                         assertEquals(0, result.getBuckets().size());
                         assertFalse(AggregationInspectionHelper.hasValue((InternalTerms)result));
@@ -945,11 +962,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
                             .userValueTypeHint(valueTypes[i])
                             .field(fieldNames[i]).missing(missingValues[i]);
-                        Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType1);
+                        SearchContext context = createSearchContext(indexSearcher, null, fieldType1);
+                        Aggregator aggregator = createAggregator(aggregationBuilder, context);
                         aggregator.preCollection();
                         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                         aggregator.postCollection();
-                        Terms result = reduce(aggregator);
+                        Terms result = reduce(aggregator, context.bigArrays());
                         assertEquals("_name", result.getName());
                         assertEquals(1, result.getBuckets().size());
                         assertEquals(missingValues[i], result.getBuckets().get(0).getKey());
@@ -1017,11 +1035,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     IndexSearcher indexSearcher = newIndexSearcher(indexReader);
                     TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name") .field(field);
                     // Note - other places we throw IllegalArgumentException
-                    Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals("_name", result.getName());
                     assertEquals(1, result.getBuckets().size());
                     assertEquals("192.168.100.42", result.getBuckets().get(0).getKey());
@@ -1065,11 +1084,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("field1");
                     MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("field2");
 
-                    Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType1, fieldType2);
+                    SearchContext context = createSearchContext(indexSearcher, null, fieldType1, fieldType2);
+                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
                     aggregator.postCollection();
-                    Terms result = reduce(aggregator);
+                    Terms result = reduce(aggregator, context.bigArrays());
                     assertEquals(3, result.getBuckets().size());
                     assertEquals("a", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(1L, result.getBuckets().get(0).getDocCount());
@@ -1466,13 +1486,13 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         return aggregator.buildTopLevel();
     }
 
-    private <T extends InternalAggregation> T reduce(Aggregator agg) throws IOException {
+    private <T extends InternalAggregation> T reduce(Aggregator agg, BigArrays bigArrays) throws IOException {
         // now do the final reduce
         MultiBucketConsumerService.MultiBucketConsumer reduceBucketConsumer =
             new MultiBucketConsumerService.MultiBucketConsumer(Integer.MAX_VALUE,
                 new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST));
         InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(
-            agg.context().bigArrays(), getMockScriptService(), reduceBucketConsumer, PipelineTree.EMPTY);
+            bigArrays, getMockScriptService(), reduceBucketConsumer, PipelineTree.EMPTY);
 
         T topLevel  = (T) agg.buildTopLevel();
         T result = (T) topLevel.reduce(Collections.singletonList(topLevel), context);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -55,6 +55,7 @@ import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.LeafDocLookup;
 
 import java.io.IOException;
@@ -600,7 +601,8 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         AvgAggregationBuilder aggregationBuilder = new AvgAggregationBuilder("avg")
             .field("value");
 
-        AvgAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+        SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+        AvgAggregator aggregator = createAggregator(aggregationBuilder, context);
         aggregator.preCollection();
         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
         aggregator.postCollection();
@@ -612,7 +614,7 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         assertTrue(AggregationInspectionHelper.hasValue(avg));
 
         // Test that an aggregation not using a script does get cached
-        assertTrue(aggregator.context().getQueryShardContext().isCacheable());
+        assertTrue(context.getQueryShardContext().isCacheable());
 
         multiReader.close();
         directory.close();
@@ -646,7 +648,8 @@ public class AvgAggregatorTests extends AggregatorTestCase {
             .field("value")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.emptyMap()));
 
-        AvgAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+        SearchContext context = createSearchContext(indexSearcher, null, fieldType);
+        AvgAggregator aggregator = createAggregator(aggregationBuilder, context);
         aggregator.preCollection();
         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
         aggregator.postCollection();
@@ -658,13 +661,14 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         assertTrue(AggregationInspectionHelper.hasValue(avg));
 
         // Test that an aggregation using a deterministic script gets cached
-        assertTrue(aggregator.context().getQueryShardContext().isCacheable());
+        assertTrue(context.getQueryShardContext().isCacheable());
 
         aggregationBuilder = new AvgAggregationBuilder("avg")
             .field("value")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, RANDOM_SCRIPT, Collections.emptyMap()));
 
-        aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
+        context = createSearchContext(indexSearcher, null, fieldType);
+        aggregator = createAggregator(aggregationBuilder, context);
         aggregator.preCollection();
         indexSearcher.search(new MatchAllDocsQuery(), aggregator);
         aggregator.postCollection();
@@ -677,7 +681,7 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         assertTrue(AggregationInspectionHelper.hasValue(avg));
 
         // Test that an aggregation using a nondeterministic script does not get cached
-        assertFalse(aggregator.context().getQueryShardContext().isCacheable());
+        assertFalse(context.getQueryShardContext().isCacheable());
 
         multiReader.close();
         directory.close();

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -212,43 +212,9 @@ public abstract class AggregatorTestCase extends ESTestCase {
     }
 
     protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder,
-                                                        IndexSearcher indexSearcher,
+                                                        IndexSearcher searcher,
                                                         MappedFieldType... fieldTypes) throws IOException {
-        return createAggregator(aggregationBuilder, indexSearcher, createIndexSettings(),
-            new MultiBucketConsumer(DEFAULT_MAX_BUCKETS, new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)), fieldTypes);
-    }
-
-    protected <A extends Aggregator> A createAggregator(Query query,
-                                                        AggregationBuilder aggregationBuilder,
-                                                        IndexSearcher indexSearcher,
-                                                        IndexSettings indexSettings,
-                                                        MappedFieldType... fieldTypes) throws IOException {
-        return createAggregator(query, aggregationBuilder, indexSearcher, indexSettings,
-            new MultiBucketConsumer(DEFAULT_MAX_BUCKETS, new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)), fieldTypes);
-    }
-
-    protected <A extends Aggregator> A createAggregator(Query query, AggregationBuilder aggregationBuilder,
-                                                        IndexSearcher indexSearcher,
-                                                        MultiBucketConsumer bucketConsumer,
-                                                        MappedFieldType... fieldTypes) throws IOException {
-        return createAggregator(query, aggregationBuilder, indexSearcher, createIndexSettings(), bucketConsumer, fieldTypes);
-    }
-
-    protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder,
-                                                        IndexSearcher indexSearcher,
-                                                        IndexSettings indexSettings,
-                                                        MultiBucketConsumer bucketConsumer,
-                                                        MappedFieldType... fieldTypes) throws IOException {
-        return createAggregator(null, aggregationBuilder, indexSearcher, indexSettings, bucketConsumer, fieldTypes);
-    }
-
-    protected <A extends Aggregator> A createAggregator(Query query,
-                                                        AggregationBuilder aggregationBuilder,
-                                                        IndexSearcher indexSearcher,
-                                                        IndexSettings indexSettings,
-                                                        MultiBucketConsumer bucketConsumer,
-                                                        MappedFieldType... fieldTypes) throws IOException {
-        SearchContext searchContext = createSearchContext(indexSearcher, indexSettings, query, bucketConsumer, fieldTypes);
+        SearchContext searchContext = createSearchContext(searcher, null, fieldTypes);
         return createAggregator(aggregationBuilder, searchContext);
     }
 
@@ -264,12 +230,17 @@ public abstract class AggregatorTestCase extends ESTestCase {
     /**
      * Create a {@linkplain SearchContext} for testing an {@link Aggregator}.
      */
-    protected SearchContext createSearchContext(IndexSearcher indexSearcher,
-                                                IndexSettings indexSettings,
-                                                Query query,
-                                                MultiBucketConsumer bucketConsumer,
-                                                MappedFieldType... fieldTypes) throws IOException {
-        return createSearchContext(indexSearcher, indexSettings, query, bucketConsumer, new NoneCircuitBreakerService(), fieldTypes);
+    protected SearchContext createSearchContext(
+        IndexSearcher indexSearcher,
+        Query query,
+        MappedFieldType... fieldTypes
+    ) throws IOException {
+        CircuitBreakerService breakerService = new NoneCircuitBreakerService();
+        MultiBucketConsumer bucketConsumer = new MultiBucketConsumer(
+            DEFAULT_MAX_BUCKETS,
+            breakerService.getBreaker(CircuitBreaker.REQUEST)
+        );
+        return createSearchContext(indexSearcher, createIndexSettings(), query, bucketConsumer, breakerService, fieldTypes);
     }
 
     protected SearchContext createSearchContext(IndexSearcher indexSearcher,
@@ -441,9 +412,10 @@ public abstract class AggregatorTestCase extends ESTestCase {
         final PipelineTree pipelines = builder.buildPipelineTree();
         List<InternalAggregation> aggs = new ArrayList<>();
         Query rewritten = searcher.rewrite(query);
-        MultiBucketConsumer bucketConsumer = new MultiBucketConsumer(maxBucket,
-            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST));
-        C root = createAggregator(query, builder, searcher, bucketConsumer, fieldTypes);
+        CircuitBreakerService breakerService = new NoneCircuitBreakerService();
+        MultiBucketConsumer bucketConsumer = new MultiBucketConsumer(maxBucket, breakerService.getBreaker(CircuitBreaker.REQUEST));
+        SearchContext searchContext = createSearchContext(searcher, indexSettings, query, bucketConsumer, breakerService, fieldTypes);
+        C root = createAggregator(builder, searchContext);
 
         if (randomBoolean() && searcher.getIndexReader().leaves().size() > 0) {
             assertThat(ctx, instanceOf(CompositeReaderContext.class));
@@ -457,7 +429,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             for (ShardSearcher subSearcher : subSearchers) {
                 MultiBucketConsumer shardBucketConsumer = new MultiBucketConsumer(maxBucket,
                     new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST));
-                C a = createAggregator(query, builder, subSearcher, indexSettings, shardBucketConsumer, fieldTypes);
+                C a = createAggregator(builder, searchContext);
                 a.preCollection();
                 Weight weight = subSearcher.createWeight(rewritten, ScoreMode.COMPLETE, 1f);
                 subSearcher.search(weight, a);
@@ -478,7 +450,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             int r = randomIntBetween(1, toReduceSize);
             List<InternalAggregation> toReduce = aggs.subList(0, r);
             InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forPartialReduction(
-                root.context().bigArrays(), getMockScriptService(), () -> PipelineAggregator.PipelineTree.EMPTY);
+                searchContext.bigArrays(), getMockScriptService(), () -> PipelineAggregator.PipelineTree.EMPTY);
             A reduced = (A) aggs.get(0).reduce(toReduce, context);
             aggs = new ArrayList<>(aggs.subList(r, toReduceSize));
             aggs.add(reduced);
@@ -488,7 +460,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         MultiBucketConsumer reduceBucketConsumer = new MultiBucketConsumer(maxBucket,
             new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST));
         InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(
-            root.context().bigArrays(), getMockScriptService(), reduceBucketConsumer, pipelines);
+            searchContext.bigArrays(), getMockScriptService(), reduceBucketConsumer, pipelines);
 
         @SuppressWarnings("unchecked")
         A internalAgg = (A) aggs.get(0).reduce(aggs, context);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
@@ -63,13 +63,12 @@ abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetric
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final HistogramValues values = ((HistogramValuesSource.Histogram)valuesSource).getHistogramValues(ctx);
 
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                DoubleHistogram state = getExistingOrNewHistogram(bigArrays, bucket);
+                DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
                     final HistogramValue sketch = values.histogram();
                     while (sketch.next()) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedTDigestPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedTDigestPercentilesAggregator.java
@@ -63,13 +63,12 @@ abstract class AbstractHistoBackedTDigestPercentilesAggregator extends NumericMe
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final HistogramValues values = ((HistogramValuesSource.Histogram)valuesSource).getHistogramValues(ctx);
 
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                TDigestState state = getExistingOrNewHistogram(bigArrays, bucket);
+                TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
                     final HistogramValue sketch = values.histogram();
                     while(sketch.next()) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.HistogramValue;
@@ -53,10 +52,9 @@ public class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleVal
         this.valuesSource = valuesSourceConfig.hasValues() ? (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource() : null;
         this.format = valuesSourceConfig.format();
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            counts = bigArrays.newLongArray(1, true);
-            sums = bigArrays.newDoubleArray(1, true);
-            compensations = bigArrays.newDoubleArray(1, true);
+            counts = bigArrays().newLongArray(1, true);
+            sums = bigArrays().newDoubleArray(1, true);
+            compensations = bigArrays().newDoubleArray(1, true);
         }
     }
 
@@ -71,16 +69,15 @@ public class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleVal
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final HistogramValues values = valuesSource.getHistogramValues(ctx);
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
 
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays.grow(counts, bucket + 1);
-                sums = bigArrays.grow(sums, bucket + 1);
-                compensations = bigArrays.grow(compensations, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
+                sums = bigArrays().grow(sums, bucket + 1);
+                compensations = bigArrays().grow(compensations, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final HistogramValue sketch = values.histogram();

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
@@ -9,7 +9,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.HistogramValue;
 import org.elasticsearch.index.fielddata.HistogramValues;
@@ -43,7 +42,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
         super(name, context, parent, metadata);
         this.valuesSource = config.hasValues() ? (HistogramValuesSource.Histogram) config.getValuesSource() : null;
         if (valuesSource != null) {
-            maxes = context.bigArrays().newDoubleArray(1, false);
+            maxes = bigArrays().newDoubleArray(1, false);
             maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         }
         this.formatter = config.format();
@@ -65,7 +64,6 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
             }
         }
 
-        final BigArrays bigArrays = context.bigArrays();
         final HistogramValues values = valuesSource.getHistogramValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
 
@@ -73,7 +71,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= maxes.size()) {
                     long from = maxes.size();
-                    maxes = bigArrays.grow(maxes, bucket + 1);
+                    maxes = bigArrays().grow(maxes, bucket + 1);
                     maxes.fill(from, maxes.size(), Double.NEGATIVE_INFINITY);
                 }
                 if (values.advanceExact(doc)) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
@@ -9,7 +9,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.HistogramValue;
 import org.elasticsearch.index.fielddata.HistogramValues;
@@ -43,7 +42,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
         super(name, context, parent, metadata);
         this.valuesSource = config.hasValues() ? (HistogramValuesSource.Histogram) config.getValuesSource() : null;
         if (valuesSource != null) {
-            mins = context.bigArrays().newDoubleArray(1, false);
+            mins = bigArrays().newDoubleArray(1, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         }
         this.format = config.format();
@@ -65,7 +64,6 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
             }
         }
 
-        final BigArrays bigArrays = context.bigArrays();
         final HistogramValues values = valuesSource.getHistogramValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
 
@@ -73,7 +71,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= mins.size()) {
                     long from = mins.size();
-                    mins = bigArrays.grow(mins, bucket + 1);
+                    mins = bigArrays().grow(mins, bucket + 1);
                     mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
                 }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.HistogramValue;
 import org.elasticsearch.index.fielddata.HistogramValues;
@@ -46,7 +45,7 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
         // TODO: stop using nulls here
         this.valuesSource = valuesSourceConfig.hasValues() ? (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource() : null;
         if (valuesSource != null) {
-            counts = context.bigArrays().newLongArray(1, true);
+            counts = bigArrays().newLongArray(1, true);
         }
     }
 
@@ -56,13 +55,12 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
 
         final HistogramValues values = valuesSource.getHistogramValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays.grow(counts, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
                 if (values.advanceExact(doc)) {
                     final HistogramValue sketch = values.histogram();
                     while (sketch.next()) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
@@ -57,13 +57,12 @@ public class BoxplotAggregator extends NumericMetricsAggregator.MultiValue {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         if (valuesSource instanceof HistogramValuesSource.Histogram) {
             final HistogramValues values = ((HistogramValuesSource.Histogram)valuesSource).getHistogramValues(ctx);
             return new LeafBucketCollectorBase(sub, values) {
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    TDigestState state = getExistingOrNewHistogram(bigArrays, bucket);
+                    TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                     if (values.advanceExact(doc)) {
                         final HistogramValue sketch = values.histogram();
                         while(sketch.next()) {
@@ -77,9 +76,9 @@ public class BoxplotAggregator extends NumericMetricsAggregator.MultiValue {
             return new LeafBucketCollectorBase(sub, values) {
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    states = bigArrays.grow(states, bucket + 1);
+                    states = bigArrays().grow(states, bucket + 1);
                     if (values.advanceExact(doc)) {
-                        TDigestState state = getExistingOrNewHistogram(bigArrays, bucket);
+                        TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                         if (values.advanceExact(doc)) {
                             final int valueCount = values.docValueCount();
                             for (int i = 0; i < valueCount; i++) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
@@ -45,8 +45,8 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
         this.valuesSource = valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
         if (valuesSource != null) {
-            sums = context.bigArrays().newDoubleArray(1, true);
-            compensations = context.bigArrays().newDoubleArray(1, true);
+            sums = bigArrays().newDoubleArray(1, true);
+            compensations = bigArrays().newDoubleArray(1, true);
             if (rateMode == null) {
                 rateMode = RateMode.SUM;
             }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/HistogramRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/HistogramRateAggregator.java
@@ -6,12 +6,8 @@
 
 package org.elasticsearch.xpack.analytics.rate;
 
-import java.io.IOException;
-import java.util.Map;
-
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.HistogramValue;
 import org.elasticsearch.index.fielddata.HistogramValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -21,6 +17,9 @@ import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class HistogramRateAggregator extends AbstractRateAggregator {
     public HistogramRateAggregator(
@@ -37,14 +36,13 @@ public class HistogramRateAggregator extends AbstractRateAggregator {
 
     @Override
     public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, final LeafBucketCollector sub) throws IOException {
-        final BigArrays bigArrays = context.bigArrays();
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         final HistogramValues values = ((HistogramValuesSource.Histogram) valuesSource).getHistogramValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                sums = bigArrays.grow(sums, bucket + 1);
-                compensations = bigArrays.grow(compensations, bucket + 1);
+                sums = bigArrays().grow(sums, bucket + 1);
+                compensations = bigArrays().grow(compensations, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final HistogramValue sketch = values.histogram();

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/NumericRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/NumericRateAggregator.java
@@ -6,12 +6,8 @@
 
 package org.elasticsearch.xpack.analytics.rate;
 
-import java.io.IOException;
-import java.util.Map;
-
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
@@ -20,6 +16,9 @@ import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class NumericRateAggregator extends AbstractRateAggregator {
     public NumericRateAggregator(
@@ -36,14 +35,13 @@ public class NumericRateAggregator extends AbstractRateAggregator {
 
     @Override
     public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, final LeafBucketCollector sub) throws IOException {
-        final BigArrays bigArrays = context.bigArrays();
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         final SortedNumericDoubleValues values = ((ValuesSource.Numeric) valuesSource).doubleValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                sums = bigArrays.grow(sums, bucket + 1);
-                compensations = bigArrays.grow(compensations, bucket + 1);
+                sums = bigArrays().grow(sums, bucket + 1);
+                compensations = bigArrays().grow(compensations, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final int valuesCount = values.docValueCount();

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
@@ -54,12 +54,11 @@ public class StringStatsAggregator extends MetricsAggregator {
         this.showDistribution = showDistribution;
         this.valuesSource = (ValuesSource.Bytes) valuesSource;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            count = bigArrays.newLongArray(1, true);
-            totalLength = bigArrays.newLongArray(1, true);
-            minLength = bigArrays.newIntArray(1, false);
+            count = bigArrays().newLongArray(1, true);
+            totalLength = bigArrays().newLongArray(1, true);
+            minLength = bigArrays().newIntArray(1, false);
             minLength.fill(0, minLength.size(), Integer.MAX_VALUE);
-            maxLength = bigArrays.newIntArray(1, false);
+            maxLength = bigArrays().newIntArray(1, false);
             maxLength.fill(0, maxLength.size(), Integer.MIN_VALUE);
             charOccurrences = new HashMap<>();
         }
@@ -77,7 +76,6 @@ public class StringStatsAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
 
         return new LeafBucketCollectorBase(sub, values) {
@@ -86,10 +84,10 @@ public class StringStatsAggregator extends MetricsAggregator {
                 final long overSize = BigArrays.overSize(bucket + 1);
                 if (bucket >= count.size()) {
                     final long from = count.size();
-                    count = bigArrays.resize(count, overSize);
-                    totalLength = bigArrays.resize(totalLength, overSize);
-                    minLength = bigArrays.resize(minLength, overSize);
-                    maxLength = bigArrays.resize(maxLength, overSize);
+                    count = bigArrays().resize(count, overSize);
+                    totalLength = bigArrays().resize(totalLength, overSize);
+                    minLength = bigArrays().resize(minLength, overSize);
+                    maxLength = bigArrays().resize(maxLength, overSize);
                     minLength.fill(from, overSize, Integer.MAX_VALUE);
                     maxLength.fill(from, overSize, Integer.MIN_VALUE);
                 }
@@ -115,10 +113,10 @@ public class StringStatsAggregator extends MetricsAggregator {
                             for (Character c : valueStr.toCharArray()) {
                                 LongArray occ = charOccurrences.get(c);
                                 if (occ == null) {
-                                    occ = bigArrays.newLongArray(overSize, true);
+                                    occ = bigArrays().newLongArray(overSize, true);
                                 } else {
                                     if (bucket >= occ.size()) {
-                                        occ = bigArrays.resize(occ, overSize);
+                                        occ = bigArrays().resize(occ, overSize);
                                     }
                                 }
                                 occ.increment(bucket, 1);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.analytics.ttest;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -31,7 +30,7 @@ public class PairedTTestAggregator extends TTestAggregator<PairedTTestState> {
     PairedTTestAggregator(String name, MultiValuesSource.NumericMultiValuesSource valuesSources, int tails, DocValueFormat format,
                           SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
         super(name, valuesSources, tails, format, context, parent, metadata);
-        statsBuilder = new TTestStatsBuilder(context.bigArrays());
+        statsBuilder = new TTestStatsBuilder(bigArrays());
     }
 
     @Override
@@ -55,7 +54,6 @@ public class PairedTTestAggregator extends TTestAggregator<PairedTTestState> {
         if (valuesSources == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues docAValues = valuesSources.getField(A_FIELD.getPreferredName(), ctx);
         final SortedNumericDoubleValues docBValues = valuesSources.getField(B_FIELD.getPreferredName(), ctx);
         final CompensatedSum compDiffSum = new CompensatedSum(0, 0);
@@ -69,7 +67,7 @@ public class PairedTTestAggregator extends TTestAggregator<PairedTTestState> {
                         throw new AggregationExecutionException("Encountered more than one value for a " +
                             "single document. Use a script to combine multiple values per doc into a single value.");
                     }
-                    statsBuilder.grow(bigArrays, bucket + 1);
+                    statsBuilder.grow(bigArrays(), bucket + 1);
                     // There should always be one value if advanceExact lands us here, either
                     // a real value or a `missing` value
                     assert docAValues.docValueCount() == 1;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
@@ -12,7 +12,6 @@ import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -39,9 +38,8 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
                             Supplier<Tuple<Weight, Weight>> weightsSupplier, DocValueFormat format, SearchContext context,
                             Aggregator parent, Map<String, Object> metadata) throws IOException {
         super(name, valuesSources, tails, format, context, parent, metadata);
-        BigArrays bigArrays = context.bigArrays();
-        a = new TTestStatsBuilder(bigArrays);
-        b = new TTestStatsBuilder(bigArrays);
+        a = new TTestStatsBuilder(bigArrays());
+        b = new TTestStatsBuilder(bigArrays());
         this.weightsSupplier = weightsSupplier;
         this.homoscedastic = homoscedastic;
     }
@@ -67,7 +65,6 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
         if (valuesSources == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final SortedNumericDoubleValues docAValues = valuesSources.getField(A_FIELD.getPreferredName(), ctx);
         final SortedNumericDoubleValues docBValues = valuesSources.getField(B_FIELD.getPreferredName(), ctx);
         final CompensatedSum compSumA = new CompensatedSum(0, 0);
@@ -93,12 +90,12 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (bitsA == null || bitsA.get(doc)) {
-                    a.grow(bigArrays, bucket + 1);
+                    a.grow(bigArrays(), bucket + 1);
                     processValues(doc, bucket, docAValues, compSumA, compSumOfSqrA, a);
                 }
                 if (bitsB == null || bitsB.get(doc)) {
                     processValues(doc, bucket, docBValues, compSumB, compSumOfSqrB, b);
-                    b.grow(bigArrays, bucket + 1);
+                    b.grow(bigArrays(), bucket + 1);
                 }
             }
         };

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.spatial.aggregations.metrics;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
@@ -50,15 +49,14 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         // TODO: stop expecting nulls here
         this.valuesSource = valuesSourceConfig.hasValues() ? (GeoShapeValuesSource) valuesSourceConfig.getValuesSource() : null;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            lonSum = bigArrays.newDoubleArray(1, true);
-            lonCompensations = bigArrays.newDoubleArray(1, true);
-            latSum = bigArrays.newDoubleArray(1, true);
-            latCompensations = bigArrays.newDoubleArray(1, true);
-            weightSum = bigArrays.newDoubleArray(1, true);
-            weightCompensations = bigArrays.newDoubleArray(1, true);
-            counts = bigArrays.newLongArray(1, true);
-            dimensionalShapeTypes = bigArrays.newByteArray(1, true);
+            lonSum = bigArrays().newDoubleArray(1, true);
+            lonCompensations = bigArrays().newDoubleArray(1, true);
+            latSum = bigArrays().newDoubleArray(1, true);
+            latCompensations = bigArrays().newDoubleArray(1, true);
+            weightSum = bigArrays().newDoubleArray(1, true);
+            weightCompensations = bigArrays().newDoubleArray(1, true);
+            counts = bigArrays().newLongArray(1, true);
+            dimensionalShapeTypes = bigArrays().newByteArray(1, true);
         }
     }
 
@@ -67,7 +65,6 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final MultiGeoShapeValues values = valuesSource.geoShapeValues(ctx);
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
@@ -76,14 +73,14 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                latSum = bigArrays.grow(latSum, bucket + 1);
-                lonSum = bigArrays.grow(lonSum, bucket + 1);
-                weightSum = bigArrays.grow(weightSum, bucket + 1);
-                lonCompensations = bigArrays.grow(lonCompensations, bucket + 1);
-                latCompensations = bigArrays.grow(latCompensations, bucket + 1);
-                weightCompensations = bigArrays.grow(weightCompensations, bucket + 1);
-                counts = bigArrays.grow(counts, bucket + 1);
-                dimensionalShapeTypes = bigArrays.grow(dimensionalShapeTypes, bucket + 1);
+                latSum = bigArrays().grow(latSum, bucket + 1);
+                lonSum = bigArrays().grow(lonSum, bucket + 1);
+                weightSum = bigArrays().grow(weightSum, bucket + 1);
+                lonCompensations = bigArrays().grow(lonCompensations, bucket + 1);
+                latCompensations = bigArrays().grow(latCompensations, bucket + 1);
+                weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
+                dimensionalShapeTypes = bigArrays().grow(dimensionalShapeTypes, bucket + 1);
 
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.spatial.search.aggregations.metrics;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -46,18 +45,17 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
         this.valuesSource = valuesSourceConfig.hasValues() ? (GeoShapeValuesSource) valuesSourceConfig.getValuesSource() : null;
         this.wrapLongitude = wrapLongitude;
         if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            tops = bigArrays.newDoubleArray(1, false);
+            tops = bigArrays().newDoubleArray(1, false);
             tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
-            bottoms = bigArrays.newDoubleArray(1, false);
+            bottoms = bigArrays().newDoubleArray(1, false);
             bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
-            posLefts = bigArrays.newDoubleArray(1, false);
+            posLefts = bigArrays().newDoubleArray(1, false);
             posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
-            posRights = bigArrays.newDoubleArray(1, false);
+            posRights = bigArrays().newDoubleArray(1, false);
             posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
-            negLefts = bigArrays.newDoubleArray(1, false);
+            negLefts = bigArrays().newDoubleArray(1, false);
             negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
-            negRights = bigArrays.newDoubleArray(1, false);
+            negRights = bigArrays().newDoubleArray(1, false);
             negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
         }
     }
@@ -68,24 +66,23 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final BigArrays bigArrays = context.bigArrays();
         final MultiGeoShapeValues values = valuesSource.geoShapeValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (bucket >= tops.size()) {
                     long from = tops.size();
-                    tops = bigArrays.grow(tops, bucket + 1);
+                    tops = bigArrays().grow(tops, bucket + 1);
                     tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
-                    bottoms = bigArrays.resize(bottoms, tops.size());
+                    bottoms = bigArrays().resize(bottoms, tops.size());
                     bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
-                    posLefts = bigArrays.resize(posLefts, tops.size());
+                    posLefts = bigArrays().resize(posLefts, tops.size());
                     posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
-                    posRights = bigArrays.resize(posRights, tops.size());
+                    posRights = bigArrays().resize(posRights, tops.size());
                     posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
-                    negLefts = bigArrays.resize(negLefts, tops.size());
+                    negLefts = bigArrays().resize(negLefts, tops.size());
                     negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
-                    negRights = bigArrays.resize(negRights, tops.size());
+                    negRights = bigArrays().resize(negRights, tops.size());
                     negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
                 }
 


### PR DESCRIPTION
This takes away access to the `SearchContext` from all subclasses of
`Aggregator`. Now they have access to three things:
* BigArrays
* The top level Query
* The IndexSearcher

These are used by a whole bunch of aggs.

This is a useful change because `SearchContext` is very large and
difficult to mock in tests and difficult to reason about in general.
Limiting what aggs can use when they are being collected helps with
this.

We still pass `SearchContext` to `AggregatorBase`'s ctor so the thing is
still around. But we can remove that access in a follow up.
