### PR TITLE
[7.x][ML] Refactor fetching of datafeed restart info (#64555)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -136,6 +136,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -1588,6 +1589,50 @@ public class JobResultsProvider {
         } else {
             modelSizeStats(jobId, modelSizeStats -> handler.accept(modelSizeStats.getModelBytes()), errorHandler);
         }
+    }
+
+    /**
+     * Returns information needed to decide how to restart a job from a datafeed
+     * @param jobId the job id
+     * @param listener the listener
+     */
+    public void getRestartTimeInfo(String jobId, ActionListener<RestartTimeInfo> listener) {
+        AtomicReference<Bucket> latestFinalBucketHolder = new AtomicReference<>();
+
+        Consumer<DataCounts> dataCountsHandler = dataCounts -> listener.onResponse(
+            new RestartTimeInfo(
+                latestFinalBucketHolder.get() == null ? null : latestFinalBucketHolder.get().getTimestamp().getTime(),
+                dataCounts.getLatestRecordTimeStamp() == null ? null : dataCounts.getLatestRecordTimeStamp().getTime(),
+                dataCounts.getInputRecordCount() > 0)
+            );
+
+        ActionListener<Bucket> latestFinalBucketListener = ActionListener.wrap(
+            latestFinalBucket -> {
+                latestFinalBucketHolder.set(latestFinalBucket);
+                dataCounts(jobId, dataCountsHandler, listener::onFailure);
+            },
+            listener::onFailure
+        );
+
+        getLatestFinalBucket(jobId, latestFinalBucketListener);
+    }
+
+    private void getLatestFinalBucket(String jobId, ActionListener<Bucket> listener) {
+        BucketsQueryBuilder latestBucketQuery = new BucketsQueryBuilder()
+            .sortField(Result.TIMESTAMP.getPreferredName())
+            .sortDescending(true)
+            .size(1)
+            .includeInterim(false);
+        bucketsViaInternalClient(jobId, latestBucketQuery,
+            queryPage -> {
+                if (queryPage.results().isEmpty()) {
+                    listener.onResponse(null);
+                } else {
+                    listener.onResponse(queryPage.results().get(0));
+                }
+            },
+            listener::onFailure
+        );
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.job.persistence;
+
+import org.elasticsearch.common.Nullable;
+
+public class RestartTimeInfo {
+
+    private final Long latestFinalBucketTimeMs;
+    private final Long latestRecordTimeMs;
+    private final boolean haveSeenDataPreviously;
+
+    public RestartTimeInfo(@Nullable Long latestFinalBucketTimeMs, @Nullable Long latestRecordTimeMs, boolean haveSeenDataPreviously) {
+        this.latestFinalBucketTimeMs = latestFinalBucketTimeMs;
+        this.latestRecordTimeMs = latestRecordTimeMs;
+        this.haveSeenDataPreviously = haveSeenDataPreviously;
+    }
+
+    @Nullable
+    public Long getLatestFinalBucketTimeMs() {
+        return latestFinalBucketTimeMs;
+    }
+
+    @Nullable
+    public Long getLatestRecordTimeMs() {
+        return latestRecordTimeMs;
+    }
+
+    public boolean haveSeenDataPreviously() {
+        return haveSeenDataPreviously;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.Before;
 
@@ -186,7 +187,7 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         assertBusy(() -> wasHandlerCalled.get());
     }
 
-    public void testBuild_GivenBucketsRequestFails() {
+    public void testBuild_GivenRestartInfoRequestFails() {
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
@@ -197,10 +198,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         Exception error = new RuntimeException("error");
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            Consumer<Exception> consumer = (Consumer<Exception>) invocationOnMock.getArguments()[3];
-            consumer.accept(error);
+            ActionListener<RestartTimeInfo> restartTimeInfoListener = (ActionListener<RestartTimeInfo>) invocationOnMock.getArguments()[1];
+            restartTimeInfoListener.onFailure(error);
             return null;
-        }).when(jobResultsProvider).bucketsViaInternalClient(any(), any(), any(), any());
+        }).when(jobResultsProvider).getRestartTimeInfo(any(), any());
 
 
         givenJob(jobBuilder);


### PR DESCRIPTION
This moves the logic of fetching the information needed
to restart a datafeed into `JobResultsProvider`.

Backport of #64555
