### PR TITLE
[7.9] [DOCS] Add tab widget for default log locations (#64510)

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -1,4 +1,19 @@
 [[logging]]
+=== Logging
+
+include::{es-repo-dir}/tab-widgets/code.asciidoc[]
+
+You can use {es}'s application logs to monitor your cluster and diagnose issues.
+If you run {es} as a service, the default location of the logs varies based on
+your platform and installation method:
+
+include::{es-repo-dir}/tab-widgets/logging-widget.asciidoc[]
+
+If you run {es} from the command line, {es} prints logs to the standard output
+(`stdout`).
+
+[discrete]
+[[loggin-configuration]]
 === Logging configuration
 
 Elasticsearch uses https://logging.apache.org/log4j/2.x/[Log4j 2] for

--- a/docs/reference/tab-widgets/code.asciidoc
+++ b/docs/reference/tab-widgets/code.asciidoc
@@ -1,0 +1,163 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+  
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+  
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+  
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+  
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++

--- a/docs/reference/tab-widgets/logging-widget.asciidoc
+++ b/docs/reference/tab-widgets/logging-widget.asciidoc
@@ -1,0 +1,147 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="logs">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="docker-tab-logs"
+            id="docker-logs">
+      Docker
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="deb-tab-logs"
+            id="deb-logs">
+      Debian (APT)
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-logs"
+            id="rpm-logs"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-logs"
+            id="mac-logs"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-logs"
+            id="brew-logs"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-logs"
+            id="linux-logs"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-zip-tab-logs"
+            id="win-zip-logs"
+            tabindex="-1">
+      Windows .zip
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-msi-tab-logs"
+            id="win--msilogs"
+            tabindex="-1">
+      Windows .msi
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-tab-logs"
+       aria-labelledby="docker-logs">
+++++
+
+include::logging.asciidoc[tag=docker]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-logs"
+       aria-labelledby="deb-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-logs"
+       aria-labelledby="rpm-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-logs"
+       aria-labelledby="mac-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-logs"
+       aria-labelledby="brew-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-logs"
+       aria-labelledby="linux-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-zip-tab-logs"
+       aria-labelledby="win-zip-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=win-zip]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-msi-tab-logs"
+       aria-labelledby="win-msi-logs"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=win-msi]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/logging.asciidoc
+++ b/docs/reference/tab-widgets/logging.asciidoc
@@ -1,0 +1,37 @@
+// tag::docker[]
+On <<docker,Docker>>, log messages go to the console and are handled by the
+configured Docker logging driver. To access logs, run `docker logs`.
+// end::docker[]
+
+// tag::deb[]
+For <<deb,Debian installations>>, {es} writes logs to `/var/log/elasticsearch`.
+// end::deb[]
+
+// tag::rpm[]
+For <<rpm,RPM installations>>, {es} writes logs to `/var/log/elasticsearch`.
+// end::rpm[]
+
+// tag::mac[]
+For <<targz,MacOS `.tar.gz`>> installations, {es} writes logs to
+`$ES_HOME/logs`.
+// end::mac[]
+
+// tag::brew[]
+For <<brew,MacOS Homebrew>> installations, {es} writes logs to
+`/usr/local/var/log/elasticsearch`.
+// end::brew[]
+
+// tag::linux[]
+For <<targz,Linux `.tar.gz`>> installations, {es} writes logs to
+`$ES_HOME/logs`.
+// end::linux[]
+
+// tag::win-zip[]
+For <<zip-windows,Windows `.zip`>> installations, {es} writes logs to
+`%ES_HOME%\logs`.
+// end::win-zip[]
+
+// tag::win-msi[]
+For <<windows,Windows `.msi`>> installations, {es} writes logs to
+`%ALLUSERSPROFILE%\Elastic\Elasticsearch\logs`.
+// end::win-msi[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Add tab widget for default log locations (#64510)