### PR TITLE
Change finalization of elasticsearch distribution

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -150,7 +150,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
     private static String setupDistroTask() {
         return """
             tasks.register("setupDistro", Sync) {
-                from(elasticsearch_distributions.test_distro.extracted)
+                from(elasticsearch_distributions.test_distro)
                 into("build/distro")
             }
             """

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -63,7 +63,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
               }
             }
             tasks.register("setupDistro", Sync) {
-                from(elasticsearch_distributions.test_distro.extracted)
+                from(elasticsearch_distributions.test_distro)
                 into("build/distro")
             }
         """
@@ -93,7 +93,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
               }
             }
             tasks.register("setupDistro", Sync) {
-                from(elasticsearch_distributions.test_distro.extracted)
+                from(elasticsearch_distributions.test_distro)
                 into("build/distro")
             }
         """
@@ -124,7 +124,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
               }
             }
             tasks.register("createExtractedTestDistro") {
-                dependsOn elasticsearch_distributions.test_distro.extracted
+                dependsOn elasticsearch_distributions.test_distro
             }
         """
         when:

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -81,7 +81,6 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         setupResolutionsContainer(project);
         setupDistributionContainer(project, dockerSupport);
         setupDownloadServiceRepo(project);
-        project.afterEvaluate(this::setupDistributions);
     }
 
     private void setupDistributionContainer(Project project, Provider<DockerSupportService> dockerSupport) {
@@ -89,7 +88,14 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             Configuration fileConfiguration = project.getConfigurations().create("es_distro_file_" + name);
             Configuration extractedConfiguration = project.getConfigurations().create(DISTRO_EXTRACTED_CONFIG_PREFIX + name);
             extractedConfiguration.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
-            return new ElasticsearchDistribution(name, project.getObjects(), dockerSupport, fileConfiguration, extractedConfiguration);
+            return new ElasticsearchDistribution(
+                name,
+                project.getObjects(),
+                dockerSupport,
+                fileConfiguration,
+                extractedConfiguration,
+                (dist) -> finalizeDistributionDependencies(project, dist)
+            );
         });
         project.getExtensions().add(CONTAINER_NAME, distributionsContainer);
     }
@@ -113,21 +119,18 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         return (NamedDomainObjectContainer<DistributionResolution>) project.getExtensions().getByName(RESOLUTION_CONTAINER_NAME);
     }
 
-    // pkg private for tests
-    void setupDistributions(Project project) {
-        for (ElasticsearchDistribution distribution : distributionsContainer) {
-            distribution.finalizeValues();
-            DependencyHandler dependencies = project.getDependencies();
-            // for the distribution as a file, just depend on the artifact directly
-            DistributionDependency distributionDependency = resolveDependencyNotation(project, distribution);
-            dependencies.add(distribution.configuration.getName(), distributionDependency.getDefaultNotation());
-            // no extraction allowed for rpm, deb or docker
-            if (distribution.getType().shouldExtract()) {
-                // The extracted configuration depends on the artifact directly but has
-                // an artifact transform registered to resolve it as an unpacked folder.
-                dependencies.add(distribution.getExtracted().getName(), distributionDependency.getExtractedNotation());
-            }
+    private ElasticsearchDistribution finalizeDistributionDependencies(Project project, ElasticsearchDistribution distribution) {
+        DependencyHandler dependencies = project.getDependencies();
+        // for the distribution as a file, just depend on the artifact directly
+        DistributionDependency distributionDependency = resolveDependencyNotation(project, distribution);
+        dependencies.add(distribution.configuration.getName(), distributionDependency.getDefaultNotation());
+        // no extraction needed for rpm, deb or docker
+        if (distribution.getType().shouldExtract()) {
+            // The extracted configuration depends on the artifact directly but has
+            // an artifact transform registered to resolve it as an unpacked folder.
+            dependencies.add(distribution.getExtracted().getName(), distributionDependency.getExtractedNotation());
         }
+        return distribution;
     }
 
     private DistributionDependency resolveDependencyNotation(Project p, ElasticsearchDistribution distribution) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -119,7 +119,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         return (NamedDomainObjectContainer<DistributionResolution>) project.getExtensions().getByName(RESOLUTION_CONTAINER_NAME);
     }
 
-    private ElasticsearchDistribution finalizeDistributionDependencies(Project project, ElasticsearchDistribution distribution) {
+    private void finalizeDistributionDependencies(Project project, ElasticsearchDistribution distribution) {
         DependencyHandler dependencies = project.getDependencies();
         // for the distribution as a file, just depend on the artifact directly
         DistributionDependency distributionDependency = resolveDependencyNotation(project, distribution);
@@ -130,7 +130,6 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             // an artifact transform registered to resolve it as an unpacked folder.
             dependencies.add(distribution.getExtracted().getName(), distributionDependency.getExtractedNotation());
         }
-        return distribution;
     }
 
     private DistributionDependency resolveDependencyNotation(Project p, ElasticsearchDistribution distribution) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.function.Function;
 
 public class ElasticsearchDistribution implements Buildable, Iterable<File> {
 
@@ -103,13 +104,16 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
     private final Property<Boolean> bundledJdk;
     private final Property<Boolean> failIfUnavailable;
     private final Configuration extracted;
+    private Function<ElasticsearchDistribution, ElasticsearchDistribution> distributionFinalizer;
+    private boolean froozen = false;
 
     ElasticsearchDistribution(
         String name,
         ObjectFactory objectFactory,
         Provider<DockerSupportService> dockerSupport,
         Configuration fileConfiguration,
-        Configuration extractedConfiguration
+        Configuration extractedConfiguration,
+        Function<ElasticsearchDistribution, ElasticsearchDistribution> distributionFinalizer
     ) {
         this.name = name;
         this.dockerSupport = dockerSupport;
@@ -123,6 +127,7 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
         this.bundledJdk = objectFactory.property(Boolean.class);
         this.failIfUnavailable = objectFactory.property(Boolean.class).convention(true);
         this.extracted = extractedConfiguration;
+        this.distributionFinalizer = distributionFinalizer;
     }
 
     public String getName() {
@@ -196,7 +201,22 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
         return getName() + "_" + getType() + "_" + getVersion();
     }
 
+    /**
+     * if not executed before, this
+     * freezes the distribution configuration and
+     * runs distribution finalizer logic.
+     * */
+    public ElasticsearchDistribution maybeFreeze() {
+        if (!froozen) {
+            finalizeValues();
+            distributionFinalizer.apply(this);
+            froozen = true;
+        }
+        return this;
+    }
+
     public String getFilepath() {
+        maybeFreeze();
         return configuration.getSingleFile().toString();
     }
 
@@ -221,18 +241,26 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
         if (isDocker() && getFailIfUnavailable() == false && dockerSupport.get().getDockerAvailability().isAvailable == false) {
             return task -> Collections.emptySet();
         }
+        maybeFreeze();
+        return getType().shouldExtract() ? extracted.getBuildDependencies() : configuration.getBuildDependencies();
+    }
 
+    public TaskDependency getArchiveBuildDependencies() {
+        // For non-required Docker distributions, skip building the distribution is Docker is unavailable
+        if (isDocker() && getFailIfUnavailable() == false && dockerSupport.get().getDockerAvailability().isAvailable == false) {
+            return task -> Collections.emptySet();
+        }
+        maybeFreeze();
         return configuration.getBuildDependencies();
     }
 
     @Override
     public Iterator<File> iterator() {
-        return configuration.iterator();
+        return getType().shouldExtract() ? extracted.iterator() : configuration.iterator();
     }
 
     // internal, make this distribution's configuration unmodifiable
     void finalizeValues() {
-
         if (getType() == Type.INTEG_TEST_ZIP) {
             if (platform.getOrNull() != null) {
                 throw new IllegalArgumentException(

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -113,7 +113,8 @@ public class DistroTestPlugin implements Plugin<Project> {
         for (ElasticsearchDistribution distribution : testDistributions) {
             String taskname = destructiveDistroTestTaskName(distribution);
             TaskProvider<?> depsTask = project.getTasks().register(taskname + "#deps");
-            depsTask.configure(t -> t.dependsOn(distribution, examplePlugin, quotaAwareFsPlugin));
+            // explicitly depend on the archive not on the implicit extracted distribution
+            depsTask.configure(t -> t.dependsOn(distribution.getArchiveBuildDependencies(), examplePlugin, quotaAwareFsPlugin));
             depsTasks.put(taskname, depsTask);
             TaskProvider<Test> destructiveTask = configureTestTask(project, taskname, distribution, t -> {
                 t.onlyIf(t2 -> distribution.isDocker() == false || dockerSupport.get().getDockerAvailability().isAvailable);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -114,7 +114,7 @@ public class DistroTestPlugin implements Plugin<Project> {
             String taskname = destructiveDistroTestTaskName(distribution);
             TaskProvider<?> depsTask = project.getTasks().register(taskname + "#deps");
             // explicitly depend on the archive not on the implicit extracted distribution
-            depsTask.configure(t -> t.dependsOn(distribution.getArchiveBuildDependencies(), examplePlugin, quotaAwareFsPlugin));
+            depsTask.configure(t -> t.dependsOn(distribution.getArchive(), examplePlugin, quotaAwareFsPlugin));
             depsTasks.put(taskname, depsTask);
             TaskProvider<Test> destructiveTask = configureTestTask(project, taskname, distribution, t -> {
                 t.onlyIf(t2 -> distribution.isDocker() == false || dockerSupport.get().getDockerAvailability().isAvailable);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -231,7 +231,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private void doSetVersion(String version) {
-        String distroName = "testclusters" + path.replace(":", "-") + "-" + this.name + "-" + version + "-";
+        String distroName = "testclusters" + path.replace(":", "-") + "-" + this.name + "-" + version;
         NamedDomainObjectContainer<ElasticsearchDistribution> container = DistributionDownloadPlugin.getContainer(project);
         if (container.findByName(distroName) == null) {
             container.create(distroName);
@@ -425,6 +425,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     public void freeze() {
         requireNonNull(testDistribution, "null testDistribution passed when configuring test cluster `" + this + "`");
         LOGGER.info("Locking configuration of `{}`", this);
+        distributions.stream().forEach(d -> d.maybeFreeze());
         configurationFrozen.set(true);
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -35,7 +35,10 @@ public interface TestClustersAware extends Task {
             throw new TestClustersException("Task " + getPath() + " can't use test cluster from" + " another project " + cluster);
         }
 
-        cluster.getNodes().stream().flatMap(node -> node.getDistributions().stream()).forEach(distro -> dependsOn(distro.getExtracted()));
+        cluster.getNodes()
+            .stream()
+            .flatMap(node -> node.getDistributions().stream())
+            .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze())));
         cluster.getNodes().forEach(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
         getClusters().add(cluster);
     }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/DistributionDownloadPluginTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/DistributionDownloadPluginTests.java
@@ -185,7 +185,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
         archiveProject.getConfigurations().create("default");
         archiveProject.getArtifacts().add("default", new File("doesnotmatter"));
         createDistro(project, "distro", VersionProperties.getElasticsearch(), Type.INTEG_TEST_ZIP, null, null, null);
-        checkPlugin(project);
     }
 
     public void testLocalCurrentVersionArchives() {
@@ -200,7 +199,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
                     archiveProject.getConfigurations().create("default");
                     archiveProject.getArtifacts().add("default", new File("doesnotmatter"));
                     createDistro(project, "distro", VersionProperties.getElasticsearch(), Type.ARCHIVE, platform, flavor, bundledJdk);
-                    checkPlugin(project);
                 }
             }
         }
@@ -216,7 +214,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
                     packageProject.getConfigurations().create("default");
                     packageProject.getArtifacts().add("default", new File("doesnotmatter"));
                     createDistro(project, "distro", VersionProperties.getElasticsearch(), packageType, null, flavor, bundledJdk);
-                    checkPlugin(project);
                 }
             }
         }
@@ -294,7 +291,7 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
             if (bundledJdk != null) {
                 distro.setBundledJdk(bundledJdk);
             }
-        });
+        }).maybeFreeze();
     }
 
     // create a distro and finalize its configuration
@@ -312,12 +309,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
         return distribution;
     }
 
-    // check the download plugin can be fully configured
-    private void checkPlugin(Project project) {
-        DistributionDownloadPlugin plugin = project.getPlugins().getPlugin(DistributionDownloadPlugin.class);
-        plugin.setupDistributions(project);
-    }
-
     private void checkBwc(
         String projectName,
         String config,
@@ -333,7 +324,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
         archiveProject.getConfigurations().create(config);
         archiveProject.getArtifacts().add(config, new File("doesnotmatter"));
         createDistro(project, "distro", version.toString(), type, platform, flavor, true);
-        checkPlugin(project);
     }
 
     private Project createProject(BwcVersions bwcVersions, boolean isInternal) {


### PR DESCRIPTION
- Avoid to rely on afterEvaluate lifecycle hook in `DistributionDownloadPlugin`
- Allows us to define test cluster only in the task creation which can be later than afterevaluate which allows us to move tasks that rely on test clusters using task avoidance api.
- This should result in test clusters only being defined when actually used in the build
- This unblocks further progress on https://github.com/elastic/elasticsearch/issues/56610