### PR TITLE
[7.x] [DOCS] Add redirect for heap size (#64507)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -13,6 +13,11 @@ See <<node-name,Node name setting>>.
 
 See <<cluster-name,Cluster name setting>>.
 
+[role="exclude",id="heap-size"]
+=== Heap size settings
+
+See <<heap-size-settings>>.
+
 [role="exclude",id="ccr-remedy-follower-index"]
 === Leader index retaining operations for replication
 

--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -1,4 +1,4 @@
-[[heap-size]]
+[[heap-size-settings]]
 [discrete]
 === Heap size settings
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add redirect for heap size (#64507)