### PR TITLE
remove node.ingest setting in the documentation

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -222,14 +222,6 @@ To create a dedicated ingest node, set:
 node.roles: [ ingest ]
 ----
 
-[[node-ingest-node-setting]]
-// tag::node-ingest-tag[]
-`node.ingest` {ess-icon}::
-Determines whether a node is an ingest node. <<ingest,Ingest nodes>> can apply
-an ingest pipeline to transform and enrich a document before indexing. Default:
-`true`.
-// end::node-ingest-tag[]
-
 [[coordinating-only-node]]
 ==== Coordinating only node
 


### PR DESCRIPTION
I'm not sure if this setting was left here deliberately? or by accident?
With all other node role definition has changed syntax from `node.xxx` to `node.roles: [ ]`, the ingest one is the only one left behind.

1. Please check with dev.
2. Please make the same change to 7.10, and master if necessary.
