### PR TITLE
[7.10] [DOCS] Fix `refresh` def in `update_by_query` docs (#64277)

### DIFF
--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -195,7 +195,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
+`refresh`::
+(Optional, Boolean)
+If `true`, {es} refreshes affected shards to make the operation visible to
+search. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix `refresh` def in `update_by_query` docs (#64277)