### PR TITLE
Use watcher get api instead of .watches index. (#64199)

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/ack_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/ack_watch/10_basic.yml
@@ -46,14 +46,11 @@
   - match: { "status.actions.test_index.ack.state" : "awaits_successful_execution" }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body: { "query": { "term": { "_id": "my_watch" } } }
-  - match: { hits.total: 1 }
-  - match: { hits.hits.0._source.status.actions.test_index.ack.state: "awaits_successful_execution" }
+      watcher.get_watch:
+        id: "my_watch"
+  - match: { found: true }
+  - match: { _id: "my_watch" }
+  - match: { status.actions.test_index.ack.state: "awaits_successful_execution" }
 
   - do:
       watcher.delete_watch:

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/activate_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/activate_watch/10_basic.yml
@@ -50,16 +50,6 @@
   - match: { status.state.active : false }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body: { "query": { "term": { "_id": "my_watch" } } }
-  - match: { hits.total: 1 }
-  - match: { hits.hits.0._source.status.state.active: false }
-
-  - do:
       watcher.get_watch:
         id: "my_watch"
   - match: { found : true}
@@ -71,16 +61,6 @@
         watch_id: "my_watch"
 
   - match: { status.state.active : true }
-
-  - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body: { "query": { "term": { "_id": "my_watch" } } }
-  - match: { hits.total: 1 }
-  - match: { hits.hits.0._source.status.state.active: true }
 
   - do:
       watcher.get_watch:

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/delete_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/delete_watch/10_basic.yml
@@ -49,18 +49,22 @@ teardown:
   - match: { created: true }
 
   - do:
+      watcher.get_watch:
+        id: "my_watch"
+  - match: { found: true }
+  - match: { _id: "my_watch" }
+
+  - do:
       watcher.delete_watch:
         id: "my_watch"
   - match: { found: true }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body: { "query": { "term": { "_id": "my_watch" } } }
-  - match: { hits.total: 0 }
+      catch: missing
+      watcher.get_watch:
+        id: "my_watch"
+  - match: { found: false }
+  - match: { _id: "my_watch" }
 
 ---
 "Non existent watch returns 404":

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/get_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/get_watch/10_basic.yml
@@ -49,15 +49,6 @@ teardown:
   - match: { created: true }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body: { "query": { "term": { "_id": "my_watch" } } }
-  - match: { hits.total: 1 }
-
-  - do:
       watcher.get_watch:
         id: "my_watch"
   - match: { found : true}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/80_put_get_watch_with_passwords.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/80_put_get_watch_with_passwords.yml
@@ -265,25 +265,9 @@ setup:
           }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.watches], but in a future major version, direct access to system indices will be prevented by default"
-      search:
-        rest_total_hits_as_int: true
-        index: .watches
-        body:  >
-          {
-            "query": {
-              "term": {
-                "_id": {
-                  "value": "watch_with_seq_no"
-                }
-              }
-            }
-          }
-
-
-  - match: { hits.total: 1 }
-  - match: { hits.hits.0._id: "watch_with_seq_no" }
-  - match: { hits.hits.0._source.input.http.request.auth.basic.username: "new_user" }
-  - match: { hits.hits.0._source.input.http.request.auth.basic.password: "pass" }
-
+      watcher.get_watch:
+        id: "watch_with_seq_no"
+  - match: { found: true }
+  - match: { _id: "watch_with_seq_no" }
+  - match: { watch.input.http.request.auth.basic.username: "new_user" }
+  - match: { watch.input.http.request.auth.basic.password: "::es_redacted::" }


### PR DESCRIPTION
Backport of #64199 to 7.x branch.

Replaces querying .watches index with using the watcher get api where possible.
These cases queried a specific watch by id and then checked if the count is 1 and
some properties of the actual watch. This can be replaced by just using the get
watch api.

Relates to #62501