### PR TITLE
Increase timeout in testCleanUpShardFollowTasksForDeletedIndices

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -1385,7 +1385,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             String action = ShardFollowTask.NAME + "[c]";
             ListTasksResponse listTasksResponse = followerClient().admin().cluster().prepareListTasks().setActions(action).get();
             assertThat(listTasksResponse.getTasks(), hasSize(0));
-        });
+        }, 60, TimeUnit.SECONDS);
         ensureNoCcrTasks();
     }
 


### PR DESCRIPTION
If the deleted index has N shards, then ShardFollowTaskCleaner can send N*(N-1)/2 requests to remove N shard-follow tasks. I think that's fine as the implementation is straightforward. The test failed when the deleted index has 8 shards. This commit increases the timeout in the test.

Closes #64311