### PR TITLE
Fix using bundled JDK detection on macOS

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -196,7 +196,7 @@ public class JvmInfo implements ReportingService.Info {
         final String javaHome = System.getProperty("java.home");
         final String userDir = System.getProperty("user.dir");
         if (Constants.MAC_OS_X) {
-            return PathUtils.get(javaHome).equals(PathUtils.get(userDir).resolve("jdk/Contents/Home").toAbsolutePath());
+            return PathUtils.get(javaHome).equals(PathUtils.get(userDir).resolve("jdk.app/Contents/Home").toAbsolutePath());
         } else {
             return PathUtils.get(javaHome).equals(PathUtils.get(userDir).resolve("jdk").toAbsolutePath());
         }


### PR DESCRIPTION
This commit fixes an issue with the detection on macOS for whether or not the bundled JDK is being used. The logic between macOS and non-macOS is different because the JDK has a different directory structure on macOS versus non-macOS. However, due to notarization issues, we changed the top-level directory from jdk to jdk.app, yet never updated this detection logic to account for that.

Ideally, we would have a packaging test that asserts that we have the behavior here correct, and it maintains over time. Alas, we do not currently have packaging tests on macOS.
