### PR TITLE
[6.8] [DOCS] Note heap size must be set to same min and max (#64090)

### DIFF
--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -7,22 +7,19 @@ to ensure that Elasticsearch has enough heap available.
 
 Elasticsearch will assign the entire heap specified in
 <<jvm-options,jvm.options>> via the `Xms` (minimum heap size) and `Xmx` (maximum
-heap size) settings.
+heap size) settings. These two settings must be equal to each other.
 
 The value for these setting depends on the amount of RAM available on your
 server. Good rules of thumb are:
-
-* Set the minimum heap size (`Xms`) and maximum heap size (`Xmx`) to be equal to
-  each other.
 
 * The more heap available to Elasticsearch, the more memory it can use for
   caching. But note that too much heap can subject you to long garbage
   collection pauses.
 
-* Set `Xmx` to no more than 50% of your physical RAM, to ensure that there is
+* Set `Xms` and `Xmx` to no more than 50% of your physical RAM, to ensure that there is
   enough physical RAM left for kernel file system caches.
 
-* Don’t set `Xmx` to above the cutoff that the JVM uses for compressed object
+* Don’t set `Xms` and `Xmx` to above the cutoff that the JVM uses for compressed object
   pointers (compressed oops); the exact cutoff varies but is near 32 GB. You can
   verify that you are under the limit by looking for a line in the logs like the
   following:


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [DOCS] Note heap size must be set to same min and max (#64090)