### PR TITLE
[7.x] [DOCS] Fix whitespace in pattern replace token filter docs (#64345)

### DIFF
--- a/docs/reference/analysis/tokenfilters/pattern_replace-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/pattern_replace-tokenfilter.asciidoc
@@ -8,12 +8,10 @@ Uses a regular expression to match and replace token substrings.
 
 The `pattern_replace` filter uses
 https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html[Java's
-regular expression syntax]. By default, the filter replaces matching
-substrings with an empty substring (`""`).
-
-Replacement substrings can use Java's
-https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#appendReplacement-java.lang.StringBuffer-java.lang.String-[`$g` syntax] to reference capture groups
-from the original token text.
+regular expression syntax]. By default, the filter replaces matching substrings
+with an empty substring (`""`). Replacement substrings can use Java's
+https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#appendReplacement-java.lang.StringBuffer-java.lang.String-[`$g`
+syntax] to reference capture groups from the original token text.
 
 [WARNING]
 ====


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix whitespace in pattern replace token filter docs (#64345)