### PR TITLE
MultiGeoShapeValues interface always has at most one shape (#64302)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregator.java
@@ -23,7 +23,7 @@ import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.xpack.spatial.index.fielddata.DimensionalShapeType;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSource;
 
 import java.io.IOException;
@@ -61,11 +61,11 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
     }
 
     @Override
-    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final MultiGeoShapeValues values = valuesSource.geoShapeValues(ctx);
+        final GeoShapeValues values = valuesSource.geoShapeValues(ctx);
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumWeight = new CompensatedSum(0, 0);
@@ -73,55 +73,35 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                latSum = bigArrays().grow(latSum, bucket + 1);
-                lonSum = bigArrays().grow(lonSum, bucket + 1);
-                weightSum = bigArrays().grow(weightSum, bucket + 1);
-                lonCompensations = bigArrays().grow(lonCompensations, bucket + 1);
-                latCompensations = bigArrays().grow(latCompensations, bucket + 1);
-                weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
-                counts = bigArrays().grow(counts, bucket + 1);
-                dimensionalShapeTypes = bigArrays().grow(dimensionalShapeTypes, bucket + 1);
-
                 if (values.advanceExact(doc)) {
-                    final int valueCount = values.docValueCount();
+                    maybeResize(bucket);
                     // increment by the number of points for this document
-                    counts.increment(bucket, valueCount);
+                    counts.increment(bucket, 1);
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    DimensionalShapeType shapeType = DimensionalShapeType.fromOrdinalByte(dimensionalShapeTypes.get(bucket));
-                    double sumLat = latSum.get(bucket);
-                    double compensationLat = latCompensations.get(bucket);
-                    double sumLon = lonSum.get(bucket);
-                    double compensationLon = lonCompensations.get(bucket);
-                    double sumWeight = weightSum.get(bucket);
-                    double compensatedWeight = weightCompensations.get(bucket);
-
-                    compensatedSumLat.reset(sumLat, compensationLat);
-                    compensatedSumLon.reset(sumLon, compensationLon);
-                    compensatedSumWeight.reset(sumWeight, compensatedWeight);
-
+                    final DimensionalShapeType shapeType = DimensionalShapeType.fromOrdinalByte(dimensionalShapeTypes.get(bucket));
+                    final GeoShapeValues.GeoShapeValue value = values.value();
+                    final int compares = shapeType.compareTo(value.dimensionalShapeType());
                     // update the sum
-                    for (int i = 0; i < valueCount; ++i) {
-                        MultiGeoShapeValues.GeoShapeValue value = values.nextValue();
-                        int compares = shapeType.compareTo(value.dimensionalShapeType());
-                        if (compares < 0) {
-                            double coordinateWeight = value.weight();
-                            compensatedSumLat.reset(coordinateWeight * value.lat(), 0.0);
-                            compensatedSumLon.reset(coordinateWeight * value.lon(), 0.0);
-                            compensatedSumWeight.reset(coordinateWeight, 0.0);
-                            dimensionalShapeTypes.set(bucket, (byte) value.dimensionalShapeType().ordinal());
-                        } else if (compares == 0) {
-                            double coordinateWeight = value.weight();
-                            // weighted latitude
-                            compensatedSumLat.add(coordinateWeight * value.lat());
-                            // weighted longitude
-                            compensatedSumLon.add(coordinateWeight * value.lon());
-                            // weight
-                            compensatedSumWeight.add(coordinateWeight);
-                        }
-                        // else (compares > 0)
-                        //   do not modify centroid calculation since shape is of lower dimension than the running dimension
-
+                    if (compares < 0) {
+                        // shape with higher dimensional value
+                        final double coordinateWeight = value.weight();
+                        compensatedSumLat.reset(coordinateWeight * value.lat(), 0.0);
+                        compensatedSumLon.reset(coordinateWeight * value.lon(), 0.0);
+                        compensatedSumWeight.reset(coordinateWeight, 0.0);
+                        dimensionalShapeTypes.set(bucket, (byte) value.dimensionalShapeType().ordinal());
+                    } else if (compares == 0) {
+                        // shape with the same dimensional value
+                        compensatedSumLat.reset(latSum.get(bucket), latCompensations.get(bucket));
+                        compensatedSumLon.reset(lonSum.get(bucket), lonCompensations.get(bucket));
+                        compensatedSumWeight.reset(weightSum.get(bucket),  weightCompensations.get(bucket));
+                        final double coordinateWeight = value.weight();
+                        compensatedSumLat.add(coordinateWeight * value.lat());
+                        compensatedSumLon.add(coordinateWeight * value.lon());
+                        compensatedSumWeight.add(coordinateWeight);
+                    } else {
+                        // do not modify centroid calculation since shape is of lower dimension than the running dimension
+                        return;
                     }
                     lonSum.set(bucket, compensatedSumLon.value());
                     lonCompensations.set(bucket, compensatedSumLon.delta());
@@ -130,6 +110,17 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
                     weightSum.set(bucket, compensatedSumWeight.value());
                     weightCompensations.set(bucket, compensatedSumWeight.delta());
                 }
+            }
+
+            private void maybeResize(long bucket) {
+                latSum = bigArrays().grow(latSum, bucket + 1);
+                lonSum = bigArrays().grow(lonSum, bucket + 1);
+                weightSum = bigArrays().grow(weightSum, bucket + 1);
+                lonCompensations = bigArrays().grow(lonCompensations, bucket + 1);
+                latCompensations = bigArrays().grow(latCompensations, bucket + 1);
+                weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
+                counts = bigArrays().grow(counts, bucket + 1);
+                dimensionalShapeTypes = bigArrays().grow(dimensionalShapeTypes, bucket + 1);
             }
         };
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractAtomicGeoShapeShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/AbstractAtomicGeoShapeShapeFieldData.java
@@ -43,8 +43,8 @@ public abstract class AbstractAtomicGeoShapeShapeFieldData implements LeafGeoSha
             }
 
             @Override
