### PR TITLE
[master] [DOCS] Note heap size must be set to same min and max (#64090)

### DIFF
--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -8,8 +8,7 @@ to ensure that {es} has enough heap available.
 
 {es} will assign the entire heap specified in
 <<jvm-options,jvm.options>> via the `Xms` (minimum heap size) and `Xmx` (maximum
-heap size) settings. You should set these two settings to equal each
-other.
+heap size) settings. These two settings must be equal to each other.
 
 The value for these settings depends on the amount of RAM available on your
 server:


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Note heap size must be set to same min and max (#64090)