### PR TITLE
Move quota-aware-fs plugin to x-pack in 6.8

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -46,7 +46,7 @@ public class PluginBuildPlugin extends BuildPlugin {
         // this afterEvaluate must happen before the afterEvaluate added by integTest creation,
         // so that the file name resolution for installing the plugin will be setup
         project.afterEvaluate {
-            boolean isXPackModule = project.path.startsWith(':x-pack:plugin')
+            boolean isXPackModule = project.path.startsWith(':x-pack:plugin') || project.path.startsWith(':x-pack:quota-aware-fs')
             boolean isModule = project.path.startsWith(':modules:') || isXPackModule
             String name = project.pluginProperties.extension.name
             project.archivesBaseName = name

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
@@ -64,6 +64,10 @@ class PluginPropertiesExtension {
      */
     private File noticeFile = null
 
+    /** Indicates whether the user must accept the license agreement before installing the plugin */
+    @Input
+    boolean isLicensed = false
+
     Project project = null
 
     PluginPropertiesExtension(Project project) {
@@ -90,5 +94,13 @@ class PluginPropertiesExtension {
     void setNoticeFile(File noticeFile) {
         project.ext.noticeFile = noticeFile
         this.noticeFile = noticeFile
+    }
+
+    boolean isLicensed() {
+        return this.isLicensed
+    }
+
+    void setLicensed(boolean isLicensed) {
+        this.isLicensed = isLicensed
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -81,7 +81,8 @@ class PluginPropertiesTask extends Copy {
             'classname': extension.classname,
             'extendedPlugins': extension.extendedPlugins.join(','),
             'hasNativeController': extension.hasNativeController,
-            'requiresKeystore': extension.requiresKeystore
+            'requiresKeystore': extension.requiresKeystore,
+            'licensed': extension.isLicensed
         ]
     }
 }

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -43,3 +43,7 @@ extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+<% if (licensed) { %>
+# This plugin requires that a license agreement be accepted before installation
+licensed=${licensed}
+<% } %>

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -801,6 +801,11 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     private void installPlugin(Terminal terminal, boolean isBatch, Path tmpRoot,
                                Environment env, List<Path> deleteOnFailure) throws Exception {
         final PluginInfo info = loadPluginInfo(terminal, tmpRoot, env);
+
+        if (isBatch == false && info.isLicensed()) {
+            LicensedPlugin.confirmInstallation(terminal, tmpRoot);
+        }
+
         // read optional security policy (extra permissions), if it exists, confirm or warn the user
         Path policy = tmpRoot.resolve(PluginInfo.ES_PLUGIN_POLICY);
         final Set<String> permissions;

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -802,8 +802,8 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                                Environment env, List<Path> deleteOnFailure) throws Exception {
         final PluginInfo info = loadPluginInfo(terminal, tmpRoot, env);
 
-        if (isBatch == false && info.isLicensed()) {
-            LicensedPlugin.confirmInstallation(terminal, tmpRoot);
+        if (info.isLicensed()) {
+            LicensedPlugin.confirmInstallation(terminal, tmpRoot, isBatch);
         }
 
         // read optional security policy (extra permissions), if it exists, confirm or warn the user

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/LicensedPlugin.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/LicensedPlugin.java
@@ -29,32 +29,37 @@ import java.nio.file.Path;
 
 public class LicensedPlugin {
 
-    static void confirmInstallation(Terminal terminal, Path pluginRoot) throws Exception {
+    static void confirmInstallation(Terminal terminal, Path pluginRoot, boolean isBatch) throws Exception {
         terminal.println(Verbosity.NORMAL, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
         terminal.println(Verbosity.NORMAL, "@     WARNING: You must accept the license to continue    @");
         terminal.println(Verbosity.NORMAL, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
         terminal.println(Verbosity.NORMAL, "");
-        terminal.println(Verbosity.NORMAL, "This plugin requires that you accept the terms of its license");
-        terminal.println(Verbosity.NORMAL, "before continuing with the installation. Press <Enter> to view");
-        terminal.println(Verbosity.NORMAL, "the license.");
 
-        // Wait for the user to hit enter
-        terminal.readText("");
-        printLicense(pluginRoot);
+        if (isBatch) {
+            terminal.println(Verbosity.NORMAL, "This plugin requires that you accept the terms of its license");
+            terminal.println(Verbosity.NORMAL, "before continuing with the installation. Since --batch was specified,");
+            terminal.println(Verbosity.NORMAL, "installation will assume you accept the license and continue.");
+        } else {
+            terminal.println(Verbosity.NORMAL, "This plugin requires that you accept the terms of its license");
+            terminal.println(Verbosity.NORMAL, "before continuing with the installation. Press <Enter> to view");
+            terminal.println(Verbosity.NORMAL, "the license.");
 
-        terminal.println(Verbosity.NORMAL, "");
-        final String text = terminal.readText("Continue with installation? [y/N]");
-        if (!text.equalsIgnoreCase("y")) {
-            throw new UserException(ExitCodes.DATA_ERROR, "installation aborted by user");
+            // Wait for the user to hit enter
+            terminal.readText("");
+            printLicense(terminal, pluginRoot);
+
+            terminal.println(Verbosity.NORMAL, "");
+            final String text = terminal.readText("Continue with installation? [y/N]");
+            if (!text.equalsIgnoreCase("y")) {
+                throw new UserException(ExitCodes.DATA_ERROR, "installation aborted by user");
+            }
         }
     }
 
-    private static void printLicense(Path pluginRoot) throws IOException, InterruptedException {
+    private static void printLicense(Terminal terminal, Path pluginRoot) throws IOException, InterruptedException {
         // Assumption - the license file exists and always has this name.
-        final Path licenseFile = pluginRoot.resolve("LICENSE.TXT");
+        final Path licenseFile = pluginRoot.resolve("LICENSE.txt");
 
-        final Process process = new ProcessBuilder("more", licenseFile.toString()).inheritIO().start();
-
-        process.waitFor();
+        terminal.pageFile(licenseFile);
     }
 }

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/LicensedPlugin.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/LicensedPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.Terminal.Verbosity;
+import org.elasticsearch.cli.UserException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class LicensedPlugin {
+
+    static void confirmInstallation(Terminal terminal, Path pluginRoot) throws Exception {
+        terminal.println(Verbosity.NORMAL, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        terminal.println(Verbosity.NORMAL, "@     WARNING: You must accept the license to continue    @");
+        terminal.println(Verbosity.NORMAL, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        terminal.println(Verbosity.NORMAL, "");
+        terminal.println(Verbosity.NORMAL, "This plugin requires that you accept the terms of its license");
+        terminal.println(Verbosity.NORMAL, "before continuing with the installation. Press <Enter> to view");
+        terminal.println(Verbosity.NORMAL, "the license.");
+
+        // Wait for the user to hit enter
+        terminal.readText("");
+        printLicense(pluginRoot);
+
+        terminal.println(Verbosity.NORMAL, "");
+        final String text = terminal.readText("Continue with installation? [y/N]");
+        if (!text.equalsIgnoreCase("y")) {
+            throw new UserException(ExitCodes.DATA_ERROR, "installation aborted by user");
+        }
+    }
+
+    private static void printLicense(Path pluginRoot) throws IOException, InterruptedException {
+        // Assumption - the license file exists and always has this name.
+        final Path licenseFile = pluginRoot.resolve("LICENSE.TXT");
+
+        final Process process = new ProcessBuilder("more", licenseFile.toString()).inheritIO().start();
+
+        process.waitFor();
+    }
+}

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.Locale;
 
 /**
@@ -41,6 +42,9 @@ public abstract class Terminal {
 
     /** The default terminal implementation, which will be a console if available, or stdout/stderr if not. */
     public static final Terminal DEFAULT = ConsoleTerminal.isSupported() ? new ConsoleTerminal() : new SystemTerminal();
+
+    /** Display the specified file through {@code more}. Does not check if the file exists. */
+    public abstract void pageFile(Path path) throws IOException, InterruptedException;
 
     /** Defines the available verbosity levels of messages to be printed. */
     public enum Verbosity {
@@ -143,6 +147,12 @@ public abstract class Terminal {
         public char[] readSecret(String prompt) {
             return CONSOLE.readPassword("%s", prompt);
         }
+
+        @Override
+        public void pageFile(Path path) throws IOException, InterruptedException {
+            final Process process = new ProcessBuilder("more", path.toString()).inheritIO().start();
+            process.waitFor();
+        }
     }
 
     private static class SystemTerminal extends Terminal {
@@ -181,6 +191,12 @@ public abstract class Terminal {
         @Override
         public char[] readSecret(String text) {
             return readText(text).toCharArray();
+        }
+
+        @Override
+        public void pageFile(Path path) throws IOException, InterruptedException {
+            final Process process = new ProcessBuilder("more", path.toString()).inheritIO().start();
+            process.waitFor();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -235,6 +235,10 @@ public class PluginInfo implements Writeable, ToXContentObject {
             propsMap.remove("requires.keystore");
         }
 
+        if (esVersion.onOrAfter(Version.V_6_8_14)) {
+            propsMap.remove("licensed");
+        }
+
         if (propsMap.isEmpty() == false) {
             throw new IllegalArgumentException("Unknown properties in plugin descriptor: " + propsMap.keySet());
         }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -118,7 +118,7 @@ public class PluginsService {
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
             Plugin plugin = loadPlugin(pluginClass, settings, configPath);
             PluginInfo pluginInfo = new PluginInfo(pluginClass.getName(), "classpath plugin", "NA", Version.CURRENT, "1.8",
-                                                   pluginClass.getName(), Collections.emptyList(), false);
+                                                   pluginClass.getName(), Collections.emptyList(), false, false);
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from classpath [{}]", pluginInfo);
             }

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -146,14 +146,14 @@ public class NodeInfoStreamingTests extends ESTestCase {
             for (int i = 0; i < numPlugins; i++) {
                 plugins.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean(), randomBoolean()));
             }
             int numModules = randomIntBetween(0, 5);
             List<PluginInfo> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
                 modules.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean(), randomBoolean()));
             }
             pluginsAndModules = new PluginsAndModules(plugins, modules);
         }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -185,7 +185,7 @@ public class PluginInfoTests extends ESTestCase {
 
     public void testSerialize() throws Exception {
         PluginInfo info = new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-                                         Collections.singletonList("foo"), randomBoolean());
+                                         Collections.singletonList("foo"), randomBoolean(), randomBoolean());
         BytesStreamOutput output = new BytesStreamOutput();
         info.writeTo(output);
         ByteBuffer buffer = ByteBuffer.wrap(output.bytes().toBytesRef().bytes);
@@ -198,15 +198,15 @@ public class PluginInfoTests extends ESTestCase {
     public void testPluginListSorted() {
         List<PluginInfo> plugins = new ArrayList<>();
         plugins.add(new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            Collections.emptyList(), randomBoolean(), randomBoolean()));
         plugins.add(new PluginInfo("b", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            Collections.emptyList(), randomBoolean(), randomBoolean()));
         plugins.add(new PluginInfo( "e", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            Collections.emptyList(), randomBoolean(), randomBoolean()));
         plugins.add(new PluginInfo("a", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            Collections.emptyList(), randomBoolean(), randomBoolean()));
         plugins.add(new PluginInfo("d", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            Collections.emptyList(), randomBoolean(), randomBoolean()));
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
         final List<PluginInfo> infos = pluginsInfo.getPluginInfos();

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -295,7 +295,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesCycleSelfReference() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("foo"), false);
+            "MyPlugin", Collections.singletonList("foo"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.sortBundles(Collections.singleton(bundle))
@@ -307,16 +307,16 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("bar", "other"), false);
+            "MyPlugin", Arrays.asList("bar", "other"), false, false);
         bundles.add(new PluginsService.Bundle(info, pluginDir));
         PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("baz"), false);
+            "MyPlugin", Collections.singletonList("baz"), false, false);
         bundles.add(new PluginsService.Bundle(info2, pluginDir));
         PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("foo"), false);
+            "MyPlugin", Collections.singletonList("foo"), false, false);
         bundles.add(new PluginsService.Bundle(info3, pluginDir));
         PluginInfo info4 = new PluginInfo("other", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         bundles.add(new PluginsService.Bundle(info4, pluginDir));
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.sortBundles(bundles));
@@ -326,7 +326,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesSingle() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(Collections.singleton(bundle));
         assertThat(sortedBundles, Matchers.contains(bundle));
@@ -336,15 +336,15 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -354,7 +354,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesMissingDep() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dne"), false);
+            "MyPlugin", Collections.singletonList("dne"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
             PluginsService.sortBundles(Collections.singleton(bundle))
@@ -366,19 +366,19 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("grandparent", "desc", "1.0",Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("common"), false);
+            "MyPlugin", Collections.singletonList("common"), false, false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         PluginInfo info3 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("common"), false);
+            "MyPlugin", Collections.singletonList("common"), false, false);
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
         PluginInfo info4 = new PluginInfo("common", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("grandparent"), false);
+            "MyPlugin", Collections.singletonList("grandparent"), false, false);
         PluginsService.Bundle bundle4 = new PluginsService.Bundle(info4, pluginDir);
         bundles.add(bundle4);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -389,11 +389,11 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", Collections.singletonList("dep"), false, false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -452,7 +452,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", Collections.singletonList("dep"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -471,7 +471,7 @@ public class PluginsServiceTests extends ESTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", Arrays.asList("dep1", "dep2"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -488,7 +488,7 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginJar = pluginDir.resolve("plugin.jar");
         makeJar(pluginJar, Level.class);
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, new HashMap<>()));
@@ -507,7 +507,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", Collections.singletonList("dep"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -530,7 +530,7 @@ public class PluginsServiceTests extends ESTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", Arrays.asList("dep1", "dep2"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -553,7 +553,7 @@ public class PluginsServiceTests extends ESTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", Arrays.asList("dep1", "dep2"), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps);
         Set<URL> deps = transitiveDeps.get("myplugin");
@@ -602,14 +602,14 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testIncompatibleElasticsearchVersion() throws Exception {
         PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", Version.V_5_0_0,
-            "1.8", "FakePlugin", Collections.emptyList(), false);
+            "1.8", "FakePlugin", Collections.emptyList(), false, false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for Elasticsearch version 5.0.0"));
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
         PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", Version.CURRENT,
-            "1000000.0", "FakePlugin", Collections.emptyList(), false);
+            "1000000.0", "FakePlugin", Collections.emptyList(), false, false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("my_plugin requires Java"));
     }

--- a/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,9 +48,15 @@ public class MockTerminal extends Terminal {
     private int textIndex = 0;
     private final List<String> secretInput = new ArrayList<>();
     private int secretIndex = 0;
+    private final List<Path> pagedFiles = new ArrayList<>();
 
     public MockTerminal() {
         super("\n"); // always *nix newlines for tests
+    }
+
+    @Override
+    public void pageFile(Path path) {
+        pagedFiles.add(path);
     }
 
     @Override
@@ -95,5 +102,9 @@ public class MockTerminal extends Terminal {
         textInput.clear();
         secretIndex = 0;
         secretInput.clear();
+    }
+
+    public List<Path> getPagedFiles() {
+        return this.pagedFiles;
     }
 }

--- a/x-pack/quota-aware-fs/build.gradle
+++ b/x-pack/quota-aware-fs/build.gradle
@@ -1,6 +1,9 @@
+apply plugin: 'elasticsearch.esplugin'
+
 esplugin {
   description 'A bootstrap plugin that adds support for interfacing with filesystem that enforce user quotas.'
   classname '<none>'
+  licensed true
 }
 
 integTest.enabled = false

--- a/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileStore.java
+++ b/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileStore.java
@@ -1,21 +1,9 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.fs.quotaaware;
 
 import java.io.IOException;

--- a/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystem.java
+++ b/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystem.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProvider.java
+++ b/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProvider.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwarePath.java
+++ b/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwarePath.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/DelegatingProvider.java
+++ b/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/DelegatingProvider.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
+++ b/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProviderTests.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemTests.java
+++ b/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemTests.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;

--- a/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/SnapshotFilesystemProvider.java
+++ b/x-pack/quota-aware-fs/src/test/java/org/elasticsearch/fs/quotaaware/SnapshotFilesystemProvider.java
@@ -1,20 +1,7 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
 
 package org.elasticsearch.fs.quotaaware;


### PR DESCRIPTION
This PR follows-up on #64331 by moving the `quota-aware-fs` plugin in 6.8 to the `x-pack` directory. It adds a new plugin field, `licensed`, which requires a user installing the plugin to accept the terms of the license before installation.

I started with 6.8 because I haven't yet backported the original PR (#63620) to `7.x`.

This is a semi-proof-of-concept, so I welcome all feedback.

Notes:

   * I didn't move the plugin to `x-pack/plugin` since it is not intended to be added to the distribution in the usual way.
   * I haven't (yet) run the new wording in the CLI tool past Legal.
   * The internet tells me that `more` is available on Windows, so the CLI tool should be fine to use `more` to inspect the license file.