### PR TITLE
Fix CcrRepositoryIT.testCcrRepositoryFetchesSnapshotShardSizeEtc 

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -473,13 +473,18 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
                 TimeValue.ZERO.getStringRep())), XContentType.JSON));
 
         final int numDocs = scaledRandomIntBetween(0, 1_000);
-        final BulkRequestBuilder bulkRequest = leaderClient().prepareBulk(leaderIndex, "_doc");
-        for (int i = 0; i < numDocs; i++) {
-            bulkRequest.add(new IndexRequest(leaderIndex).id(Integer.toString(i)).source("field", i));
+        if (numDocs > 0) {
+            final BulkRequestBuilder bulkRequest = leaderClient().prepareBulk(leaderIndex, "_doc");
+            for (int i = 0; i < numDocs; i++) {
+                bulkRequest.add(new IndexRequest(leaderIndex).id(Integer.toString(i)).source("field", i));
+            }
+            assertThat(bulkRequest.get().hasFailures(), is(false));
         }
-        assertThat(bulkRequest.get().hasFailures(), is(false));
 
-        final ForceMergeResponse forceMergeResponse = leaderClient().admin().indices().prepareForceMerge(leaderIndex).setFlush(true).get();
+        final ForceMergeResponse forceMergeResponse = leaderClient().admin().indices().prepareForceMerge(leaderIndex)
+            .setMaxNumSegments(1)
+            .setFlush(true)
+            .get();
         assertThat(forceMergeResponse.getSuccessfulShards(), equalTo(numberOfShards));
         assertThat(forceMergeResponse.getFailedShards(), equalTo(0));
         ensureLeaderGreen(leaderIndex);
@@ -564,7 +569,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
                     assertThat(snapshotShardSize,
                         equalTo(indexStats.getIndexShards().get(shardId).getPrimary().getStore().getSizeInBytes()));
                 }
-            });
+            }, 60L, TimeUnit.SECONDS);
 
             blockCcrRestore.countDown();
             ensureFollowerGreen(followerIndex);
@@ -678,7 +683,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
                     final long randomSize = randomNonNegativeLong();
                     assertThat(snapshotShardSizeInfo.getShardSize(primary, randomSize), equalTo(randomSize));
                 }
-            });
+            }, 60L, TimeUnit.SECONDS);
         } finally {
             transportServices.forEach(MockTransportService::clearAllRules);
         }


### PR DESCRIPTION
This test failed sometimes for various reasons: an empty bulk request
that can't be validated, a background force-merge that completes after
 the store stats were collected and finally an assertBusy() that waits
10 seconds while we usually wait 60s on the follower cluster in CCR
tests.

Closes #64167