### PR TITLE
[Transform] weighted avg should map to double

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -103,7 +103,7 @@ public final class TransformAggregations {
         GEO_CENTROID("geo_centroid", GEO_POINT),
         GEO_BOUNDS("geo_bounds", GEO_SHAPE),
         SCRIPTED_METRIC("scripted_metric", DYNAMIC),
-        WEIGHTED_AVG("weighted_avg", DYNAMIC),
+        WEIGHTED_AVG("weighted_avg", DOUBLE),
         BUCKET_SELECTOR("bucket_selector", DYNAMIC),
         BUCKET_SCRIPT("bucket_script", DYNAMIC),
         PERCENTILES("percentiles", DOUBLE),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -78,8 +78,9 @@ public class TransformAggregationsTests extends ESTestCase {
         assertEquals("_dynamic", TransformAggregations.resolveTargetMapping("bucket_selector", "int"));
 
         // weighted_avg
-        assertEquals("_dynamic", TransformAggregations.resolveTargetMapping("weighted_avg", null));
-        assertEquals("_dynamic", TransformAggregations.resolveTargetMapping("weighted_avg", "double"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("weighted_avg", null));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("weighted_avg", "double"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("weighted_avg", "int"));
 
         // percentile
         assertEquals("double", TransformAggregations.resolveTargetMapping("percentiles", null));


### PR DESCRIPTION
weighted avg like avg returns always a double value, this changes changes the output mapping from
dynamic to double


/CC @przemekwitek (thanks for reporting)