### PR TITLE
Run the query phase with an immutable mapping

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -114,11 +115,11 @@ public class RankFeatureFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new SourceValueFetcher(name(), mapperService) {
+            return new SourceValueFetcher(sourcePaths.get()) {
                 @Override
                 protected Float parseSourceValue(Object value) {
                     return objectToFloat(value);

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
@@ -24,6 +24,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * This meta field only exists because rank feature fields index everything into a
@@ -52,7 +54,7 @@ public class RankFeatureMetaFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
         }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -88,8 +89,8 @@ public class RankFeaturesFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /** A {@link FieldMapper} for scaled floats. Values are internally multiplied
@@ -207,11 +208,11 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new SourceValueFetcher(name(), mapperService) {
+            return new SourceValueFetcher(sourcePaths.get()) {
                 @Override
                 protected Double parseSourceValue(Object value) {
                     double doubleValue;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -61,6 +61,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType.hasGaps;
@@ -264,8 +265,8 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.toString(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override
@@ -375,10 +376,10 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
-            return SourceValueFetcher.toString(name(), mapperService, format);
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override
@@ -481,10 +482,10 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            // Because this internal field is modeled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
-            return SourceValueFetcher.toString(name(), mapperService, format);
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
 
@@ -92,7 +94,7 @@ public class TokenCountFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (hasDocValues() == false) {
                 return lookup -> List.of();
             }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -21,7 +21,6 @@ package org.elasticsearch.join.mapper;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
@@ -32,6 +31,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -66,7 +66,7 @@ public class MetaJoinFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for metadata field [" + NAME + "].");
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -27,7 +27,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
@@ -37,6 +36,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -76,7 +76,7 @@ public final class ParentIdFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -34,7 +34,6 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -164,8 +163,8 @@ public final class ParentJoinFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -120,7 +120,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                 if (parentId == null) {
                     return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
                 }
-                q = context.mapperService().fieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
+                q = context.fieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
             }
 
             Weight weight = context.searcher().createWeight(context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
@@ -274,16 +274,16 @@ public class ChildrenToParentAggregatorTests extends AggregatorTestCase {
     }
 
     @Override
-    protected MapperService mapperServiceMock() {
+    protected MapperService.Snapshot mapperSnapshotMock() {
         ParentJoinFieldMapper joinFieldMapper = createJoinFieldMapper();
-        MapperService mapperService = mock(MapperService.class);
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
         MetaJoinFieldMapper.MetaJoinFieldType metaJoinFieldType = mock(MetaJoinFieldMapper.MetaJoinFieldType.class);
         when(metaJoinFieldType.getJoinField()).thenReturn("join_field");
-        when(mapperService.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
-        when(mapperService.fieldType("join_field")).thenReturn(joinFieldMapper.fieldType());
-        when(mapperService.fieldType("join_field#" + PARENT_TYPE))
+        when(mapperSnapshot.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
+        when(mapperSnapshot.fieldType("join_field")).thenReturn(joinFieldMapper.fieldType());
+        when(mapperSnapshot.fieldType("join_field#" + PARENT_TYPE))
             .thenReturn(new ParentIdFieldMapper.ParentIdFieldType("join_field#" + PARENT_TYPE, false));
-        return mapperService;
+        return mapperSnapshot;
     }
 
     private static ParentJoinFieldMapper createJoinFieldMapper() {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
@@ -226,16 +226,16 @@ public class ParentToChildrenAggregatorTests extends AggregatorTestCase {
     }
 
     @Override
-    protected MapperService mapperServiceMock() {
+    protected MapperService.Snapshot mapperSnapshotMock() {
         ParentJoinFieldMapper joinFieldMapper = createJoinFieldMapper();
-        MapperService mapperService = mock(MapperService.class);
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
         MetaJoinFieldMapper.MetaJoinFieldType metaJoinFieldType = mock(MetaJoinFieldMapper.MetaJoinFieldType.class);
         when(metaJoinFieldType.getJoinField()).thenReturn("join_field");
-        when(mapperService.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
-        when(mapperService.fieldType("join_field")).thenReturn(joinFieldMapper.fieldType());
-        when(mapperService.fieldType("join_field#" + PARENT_TYPE))
+        when(mapperSnapshot.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
+        when(mapperSnapshot.fieldType("join_field")).thenReturn(joinFieldMapper.fieldType());
+        when(mapperSnapshot.fieldType("join_field#" + PARENT_TYPE))
             .thenReturn(new ParentIdFieldMapper.ParentIdFieldType("join_field#" + PARENT_TYPE, false));
-        return mapperService;
+        return mapperSnapshot;
     }
 
     private static ParentJoinFieldMapper createJoinFieldMapper() {

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -59,7 +59,6 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
@@ -88,6 +87,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
@@ -218,8 +218,8 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
 
         Query percolateQuery(String name, PercolateQuery.QueryStore queryStore, List<BytesReference> documents,

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -23,6 +23,7 @@ import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RawCollationKey;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.util.ULocale;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
@@ -48,6 +49,7 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class ICUCollationKeywordFieldMapper extends ParametrizedFieldMapper {
@@ -82,12 +84,12 @@ public class ICUCollationKeywordFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                 @Override
                 protected String parseSourceValue(Object value) {
                     String keywordValue = value.toString();

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AnnotatedTextHighlighter.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AnnotatedTextHighlighter.java
@@ -23,7 +23,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.uhighlight.CustomUnifiedHighlighter;
 import org.apache.lucene.search.uhighlight.PassageFormatter;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.AnnotatedHighlighterAnalyzer;
 import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.AnnotatedText;
@@ -62,8 +61,8 @@ public class AnnotatedTextHighlighter extends UnifiedHighlighter {
     }
 
     @Override
-    protected Analyzer getAnalyzer(DocumentMapper docMapper) {
-        return new AnnotatedHighlighterAnalyzer(super.getAnalyzer(docMapper));
+    protected Analyzer getAnalyzer(Analyzer indexAnalyzer) {
+        return new AnnotatedHighlighterAnalyzer(indexAnalyzer);
     }
 
     @Override

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -43,6 +42,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class Murmur3FieldMapper extends ParametrizedFieldMapper {
@@ -105,8 +105,8 @@ public class Murmur3FieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.toString(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -193,7 +193,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             this.mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
                 // we parse all percolator queries as they would be parsed on shard 0
                 () -> newQueryShardContext(0, null, System::currentTimeMillis, null), idFieldDataEnabled, scriptService);
-            this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService, mapperService);
+            this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService);
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
                 // The sort order is validated right after the merge of the mapping later in the process.

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -590,7 +590,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         final SearchIndexNameMatcher indexNameMatcher =
             new SearchIndexNameMatcher(index().getName(), clusterAlias, clusterService, expressionResolver);
         return new QueryShardContext(
-            shardId, indexSettings, bigArrays, indexCache.bitsetFilterCache(), indexFieldData::getForField, mapperService(),
+            shardId, indexSettings, bigArrays, indexCache.bitsetFilterCache(), indexFieldData::getForField, mapperService().snapshot(),
             similarityService(), scriptService, xContentRegistry, namedWriteableRegistry, client, searcher, nowInMillis, clusterAlias,
             indexNameMatcher, allowExpensiveQueries, valuesSourceRegistry);
     }

--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -243,7 +243,7 @@ public final class BitsetFilterCache extends AbstractIndexComponent
                     hasNested = true;
                     for (ObjectMapper objectMapper : docMapper.mappers().objectMappers().values()) {
                         if (objectMapper.nested().isNested()) {
-                            ObjectMapper parentObjectMapper = objectMapper.getParentObjectMapper(mapperService);
+                            ObjectMapper parentObjectMapper = objectMapper.getParentObjectMapper(mapperService::getObjectMapper);
                             if (parentObjectMapper != null && parentObjectMapper.nested().isNested()) {
                                 warmUp.add(parentObjectMapper.nestedTypeFilter());
                             }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -60,7 +60,6 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
     private final IndicesFieldDataCache indicesFieldDataCache;
     // the below map needs to be modified under a lock
     private final Map<String, IndexFieldDataCache> fieldDataCaches = new HashMap<>();
-    private final MapperService mapperService;
     private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {
         @Override
         public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
@@ -74,11 +73,10 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
 
 
     public IndexFieldDataService(IndexSettings indexSettings, IndicesFieldDataCache indicesFieldDataCache,
-                                 CircuitBreakerService circuitBreakerService, MapperService mapperService) {
+                                 CircuitBreakerService circuitBreakerService) {
         super(indexSettings);
         this.indicesFieldDataCache = indicesFieldDataCache;
         this.circuitBreakerService = circuitBreakerService;
-        this.mapperService = mapperService;
     }
 
     public synchronized void clear() {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -37,7 +37,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Base field mapper class for all spatial field types
@@ -123,19 +125,19 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Par
         }
 
         @Override
-        public final ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public final ValueFetcher valueFetcher(Supplier<Set<String>> sourcePath, SearchLookup searchLookup, String format) {
             String geoFormat = format != null ? format : GeoJsonGeometryFormat.NAME;
 
             Function<Object, Object> valueParser = value -> geometryParser.parseAndFormatObject(value, geoFormat);
             if (parsesArrayValue) {
-                return new ArraySourceValueFetcher(name(), mapperService) {
+                return new ArraySourceValueFetcher(sourcePath.get()) {
                     @Override
                     protected Object parseSourceValue(Object value) {
                         return valueParser.apply(value);
                     }
                 };
             } else {
-                return new SourceValueFetcher(name(), mapperService) {
+                return new SourceValueFetcher(sourcePath.get()) {
                     @Override
                     protected Object parseSourceValue(Object value) {
                         return valueParser.apply(value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -43,8 +43,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     }
 
     /**
-     * @param fieldName The name of the field.
-     * @param mapperService A mapper service.
+     * @param sourcePaths The paths in the source to read.
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
     public ArraySourceValueFetcher(Set<String> sourcePaths, Object nullValue) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -38,8 +38,8 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     private final Set<String> sourcePaths;
     private final @Nullable Object nullValue;
 
-    public ArraySourceValueFetcher(String fieldName, MapperService mapperService) {
-        this(fieldName, mapperService, null);
+    public ArraySourceValueFetcher(Set<String> sourcePaths) {
+        this(sourcePaths, null);
     }
 
     /**
@@ -47,8 +47,8 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
      * @param mapperService A mapper service.
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
-    public ArraySourceValueFetcher(String fieldName, MapperService mapperService, Object nullValue) {
-        this.sourcePaths = mapperService.sourcePath(fieldName);
+    public ArraySourceValueFetcher(Set<String> sourcePaths, Object nullValue) {
+        this.sourcePaths = sourcePaths;
         this.nullValue = nullValue;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -42,6 +42,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class BinaryFieldMapper extends ParametrizedFieldMapper {
@@ -97,8 +98,8 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -43,6 +43,7 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -127,12 +128,12 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePath, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePath.get(), nullValue) {
                 @Override
                 protected Boolean parseSourceValue(Object value) {
                     if (value instanceof Boolean) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Mapper for completion field. The field values are indexed as a weighted FST for
@@ -306,12 +307,12 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePath, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new ArraySourceValueFetcher(name(), mapperService) {
+            return new ArraySourceValueFetcher(sourcePath.get()) {
                 @Override
                 protected List<?> parseSourceValue(Object value) {
                     if (value instanceof List) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -319,13 +320,13 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null
                 ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
                 : defaultFormatter;
 
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                 @Override
                 public String parseSourceValue(Object value) {
                     String date = value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
@@ -37,7 +38,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -220,7 +220,7 @@ public class DocumentMapper implements ToXContentFragment {
     /**
      * Returns the best nested {@link ObjectMapper} instances that is in the scope of the specified nested docId.
      */
-    public ObjectMapper findNestedObjectMapper(int nestedDocId, SearchContext sc, LeafReaderContext context) throws IOException {
+    public ObjectMapper findNestedObjectMapper(int nestedDocId, IndexSearcher searcher, LeafReaderContext context) throws IOException {
         ObjectMapper nestedObjectMapper = null;
         for (ObjectMapper objectMapper : mappers().objectMappers().values()) {
             if (!objectMapper.nested().isNested()) {
@@ -233,7 +233,7 @@ public class DocumentMapper implements ToXContentFragment {
             }
             // We can pass down 'null' as acceptedDocs, because nestedDocId is a doc to be fetched and
             // therefore is guaranteed to be a live doc.
-            final Weight nestedWeight = filter.createWeight(sc.searcher(), ScoreMode.COMPLETE_NO_SCORES, 1f);
+            final Weight nestedWeight = filter.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
             Scorer scorer = nestedWeight.scorer(context);
             if (scorer == null) {
                 continue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -31,6 +31,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A mapper that indexes the field names of a document under <code>_field_names</code>. This mapper is typically useful in order
@@ -131,7 +133,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -120,7 +121,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
@@ -28,6 +28,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A field mapper that records fields that have been ignored because they were malformed.
@@ -77,7 +79,7 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class IndexFieldMapper extends MetadataFieldMapper {
@@ -73,7 +74,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -158,11 +159,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                 @Override
                 protected Object parseSourceValue(Object value) {
                     InetAddress address;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -228,6 +229,10 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
             return indexAnalyzer();
         }
 
+        public int ignoreAbove() {
+            return ignoreAbove;
+        }
+
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
@@ -235,12 +240,12 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                 @Override
                 protected String parseSourceValue(Object value) {
                     String keywordValue = value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -58,6 +58,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -105,7 +106,11 @@ public abstract class MappedFieldType {
      * for metadata fields, field types should not throw {@link UnsupportedOperationException} since this
      * could cause a search retrieving multiple fields (like "fields": ["*"]) to fail.
      */
-    public abstract ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, @Nullable String format);
+    public abstract ValueFetcher valueFetcher(
+        Supplier<Set<String>> sourcePaths,
+        SearchLookup searchLookup,
+        @Nullable String format
+    );
 
     /** Returns the name of this type, as would be specified in mapping properties */
     public abstract String typeName();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -424,6 +424,11 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes();
     }
 
+    /**
+     * Get the {@linkplain ObjectMapper} at the provided path.
+     * @deprecated prefer {@link #snapshot()} then {@link Snapshot#getObjectMapper(String)}.
+     */
+    @Deprecated
     public ObjectMapper getObjectMapper(String name) {
         return snapshot().getObjectMapper(name);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
@@ -33,6 +33,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 
 public class NestedPathFieldMapper extends MetadataFieldMapper {
 
@@ -89,7 +91,7 @@ public class NestedPathFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -960,12 +961,12 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), mapperService, nullValue) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                 @Override
                 protected Object parseSourceValue(Object value) {
                     if (value.equals("")) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -450,11 +451,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
      * Returns the parent {@link ObjectMapper} instance of the specified object mapper or <code>null</code> if there
      * isn't any.
      */
-    public ObjectMapper getParentObjectMapper(MapperService mapperService) {
+    public ObjectMapper getParentObjectMapper(Function<String, ObjectMapper> getObjectMapper) {
         int indexOfLastDot = fullPath().lastIndexOf('.');
         if (indexOfLastDot != -1) {
             String parentNestObjectPath = fullPath().substring(0, indexOfLastDot);
-            return mapperService.getObjectMapper(parentNestObjectPath);
+            return getObjectMapper.apply(parentNestObjectPath);
         } else {
             return null;
         }
@@ -463,10 +464,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
     /**
      * Returns whether all parent objects fields are nested too.
      */
-    public boolean parentObjectMapperAreNested(MapperService mapperService) {
-        for (ObjectMapper parent = getParentObjectMapper(mapperService);
+    public boolean parentObjectMapperAreNested(Function<String, ObjectMapper> getObjectMapper) {
+        for (ObjectMapper parent = getParentObjectMapper(getObjectMapper);
              parent != null;
-             parent = parent.getParentObjectMapper(mapperService)) {
+             parent = parent.getParentObjectMapper(getObjectMapper)) {
 
             if (parent.nested().isNested() == false) {
                 return false;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -189,13 +189,13 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePath, SearchLookup searchLookup, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null
                 ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
                 : defaultFormatter;
 
-            return new SourceValueFetcher(name(), mapperService) {
+            return new SourceValueFetcher(sourcePath.get()) {
 
                 @Override
                 @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -27,6 +27,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 public class RoutingFieldMapper extends MetadataFieldMapper {
 
@@ -95,7 +97,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -122,7 +123,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -45,7 +45,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class SourceFieldMapper extends MetadataFieldMapper {
 
@@ -112,7 +114,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -39,17 +39,21 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     private final Set<String> sourcePaths;
     private final @Nullable Object nullValue;
 
-    public SourceValueFetcher(String fieldName, MapperService mapperService) {
-        this(fieldName, mapperService, null);
+    /**
+     * @param fieldName The name of the field.
+     * @param sourcePaths The path to the field in the _source.
+     */
+    public SourceValueFetcher(Set<String> sourcePaths) {
+        this(sourcePaths, null);
     }
 
     /**
      * @param fieldName The name of the field.
-     * @param mapperService A mapper service.
+     * @param sourcePaths The path to the field in the _source.
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
-    public SourceValueFetcher(String fieldName, MapperService mapperService, Object nullValue) {
-        this.sourcePaths = mapperService.sourcePath(fieldName);
+    public SourceValueFetcher(Set<String> sourcePaths, @Nullable Object nullValue) {
+        this.sourcePaths = sourcePaths;
         this.nullValue = nullValue;
     }
 
@@ -91,11 +95,11 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     /**
      * Creates a {@link SourceValueFetcher} that passes through source values unmodified.
      */
-    public static SourceValueFetcher identity(String fieldName, MapperService mapperService, String format) {
+    public static SourceValueFetcher identity(String fieldName, Set<String> sourcePaths, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + fieldName + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(fieldName, mapperService) {
+        return new SourceValueFetcher(sourcePaths) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value;
@@ -106,11 +110,11 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     /**
      * Creates a {@link SourceValueFetcher} that converts source values to strings.
      */
-    public static SourceValueFetcher toString(String fieldName, MapperService mapperService, String format) {
+    public static SourceValueFetcher toString(String fieldName, Set<String> sourcePaths, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + fieldName + "] doesn't support formats.");
         }
-        return new SourceValueFetcher(fieldName, mapperService) {
+        return new SourceValueFetcher(sourcePaths) {
             @Override
             protected Object parseSourceValue(Object value) {
                 return value.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -40,16 +40,14 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     private final @Nullable Object nullValue;
 
     /**
-     * @param fieldName The name of the field.
-     * @param sourcePaths The path to the field in the _source.
+     * @param sourcePaths The paths in the source to read.
      */
     public SourceValueFetcher(Set<String> sourcePaths) {
         this(sourcePaths, null);
     }
 
     /**
-     * @param fieldName The name of the field.
-     * @param sourcePaths The path to the field in the _source.
+     * @param sourcePaths The paths in the source to read.
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
     public SourceValueFetcher(Set<String> sourcePaths, @Nullable Object nullValue) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -83,6 +83,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
@@ -465,10 +466,10 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            // Because this internal field is modeled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
-            return SourceValueFetcher.toString(name(), mapperService, format);
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override
@@ -495,10 +496,10 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            // Because this internal field is modeled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
-            return SourceValueFetcher.toString(name(), mapperService, format);
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         void setAnalyzer(NamedAnalyzer delegate) {
@@ -687,8 +688,8 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.toString(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldType.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -76,7 +77,7 @@ public final class TypeFieldType extends ConstantFieldType {
     }
 
     @Override
-    public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+    public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
         throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -28,6 +28,8 @@ import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /** Mapper for the _version field. */
 public class VersionFieldMapper extends MetadataFieldMapper {
@@ -56,7 +58,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -50,7 +50,7 @@ public abstract class InnerHitContextBuilder {
 
     public final void build(SearchContext parentSearchContext, InnerHitsContext innerHitsContext) throws IOException {
         long innerResultWindow = innerHitBuilder.getFrom() + innerHitBuilder.getSize();
-        int maxInnerResultWindow = parentSearchContext.mapperService().getIndexSettings().getMaxInnerResultWindow();
+        int maxInnerResultWindow = parentSearchContext.indexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(
                 "Inner result window is too large, the inner hit definition's [" + innerHitBuilder.getName() +

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
@@ -45,7 +46,6 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -243,6 +243,13 @@ public class QueryShardContext extends QueryRewriteContext {
      */
     public Set<String> simpleMatchToIndexNames(String pattern) {
         return mapperSnapshot.simpleMatchToFullName(pattern);
+    }
+
+    /**
+     * @return Whether a field is a metadata field.
+     */
+    public boolean isMetadataField(String field) {
+        return mapperSnapshot.isMetadataField(field);
     }
 
     /**
@@ -520,5 +527,23 @@ public class QueryShardContext extends QueryRewriteContext {
 
     public BitsetFilterCache getBitsetFilterCache() {
         return bitsetFilterCache;
+    }
+
+    public Set<String> sourcePaths(String name) {
+        return mapperSnapshot.sourcePaths(name);
+    }
+
+    /**
+     * Is the source stored?
+     */
+    public boolean isSourceStored() {
+        return mapperSnapshot.isSourceStored();
+    }
+
+    /**
+     * Returns the best nested {@link ObjectMapper} instances that is in the scope of the specified nested docId.
+     */
+    public ObjectMapper findNestedObjectMapper(int nestedDocId, IndexSearcher searcher, LeafReaderContext context) throws IOException {
+        return mapperSnapshot.findNestedObjectMapper(nestedDocId, searcher, context);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -39,7 +39,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -267,8 +266,8 @@ final class DefaultSearchContext extends SearchContext {
     public Query buildFilteredQuery(Query query) {
         List<Query> filters = new ArrayList<>();
 
-        NestedHelper nestedHelper = new NestedHelper(mapperService()::getObjectMapper, field -> mapperService().fieldType(field) != null);
-        if (mapperService().hasNested()
+        NestedHelper nestedHelper = new NestedHelper(this::getObjectMapper, field -> this.fieldType(field) != null);
+        if (queryShardContext.hasNested()
                 && nestedHelper.mightMatchNestedDocs(query)
                 && (aliasFilter == null || nestedHelper.mightMatchNestedDocs(aliasFilter))) {
             filters.add(Queries.newNonNestedFilter());
@@ -468,8 +467,8 @@ final class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService mapperService() {
-        return indexService.mapperService();
+    public IndexSettings indexSettings() {
+        return indexService.getIndexSettings();
     }
 
     @Override
@@ -753,12 +752,12 @@ final class DefaultSearchContext extends SearchContext {
 
     @Override
     public MappedFieldType fieldType(String name) {
-        return mapperService().fieldType(name);
+        return queryShardContext.getFieldType(name);
     }
 
     @Override
     public ObjectMapper getObjectMapper(String name) {
-        return mapperService().getObjectMapper(name);
+        return queryShardContext.getObjectMapper(name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -985,7 +985,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
         }
         if (source.scriptFields() != null && source.size() != 0) {
-            int maxAllowedScriptFields = context.mapperService().getIndexSettings().getMaxScriptFields();
+            int maxAllowedScriptFields = context.indexSettings().getMaxScriptFields();
             if (source.scriptFields().size() > maxAllowedScriptFields) {
                 throw new IllegalArgumentException(
                         "Trying to retrieve too many script_fields. Must be less than or equal to: [" + maxAllowedScriptFields

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -19,9 +19,13 @@
 
 package org.elasticsearch.search.fetch;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
@@ -36,8 +40,10 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.rescore.RescoreContext;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Encapsulates state required to execute fetch phases
@@ -70,17 +76,10 @@ public class FetchContext {
     }
 
     /**
-     * The mapper service for the index we are fetching documents from
-     */
-    public MapperService mapperService() {
-        return searchContext.mapperService();
-    }
-
-    /**
      * The index settings for the index we are fetching documents from
      */
     public IndexSettings getIndexSettings() {
-        return mapperService().getIndexSettings();
+        return searchContext.indexSettings();
     }
 
     /**
@@ -206,5 +205,49 @@ public class FetchContext {
      */
     public SearchExtBuilder getSearchExt(String name) {
         return searchContext.getSearchExt(name);
+    }
+
+    /**
+     * Get the {@link MappedFieldType} for a field.
+     */
+    public MappedFieldType fieldType(String name) {
+        return searchContext.fieldType(name);
+    }
+
+    /**
+     * Returns all the fields that match a given pattern. If prefixed with a
+     * type then the fields will be returned with a type prefix.
+     */
+    public Set<String> simpleMatchToIndexNames(String pattern) {
+        return searchContext.simpleMatchToIndexNames(pattern);
+    }
+
+    public Set<String> sourcePaths(String name) {
+        return searchContext.sourcePaths(name);
+    }
+
+    /**
+     * @return Whether a field is a metadata field.
+     */
+    public boolean isMetadataField(String field) {
+        return searchContext.isMetadataField(field);
+    }
+
+    /**
+     * Is the source stored?
+     */
+    public boolean isSourceStored() {
+        return searchContext.isSourceStored();
+    }
+
+    public Analyzer indexAnalyzer() {
+        return searchContext.indexAnalyzer();
+    }
+
+    /**
+     * Returns the best nested {@link ObjectMapper} instances that is in the scope of the specified nested docId.
+     */
+    public ObjectMapper findNestedObjectMapper(int nestedDocId, IndexSearcher searcher, LeafReaderContext context) throws IOException {
+        return searchContext.findNestedObjectMapper(nestedDocId, searcher, context);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -52,7 +52,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
          */
         List<DocValueField> fields = new ArrayList<>();
         for (FieldAndFormat fieldAndFormat : context.docValuesContext().fields()) {
-            MappedFieldType ft = context.mapperService().fieldType(fieldAndFormat.field);
+            MappedFieldType ft = context.fieldType(fieldAndFormat.field);
             if (ft == null) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.fetch.subphase;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -48,14 +47,13 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             return null;
         }
 
-        MapperService mapperService = fetchContext.mapperService();
         SearchLookup searchLookup = fetchContext.searchLookup();
-        if (fetchContext.mapperService().documentMapper().sourceMapper().enabled() == false) {
+        if (fetchContext.isSourceStored() == false) {
             throw new IllegalArgumentException("Unable to retrieve the requested [fields] since _source is disabled " +
                 "in the mappings for index [" + fetchContext.getIndexName() + "]");
         }
 
-        FieldFetcher fieldFetcher = FieldFetcher.create(mapperService, searchLookup, fetchFieldsContext.fields());
+        FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext, searchLookup, fetchFieldsContext.fields());
         return new FetchSubPhaseProcessor() {
             @Override
             public void setNextReader(LeafReaderContext readerContext) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -22,8 +22,8 @@ package org.elasticsearch.search.fetch.subphase;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -40,7 +40,7 @@ import java.util.Set;
  * Then given a specific document, it can retrieve the corresponding fields from the document's source.
  */
 public class FieldFetcher {
-    public static FieldFetcher create(MapperService mapperService,
+    public static FieldFetcher create(FetchContext fetchContext,
                                       SearchLookup searchLookup,
                                       Collection<FieldAndFormat> fieldAndFormats) {
 
@@ -50,13 +50,13 @@ public class FieldFetcher {
             String fieldPattern = fieldAndFormat.field;
             String format = fieldAndFormat.format;
 
-            Collection<String> concreteFields = mapperService.simpleMatchToFullName(fieldPattern);
+            Collection<String> concreteFields = fetchContext.simpleMatchToIndexNames(fieldPattern);
             for (String field : concreteFields) {
-                MappedFieldType ft = mapperService.fieldType(field);
-                if (ft == null || mapperService.isMetadataField(field)) {
+                MappedFieldType ft = fetchContext.fieldType(field);
+                if (ft == null || fetchContext.isMetadataField(field)) {
                     continue;
                 }
-                ValueFetcher valueFetcher = ft.valueFetcher(mapperService, searchLookup, format);
+                ValueFetcher valueFetcher = ft.valueFetcher(() -> fetchContext.sourcePaths(ft.name()), searchLookup, format);
                 fieldContexts.add(new FieldContext(field, valueFetcher));
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -104,14 +104,13 @@ public class HighlightPhase implements FetchSubPhase {
             Highlighter highlighter = getHighlighter(field);
             Collection<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {
-                fieldNamesToHighlight = context.mapperService().simpleMatchToFullName(field.field());
+                fieldNamesToHighlight = context.simpleMatchToIndexNames(field.field());
             } else {
                 fieldNamesToHighlight = Collections.singletonList(field.field());
             }
 
             if (highlightContext.forceSource(field)) {
-                SourceFieldMapper sourceFieldMapper = context.mapperService().documentMapper().sourceMapper();
-                if (sourceFieldMapper.enabled() == false) {
+                if (context.isSourceStored() == false) {
                     throw new IllegalArgumentException("source is forced for fields " + fieldNamesToHighlight
                         + " but _source is disabled");
                 }
@@ -119,7 +118,7 @@ public class HighlightPhase implements FetchSubPhase {
 
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
-                MappedFieldType fieldType = context.mapperService().fieldType(fieldName);
+                MappedFieldType fieldType = context.fieldType(fieldName);
                 if (fieldType == null) {
                     continue;
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -100,12 +100,10 @@ public class PlainHighlighter implements Highlighter {
         int numberOfFragments = field.fieldOptions().numberOfFragments() == 0 ? 1 : field.fieldOptions().numberOfFragments();
         ArrayList<TextFragment> fragsList = new ArrayList<>();
         List<Object> textsToHighlight;
-        Analyzer analyzer = context.mapperService().documentMapper().mappers().indexAnalyzer();
+        Analyzer analyzer = context.indexAnalyzer();
         Integer keywordIgnoreAbove = null;
         if (fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
-            KeywordFieldMapper mapper = (KeywordFieldMapper) context.mapperService().documentMapper()
-                .mappers().getMapper(fieldContext.fieldName);
-            keywordIgnoreAbove = mapper.ignoreAbove();
+            keywordIgnoreAbove = ((KeywordFieldMapper.KeywordFieldType) fieldContext.fieldType).ignoreAbove();
         }
         final int maxAnalyzedOffset = context.getIndexSettings().getHighlightMaxAnalyzedOffset();
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -33,7 +33,6 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -114,12 +113,10 @@ public class UnifiedHighlighter implements Highlighter {
         int maxAnalyzedOffset = fieldContext.context.getIndexSettings().getHighlightMaxAnalyzedOffset();
         int keywordIgnoreAbove = Integer.MAX_VALUE;
         if (fieldContext.fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
-            KeywordFieldMapper mapper = (KeywordFieldMapper) fieldContext.context.mapperService().documentMapper()
-                .mappers().getMapper(fieldContext.fieldName);
-            keywordIgnoreAbove = mapper.ignoreAbove();
+            keywordIgnoreAbove = ((KeywordFieldMapper.KeywordFieldType) fieldContext.fieldType).ignoreAbove();
         }
         int numberOfFragments = fieldContext.field.fieldOptions().numberOfFragments();
-        Analyzer analyzer = getAnalyzer(fieldContext.context.mapperService().documentMapper());
+        Analyzer analyzer = getAnalyzer(fieldContext.context.indexAnalyzer());
         PassageFormatter passageFormatter = getPassageFormatter(fieldContext.hitContext, fieldContext.field, encoder);
         IndexSearcher searcher = fieldContext.context.searcher();
         OffsetSource offsetSource = getOffsetSource(fieldContext.fieldType);
@@ -165,8 +162,8 @@ public class UnifiedHighlighter implements Highlighter {
     }
 
 
-    protected Analyzer getAnalyzer(DocumentMapper docMapper) {
-        return docMapper.mappers().indexAnalyzer();
+    protected Analyzer getAnalyzer(Analyzer indexAnalyzer) {
+        return indexAnalyzer;
     }
 
     protected List<Object> loadFieldValues(

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -26,9 +26,9 @@ import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -224,8 +224,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService mapperService() {
-        return in.mapperService();
+    public IndexSettings indexSettings() {
+        return in.indexSettings();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -429,8 +429,7 @@ public class QueryPhase {
         // check if this is a field of type Long or Date, that is indexed and has doc values
         String fieldName = sortField.getField();
         if (fieldName == null) return null; // happens when _score or _doc is the 1st sort field
-        if (searchContext.mapperService() == null) return null; // mapperService can be null in tests
-        final MappedFieldType fieldType = searchContext.mapperService().fieldType(fieldName);
+        final MappedFieldType fieldType = searchContext.fieldType(fieldName);
         if (fieldType == null) return null; // for unmapped fields, default behaviour depending on "unmapped_type" flag
         if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return null;
         if (fieldType.isSearchable() == false) return null;
@@ -445,7 +444,7 @@ public class QueryPhase {
                 if (SortField.FIELD_DOC.equals(sField) == false) return null;
             } else {
                 //TODO: find out how to cover _script sort that don't use _score
-                if (searchContext.mapperService().fieldType(sFieldName) == null) return null; // could be _script sort that uses _score
+                if (searchContext.fieldType(sFieldName) == null) return null; // could be _script sort that uses _score
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -74,6 +74,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -1566,7 +1567,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         public MetadataTimestampFieldMapper(boolean enabled) {
             super(new MappedFieldType("_data_stream_timestamp", false, false, false, TextSearchInfo.NONE, Map.of()) {
                 @Override
-                public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+                public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
                     throw new UnsupportedOperationException();
                 }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -77,7 +77,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final IndexService indexService = createIndex("test");
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
-            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
+            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService());
         final BuilderContext ctx = new BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
         final MappedFieldType stringMapper = new KeywordFieldMapper.Builder("string").build(ctx).fieldType();
         ifdService.clear();
@@ -120,7 +120,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final IndexService indexService = createIndex("test");
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
-            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
+            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService());
         final SetOnce<Supplier<SearchLookup>> searchLookupSetOnce = new SetOnce<>();
         MappedFieldType ft = mock(MappedFieldType.class);
         when(ft.fielddataBuilder(Matchers.any(), Matchers.any())).thenAnswer(invocationOnMock -> {
@@ -139,7 +139,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         // copy the ifdService since we can set the listener only once.
         final IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
-            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
+            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService());
 
         final BuilderContext ctx = new BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
         final MappedFieldType mapper1
@@ -205,7 +205,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         // copy the ifdService since we can set the listener only once.
         final IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
-                indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
+                indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService());
 
         final BuilderContext ctx = new BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
         final MappedFieldType mapper1
@@ -259,7 +259,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final IndexService indexService = createIndex("test");
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final IndexFieldDataService shardPrivateService = new IndexFieldDataService(indexService.getIndexSettings(),
-            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
+            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService());
         // set it the first time...
         shardPrivateService.setListener(new IndexFieldDataCache.Listener() {
             @Override
@@ -296,7 +296,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         try {
             IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
             IndexFieldDataService ifds =
-                new IndexFieldDataService(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), cache, null, null);
+                new IndexFieldDataService(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), cache, null);
             if (ft.hasDocValues()) {
                 ifds.getForField(ft, "test", () -> {
                     throw new UnsupportedOperationException();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
 
 public class DocumentFieldMapperTests extends LuceneTestCase {
 
@@ -71,7 +73,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -33,6 +33,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * This mapper add a new sub fields
@@ -103,8 +105,8 @@ public class ExternalMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -28,6 +28,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 // Like a String mapper but with very few options. We just use it to test if highlighting on a custom string mapped field works as expected.
 public class FakeStringFieldMapper extends ParametrizedFieldMapper {
@@ -76,8 +78,8 @@ public class FakeStringFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.toString(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -44,13 +44,13 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
         Settings settings = settings(Version.CURRENT).build();
         IndexSettings indexSettings = new IndexSettings(
                 new IndexMetadata.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
-        MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fieldType("_field_names")).thenReturn(fieldNamesFieldType);
-        when(mapperService.fieldType("field_name")).thenReturn(fieldType);
-        when(mapperService.simpleMatchToFullName("field_name")).thenReturn(Collections.singleton("field_name"));
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
+        when(mapperSnapshot.fieldType("_field_names")).thenReturn(fieldNamesFieldType);
+        when(mapperSnapshot.fieldType("field_name")).thenReturn(fieldType);
+        when(mapperSnapshot.simpleMatchToFullName("field_name")).thenReturn(Collections.singleton("field_name"));
 
         QueryShardContext queryShardContext = new QueryShardContext(0,
-                indexSettings, BigArrays.NON_RECYCLING_INSTANCE, null, null, mapperService,
+                indexSettings, BigArrays.NON_RECYCLING_INSTANCE, null, null, mapperSnapshot,
                 null, null, null, null, null, null, () -> 0L, null, null, () -> true, null);
                 Query termQuery = fieldNamesFieldType.termQuery("field_name", queryShardContext);
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -590,7 +590,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject()).mapperService();
         ObjectMapper objectMapper = mapperService.getObjectMapper("comments.messages");
-        assertTrue(objectMapper.parentObjectMapperAreNested(mapperService));
+        assertTrue(objectMapper.parentObjectMapperAreNested(mapperService::getObjectMapper));
 
         mapperService = createIndex("index2", Settings.EMPTY, jsonBuilder().startObject()
             .startObject("properties")
@@ -604,7 +604,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
                 .endObject()
             .endObject()).mapperService();
         objectMapper = mapperService.getObjectMapper("comments.messages");
-        assertFalse(objectMapper.parentObjectMapperAreNested(mapperService));
+        assertFalse(objectMapper.parentObjectMapperAreNested(mapperService::getObjectMapper));
     }
 
     public void testLimitNestedDocsDefaultSettings() throws Exception{

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -314,10 +314,8 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         SearchContext searchContext = mock(SearchContext.class);
         when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
 
-        MapperService mapperService = mock(MapperService.class);
         IndexSettings settings = new IndexSettings(newIndexMeta("index", Settings.EMPTY), Settings.EMPTY);
-        when(mapperService.getIndexSettings()).thenReturn(settings);
-        when(searchContext.mapperService()).thenReturn(mapperService);
+        when(searchContext.indexSettings()).thenReturn(settings);
 
         InnerHitBuilder leafInnerHits = randomNestedInnerHits();
         NestedQueryBuilder query1 = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None);

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -40,7 +40,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         IndexReader reader = new MultiReader();
         QueryRewriteContext context = new QueryShardContext(0, indexService.getIndexSettings(), BigArrays.NON_RECYCLING_INSTANCE,
-            null, null, indexService.mapperService(), null, null, xContentRegistry(), writableRegistry(),
+            null, null, indexService.mapperService().snapshot(), null, null, xContentRegistry(), writableRegistry(),
             null, new IndexSearcher(reader), null, null, null, () -> true, null);
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         assertEquals(Relation.DISJOINT, range.getRelation(context));
@@ -58,7 +58,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
         indexService.mapperService().merge("type",
                 new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         QueryRewriteContext context = new QueryShardContext(0, indexService.getIndexSettings(), null, null, null,
-                indexService.mapperService(), null, null, xContentRegistry(), writableRegistry(),
+                indexService.mapperService().snapshot(), null, null, xContentRegistry(), writableRegistry(),
                 null, null, null, null, null, () -> true, null);
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // can't make assumptions on a missing reader, so it must return INTERSECT
@@ -78,7 +78,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
                 new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         IndexReader reader = new MultiReader();
         QueryRewriteContext context = new QueryShardContext(0, indexService.getIndexSettings(), BigArrays.NON_RECYCLING_INSTANCE,
-            null, null, indexService.mapperService(), null, null, xContentRegistry(), writableRegistry(),
+            null, null, indexService.mapperService().snapshot(), null, null, xContentRegistry(), writableRegistry(),
                 null, new IndexSearcher(reader), null, null, null, () -> true, null);
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // no values -> DISJOINT

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2451,7 +2451,7 @@ public class IndexShardTests extends IndexShardTestCase {
         IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(shard.indexSettings.getNodeSettings(),
             new IndexFieldDataCache.Listener() {});
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(shard.indexSettings, indicesFieldDataCache,
-            new NoneCircuitBreakerService(), shard.mapperService());
+            new NoneCircuitBreakerService());
         IndexFieldData.Global ifd = indexFieldDataService.getForField(foo, "test", () -> {
             throw new UnsupportedOperationException("search lookup not available");
         });

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -458,8 +458,8 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             .numberOfReplicas(0)
             .build();
         MapperService mapperService = indicesService.createIndexMapperService(indexMetadata);
-        assertNotNull(mapperService.parserContext().typeParser("fake-mapper"));
-        Similarity sim = mapperService.parserContext().getSimilarity("test").get();
+        assertNotNull(mapperService.snapshot().parserContext().typeParser("fake-mapper"));
+        Similarity sim = mapperService.snapshot().parserContext().getSimilarity("test").get();
         assertThat(sim, instanceOf(NonNegativeScoresSimilarity.class));
         sim = ((NonNegativeScoresSimilarity) sim).getDelegate();
         assertThat(sim, instanceOf(BM25Similarity.class));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -165,10 +165,10 @@ public class MinAggregatorTests extends AggregatorTestCase {
     }
 
     @Override
-    protected QueryShardContext queryShardContextMock(IndexSearcher searcher, MapperService mapperService,
+    protected QueryShardContext queryShardContextMock(IndexSearcher searcher, MapperService.Snapshot mapperSnapshot,
                                                       IndexSettings indexSettings, CircuitBreakerService circuitBreakerService,
                                                       BigArrays bigArrays) {
-         this.queryShardContext = super.queryShardContextMock(searcher, mapperService, indexSettings, circuitBreakerService, bigArrays);
+         this.queryShardContext = super.queryShardContextMock(searcher, mapperSnapshot, indexSettings, circuitBreakerService, bigArrays);
          return queryShardContext;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -551,7 +551,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
      */
     @Override
     protected QueryShardContext queryShardContextMock(IndexSearcher searcher,
-                                                        MapperService mapperService,
+                                                        MapperService.Snapshot mapperSnapshot,
                                                         IndexSettings indexSettings,
                                                         CircuitBreakerService circuitBreakerService,
                                                         BigArrays bigArrays) {
@@ -563,8 +563,8 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             indexSettings,
             BigArrays.NON_RECYCLING_INSTANCE,
             null,
-            getIndexFieldDataLookup(mapperService, circuitBreakerService),
-            mapperService,
+            getIndexFieldDataLookup(indexSettings, circuitBreakerService),
+            mapperSnapshot,
             null,
             scriptService,
             xContentRegistry(),

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
@@ -49,6 +48,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
@@ -209,7 +210,7 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
                 }
 
                 @Override
-                public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+                public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
                     throw new UnsupportedOperationException();
                 }
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.search.fetch.subphase;
 
+import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
-import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,11 +37,13 @@ import java.util.Set;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class FieldFetcherTests extends ESSingleNodeTestCase {
+public class FieldFetcherTests extends MapperServiceTestCase {
 
     public void testLeafValues() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "first", "second")
             .startObject("object")
@@ -52,7 +54,7 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
         List<FieldAndFormat> fieldAndFormats = List.of(
             new FieldAndFormat("field", null),
             new FieldAndFormat("object.field", null));
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, fieldAndFormats);
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, fieldAndFormats);
         assertThat(fields.size(), equalTo(2));
 
         DocumentField field = fields.get("field");
@@ -67,7 +69,6 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testObjectValues() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .startObject("float_range")
                 .field("gte", 0.0f)
@@ -75,7 +76,7 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endObject()
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "float_range");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "float_range");
         assertThat(fields.size(), equalTo(1));
 
         DocumentField rangeField = fields.get("float_range");
@@ -85,27 +86,24 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testNonExistentField() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", "value")
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "non-existent");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "non-existent");
         assertThat(fields.size(), equalTo(0));
     }
 
     public void testMetadataFields() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", "value")
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "_routing");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "_routing");
         assertTrue(fields.isEmpty());
     }
 
     public void testFetchAllFields() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", "value")
             .startObject("object")
@@ -113,19 +111,18 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endObject()
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "*");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "*");
         assertThat(fields.size(), equalTo(2));
     }
 
     public void testNestedArrays() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .startArray("field")
                 .startArray().value("first").value("second").endArray()
             .endArray()
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "field");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "field");
         DocumentField field = fields.get("field");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(2));
@@ -139,7 +136,7 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endArray()
             .endObject();
 
-        fields = fetchFields(mapperService, source, "object.field");
+        fields = fetchFields(createFetchContext(), source, "object.field");
         field = fields.get("object.field");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(4));
@@ -147,13 +144,11 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testArrayValueMappers() throws IOException {
-        MapperService mapperService = createMapperService();
-
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("geo_point", 27.1, 42.0)
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "geo_point");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "geo_point");
         assertThat(fields.size(), equalTo(1));
 
         DocumentField field = fields.get("geo_point");
@@ -168,7 +163,7 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endArray()
         .endObject();
 
-        fields = fetchFields(mapperService, source, "geo_point");
+        fields = fetchFields(createFetchContext(), source, "geo_point");
         assertThat(fields.size(), equalTo(1));
 
         field = fields.get("geo_point");
@@ -177,7 +172,6 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testFieldNamesWithWildcard() throws IOException {
-        MapperService mapperService = createMapperService();;
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "first", "second")
             .field("integer_field", 333)
@@ -186,7 +180,7 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endObject()
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "*field");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "*field");
         assertThat(fields.size(), equalTo(3));
 
         DocumentField field = fields.get("field");
@@ -206,13 +200,12 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testDateFormat() throws IOException {
-        MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", "value")
             .field("date_field", "1990-12-29T00:00:00.000Z")
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, List.of(
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, List.of(
             new FieldAndFormat("field", null),
             new FieldAndFormat("date_field", "yyyy/MM/dd")));
         assertThat(fields.size(), equalTo(2));
@@ -227,51 +220,35 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testIgnoreAbove() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field")
-                    .field("type", "keyword")
-                    .field("ignore_above", 20)
-                .endObject()
-            .endObject()
-        .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        MapperService mapperService = indexService.mapperService();
+        FetchContext context = createFetchContext(
+            b -> b.startObject("field").field("type", "keyword").field("ignore_above", 20).endObject()
+        );
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "value", "other_value", "really_really_long_value")
             .endObject();
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "field");
+        Map<String, DocumentField> fields = fetchFields(context, source, "field");
         DocumentField field = fields.get("field");
         assertThat(field.getValues().size(), equalTo(2));
 
         source = XContentFactory.jsonBuilder().startObject()
             .array("field", "really_really_long_value")
             .endObject();
-        fields = fetchFields(mapperService, source, "field");
+        fields = fetchFields(context, source, "field");
         assertFalse(fields.containsKey("field"));
     }
 
     public void testFieldAliases() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field").field("type", "keyword").endObject()
-                .startObject("alias_field")
-                    .field("type", "alias")
-                    .field("path", "field")
-                .endObject()
-            .endObject()
-        .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        MapperService mapperService = indexService.mapperService();
+        FetchContext context = createFetchContext(b -> {
+            b.startObject("field").field("type", "keyword").endObject();
+            b.startObject("alias_field").field("type", "alias").field("path", "field").endObject();
+        });
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", "value")
             .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "alias_field");
+        Map<String, DocumentField> fields = fetchFields(context, source, "alias_field");
         assertThat(fields.size(), equalTo(1));
 
         DocumentField field = fields.get("alias_field");
@@ -279,32 +256,31 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
         assertThat(field.getValues().size(), equalTo(1));
         assertThat(field.getValues(), hasItems("value"));
 
-        fields = fetchFields(mapperService, source, "*field");
+        fields = fetchFields(context, source, "*field");
         assertThat(fields.size(), equalTo(2));
         assertTrue(fields.containsKey("alias_field"));
         assertTrue(fields.containsKey("field"));
     }
 
     public void testMultiFields() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field")
-                    .field("type", "integer")
-                    .startObject("fields")
-                        .startObject("keyword").field("type", "keyword").endObject()
-                    .endObject()
-                .endObject()
-            .endObject()
-        .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        MapperService mapperService = indexService.mapperService();
+        FetchContext context = createFetchContext(b -> {
+            b.startObject("field");
+            {
+                b.field("type", "integer");
+                b.startObject("fields");
+                {
+                    b.startObject("keyword").field("type", "keyword").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        });
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .field("field", 42)
             .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "field.keyword");
+        Map<String, DocumentField> fields = fetchFields(context, source, "field.keyword");
         assertThat(fields.size(), equalTo(1));
 
         DocumentField field = fields.get("field.keyword");
@@ -312,34 +288,24 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
         assertThat(field.getValues().size(), equalTo(1));
         assertThat(field.getValues(), hasItems("42"));
 
-        fields = fetchFields(mapperService, source, "field*");
+        fields = fetchFields(context, source, "field*");
         assertThat(fields.size(), equalTo(2));
         assertTrue(fields.containsKey("field"));
         assertTrue(fields.containsKey("field.keyword"));
     }
 
     public void testCopyTo() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field")
-                    .field("type", "keyword")
-                .endObject()
-                .startObject("other_field")
-                    .field("type", "integer")
-                    .field("copy_to", "field")
-                .endObject()
-            .endObject()
-        .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        MapperService mapperService = indexService.mapperService();
+        FetchContext context = createFetchContext(b -> {
+            b.startObject("field").field("type", "keyword").endObject();
+            b.startObject("other_field").field("type", "integer").field("copy_to", "field").endObject();
+        });
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "one", "two", "three")
             .array("other_field", 1, 2, 3)
             .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "field");
+        Map<String, DocumentField> fields = fetchFields(context, source, "field");
         assertThat(fields.size(), equalTo(1));
 
         DocumentField field = fields.get("field");
@@ -349,7 +315,6 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     }
 
     public void testObjectFields() throws IOException {
-        MapperService mapperService = createMapperService();;
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "first", "second")
             .startObject("object")
@@ -357,29 +322,22 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
             .endObject()
         .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "object");
+        Map<String, DocumentField> fields = fetchFields(createFetchContext(), source, "object");
         assertFalse(fields.containsKey("object"));
     }
 
     public void testTextSubFields() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field")
-                    .field("type", "text")
-                    .startObject("index_prefixes").endObject()
-                    .field("index_phrases", true)
-                .endObject()
-            .endObject()
-        .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        MapperService mapperService = indexService.mapperService();
+        FetchContext context = createFetchContext(b -> {
+            b.startObject("field");
+            b.field("type", "text").startObject("index_prefixes").endObject().field("index_phrases", true);
+            b.endObject();
+        });
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "some text")
             .endObject();
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "*");
+        Map<String, DocumentField> fields = fetchFields(context, source, "*");
         assertThat(fields.size(), equalTo(3));
         assertThat(fields.keySet(), containsInAnyOrder("field", "field._index_prefix", "field._index_phrase"));
 
@@ -389,41 +347,48 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
         }
     }
 
-    private Map<String, DocumentField> fetchFields(MapperService mapperService, XContentBuilder source, String fieldPattern)
+    private Map<String, DocumentField> fetchFields(FetchContext context, XContentBuilder source, String fieldPattern)
         throws IOException {
 
         List<FieldAndFormat> fields = List.of(new FieldAndFormat(fieldPattern, null));
-        return fetchFields(mapperService, source, fields);
+        return fetchFields(context, source, fields);
     }
 
-    private Map<String, DocumentField> fetchFields(MapperService mapperService, XContentBuilder source, List<FieldAndFormat> fields)
+    private Map<String, DocumentField> fetchFields(FetchContext context, XContentBuilder source, List<FieldAndFormat> fields)
         throws IOException {
 
         SourceLookup sourceLookup = new SourceLookup();
         sourceLookup.setSource(BytesReference.bytes(source));
 
-        FieldFetcher fieldFetcher = FieldFetcher.create(mapperService, null, fields);
+        FieldFetcher fieldFetcher = FieldFetcher.create(context, null, fields);
         return fieldFetcher.fetch(sourceLookup, Set.of());
     }
 
-    public MapperService createMapperService() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-            .startObject("properties")
-                .startObject("field").field("type", "keyword").endObject()
-                .startObject("integer_field").field("type", "integer").endObject()
-                .startObject("date_field").field("type", "date").endObject()
-                .startObject("geo_point").field("type", "geo_point").endObject()
-                .startObject("float_range").field("type", "float_range").endObject()
-                .startObject("object")
-                    .startObject("properties")
-                        .startObject("field").field("type", "keyword").endObject()
-                    .endObject()
-                .endObject()
-                .startObject("field_that_does_not_match").field("type", "keyword").endObject()
-            .endObject()
-        .endObject();
+    public FetchContext createFetchContext() throws IOException {
+        return createFetchContext(b -> {
+            b.startObject("field").field("type", "keyword").endObject();
+            b.startObject("integer_field").field("type", "integer").endObject();
+            b.startObject("date_field").field("type", "date").endObject();
+            b.startObject("geo_point").field("type", "geo_point").endObject();
+            b.startObject("float_range").field("type", "float_range").endObject();
+            b.startObject("object").startObject("properties");
+            {
+                b.startObject("field").field("type", "keyword").endObject();
+            }
+            b.endObject().endObject();
+            b.startObject("field_that_does_not_match").field("type", "keyword").endObject();
+        });
+    }
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
-        return indexService.mapperService();
+    public FetchContext createFetchContext(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {
+        MapperService.Snapshot mapperSnapshot = createMapperService(mapping(buildFields)).snapshot();
+        FetchContext fetchContext = mock(FetchContext.class);
+        when(fetchContext.simpleMatchToIndexNames(anyString())).then(
+            inv -> mapperSnapshot.simpleMatchToFullName((String) inv.getArguments()[0])
+        );
+        when(fetchContext.fieldType(anyString())).then(inv -> mapperSnapshot.fieldType((String) inv.getArguments()[0]));
+        when(fetchContext.isMetadataField(anyString())).then(inv -> mapperSnapshot.isMetadataField((String) inv.getArguments()[0]));
+        when(fetchContext.sourcePaths(anyString())).then(inv -> mapperSnapshot.sourcePaths((String) inv.getArguments()[0]));
+        return fetchContext;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -51,7 +51,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -68,7 +67,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.containsString;
@@ -126,7 +127,7 @@ public class SliceBuilderTests extends ESTestCase {
             TextSearchInfo.NONE, Collections.emptyMap()) {
 
             @Override
-            public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+            public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
                 throw new UnsupportedOperationException();
             }
 

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -162,10 +162,10 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
             IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index(randomAlphaOfLengthBetween(1, 10), "_na_"),
                     indexSettings);
-            MapperService mapperService = mock(MapperService.class);
+            MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
             ScriptService scriptService = mock(ScriptService.class);
             MappedFieldType fieldType = mockFieldType(suggestionBuilder.field());
-            when(mapperService.fieldType(any(String.class))).thenReturn(fieldType);
+            when(mapperSnapshot.fieldType(any(String.class))).thenReturn(fieldType);
             IndexAnalyzers indexAnalyzers = new IndexAnalyzers(
                 new HashMap<>() {
                     @Override
@@ -175,11 +175,11 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
                 },
                 Collections.emptyMap(),
                 Collections.emptyMap());
-            when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
+            when(mapperSnapshot.getIndexAnalyzers()).thenReturn(indexAnalyzers);
             when(scriptService.compile(any(Script.class), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(
                     ((Script) invocation.getArguments()[0]).getIdOrCode()));
             QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, BigArrays.NON_RECYCLING_INSTANCE, null,
-                null, mapperService, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
+                null, mapperSnapshot, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
                     System::currentTimeMillis, null, null, () -> true, null);
 
             SuggestionContext suggestionContext = suggestionBuilder.build(mockShardContext);
@@ -213,13 +213,11 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
         Settings indexSettings = builder.build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index(randomAlphaOfLengthBetween(1, 10), "_na_"),
             indexSettings);
-        MapperService mapperService = mock(MapperService.class);
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
         ScriptService scriptService = mock(ScriptService.class);
 
-        when(mapperService.getNamedAnalyzer(any(String.class))).then(
-            invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
         QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, BigArrays.NON_RECYCLING_INSTANCE, null,
-            null, mapperService, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
+            null, mapperSnapshot, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
             System::currentTimeMillis, null, null, () -> true, null);
         if (randomBoolean()) {
             mockShardContext.setAllowUnmappedFields(randomBoolean());

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -52,10 +52,7 @@ public abstract class FieldTypeTestCase extends ESTestCase {
 
     public static List<?> fetchSourceValue(MappedFieldType fieldType, Object sourceValue, String format) throws IOException {
         String field = fieldType.name();
-        MapperService mapperService = mock(MapperService.class);
-        when(mapperService.sourcePath(field)).thenReturn(Set.of(field));
-
-        ValueFetcher fetcher = fieldType.valueFetcher(mapperService, null, format);
+        ValueFetcher fetcher = fieldType.valueFetcher(() -> Set.of(field), null, format);
         SourceLookup lookup = new SourceLookup();
         lookup.setSource(Collections.singletonMap(field, sourceValue));
         return fetcher.fetchValues(lookup);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -26,6 +26,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 // this sucks how much must be overridden just do get a dummy field mapper...
 public class MockFieldMapper extends ParametrizedFieldMapper {
@@ -70,7 +72,7 @@ public class MockFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException();
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -279,12 +279,10 @@ public abstract class AggregatorTestCase extends ESTestCase {
         when(searchContext.bigArrays()).thenReturn(bigArrays);
 
         // TODO: now just needed for top_hits, this will need to be revised for other agg unit tests:
-        MapperService mapperService = mapperServiceMock();
-        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
-        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
+        MapperService.Snapshot mapperSnapshot = mapperSnapshotMock();
         IndexFieldDataService ifds = new IndexFieldDataService(indexSettings,
             new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
-            }), circuitBreakerService, mapperService);
+            }), circuitBreakerService);
         QueryShardContext queryShardContext =
             queryShardContextMock(contextIndexSearcher, mapperSnapshot, indexSettings, circuitBreakerService, bigArrays);
         when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
@@ -327,8 +325,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
     /**
      * sub-tests that need a more complex mock can overwrite this
      */
-    protected MapperService mapperServiceMock() {
-        return mock(MapperService.class);
+    protected MapperService.Snapshot mapperSnapshotMock() {
+        return mock(MapperService.Snapshot.class);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -359,7 +359,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {
             });
             indexFieldDataService = new IndexFieldDataService(idxSettings, indicesFieldDataCache,
-                    new NoneCircuitBreakerService(), mapperService);
+                    new NoneCircuitBreakerService());
             bitsetFilterCache = new BitsetFilterCache(idxSettings, new BitsetFilterCache.Listener() {
                 @Override
                 public void onCache(ShardId shardId, Accountable accountable) {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -412,7 +412,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
 
         QueryShardContext createShardContext(IndexSearcher searcher) {
             return new QueryShardContext(0, idxSettings, BigArrays.NON_RECYCLING_INSTANCE, bitsetFilterCache,
-                indexFieldDataService::getForField, mapperService, similarityService, scriptService, xContentRegistry,
+                indexFieldDataService::getForField, mapperService.snapshot(), similarityService, scriptService, xContentRegistry,
                 namedWriteableRegistry, this.client, searcher, () -> nowInMillis, null, indexNameMatcher(), () -> true, null);
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -27,9 +27,9 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -93,7 +93,6 @@ public class TestSearchContext extends SearchContext {
     private SearchContextAggregations aggregations;
     private ScrollContext scrollContext;
 
-    private final long originNanoTime = System.nanoTime();
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
 
     public TestSearchContext(BigArrays bigArrays, IndexService indexService) {
@@ -285,9 +284,9 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService mapperService() {
+    public IndexSettings indexSettings() {
         if (indexService != null) {
-            return indexService.mapperService();
+            return indexService.getIndexSettings();
         }
         return null;
     }
@@ -558,18 +557,12 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public MappedFieldType fieldType(String name) {
-        if (mapperService() != null) {
-            return mapperService().fieldType(name);
-        }
-        return null;
+        return queryShardContext.getFieldType(name);
     }
 
     @Override
     public ObjectMapper getObjectMapper(String name) {
-        if (mapperService() != null) {
-            return mapperService().getObjectMapper(name);
-        }
-        return null;
+        return queryShardContext.getObjectMapper(name);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.analytics.mapper;
 
 import com.carrotsearch.hppc.DoubleArrayList;
 import com.carrotsearch.hppc.IntArrayList;
+
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.BinaryDocValues;
@@ -34,7 +35,6 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -51,6 +51,7 @@ import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSou
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -135,8 +136,8 @@ public class HistogramFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -494,7 +494,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         }
     }
 
-    private TestIndexContext testIndex(MapperService mapperService, Client client) throws IOException {
+    private TestIndexContext testIndex(MapperService.Snapshot mapperSnapshot, Client client) throws IOException {
         TestIndexContext context = null;
 
         final long nowInMillis = randomNonNegativeLong();
@@ -522,7 +522,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             final LeafReaderContext leaf = directoryReader.leaves().get(0);
 
             final QueryShardContext shardContext = new QueryShardContext(shardId.id(), indexSettings, BigArrays.NON_RECYCLING_INSTANCE,
-                null, null, mapperService.snapshot(), null, null, xContentRegistry(), writableRegistry(),
+                null, null, mapperSnapshot, null, null, xContentRegistry(), writableRegistry(),
                 client, new IndexSearcher(directoryReader), () -> nowInMillis, null, null, () -> true, null);
 
             context = new TestIndexContext(directory, iw, directoryReader, shardContext, leaf);
@@ -543,8 +543,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
     }
 
     private void runTestOnIndices(int numberIndices, CheckedConsumer<List<TestIndexContext>, Exception> body) throws Exception {
-        final MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fieldType(Mockito.anyString())).thenAnswer(invocation -> {
+        final MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
+        when(mapperSnapshot.fieldType(Mockito.anyString())).thenAnswer(invocation -> {
             final String fieldName = (String) invocation.getArguments()[0];
             if (fieldName.equals(MISSING_FIELD_NAME)) {
                 return null;
@@ -559,7 +559,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         final List<TestIndexContext> context = new ArrayList<>(numberIndices);
         try {
             for (int i = 0; i < numberIndices; i++) {
-                context.add(testIndex(mapperService, client));
+                context.add(testIndex(mapperSnapshot, client));
             }
 
             body.accept(context);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -522,7 +522,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             final LeafReaderContext leaf = directoryReader.leaves().get(0);
 
             final QueryShardContext shardContext = new QueryShardContext(shardId.id(), indexSettings, BigArrays.NON_RECYCLING_INSTANCE,
-                null, null, mapperService, null, null, xContentRegistry(), writableRegistry(),
+                null, null, mapperService.snapshot(), null, null, xContentRegistry(), writableRegistry(),
                 client, new IndexSearcher(directoryReader), () -> nowInMillis, null, null, () -> true, null);
 
             context = new TestIndexContext(directory, iw, directoryReader, shardContext, leaf);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -67,12 +67,11 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
     public void testDLS() throws Exception {
         ShardId shardId = new ShardId("_index", "_na_", 0);
-        MapperService mapperService = mock(MapperService.class);
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
         ScriptService  scriptService = mock(ScriptService.class);
-        when(mapperService.documentMapper()).thenReturn(null);
-        when(mapperService.simpleMatchToFullName(anyString()))
+        when(mapperSnapshot.simpleMatchToFullName(anyString()))
                 .then(invocationOnMock -> Collections.singletonList((String) invocationOnMock.getArguments()[0]));
-        when(mapperService.fieldType(Mockito.anyString())).then(invocation -> {
+        when(mapperSnapshot.fieldType(Mockito.anyString())).then(invocation -> {
             final String fieldName = (String) invocation.getArguments()[0];
             return new KeywordFieldMapper.KeywordFieldType(fieldName);
         });
@@ -90,7 +89,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         when(client.settings()).thenReturn(Settings.EMPTY);
         final long nowInMillis = randomNonNegativeLong();
         QueryShardContext realQueryShardContext = new QueryShardContext(shardId.id(), indexSettings, BigArrays.NON_RECYCLING_INSTANCE,
-                null, null, mapperService, null, null, xContentRegistry(), writableRegistry(),
+                null, null, mapperSnapshot, null, null, xContentRegistry(), writableRegistry(),
                 client, null, () -> nowInMillis, null, null, () -> true, null);
         QueryShardContext queryShardContext = spy(realQueryShardContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());
@@ -181,12 +180,11 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
     public void testDLSWithLimitedPermissions() throws Exception {
         ShardId shardId = new ShardId("_index", "_na_", 0);
-        MapperService mapperService = mock(MapperService.class);
+        MapperService.Snapshot mapperSnapshot = mock(MapperService.Snapshot.class);
         ScriptService  scriptService = mock(ScriptService.class);
-        when(mapperService.documentMapper()).thenReturn(null);
-        when(mapperService.simpleMatchToFullName(anyString()))
+        when(mapperSnapshot.simpleMatchToFullName(anyString()))
                 .then(invocationOnMock -> Collections.singletonList((String) invocationOnMock.getArguments()[0]));
-        when(mapperService.fieldType(Mockito.anyString())).then(invocation -> {
+        when(mapperSnapshot.fieldType(Mockito.anyString())).then(invocation -> {
             final String fieldName = (String) invocation.getArguments()[0];
             return new KeywordFieldMapper.KeywordFieldType(fieldName);
         });
@@ -222,7 +220,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         when(client.settings()).thenReturn(Settings.EMPTY);
         final long nowInMillis = randomNonNegativeLong();
         QueryShardContext realQueryShardContext = new QueryShardContext(shardId.id(), indexSettings, BigArrays.NON_RECYCLING_INSTANCE,
-                null, null, mapperService, null, null, xContentRegistry(), writableRegistry(),
+                null, null, mapperSnapshot, null, null, xContentRegistry(), writableRegistry(),
                 client, null, () -> nowInMillis, null, null, () -> true, null);
         QueryShardContext queryShardContext = spy(realQueryShardContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
@@ -17,7 +17,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
@@ -32,6 +31,8 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
@@ -64,7 +65,7 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException();
         }
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ValueFetcher;

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -131,7 +132,7 @@ public class ConstantKeywordFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/x-pack/plugin/mapper-flattened/src/internalClusterTest/java/org/elasticsearch/xpack/flattened/mapper/FlattenedIndexFieldDataTests.java
+++ b/x-pack/plugin/mapper-flattened/src/internalClusterTest/java/org/elasticsearch/xpack/flattened/mapper/FlattenedIndexFieldDataTests.java
@@ -49,8 +49,7 @@ public class FlattenedIndexFieldDataTests extends ESSingleNodeTestCase  {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
-            indicesService.getCircuitBreakerService(),
-            indexService.mapperService());
+            indicesService.getCircuitBreakerService());
 
         Mapper.BuilderContext ctx = new Mapper.BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
         FlattenedFieldMapper fieldMapper = new FlattenedFieldMapper.Builder("json").build(ctx);

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.DynamicKeyFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -54,6 +53,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -257,7 +257,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException();
         }
     }
@@ -403,8 +403,8 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.identity(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.identity(name(), sourcePaths.get(), format);
         }
     }
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.unsignedlong;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -26,7 +27,6 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SimpleMappedFieldType;
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -232,12 +233,12 @@ public class UnsignedLongFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), mapperService, nullValueFormatted) {
+            return new SourceValueFetcher(sourcePaths.get(), nullValueFormatted) {
                 @Override
                 protected Object parseSourceValue(Object value) {
                     if (value.equals("")) {

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
@@ -58,6 +57,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
@@ -133,8 +133,8 @@ public class VersionStringFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
-            return SourceValueFetcher.toString(name(), mapperService, format);
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
+            return SourceValueFetcher.toString(name(), sourcePaths.get(), format);
         }
 
         @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -28,6 +27,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
@@ -214,7 +215,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType {
     }
 
     @Override
-    public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup lookup, String format) {
+    public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup lookup, String format) {
         return new DocValueFetcher(docValueFormat(format, null), lookup.doc().getForField(this));
     }
 }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldMapperTests.java
@@ -322,7 +322,7 @@ public class RuntimeFieldMapperTests extends MapperTestCase {
         IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("index").settings(build).build(), Settings.EMPTY);
         IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
         NoneCircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
-        final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService, null);
+        final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService);
         IndexSortConfig config = indexSettings.getIndexSortConfig();
         assertTrue(config.hasIndexSort());
         IllegalArgumentException iae = expectThrows(

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -19,7 +19,6 @@ import org.elasticsearch.index.mapper.ArraySourceValueFetcher;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -35,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -111,11 +111,11 @@ public class DenseVectorFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new ArraySourceValueFetcher(name(), mapperService) {
+            return new ArraySourceValueFetcher(sourcePaths.get()) {
                 @Override
                 protected Object parseSourceValue(Object value) {
                     return value;

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -12,7 +12,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -24,6 +23,8 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A {@link FieldMapper} for indexing a sparse vector of floats.
@@ -88,7 +89,7 @@ public class SparseVectorFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+        public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
             throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -56,7 +56,6 @@ import org.elasticsearch.index.mapper.BinaryFieldMapper.CustomBinaryDocValuesFie
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParametrizedFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
@@ -906,12 +905,12 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
         }
 
          @Override
-         public ValueFetcher valueFetcher(MapperService mapperService, SearchLookup searchLookup, String format) {
+         public ValueFetcher valueFetcher(Supplier<Set<String>> sourcePaths, SearchLookup searchLookup, String format) {
              if (format != null) {
                  throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
              }
 
-             return new SourceValueFetcher(name(), mapperService, nullValue) {
+             return new SourceValueFetcher(sourcePaths.get(), nullValue) {
                  @Override
                  protected String parseSourceValue(Object value) {
                      String keywordValue = value.toString();


### PR DESCRIPTION
I was looking at #62033 and it reminded me that one of the issues that we
have is that a search isn't handled by a single version of the mapping.
So I looked into taking a "snapshot" of the mutable part of the mapping
before starting the search request and always using it. It turned out to
be a single volatile read to get a pointer to an immutable copy of the
mapping.

This isn't perfect in that subsequent phases may get a new mapping, but
at least the entire search phase *should* use the same snapshot.
