### PR TITLE
Fix expected warning header in data stream tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -110,7 +110,7 @@ setup:
       reason: "hidden data streams only available in 7.11"
   - do:
       allowed_warnings:
-        - "index template [my-template3] has index patterns [.hidden-data-stream,hidden-data-stream] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template3] will take precedence during new index creation"
+        - "index template [my-template3] has index patterns [.hidden-data-stream, hidden-data-stream] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template3] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template3
         body:


### PR DESCRIPTION
Just a small typo related to 388a86ab6fa1