### PR TITLE
LinearCounting recompute size tripping assertion (#64465)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -99,7 +99,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
 
     @Override
     public long maxOrd() {
-        return hll.runLens.size() >>> hll.precision();
+        return hll.maxOrd();
     }
 
     @Override
@@ -222,6 +222,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             this.runLens =  bigArrays.newByteArray(initialBucketCount << precision);
             this.bigArrays = bigArrays;
             this.iterator = new HyperLogLogIterator(this, precision, m);
+        }
+
+        public long maxOrd() {
+            return runLens.size() >>> precision();
         }
 
         @Override
@@ -359,6 +363,9 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
 
         private int recomputedSize(long bucketOrd) {
+            if (bucketOrd >= hll.maxOrd()) {
+                return 0;
+            }
             int size = 0;
             for (int i = 0; i <= mask; ++i) {
                 final int v = get(bucketOrd, i);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
@@ -171,4 +171,16 @@ public class HyperLogLogPlusPlusTests extends ESTestCase {
 
         assertThat(total.get(), equalTo(0L));
     }
+
+    public void testRetrieveCardinality() {
+        final int p = randomIntBetween(MIN_PRECISION, MAX_PRECISION);
+        final HyperLogLogPlusPlus counts = new HyperLogLogPlusPlus(p, BigArrays.NON_RECYCLING_INSTANCE, 1);
+        int bucket = randomInt(100);
+        counts.collect(bucket, randomLong());
+        for (int i = 0; i < 1000; i++) {
+            int cardinality = bucket == i ? 1 : 0;
+            assertEquals(cardinality, counts.cardinality(i));
+        }
+    }
+
 }


### PR DESCRIPTION
Linear counting algorithm holds two big arrays, one for holding the number of elements per buckets (sizes) and another one that holds the values for a given bucket (hll.runlens). The issue here is that in #60201 we changed the way BigArrays are resized. So it might happen that the sizes array contains more buckets than hll.runlens array. When we recompute the size (in an assertion), we might try to read values for thehll.runlens array and trip an out of bounds exception.

This commit adds a safeguard against this case.

backport #64465