### PR TITLE
[docs] update_by_query doesn't support refresh=wait_for

### DIFF
--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -196,9 +196,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
 `refresh`::
-(Optional, boolean) If `true`, {es} refreshes the affected shards to make this
-operation visible to search, if `false` do nothing with refreshes.
-Valid values: `true`, `false`. Default: `false`.
+(Optional, Boolean)
+If `true`, {es} refreshes affected shards to make the operation visible to
+search. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -195,7 +195,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
+`refresh`::
+(Optional, boolean) If `true`, {es} refreshes the affected shards to make this
+operation visible to search, if `false` do nothing with refreshes.
+Valid values: `true`, `false`. Default: `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 


### PR DESCRIPTION
update_by_query doesn't support refresh=wait_for

The docs contains the note 
> Unlike the update API, it does not support `wait_for`.

But later down in the parameter list it seems like it's possible to use `refresh=wait_for`