### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -389,8 +389,8 @@ setup:
 ---
 "Date range unmapped with children":
   - skip:
-      version: " - 7.99.99"
-      reason: Fixed in 8.0.0 to be backported to 7.10.0
+      version: " - 7.9.99"
+      reason: Fixed in 7.10.0
 
   - do:
       indices.create:


### PR DESCRIPTION
Now that #64214 has landed in 7.10 we can run the bwc test including it.