-            public MultiGeoShapeValues getGeoShapeValues() {
-                return MultiGeoShapeValues.EMPTY;
+            public GeoShapeValues getGeoShapeValues() {
+                return GeoShapeValues.EMPTY;
             }
         };
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -24,32 +24,27 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A stateful lightweight per document set of geo values.
+ * A stateful lightweight per document geo values.
  * To iterate over values in a document use the following pattern:
  * <pre>
  *   MultiGeoValues values = ..;
- *   values.setDocId(docId);
- *   final int numValues = values.count();
- *   for (int i = 0; i &lt; numValues; i++) {
- *       GeoValue value = values.valueAt(i);
- *       // process value
+ *   // for each docID
+ *   if (values.advanceExact(docId)) {
+ *     GeoValue value = values.value()
+ *     final int numValues = values.count();
+ *     // process value
  *   }
  * </pre>
- * The set of values associated with a document might contain duplicates and
- * comes in a non-specified order.
+ *
+ * There is just one value for one document.
  */
-public abstract class MultiGeoShapeValues {
+public abstract class GeoShapeValues {
 
-    public static MultiGeoShapeValues EMPTY = new MultiGeoShapeValues() {
+    public static GeoShapeValues EMPTY = new GeoShapeValues() {
         private GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();
         @Override
         public boolean advanceExact(int doc) {
             return false;
-        }
-
-        @Override
-        public int docValueCount() {
-            return 0;
         }
 
         @Override
@@ -58,15 +53,15 @@ public abstract class MultiGeoShapeValues {
         }
 
         @Override
-        public GeoShapeValue nextValue() {
+        public GeoShapeValue value() {
             throw new UnsupportedOperationException();
         }
     };
 
     /**
-     * Creates a new {@link MultiGeoShapeValues} instance
+     * Creates a new {@link GeoShapeValues} instance
      */
-    protected MultiGeoShapeValues() {
+    protected GeoShapeValues() {
     }
 
     /**
@@ -75,22 +70,17 @@ public abstract class MultiGeoShapeValues {
      */
     public abstract boolean advanceExact(int doc) throws IOException;
 
-    /**
-     * Return the number of geo points the current document has.
-     */
-    public abstract int docValueCount();
 
     public abstract ValuesSourceType valuesSourceType();
 
     /**
-     * Return the next value associated with the current document. This must not be
-     * called more than {@link #docValueCount()} times.
+     * Return the value associated with the current document.
      *
      * Note: the returned {@link GeoShapeValue} might be shared across invocations.
      *
-     * @return the next value for the current docID set to {@link #advanceExact(int)}.
+     * @return the value for the current docID set to {@link #advanceExact(int)}.
      */
-    public abstract GeoShapeValue nextValue() throws IOException;
+    public abstract GeoShapeValue value() throws IOException;
 
     /** thin wrapper around a {@link GeometryDocValueReader} which encodes / decodes values using
      * the Geo decoder */

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonShapeDVAtomicShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonShapeDVAtomicShapeFieldData.java
@@ -44,21 +44,16 @@ final class LatLonShapeDVAtomicShapeFieldData extends AbstractAtomicGeoShapeShap
     }
 
     @Override
-    public MultiGeoShapeValues getGeoShapeValues() {
+    public GeoShapeValues getGeoShapeValues() {
         try {
             final BinaryDocValues binaryValues = DocValues.getBinary(reader, fieldName);
             final GeometryDocValueReader reader = new GeometryDocValueReader();
-            final MultiGeoShapeValues.GeoShapeValue geoShapeValue = new MultiGeoShapeValues.GeoShapeValue(reader);
-            return new MultiGeoShapeValues() {
+            final GeoShapeValues.GeoShapeValue geoShapeValue = new GeoShapeValues.GeoShapeValue(reader);
+            return new GeoShapeValues() {
 
                 @Override
                 public boolean advanceExact(int doc) throws IOException {
                     return binaryValues.advanceExact(doc);
-                }
-
-                @Override
-                public int docValueCount() {
-                    return 1;
                 }
 
                 @Override
@@ -67,7 +62,7 @@ final class LatLonShapeDVAtomicShapeFieldData extends AbstractAtomicGeoShapeShap
                 }
 
                 @Override
-                public GeoShapeValue nextValue() throws IOException {
+                public GeoShapeValue value() throws IOException {
                     final BytesRef encoded = binaryValues.binaryValue();
                     reader.reset(encoded);
                     return geoShapeValue;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LeafGeoShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LeafGeoShapeFieldData.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 
 /**
- * {@link LeafFieldData} specialization for geo points and shapes.
+ * {@link LeafFieldData} specialization for geo shapes.
  */
 public interface LeafGeoShapeFieldData extends LeafFieldData {
     /**
      * Return geo shape values.
      */
-    MultiGeoShapeValues getGeoShapeValues();
+    GeoShapeValues getGeoShapeValues();
 
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AllCellValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AllCellValues.java
@@ -6,16 +6,16 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 import java.util.function.LongConsumer;
 
 /** Sorted numeric doc values for precision 0 */
 class AllCellValues extends ByteTrackingSortingNumericDocValues {
-    private MultiGeoShapeValues geoValues;
+    private GeoShapeValues geoValues;
 
-    protected AllCellValues(MultiGeoShapeValues geoValues, GeoGridTiler tiler, LongConsumer circuitBreakerConsumer) {
+    protected AllCellValues(GeoShapeValues geoValues, GeoGridTiler tiler, LongConsumer circuitBreakerConsumer) {
         super(circuitBreakerConsumer);
         this.geoValues = geoValues;
         resize(1);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
@@ -10,7 +10,7 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 public class BoundedGeoHashGridTiler extends GeoHashGridTiler {
     private final double boundsTop;
@@ -47,7 +47,7 @@ public class BoundedGeoHashGridTiler extends GeoHashGridTiler {
     }
 
     @Override
-    protected int setValue(GeoShapeCellValues docValues, MultiGeoShapeValues.GeoShapeValue geoValue, MultiGeoShapeValues.BoundingBox bounds,
+    protected int setValue(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue, GeoShapeValues.BoundingBox bounds,
                            int precision) {
         String hash = Geohash.stringEncode(bounds.minX(), bounds.minY(), precision);
         GeoRelation relation = relateTile(geoValue, hash);
@@ -60,7 +60,7 @@ public class BoundedGeoHashGridTiler extends GeoHashGridTiler {
     }
 
     @Override
-    protected GeoRelation relateTile(MultiGeoShapeValues.GeoShapeValue geoValue, String hash) {
+    protected GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, String hash) {
         Rectangle rectangle = Geohash.toBoundingBox(hash);
         if (cellIntersectsGeoBoundingBox(rectangle)) {
             return geoValue.relate(rectangle);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
@@ -10,7 +10,7 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 public class BoundedGeoTileGridTiler extends GeoTileGridTiler {
     private final double boundsTop;
@@ -56,7 +56,7 @@ public class BoundedGeoTileGridTiler extends GeoTileGridTiler {
     }
 
     @Override
-    public GeoRelation relateTile(MultiGeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
+    public GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
         Rectangle rectangle = GeoTileUtils.toBoundingBox(xTile, yTile, precision);
         if (cellIntersectsGeoBoundingBox(rectangle)) {
             return geoValue.relate(rectangle);
@@ -65,7 +65,7 @@ public class BoundedGeoTileGridTiler extends GeoTileGridTiler {
     }
 
     @Override
-    protected int setValue(GeoShapeCellValues docValues, MultiGeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
+    protected int setValue(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
         if (cellIntersectsGeoBoundingBox(GeoTileUtils.toBoundingBox(xTile, yTile, precision))) {
             docValues.resizeCell(1);
             docValues.add(0, GeoTileUtils.longEncodeTiles(precision, xTile, yTile));

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
@@ -6,7 +6,7 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 /**
  * The tiler to use to convert a geo value into long-encoded bucket keys for aggregating.
@@ -29,6 +29,6 @@ public interface GeoGridTiler {
      *
      * @return the number of tiles the geoValue intersects
      */
-    int setValues(GeoShapeCellValues docValues, MultiGeoShapeValues.GeoShapeValue geoValue, int precision);
+    int setValues(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue, int precision);
 }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellIdSource.java
@@ -12,7 +12,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSource;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
@@ -51,7 +51,7 @@ public class GeoShapeCellIdSource  extends ValuesSource.Numeric {
 
     @Override
     public SortedNumericDocValues longValues(LeafReaderContext ctx) {
-        MultiGeoShapeValues geoValues = valuesSource.geoShapeValues(ctx);
+        GeoShapeValues geoValues = valuesSource.geoShapeValues(ctx);
         if (precision == 0) {
             // special case, precision 0 is the whole world
             return new AllCellValues(geoValues, encoder, circuitBreakerConsumer);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellValues.java
@@ -6,18 +6,18 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 import java.util.function.LongConsumer;
 
 /** Sorted numeric doc values for geo shapes */
 class GeoShapeCellValues extends ByteTrackingSortingNumericDocValues {
-    private final MultiGeoShapeValues geoShapeValues;
+    private final GeoShapeValues geoShapeValues;
     protected int precision;
     protected GeoGridTiler tiler;
 
-    protected GeoShapeCellValues(MultiGeoShapeValues geoShapeValues, int precision, GeoGridTiler tiler,
+    protected GeoShapeCellValues(GeoShapeValues geoShapeValues, int precision, GeoGridTiler tiler,
                                  LongConsumer circuitBreakerConsumer) {
         super(circuitBreakerConsumer);
         this.geoShapeValues = geoShapeValues;
@@ -28,8 +28,7 @@ class GeoShapeCellValues extends ByteTrackingSortingNumericDocValues {
     @Override
     public boolean advanceExact(int docId) throws IOException {
         if (geoShapeValues.advanceExact(docId)) {
-            assert geoShapeValues.docValueCount() == 1;
-            int j = advanceValue(geoShapeValues.nextValue());
+            int j = advanceValue(geoShapeValues.value());
             resize(j);
             sort();
             return true;
@@ -59,7 +58,7 @@ class GeoShapeCellValues extends ByteTrackingSortingNumericDocValues {
      * @param target    the geo-shape to encode
      * @return          number of buckets for given shape tiling of <code>target</code>.
      */
-    int advanceValue(MultiGeoShapeValues.GeoShapeValue target) {
+    int advanceValue(GeoShapeValues.GeoShapeValue target) {
         return tiler.setValues(this, target, precision);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 public class GeoTileGridTiler implements GeoGridTiler {
 
@@ -37,8 +37,8 @@ public class GeoTileGridTiler implements GeoGridTiler {
      * @return the number of tiles set by the shape
      */
     @Override
-    public int setValues(GeoShapeCellValues values, MultiGeoShapeValues.GeoShapeValue geoValue, int precision) {
-        MultiGeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
+    public int setValues(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue, int precision) {
+        GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         assert bounds.minX() <= bounds.maxX();
 
         if (precision == 0) {
@@ -70,16 +70,16 @@ public class GeoTileGridTiler implements GeoGridTiler {
         }
     }
 
-    protected GeoRelation relateTile(MultiGeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
+    protected GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
         Rectangle rectangle = GeoTileUtils.toBoundingBox(xTile, yTile, precision);
         return geoValue.relate(rectangle);
     }
 
     /**
-     * Sets a singular doc-value for the {@link MultiGeoShapeValues.GeoShapeValue}. To be overriden by {@link BoundedGeoTileGridTiler}
+     * Sets a singular doc-value for the {@link GeoShapeValues.GeoShapeValue}. To be overriden by {@link BoundedGeoTileGridTiler}
      * to account for {@link org.elasticsearch.common.geo.GeoBoundingBox} conditions
      */
-    protected int setValue(GeoShapeCellValues docValues, MultiGeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
+    protected int setValue(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
         docValues.resizeCell(1);
         docValues.add(0, GeoTileUtils.longEncodeTiles(precision, xTile, yTile));
         return 1;
@@ -92,7 +92,7 @@ public class GeoTileGridTiler implements GeoGridTiler {
      * @param precision the target precision to split the shape up into
      * @return the number of buckets the geoValue is found in
      */
-    protected int setValuesByBruteForceScan(GeoShapeCellValues values, MultiGeoShapeValues.GeoShapeValue geoValue,
+    protected int setValuesByBruteForceScan(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue,
                                             int precision, int minXTile, int minYTile, int maxXTile, int maxYTile) {
         int idx = 0;
         for (int i = minXTile; i <= maxXTile; i++) {
@@ -108,7 +108,7 @@ public class GeoTileGridTiler implements GeoGridTiler {
     }
 
     protected int setValuesByRasterization(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex,
-                                           int targetPrecision, MultiGeoShapeValues.GeoShapeValue geoValue) {
+                                           int targetPrecision, GeoShapeValues.GeoShapeValue geoValue) {
         zTile++;
         for (int i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
@@ -14,7 +14,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexGeoShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -23,8 +23,8 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
     public static final GeoShapeValuesSource EMPTY = new GeoShapeValuesSource() {
 
         @Override
-        public MultiGeoShapeValues geoShapeValues(LeafReaderContext context) {
-            return MultiGeoShapeValues.EMPTY;
+        public GeoShapeValues geoShapeValues(LeafReaderContext context) {
+            return GeoShapeValues.EMPTY;
         }
 
         @Override
@@ -34,7 +34,7 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
 
     };
 
-    public abstract MultiGeoShapeValues geoShapeValues(LeafReaderContext context);
+    public abstract GeoShapeValues geoShapeValues(LeafReaderContext context);
 
     @Override
     protected Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
@@ -43,7 +43,7 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
 
     @Override
     public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {
-        MultiGeoShapeValues values = geoShapeValues(context);
+        GeoShapeValues values = geoShapeValues(context);
         return new DocValueBits() {
             @Override
             public boolean advanceExact(int doc) throws IOException {
@@ -65,7 +65,7 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
             return indexFieldData.load(context).getBytesValues();
         }
 
-        public MultiGeoShapeValues geoShapeValues(LeafReaderContext context) {
+        public GeoShapeValues geoShapeValues(LeafReaderContext context) {
             return indexFieldData.load(context).getGeoShapeValues();
         }
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueReader;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,7 +64,7 @@ public class GeoGridTilerTests extends ESTestCase {
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
         GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
-        MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+        GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         // test shape within tile bounds
         {
             GeoShapeCellValues values = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
@@ -117,7 +117,7 @@ public class GeoGridTilerTests extends ESTestCase {
 
             GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
             GeoBoundingBox geoBoundingBox = randomBBox();
-            MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+            GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues cellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
 
             int numTiles = new BoundedGeoTileGridTiler(geoBoundingBox).setValues(cellValues, value, precision);
@@ -143,7 +143,7 @@ public class GeoGridTilerTests extends ESTestCase {
             }, () -> boxToGeo(randomBBox())));
 
             GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
-            MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+            GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
             int expected = numTiles(value, precision);
@@ -176,7 +176,7 @@ public class GeoGridTilerTests extends ESTestCase {
                 continue;
             }
             GeometryDocValueReader reader = GeometryDocValueReader(point, CoordinateEncoder.GEO);
-            MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+            GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
             assertThat(numTiles, equalTo(1));
@@ -197,7 +197,7 @@ public class GeoGridTilerTests extends ESTestCase {
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
         GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
-        MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
+        GeoShapeValues.GeoShapeValue value =  new GeoShapeValues.GeoShapeValue(reader);
 
         // test shape within tile bounds
         {
@@ -247,8 +247,8 @@ public class GeoGridTilerTests extends ESTestCase {
             || (crossesDateline && boundsWestLeft <= tile.getMaxX() && boundsWestRight >= tile.getMinX())));
     }
 
-    private int numTiles(MultiGeoShapeValues.GeoShapeValue geoValue, int precision, GeoBoundingBox geoBox) throws Exception {
-        MultiGeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
+    private int numTiles(GeoShapeValues.GeoShapeValue geoValue, int precision, GeoBoundingBox geoBox) throws Exception {
+        GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         int count = 0;
 
         if (precision == 0) {
@@ -316,7 +316,7 @@ public class GeoGridTilerTests extends ESTestCase {
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
         GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
-        MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+        GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
         int recursiveCount;
         {
@@ -326,7 +326,7 @@ public class GeoGridTilerTests extends ESTestCase {
         int bruteForceCount;
         {
             final double tiles = 1 << precision;
-            MultiGeoShapeValues.BoundingBox bounds = value.boundingBox();
+            GeoShapeValues.BoundingBox bounds = value.boundingBox();
             int minXTile = GeoTileUtils.getXTile(bounds.minX(), (long) tiles);
             int minYTile = GeoTileUtils.getYTile(bounds.maxY(), (long) tiles);
             int maxXTile = GeoTileUtils.getXTile(bounds.maxX(), (long) tiles);
@@ -346,7 +346,7 @@ public class GeoGridTilerTests extends ESTestCase {
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
         GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
-        MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+        GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOHASH, NOOP_BREAKER);
         int recursiveCount;
         {
@@ -355,7 +355,7 @@ public class GeoGridTilerTests extends ESTestCase {
         GeoShapeCellValues bruteForceValues = new GeoShapeCellValues(null, precision, GEOHASH, NOOP_BREAKER);
         int bruteForceCount;
         {
-            MultiGeoShapeValues.BoundingBox bounds = value.boundingBox();
+            GeoShapeValues.BoundingBox bounds = value.boundingBox();
             bruteForceCount = GEOHASH.setValuesByBruteForceScan(bruteForceValues, value, precision, bounds);
         }
 
@@ -388,8 +388,8 @@ public class GeoGridTilerTests extends ESTestCase {
         }
     }
 
-    private int numTiles(MultiGeoShapeValues.GeoShapeValue geoValue, int precision) {
-        MultiGeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
+    private int numTiles(GeoShapeValues.GeoShapeValue geoValue, int precision) {
+        GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         int count = 0;
 
         if (precision == 0) {
@@ -467,7 +467,7 @@ public class GeoGridTilerTests extends ESTestCase {
         Geometry geometry = GeometryTestUtils.randomPolygon(false);
         int precision = randomIntBetween(0, 3);
         GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
-        MultiGeoShapeValues.GeoShapeValue value =  new MultiGeoShapeValues.GeoShapeValue(reader);
+        GeoShapeValues.GeoShapeValue value =  new GeoShapeValues.GeoShapeValue(reader);
 
         List<Long> byteChangeHistory = new ArrayList<>();
         if (precision == 0) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -41,7 +41,7 @@ import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
 import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueReader;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
-import org.elasticsearch.xpack.spatial.index.fielddata.MultiGeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
@@ -190,7 +190,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             Rectangle pointTile = getTile(x, y, precision);
 
             GeometryDocValueReader reader = GeometryDocValueReader(p, CoordinateEncoder.GEO);
-            MultiGeoShapeValues.GeoShapeValue value = new MultiGeoShapeValues.GeoShapeValue(reader);
+            GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoRelation tileRelation =  value.relate(pointTile);
             boolean intersectsBounds = boundsTop >= pointTile.getMinY() && boundsBottom <= pointTile.getMaxY()
                 && (boundsEastLeft <= pointTile.getMaxX() && boundsEastRight >= pointTile.getMinX()


### PR DESCRIPTION
Currently the interface MultiGeoShapeValues implies that we can have more than one geo_shape in a doc value which is
not possible. This PR renames the interface to GeoShapeValues and removes the possibility of iterating over more than
one value.

backport #64302