### PR TITLE
Fix CoordinatorTests.testUnresponsiveLeaderDetectedEventually 7.x

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -541,6 +541,14 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     + defaultMillis(PUBLISH_TIMEOUT_SETTING)
                     // there might be a term bump causing another election
                     + DEFAULT_ELECTION_DELAY
+                    // in clusters with 5 nodes the chances of concurrent elections
+                    // increase, meaning that it takes longer to get a leader elected
+                    // so we should take into account those cases to ensure that the
+                    // cluster stabilises over time. See #63918 for a really messy scenario.
+                    + DEFAULT_ELECTION_DELAY
+                    // additionally take into account that publications might take longer
+                    // until the new leader detects that the old leader is unresponsive
+                    + defaultMillis(PUBLISH_TIMEOUT_SETTING)
 
                     // then wait for both of:
                     + Math.max(


### PR DESCRIPTION
Take into account messy scenarios of 5 node clusters elections
where multiple nodes can trigger an election concurrently, meaning
that it takes longer to stabilize the cluster and elect a leader.

Fixes #63918
Backport of #64462