### PR TITLE
[ML] Handle null value of FieldCapabilitiesResponse

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -377,6 +377,9 @@ public class Classification implements DataFrameAnalysis {
     public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
+        if (fieldCapabilitiesResponse == null) {
+            return additionalProperties;
+        }
         Map<String, FieldCapabilities> dependentVariableFieldCaps = fieldCapabilitiesResponse.getField(dependentVariable);
         if (dependentVariableFieldCaps == null || dependentVariableFieldCaps.isEmpty()) {
             return additionalProperties;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -362,6 +362,11 @@ public class ClassificationTests extends AbstractBWCSerializationTestCase<Classi
         assertThat(constraints.get(0).getUpperBound(), equalTo(30L));
     }
 
+    public void testGetExplicitlyMappedFields_FieldCapabilitiesResponseIsNull() {
+        Map<String, Object> explicitlyMappedFields = new Classification("foo").getExplicitlyMappedFields("results", null);
+        assertThat(explicitlyMappedFields, equalTo(singletonMap("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING)));
+    }
+
     public void testGetExplicitlyMappedFields_DependentVariableMappingIsAbsent() {
         FieldCapabilitiesResponse fieldCapabilitiesResponse = new FieldCapabilitiesResponse(new String[0], Collections.emptyMap());
         Map<String, Object> explicitlyMappedFields =


### PR DESCRIPTION
This PR is a followup to https://github.com/elastic/elasticsearch/pull/63813

It does not need to be backported as the fix is included in the `7.x` and `7.10` backports of the PR mentioned above.

Relates elastic/machine-learning-qa#868