### PR TITLE
[7.x] Add hard_bounds support for histogram field-based histograms (#64246)

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
@@ -76,16 +76,18 @@ public class HistoBackedHistogramAggregator extends AbstractHistogramAggregator 
 
                         double key = Math.floor((value - offset) / interval);
                         assert key >= previousKey;
-                        long bucketOrd = bucketOrds.add(owningBucketOrd, Double.doubleToLongBits(key));
-                        if (bucketOrd < 0) { // already seen
-                            bucketOrd = -1 - bucketOrd;
-                            collectExistingBucket(sub, doc, bucketOrd);
-                        } else {
-                            collectBucket(sub, doc, bucketOrd);
+                        if (hardBounds == null || hardBounds.contain(key * interval)) {
+                            long bucketOrd = bucketOrds.add(owningBucketOrd, Double.doubleToLongBits(key));
+                            if (bucketOrd < 0) { // already seen
+                                bucketOrd = -1 - bucketOrd;
+                                collectExistingBucket(sub, doc, bucketOrd);
+                            } else {
+                                collectBucket(sub, doc, bucketOrd);
+                            }
+                            // We have added the document already. We should increment doc_count by count - 1
+                            // so that we have added it count times.
+                            incrementBucketDocCount(bucketOrd, count - 1);
                         }
-                        // We have added the document already. We should increment doc_count by count - 1
-                        // so that we have added it count times.
-                        incrementBucketDocCount(bucketOrd, count - 1);
                         previousKey = key;
                     }
                 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregatorTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.bucket.histogram.DoubleBounds;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
@@ -159,6 +160,28 @@ public class HistoBackedHistogramAggregatorTests extends AggregatorTestCase {
                 assertEquals(0, histogram.getBuckets().get(4).getDocCount());
                 assertEquals(10d, histogram.getBuckets().get(5).getKey());
                 assertEquals(0, histogram.getBuckets().get(5).getDocCount());
+                assertTrue(AggregationInspectionHelper.hasValue(histogram));
+            }
+        }
+    }
+
+    public void testHardBounds() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+
+            w.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -4.5, 4.3 })));
+            w.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -5, 3.2 })));
+            w.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 1.0, 2.2 })));
+            w.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -6.0, 12.2 })));
+
+            HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field(FIELD_NAME)
+                .interval(5)
+                .hardBounds(new DoubleBounds(0.0, 5.0));
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalHistogram histogram = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, defaultFieldType(FIELD_NAME));
+                assertEquals(1, histogram.getBuckets().size());
+                assertEquals(0d, histogram.getBuckets().get(0).getKey());
+                assertEquals(4, histogram.getBuckets().get(0).getDocCount());
                 assertTrue(AggregationInspectionHelper.hasValue(histogram));
             }
         }


### PR DESCRIPTION
hard_bounds should now support histogram fields, previously hard bounds
on histogram fields were ignored.

Closes #62124
