### PR TITLE
[7.9] [DOCS] Fixes 'the the' typo in transforms docs. (#64393)

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -25,8 +25,8 @@ the Painless scripts in the snippets below can be used in other {es} search
 aggregations, too.
 * All the following examples use scripts, {transforms} cannot deduce mappings of 
 output fields when the fields are created by a script. {transforms-cap} don't 
-create any mappings in the the destination index for these fields, which means 
-they get dynamically mapped. Create the destination index prior to starting the 
+create any mappings in the destination index for these fields, which means they 
+get dynamically mapped. Create the destination index prior to starting the 
 {transform} in case you want explicit mappings.
 --
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fixes 'the the' typo in transforms docs. (#64393)