### PR TITLE
[7.x] Fix IngestDocument.deepCopy to support sets (#63067)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -711,6 +712,13 @@ public final class IngestDocument {
             List<?> listValue = (List<?>) value;
             List<Object> copy = new ArrayList<>(listValue.size());
             for (Object itemValue : listValue) {
+                copy.add(deepCopy(itemValue));
+            }
+            return copy;
+        } else if (value instanceof Set) {
+            Set<?> setValue = (Set<?>) value;
+            Set<Object> copy = new HashSet<>(setValue.size());
+            for (Object itemValue : setValue) {
                 copy.add(deepCopy(itemValue));
             }
             return copy;

--- a/server/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
@@ -160,7 +160,8 @@ public class WriteableIngestDocumentTests extends AbstractXContentTestCase<Write
     }
 
     public void testXContentHashSetSerialization() throws Exception {
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Map.of("key", Set.of("value")));
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(),
+            org.elasticsearch.common.collect.Map.of("key", org.elasticsearch.common.collect.Set.of("value")));
         final WriteableIngestDocument writeableIngestDocument = new WriteableIngestDocument(ingestDocument);
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             builder.startObject();

--- a/server/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Predicate;
 


### PR DESCRIPTION
Closes #63066

Backport of #63067
