### PR TITLE
Generate bounding box on bounds for GeoTileGrid in GeoShapeGeoGridTestCase

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGridBucket;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
@@ -58,7 +57,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.randomBBox;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.GeometryDocValueReader;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -79,6 +77,11 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
      * Return a point within the bounds of the tile grid
      */
     protected abstract Point randomPoint();
+
+    /**
+     * Return a random {@link GeoBoundingBox} within the bounds of the tile grid.
+     */
+    protected abstract GeoBoundingBox randomBBox();
 
     /**
      * Return the bounding tile as a {@link Rectangle} for a given point
@@ -157,10 +160,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
 
         expectThrows(IllegalArgumentException.class, () -> builder.precision(-1));
         expectThrows(IllegalArgumentException.class, () -> builder.precision(30));
-        // make sure we generate a bounding box on bounds for GeoTileGrid
-        GeoBoundingBox bbox = randomValueOtherThanMany(
-            (b) -> b.top() > GeoTileUtils.LATITUDE_MASK || b.bottom() < -GeoTileUtils.LATITUDE_MASK,
-            GeoTestUtils::randomBBox);
+        GeoBoundingBox bbox = randomBBox();
         final double boundsTop = bbox.top();
         final double boundsBottom = bbox.bottom();
         final double boundsWestLeft;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGridBucket;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
@@ -156,8 +157,10 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
 
         expectThrows(IllegalArgumentException.class, () -> builder.precision(-1));
         expectThrows(IllegalArgumentException.class, () -> builder.precision(30));
-
-        GeoBoundingBox bbox = randomBBox();
+        // make sure we generate a bounding box on bounds for GeoTileGrid
+        GeoBoundingBox bbox = randomValueOtherThanMany(
+            (b) -> b.top() > GeoTileUtils.LATITUDE_MASK || b.bottom() < -GeoTileUtils.LATITUDE_MASK,
+            GeoTestUtils::randomBBox);
         final double boundsTop = bbox.top();
         final double boundsBottom = bbox.bottom();
         final double boundsWestLeft;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
+import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
@@ -13,6 +14,7 @@ import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGridBucket;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 
@@ -31,6 +33,11 @@ public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<
     @Override
     protected Point randomPoint() {
         return GeometryTestUtils.randomPoint(false);
+    }
+
+    @Override
+    protected GeoBoundingBox randomBBox() {
+        return GeoTestUtils.randomBBox();
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
+import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
@@ -13,6 +14,7 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBu
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoTileGridBucket;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<InternalGeoTileGridBucket> {
 
@@ -30,6 +32,13 @@ public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<
     protected Point randomPoint() {
         return new Point(randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true),
             randomDoubleBetween(-GeoTileUtils.LATITUDE_MASK, GeoTileUtils.LATITUDE_MASK, false));
+    }
+
+    @Override
+    protected GeoBoundingBox randomBBox() {
+         return randomValueOtherThanMany(
+            (b) -> b.top() > GeoTileUtils.LATITUDE_MASK || b.bottom() < -GeoTileUtils.LATITUDE_MASK,
+            GeoTestUtils::randomBBox);
     }
 
     @Override


### PR DESCRIPTION
This PR makes sure we generate bounding boxes that are on bound for the tile grid in GeoShapeGeoGridTestCase.

closes #64371