### PR TITLE
Query cache add skip cache factor

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -208,6 +208,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING,
             IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING,
             IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING,
+            IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING,
             IndicesService.INDICES_ID_FIELD_DATA_ENABLED_SETTING,
             IndicesService.WRITE_DANGLING_INDICES_INFO_SETTING,
             MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING,

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -65,7 +65,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
             Setting.boolSetting("indices.queries.cache.all_segments", false, Property.NodeScope);
     // add tuning skip_cache_factor when caching is enabled on all segments
     public static final Setting<Float> INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING =
-        Setting.floatSetting("indices.queries.cache.skip_cache_factor", 250f, 1f, Property.NodeScope);
+        Setting.floatSetting("indices.queries.cache.skip_cache_factor", 1f, 1f, Property.NodeScope);
     
     private final LRUQueryCache cache;
     private final ShardCoreKeyMap shardKeyMap = new ShardCoreKeyMap();

--- a/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
@@ -117,6 +117,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
                 .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+                .put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING.getKey(), 10f)
                 .build();
         IndicesQueryCache cache = new IndicesQueryCache(settings);
         s.setQueryCache(cache);
@@ -198,6 +199,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
                 .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+                .put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING.getKey(), 10f)
                 .build();
         IndicesQueryCache cache = new IndicesQueryCache(settings);
         s1.setQueryCache(cache);
@@ -324,6 +326,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
                 .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+                .put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING.getKey(), 10f)
                 .build();
         IndicesQueryCache cache = new IndicesQueryCache(settings);
         s1.setQueryCache(cache);
@@ -411,6 +414,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
                 .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+                .put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR_SETTING.getKey(), 10f)
                 .build();
         IndicesQueryCache cache = new IndicesQueryCache(settings);
         s.setQueryCache(cache);


### PR DESCRIPTION
In high concurrency and high traffic search scenarios, the cache of all segments needs to be enabled. However, Lucene has added a skipCacheFactor parameter to control the querycache factor, which is 1 by default, which results in slow loading of querycache and high query latency. So submit the PR to adjust the skipCacheFactor.