### PR TITLE
[7.10][DOCS]: ILM rollover max_age condition disregards origination date (#64404)

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -49,8 +49,12 @@ You must specify at least one rollover condition.
 An empty rollover action is invalid.
 
 `max_age`::
-(Optional,  <<time-units, time units>>)  
-Triggers roll over after the maximum elapsed time from index creation is reached. 
+(Optional,  <<time-units, time units>>)
+Triggers roll over after the maximum elapsed time from index creation is reached.
+The elapsed time is always calculated since the index creation time, even if the
+index origination date is configured to a custom date (via the
+<<index-lifecycle-parse-origination-date, index.lifecycle.parse_origination_date>> or
+<<index-lifecycle-origination-date, index.lifecycle.origination_date>> settings)
 
 `max_docs`::
 (Optional, integer)

--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -48,6 +48,7 @@ Use this setting if you create a new index that contains old data and
 want to use the original creation date to calculate the index age. 
 Specified as a Unix epoch value.
 
+[[index-lifecycle-parse-origination-date]]
 `index.lifecycle.parse_origination_date`::
 (<<indices-update-settings,Dynamic>>, Boolean) 
 Set to `true` to parse the origination date from the index name. 


### PR DESCRIPTION
(cherry picked from commit d061c11899d6616b6d4356665b4a78a521bbc06f)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #64404 