### PR TITLE
Avoid Needless Context Switches in CacheFile#populateAndRead

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -111,6 +111,7 @@ public class CacheFile {
         this.tracker = new SparseFileTracker(file.toString(), length);
         this.description = Objects.requireNonNull(description);
         this.file = Objects.requireNonNull(file);
+        assert invariant();
     }
 
     public long getLength() {
@@ -154,6 +155,7 @@ public class CacheFile {
             assert evicted.get();
             throwAlreadyEvicted();
         }
+        assert invariant();
     }
 
     public void release(final EvictionListener listener) {
@@ -179,6 +181,7 @@ public class CacheFile {
                 decrementRefCount();
             }
         }
+        assert invariant();
     }
 
     private boolean assertNoPendingListeners() {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -144,7 +144,8 @@ public class CacheFileTests extends ESTestCase {
                 Tuple.tuple(0L, length),
                 channel -> Math.toIntExact(length),
                 (channel, from, to, progressUpdater) -> progressUpdater.accept(length),
-                threadPool.generic()
+                threadPool.generic(),
+                randomBoolean()
             );
         } else {
             populateAndReadFuture = null;


### PR DESCRIPTION
If we are going to block on the current thread anyway we migtht as well use it for pulling
down data from the repo and avoid context switches (as well as waiting for pool executors to
become available under load).


This could be made even more efficient by putting the gaps to process in a queue and making maximum use of the current thread (instead of just handling a single gap on it) in case the passed `executor` is busy but I figured I'd keep it simple here and see if there's any potential downside to doing this first.