### PR TITLE
Add merge with best_compression test

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -76,7 +76,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         Map<String, LifecycleAction> actions = VALID_HOT_ACTIONS
             .stream().map(this::getTestAction).collect(Collectors.toMap(LifecycleAction::getWriteableName, Function.identity()));
         if (randomBoolean()) {
-            invalidAction = getTestAction(randomFrom("allocate", "delete", "shrink", "freeze"));
+            invalidAction = getTestAction(randomFrom("allocate", "delete", "freeze"));
             actions.put(invalidAction.getWriteableName(), invalidAction);
         }
         Map<String, Phase> hotPhase = Collections.singletonMap("hot",

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -471,6 +471,10 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         forceMergeActionWithCodec(null);
     }
 
+    public void testForceMergeActionWithCompressionCodec() throws Exception {
+        forceMergeActionWithCodec("best_compression");
+    }
+
     public void testShrinkAction() throws Exception {
         int numShards = 4;
         int divisor = randomFrom(2, 4);


### PR DESCRIPTION
[As promised to @dakrone](https://github.com/elastic/elasticsearch/pull/64008#discussion_r514424358), here's a PR that adds the missing merge with compression test.

Also I'm including a second commit here that fixes a wrong test scenario that I discovered while backporting https://github.com/elastic/elasticsearch/pull/64008 (over on https://github.com/elastic/elasticsearch/pull/64376).