### PR TITLE
[7.x] [DOCS] Sort field data types in docs (#64288)

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -51,7 +51,7 @@ Dates::                 Date types, including <<date,`date`>> and
 <<range,Range>>::   Range types, such as `long_range`, `double_range`,
                     `date_range`, and `ip_range`.
 <<ip,`ip`>>::       IPv4 and IPv6 addresses.
-<<version,Version>>::  Software versions. Supports https://semver.org/[Semantic Versioning]
+<<version,`version`>>::  Software versions. Supports https://semver.org/[Semantic Versioning]
 precedence rules.
 {plugins}/mapper-murmur3.html[`murmur3`]:: Compute and stores hashes of
 values.
@@ -140,17 +140,15 @@ include::types/date_nanos.asciidoc[]
 
 include::types/dense-vector.asciidoc[]
 
-include::types/histogram.asciidoc[]
-
 include::types/flattened.asciidoc[]
 
 include::types/geo-point.asciidoc[]
 
 include::types/geo-shape.asciidoc[]
 
-include::types/ip.asciidoc[]
+include::types/histogram.asciidoc[]
 
-include::types/version.asciidoc[]
+include::types/ip.asciidoc[]
 
 include::types/parent-join.asciidoc[]
 
@@ -174,10 +172,14 @@ include::types/rank-features.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
 
+include::types/shape.asciidoc[]
+
 include::types/sparse-vector.asciidoc[]
 
 include::types/text.asciidoc[]
 
 include::types/token-count.asciidoc[]
 
-include::types/shape.asciidoc[]
+include::types/unsigned_long.asciidoc[]
+
+include::types/version.asciidoc[]

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -170,5 +170,3 @@ The following parameters are accepted by numeric types:
     sorting) will behave as if the document had a value of +2.3+. High values
     of `scaling_factor` improve accuracy but also increase space requirements.
     This parameter is required.
-
-include::unsigned_long.asciidoc[]

--- a/docs/reference/mapping/types/unsigned_long.asciidoc
+++ b/docs/reference/mapping/types/unsigned_long.asciidoc
@@ -2,7 +2,10 @@
 [testenv="basic"]
 
 [[unsigned-long]]
-=== Unsigned long data type
+=== Unsigned long field type
+++++
+<titleabbrev>Unsigned long</titleabbrev>
+++++
 Unsigned long is a numeric field type that represents an unsigned 64-bit
 integer with a minimum value of 0 and a maximum value of +2^64^-1+
 (from 0 to 18446744073709551615 inclusive).


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Sort field data types in docs (#64288)