### PR TITLE
[DOCS] Adds note box about mappings to Transforms Painless examples

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -23,10 +23,11 @@ more about the Painless scripting language in the
 * While the context of the following examples is the {transform} use case, 
 the Painless scripts in the snippets below can be used in other {es} search 
 aggregations, too.
-* {transforms-cap} rely on dynamic mappings when creating the destination index. 
-They cannot deduce mappings of output fields when the fields are created by a 
-script. In this case, create the mappings of the destination index prior to 
-creating the {transform}. 
+* All the following examples use scripts, {transforms} cannot deduce mappings of 
+output fields when the fields are created by a script. {transforms-cap} don't 
+create any mappings in the the destination index for these fields, which means 
+they get dynamically mapped. Create the destination index prior to starting the 
+{transform} in case you want explicit mappings.
 --
 
 [[painless-top-hits]]

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -18,9 +18,16 @@ more about the Painless scripting language in the
 * <<painless-compare>>
 * <<painless-web-session>>
 
-NOTE: While the context of the following examples is the {transform} use case, 
+[NOTE] 
+--
+* While the context of the following examples is the {transform} use case, 
 the Painless scripts in the snippets below can be used in other {es} search 
 aggregations, too.
+* {transforms-cap} rely on dynamic mappings when creating the destination index. 
+They cannot deduce mappings of output fields when the fields are created by a 
+script. In this case, create the mappings of the destination index prior to 
+creating the {transform}. 
+--
 
 [[painless-top-hits]]
 == Getting top hits by using scripted metric aggregation


### PR DESCRIPTION
## Overview

This PR adds a new note to the note box near the top of the page about how mapping works in Transforms.

### Preview

[Painless examples for transforms](https://elasticsearch_64285.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-painless-examples.html)