### PR TITLE
Fix BWC distribution resolution errors

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -151,11 +151,13 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
     private static List<DistributionProject> resolveArchiveProjects(File checkoutDir, Version bwcVersion) {
         List<String> projects = new ArrayList<>();
-        projects.addAll(asList("deb", "rpm"));
-        if (bwcVersion.onOrAfter("7.0.0")) {
+        // All active BWC branches publish default and oss variants of rpm and deb packages
+        projects.addAll(asList("deb", "rpm", "oss-deb", "oss-rpm"));
+
+        if (bwcVersion.onOrAfter("7.0.0")) { // starting with 7.0 we bundle a jdk which means we have platform-specific archives
             projects.addAll(asList("oss-windows-zip", "windows-zip", "oss-darwin-tar", "darwin-tar", "oss-linux-tar", "linux-tar"));
-        } else {
-            projects.addAll(asList("oss-zip", "zip", "oss-deb", "oss-rpm"));
+        } else { // prior to 7.0 we published only a single zip and tar archives for oss and default distributions
+            projects.addAll(asList("oss-zip", "zip", "tar", "oss-tar"));
         }
 
         return projects.stream().map(name -> {


### PR DESCRIPTION
This fixes issues in resolving BWC artifacts for certain distribution types. Different Elasticsearch versions publish different subsets of artifacts. For example, before version 7.0.0 we did not produce platform-specific archive (zip/tar) artifacts since we didn't bundle a JDK. This pull request fixes the mappings of version to distribution types, which fixes some errors encountered when resolving dependencies.