### PR TITLE
[7.x] Tests: Disable ilm history index for doc tests (#64495)

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -37,6 +37,8 @@ testClusters.integTest {
   // Disable monitoring exporters for the docs tests
   setting 'xpack.monitoring.exporters._local.type', 'local'
   setting 'xpack.monitoring.exporters._local.enabled', 'false'
+  // disable the ILM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
+  setting 'indices.lifecycle.history_index_enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.authc.realms.file.file.order', '0'
   setting 'xpack.security.authc.realms.native.native.order', '1'


### PR DESCRIPTION
(cherry picked from commit d9905e6991a2f5370914989336585e711dfa5bf9)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #64495 