### PR TITLE
Fix a quota-aware-fs test on Windows

### DIFF
--- a/plugins/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
+++ b/plugins/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
@@ -267,6 +267,7 @@ public class QuotaAwareFileSystemProviderTests extends LuceneTestCase {
         FileSystemProvider systemProvider = quotaFile.getFileSystem().provider();
         DelegatingProvider cyclicProvider = new DelegatingProvider(systemProvider) {
             @Override
+            @SuppressForbidden(reason = "Uses new File() to work around test issue on Windows")
             public Path getPath(URI uri) {
                 try {
                     // This convoluted line is necessary in order to get a valid path on Windows.

--- a/plugins/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
+++ b/plugins/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
@@ -269,7 +269,9 @@ public class QuotaAwareFileSystemProviderTests extends LuceneTestCase {
             @Override
             public Path getPath(URI uri) {
                 try {
-                    return cyclicReference.getFileSystem(new URI("file:///")).getPath(uri.getPath());
+                    // This convoluted line is necessary in order to get a valid path on Windows.
+                    final String uriPath = new File(uri.getPath()).toPath().toString();
+                    return cyclicReference.getFileSystem(new URI("file:///")).getPath(uriPath);
                 } catch (URISyntaxException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
One of the `quota-aware-fs` plugin's tests was failing on Windows, due to a path being constructed like `/C:/...`. This PR applies a workaround, and was tested on a Windows 2012 instance in GCP.

Since I haven't finished backporting #61145 yet, I'll incorporate the same fix in the backports.