### PR TITLE
[DOCS] Sort field data types in docs

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -178,6 +178,6 @@ include::types/text.asciidoc[]
 
 include::types/token-count.asciidoc[]
 
-include::unsigned_long.asciidoc[]
+include::types/unsigned_long.asciidoc[]
 
 include::types/version.asciidoc[]

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -150,8 +150,6 @@ include::types/geo-shape.asciidoc[]
 
 include::types/ip.asciidoc[]
 
-include::types/version.asciidoc[]
-
 include::types/parent-join.asciidoc[]
 
 include::types/keyword.asciidoc[]
@@ -174,8 +172,12 @@ include::types/rank-features.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
 
+include::types/shape.asciidoc[]
+
 include::types/text.asciidoc[]
 
 include::types/token-count.asciidoc[]
 
-include::types/shape.asciidoc[]
+include::unsigned_long.asciidoc[]
+
+include::types/version.asciidoc[]

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -140,13 +140,13 @@ include::types/date_nanos.asciidoc[]
 
 include::types/dense-vector.asciidoc[]
 
-include::types/histogram.asciidoc[]
-
 include::types/flattened.asciidoc[]
 
 include::types/geo-point.asciidoc[]
 
 include::types/geo-shape.asciidoc[]
+
+include::types/histogram.asciidoc[]
 
 include::types/ip.asciidoc[]
 

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -51,7 +51,7 @@ Dates::                 Date types, including <<date,`date`>> and
 <<range,Range>>::   Range types, such as `long_range`, `double_range`,
                     `date_range`, and `ip_range`.
 <<ip,`ip`>>::       IPv4 and IPv6 addresses.
-<<version,Version>>::  Software versions. Supports https://semver.org/[Semantic Versioning]
+<<version,`version`>>::  Software versions. Supports https://semver.org/[Semantic Versioning]
 precedence rules.
 {plugins}/mapper-murmur3.html[`murmur3`]:: Compute and stores hashes of
 values.

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -165,5 +165,3 @@ The following parameters are accepted by numeric types:
     sorting) will behave as if the document had a value of +2.3+. High values
     of `scaling_factor` improve accuracy but also increase space requirements.
     This parameter is required.
-
-include::unsigned_long.asciidoc[]

--- a/docs/reference/mapping/types/unsigned_long.asciidoc
+++ b/docs/reference/mapping/types/unsigned_long.asciidoc
@@ -2,7 +2,10 @@
 [testenv="basic"]
 
 [[unsigned-long]]
-=== Unsigned long
+=== Unsigned long field type
+++++
+<titleabbrev>Unsigned long</titleabbrev>
+++++
 Unsigned long is a numeric field type that represents an unsigned 64-bit
 integer with a minimum value of 0 and a maximum value of +2^64^-1+
 (from 0 to 18446744073709551615 inclusive).

--- a/docs/reference/mapping/types/unsigned_long.asciidoc
+++ b/docs/reference/mapping/types/unsigned_long.asciidoc
@@ -2,7 +2,7 @@
 [testenv="basic"]
 
 [[unsigned-long]]
-=== Unsigned long data type
+=== Unsigned long
 Unsigned long is a numeric field type that represents an unsigned 64-bit
 integer with a minimum value of 0 and a maximum value of +2^64^-1+
 (from 0 to 18446744073709551615 inclusive).


### PR DESCRIPTION
This sorts the field data types alphabetically in the navigation. Additionally the title for unsigned long
included "data type", but none of the others included this so I removed it for consistency.

<img width="285" alt="Screen Shot 2020-10-28 at 10 04 44 AM" src="https://user-images.githubusercontent.com/4565752/97446759-320a5180-1905-11eb-9b0f-81f5f8368626.png">
