### PR TITLE
Clarify preferred method for setting heap size

### DIFF
--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -66,7 +66,12 @@ Here is an example of how to set the heap size via a `jvm.options.d/` file:
 <1> Set the minimum heap size to 2g.
 <2> Set the maximum heap size to 2g.
 
-You can set the heap size using the `ES_JAVA_OPTS` environment variable:
+Using `jvm.options.d` is the preferred method for configuring the heap size for
+production deployments.
+
+It is also possible to set the heap size via the `ES_JAVA_OPTS` environment
+variable. This is generally discouraged for production deployments but is useful
+for testing because it overrides all other means of setting JVM options.
 
 [source,sh]
 ------------------


### PR DESCRIPTION
This commit clarifies that the preferred method for setting the heap size is via jvm.options.d and that using the ES_JAVA_OPTS environment variable is discouraged for production deployments.

Relates #64237
