### PR TITLE
[7.10] [DOCS] Fix local build directory in README.asciidoc (#64408)

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -192,9 +192,23 @@ We have just covered a very small portion of what Elasticsearch is all about. Fo
 
 Elasticsearch uses https://gradle.org[Gradle] for its build system.
 
-In order to create a distribution, simply run the `./gradlew assemble` command in the cloned directory.
+For a local distribution, you can run:
+----
+./gradlew localDistro 
+----
+which will build the appropriate distribution for the current platform as well as  prints the output location 
 
-The distribution for each project will be created under the `build/distributions` directory in that project.
+In order to create a distribution:
+----
+./gradlew assemble
+----
+To build the distribution for a specific platform, run the related command:
+----
+./gradlew :distribution:archives:linux-tar:assemble
+./gradlew :distribution:archives:darwin-tar:assemble
+./gradlew :distribution:archives:windows-zip:assemble
+----
+Finished distributions are output to `distributions/archives`.
 
 See the xref:TESTING.asciidoc[TESTING] for more information about running the Elasticsearch test suite.
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix local build directory in README.asciidoc (#64408)