### PR TITLE
[DOCS] Redirect moving avg aggregation

### DIFF
--- a/docs/reference/aggregations/pipeline.asciidoc
+++ b/docs/reference/aggregations/pipeline.asciidoc
@@ -289,8 +289,6 @@ include::pipeline/max-bucket-aggregation.asciidoc[]
 
 include::pipeline/min-bucket-aggregation.asciidoc[]
 
-include::pipeline/movavg-aggregation.asciidoc[]
-
 include::pipeline/movfn-aggregation.asciidoc[]
 
 include::pipeline/moving-percentiles-aggregation.asciidoc[]

--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -1,8 +1,0 @@
-[[search-aggregations-pipeline-movavg-aggregation]]
-=== Moving average aggregation
-++++
-<titleabbrev>Moving average</titleabbrev>
-++++
-
-The Moving Average aggregation has been removed.  Use the more general
-<<search-aggregations-pipeline-movfn-aggregation,Moving Function Aggregation>> instead.

--- a/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
@@ -8,9 +8,6 @@ Given an ordered series of data, the Moving Function aggregation will slide a wi
 script that is executed on each window of data.  For convenience, a number of common functions are predefined such as min/max, moving averages,
 etc.
 
-This is conceptually very similar to the <<search-aggregations-pipeline-movavg-aggregation, Moving Average>> pipeline aggregation, except
-it provides more functionality.
-
 ==== Syntax
 
 A `moving_fn` aggregation looks like this in isolation:

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1261,3 +1261,10 @@ See <<transforms>>.
 === Matrix aggregations
 
 See <<search-aggregations-matrix-stats-aggregation>>.
+
+[[search-aggregations-pipeline-movavg-aggregation]]
+=== Moving average aggregation
+
+The moving average aggregation has been removed. Use the
+<<search-aggregations-pipeline-movfn-aggregation,moving function aggregation>>
+instead.


### PR DESCRIPTION
The moving avg agg was deprecated with #29594. This replaces the current empty-ish page with a redirect so
the agg no longer displays in the nav.