### PR TITLE
msearch - new mode that supports query relaxation

### DIFF
--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -121,6 +121,18 @@ conditions is met:
   - The request targets one or more read-only index.
   - The primary sort of the query targets an indexed field.
 
+`recall_goal`::
+(Optional, integer)
+An aid for "query relaxation". If > 0 then requests are processed sequentially
+until a search produces the required minimum number of matches (subsequent requests
+ are ignored). Requests should be provided in order of
+precision so an end-user querying for `foo bar` might be tried as a phrase query,
+then ORed and, as a last resort, a fuzzy match. Each request might use different
+aggregations - a high-precision search might sum all matches while a fuzzier match
+might choose to use a sampler aggregation to avoid summarising the long tail of
+weaker matches.
+
+
 `rest_total_hits_as_int`::
 (Optional, boolean)
 If `true`, `hits.total` are returned as an integer in the

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
@@ -82,4 +82,16 @@ public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchR
         request().maxConcurrentSearchRequests(maxConcurrentSearchRequests);
         return this;
     }
+    
+
+    /**
+     * Sets minimum number of document matches required by any single search request before
+     * the next request is tried. Searches are typically arranged in strict to sloppy order.
+     * A value greater than zero means searches are executed sequentially until recallGoal
+     * is met.
+     */
+    public MultiSearchRequestBuilder setRecallGoal(int recallGoal) {
+        request().recallGoal(recallGoal);
+        return this;
+    }    
 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -171,11 +171,13 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
                         long recall = hits.getTotalHits().value;
                         if (recall >= recallGoal) {                    
                             // Early exit. Don't run remaining searches and exit with responses gathered so far
-                            responseCounter.decrementAndGet();
+                            int remaining = responseCounter.decrementAndGet();
                             requests.clear();
                             Item[] result = responses.toArray(new MultiSearchResponse.Item[responses.length()]);
                             // Trim response of null responses we will never collect
-                            result = Arrays.copyOfRange(result, 0, result.length - responseCounter.get());
+                            if (remaining > 0) {
+                                result = Arrays.copyOfRange(result, 0, result.length - remaining);                                
+                            }
                             listener.onResponse(new MultiSearchResponse(result, buildTookInMillis()));
                             return;
                         }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -189,7 +189,8 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
                     if (thread == Thread.currentThread()) {
                         // we are on the same thread, we need to fork to another thread to avoid recursive stack overflow on a single thread
                         threadPool.generic()
-                                .execute(() -> executeSearch(requests, responses, responseCounter, recallGoal, listener, relativeStartTime));
+                                .execute(() -> executeSearch(requests, responses, responseCounter, recallGoal, listener, 
+                                    relativeStartTime));
                     } else {
                         // we are on a different thread (we went asynchronous), it's safe to recurse
                         executeSearch(requests, responses, responseCounter, recallGoal, listener, relativeStartTime);

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -98,7 +98,9 @@ public class RestMultiSearchAction extends BaseRestHandler {
         if (restRequest.hasParam("max_concurrent_searches")) {
             multiRequest.maxConcurrentSearchRequests(restRequest.paramAsInt("max_concurrent_searches", 0));
         }
-
+        if (restRequest.hasParam("recall_goal")) {
+            multiRequest.recallGoal(restRequest.paramAsInt("recall_goal", 0));
+        }
         Integer preFilterShardSize = null;
         if (restRequest.hasParam("pre_filter_shard_size")) {
             preFilterShardSize = restRequest.paramAsInt("pre_filter_shard_size", SearchRequest.DEFAULT_PRE_FILTER_SHARD_SIZE);

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
@@ -172,9 +172,10 @@ public class MultiSearchActionTookTests extends ESTestCase {
                                                   expected::get, client) {
                 @Override
                 void executeSearch(final Queue<SearchRequestSlot> requests, final AtomicArray<MultiSearchResponse.Item> responses,
-                        final AtomicInteger responseCounter, final ActionListener<MultiSearchResponse> listener, long startTimeInNanos) {
+                        final AtomicInteger responseCounter, long recallGoal, final ActionListener<MultiSearchResponse> listener,
+                        long startTimeInNanos) {
                     expected.set(1000000);
-                    super.executeSearch(requests, responses, responseCounter, listener, startTimeInNanos);
+                    super.executeSearch(requests, responses, responseCounter, recallGoal, listener, startTimeInNanos);
                 }
             };
         } else {
@@ -182,10 +183,11 @@ public class MultiSearchActionTookTests extends ESTestCase {
                                                   availableProcessors, System::nanoTime, client) {
                 @Override
                 void executeSearch(final Queue<SearchRequestSlot> requests, final AtomicArray<MultiSearchResponse.Item> responses,
-                        final AtomicInteger responseCounter, final ActionListener<MultiSearchResponse> listener, long startTimeInNanos) {
+                        final AtomicInteger responseCounter, long recallGoal, final ActionListener<MultiSearchResponse> listener,
+                        long startTimeInNanos) {
                     long elapsed = spinForAtLeastNMilliseconds(randomIntBetween(0, 10));
                     expected.set(elapsed);
-                    super.executeSearch(requests, responses, responseCounter, listener, startTimeInNanos);
+                    super.executeSearch(requests, responses, responseCounter, recallGoal, listener, startTimeInNanos);
                 }
             };
         }


### PR DESCRIPTION
Proof of concept for fallback queries - msearch has a new “recall_goal” parameter which, if > 0, causes sequential operation of requests, stopping after required number of hits are met.

Relates to #51840