### PR TITLE
Compute polygon orientation using signed area (#64095)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
@@ -430,6 +430,19 @@ public class GeometryIndexerTests extends ESTestCase {
         assertThat(e.getMessage(), not(containsString("NaN")));
     }
 
+    public void testCrossingDateline() {
+        Polygon polygon = new Polygon(new LinearRing(
+            new double[]{170, -170, -170, 170, 170}, new double[]{-10, -10, 10, 10, -10}
+        ));
+        Geometry geometry = indexer.prepareForIndexing(polygon);
+        assertTrue(geometry instanceof MultiPolygon);
+        polygon = new Polygon(new LinearRing(
+            new double[]{180, -170, -170, 170, 180}, new double[]{-10, -5, 15, -15, -10}
+        ));
+        geometry = indexer.prepareForIndexing(polygon);
+        assertTrue(geometry instanceof MultiPolygon);
+    }
+
     private XContentBuilder polygon(Boolean orientation, double... val) throws IOException {
         XContentBuilder pointGeoJson = XContentFactory.jsonBuilder().startObject();
         {

--- a/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -248,7 +248,7 @@ public class ShapeBuilderTests extends ESTestCase {
                     .coordinate(-40.0, -50.0)
                     .coordinate(40.0, -50.0).close());
         Exception e = expectThrows(InvalidShapeException.class, () -> newPolygon.buildS4J());
-        assertThat(e.getMessage(), containsString("Self-intersection at or near point (0.0"));
+        assertThat(e.getMessage(), containsString("Cannot determine orientation: signed area equal to 0"));
     }
 
     /** note: only supported by S4J at the moment */


### PR DESCRIPTION
We currently relay in the southernmost point of a polygon ring to compute the orientation of the polygon. 
This might lead to wrong results if the point neighbours cross the dateline. 
This commit changes the computation by using the signed area of the polygon ring.

backport #64095