### PR TITLE
Use no-kpi subdomains for tests downloading artifacts

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -146,12 +146,6 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             repo.setName(name);
             repo.setUrl(url);
             repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
-            // this header is not a credential but we hack the capability to send this header to avoid polluting our download stats
-            repo.credentials(HttpHeaderCredentials.class, creds -> {
-                creds.setName("X-Elastic-No-KPI");
-                creds.setValue("1");
-            });
-            repo.getAuthentication().create("header", HttpHeaderAuthentication.class);
             repo.patternLayout(layout -> layout.artifact("/downloads/elasticsearch/[module]-[revision](-[classifier]).[ext]"));
         });
         project.getRepositories().exclusiveContent(exclusiveContentRepository -> {
@@ -164,8 +158,8 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         if (project.getRepositories().findByName(DOWNLOAD_REPO_NAME) != null) {
             return;
         }
-        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts.elastic.co", FAKE_IVY_GROUP);
-        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots.elastic.co", FAKE_SNAPSHOT_IVY_GROUP);
+        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts-no-kpi.elastic.co", FAKE_IVY_GROUP);
+        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots-no-kpi.elastic.co", FAKE_SNAPSHOT_IVY_GROUP);
     }
 
     /**

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -34,10 +34,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
-import org.gradle.api.credentials.HttpHeaderCredentials;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.provider.Provider;
-import org.gradle.authentication.http.HttpHeaderAuthentication;
 
 import java.util.Comparator;
 

--- a/client/sniffer/src/test/resources/create_test_nodes_info.bash
+++ b/client/sniffer/src/test/resources/create_test_nodes_info.bash
@@ -22,8 +22,8 @@ pushd ${work} >> /dev/null
 echo Working in ${work}
 
 wget https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0/elasticsearch-2.0.0.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
+wget https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
+wget https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
 sha1sum -c - << __SHAs
 e369d8579bd3a2e8b5344278d5043f19f14cac88 elasticsearch-2.0.0.tar.gz
 d25f6547bccec9f0b5ea7583815f96a6f50849e0 elasticsearch-5.0.0.tar.gz

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -57,7 +57,7 @@ ext.expansions = { Architecture architecture, boolean oss, DockerBase base, bool
     sourceElasticsearch = """
 RUN curl --retry 8 -S -L \\
       --output /opt/elasticsearch.tar.gz \\
-      https://artifacts.elastic.co/downloads/elasticsearch/$elasticsearch
+      https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/$elasticsearch
 """.trim()
   }
 

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -36,7 +36,7 @@ subprojects {
   repositories {
     maven {
       // Repository for downloading BWC compatible JDBC driver releases
-      url = 'https://artifacts.elastic.co/maven'
+      url = 'https://artifacts-no-kpi.elastic.co/maven'
     }
   }
 


### PR DESCRIPTION
This commit converts build code that downloads distributions or other
artifacts to use the new no-kpi subdomain, and removes the formerly used
no-kpi header.