### PR TITLE
[ML] Refactor fetching of datafeed restart info

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.job.persistence;
+
+import org.elasticsearch.common.Nullable;
+
+public class RestartTimeInfo {
+
+    private final Long latestFinalBucketTimeMs;
+    private final Long latestRecordTimeMs;
+    private final boolean haveSeenDataPreviously;
+
+    public RestartTimeInfo(@Nullable Long latestFinalBucketTimeMs, @Nullable Long latestRecordTimeMs, boolean haveSeenDataPreviously) {
+        this.latestFinalBucketTimeMs = latestFinalBucketTimeMs;
+        this.latestRecordTimeMs = latestRecordTimeMs;
+        this.haveSeenDataPreviously = haveSeenDataPreviously;
+    }
+
+    @Nullable
+    public Long getLatestFinalBucketTimeMs() {
+        return latestFinalBucketTimeMs;
+    }
+
+    @Nullable
+    public Long getLatestRecordTimeMs() {
+        return latestRecordTimeMs;
+    }
+
+    public boolean haveSeenDataPreviously() {
+        return haveSeenDataPreviously;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.Before;
 
@@ -186,7 +187,7 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         assertBusy(() -> wasHandlerCalled.get());
     }
 
-    public void testBuild_GivenBucketsRequestFails() {
+    public void testBuild_GivenRestartInfoRequestFails() {
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
@@ -197,10 +198,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         Exception error = new RuntimeException("error");
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            Consumer<Exception> consumer = (Consumer<Exception>) invocationOnMock.getArguments()[3];
-            consumer.accept(error);
+            ActionListener<RestartTimeInfo> restartTimeInfoListener = (ActionListener<RestartTimeInfo>) invocationOnMock.getArguments()[1];
+            restartTimeInfoListener.onFailure(error);
             return null;
-        }).when(jobResultsProvider).bucketsViaInternalClient(any(), any(), any(), any());
+        }).when(jobResultsProvider).getRestartTimeInfo(any(), any());
 
 
         givenJob(jobBuilder);


### PR DESCRIPTION
This moves the logic of fetching the information needed
to restart a datafeed into `JobResultsProvider`.
