### PR TITLE
[7.9] [DOCS] EQL: Fix operator docs (#64286)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -208,13 +208,13 @@ Returns `true` if the value is not contained in the provided list.
 `+` (add)::
 Adds the values to the left and right of the operator.
 
-`-` (Subtract)::
+`-` (subtract)::
 Subtracts the value to the right of the operator from the value to the left.
 
-`*` (Subtract)::
+`*` (multiply)::
 Multiplies the values to the left and right of the operator.
 
-`/` (Divide)::
+`/` (divide)::
 Divides the value to the left of the operator by the value to the right.
 
 `%` (modulo)::


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] EQL: Fix operator docs (#64286)