### PR TITLE
Upgrade bundled jdk to 15.0.1 and switch back to AdoptOpenJDK

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 8.0.0
 lucene            = 8.7.0-snapshot-72d8528c3a6
 
-bundled_jdk_vendor = openjdk
-bundled_jdk = 15+36@779bf45e88a44cbd9ea6621d33e33db1
+bundled_jdk_vendor = adoptopenjdk
+bundled_jdk = 15.0.1+9
 
 checkstyle = 8.20
 


### PR DESCRIPTION
This commit updates the bundled jdk to 15.0.1, and at the same time once
again switches the bundled jdk back to adoptopenjdk, which has fixed
their build problem and regained support for glibc 2.12.

closes #64026