### PR TITLE
Upgrade to version 3.5 of Gradle Enterprise plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.4.1"
+  id "com.gradle.enterprise" version "3.5"
 }
 
 String dirName = rootProject.projectDir.name


### PR DESCRIPTION
We've upgraded our Gradle Enterprise server to 2020.4 and so we'll want to use the latest plugin as well. 