### PR TITLE
[ML] Ignore _doc_count field in data frame analytics

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -59,7 +59,7 @@ public class ExtractedFieldsDetector {
      */
     private static final List<String> IGNORE_FIELDS = Arrays.asList("_id", "_field_names", "_index", "_parent", "_routing", "_seq_no",
         "_source", "_type", "_uid", "_version", "_feature", "_ignored", DestinationIndex.INCREMENTAL_ID,
-        "_data_stream_timestamp");
+        "_data_stream_timestamp", "_doc_count");
 
     private final DataFrameAnalyticsConfig config;
     private final int docValueFieldsLimit;


### PR DESCRIPTION
This field is added from version 7.11 onwards. We are
adding it to the list of ignored fields for data frame analytics
in 7.10 to avoid failing to start an outlier detection job
in a mixed cluster environment.
