### PR TITLE
[7.x] [DOCS] Fix "the the" typos (#64344)

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -289,7 +289,7 @@ the elasticsearch official clients. The YAML based tests describe the
 operations to be executed and the obtained results that need to be tested.
 
 The YAML tests support various operators defined in the link:/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc[rest-api-spec] and adhere to the link:/rest-api-spec/README.markdown[Elasticsearch REST API JSON specification]
-In order to run the the YAML tests, the relevant API specification needs
+In order to run the YAML tests, the relevant API specification needs
 to be on the test classpath. Any gradle project that has support for REST
 tests will get the primary API on it's class path. However, to better support
 Gradle incremental builds, it is recommended to explicitly declare which

--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -177,7 +177,7 @@ more examples of customizing the options.
 [[java-rest-high-getting-started-asynchronous-usage]]
 === Asynchronous usage
 
-All of the the methods across the different clients exist in a traditional synchronous and 
+All of the methods across the different clients exist in a traditional synchronous and 
 asynchronous variant. The difference is that the asynchronous ones use asynchronous requests 
 in the REST Low Level Client. This is useful if you are doing multiple requests or are using e.g.
 rx java, Kotlin co-routines, or similar frameworks.

--- a/docs/reference/high-availability/cluster-design.asciidoc
+++ b/docs/reference/high-availability/cluster-design.asciidoc
@@ -60,7 +60,7 @@ as possible to the failure of an individual node.
 If your cluster consists of one node, that single node must do everything.
 To accommodate this, {es} assigns nodes every role by default.
 
-A single node cluster is not resilient. If the the node fails, the cluster will
+A single node cluster is not resilient. If the node fails, the cluster will
 stop working. Because there are no replicas in a one-node cluster, you cannot
 store your data redundantly. However, by default at least one replica is
 required for a <<cluster-health,`green` cluster health status>>. To ensure your

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 IMPORTANT: Use this API to check for deprecated configuration before performing
-a major version upgrade. You should run it on the the last minor version of the
+a major version upgrade. You should run it on the last minor version of the
 major version you are upgrading from, as earlier minor versions may not include
 all deprecations.
 

--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -168,7 +168,7 @@ that have been previously described:
                             this instead denotes the name of the  _impersonated_ user.
                             If authenticated using an API key, this is
                             the name of the API key owner.
-  `user.realm`         ::   Name of the the realm to which the _effective_ user 
+  `user.realm`         ::   Name of the realm to which the _effective_ user 
                             belongs. If authenticated using an API key, this is
                             the name of the realm to which the API key owner belongs.
   `user.run_by.name`   ::   This attribute is present only if the request is
@@ -216,7 +216,7 @@ that have been previously described:
                              this instead denotes the name of the  _impersonated_ user.
                              If authenticated using an API key, this is
                              the name of the API key owner.
-  `user.realm`         ::   Name of the the realm to which the _effective_ user 
+  `user.realm`         ::   Name of the realm to which the _effective_ user 
                             belongs. If authenticated using an API key, this is
                             the name of the realm to which the API key owner belongs.
   `user.run_by.name`   ::    This attribute is present only if the request is

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -82,7 +82,7 @@ as a minimal administrative function and is not intended to cover and be used to
 define roles for all use cases.
 
 IMPORTANT: You cannot view, edit, or remove any roles that are defined in the role
-mapping files by using the the role mapping APIs. 
+mapping files by using the role mapping APIs. 
 
 ==== Realm specific details
 [discrete]

--- a/x-pack/docs/en/watcher/customizing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/customizing-watches.asciidoc
@@ -116,7 +116,7 @@ See <<input-http>> for more details.
 ==== Chaining inputs
 
 You can create an <<input-chain,input chain>> to load data from multiple sources
-into a watch payload. The inputs in a chain are processed in order, so the the
+into a watch payload. The inputs in a chain are processed in order, so the
 data loaded by one input can be used by subsequent inputs.
 
 See <<input-chain>> for more details.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix "the the" typos (#64344)