### PR TITLE
[7.9] [DOCS] Fix glossary formatting (#64118)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -4,20 +4,22 @@
 
 [glossary]
 [[glossary-analysis]] analysis ::
-
++
+--
+// tag::analysis-def[]
 Analysis is the process of converting <<glossary-text,full text>> to
 <<glossary-term,terms>>. Depending on which analyzer is used, these phrases:
 `FOO BAR`, `Foo-Bar`, `foo,bar` will probably all result in the
 terms `foo` and `bar`. These terms are what is actually stored in
 the index.
-+
+
 A full text query (not a <<glossary-term,term>> query) for `FoO:bAR` will
 also be analyzed to the terms `foo`,`bar` and will thus match the
 terms stored in the index.
-+
+
 It is this process of analysis (both at index time and at search time)
 that allows Elasticsearch to perform full text queries.
-+
+
 Also see <<glossary-text,text>> and <<glossary-term,term>>.
 // end::analysis-def[]
 --
@@ -197,13 +199,11 @@ An optimized collection of JSON documents. Each document is a collection of fiel
 the key-value pairs that contain your data.
 // end::index-def-short[]
 
-An index is like a _table_ in a relational database. It has a
-<<glossary-mapping,mapping>> which contains a <<glossary-type,type>>,
-which contains the <<glossary-field,fields>> in the index.
-+
 An index is a logical namespace which maps to one or more
 <<glossary-primary-shard,primary shards>> and can have zero or more
 <<glossary-replica-shard,replica shards>>.
+// end::index-def[]
+--
 
 [[glossary-index-alias]] index alias ::
 +


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fix glossary formatting (#64118)