### PR TITLE
Centralize cache service instances creation in tests

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -42,11 +42,13 @@ public class CacheService extends AbstractLifecycleComponent {
         Setting.Property.NodeScope
     );
 
+    public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(4, ByteSizeUnit.KB);
+    public static final ByteSizeValue MAX_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES);
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_RANGE_SIZE_SETTING = Setting.byteSizeSetting(
         SETTINGS_PREFIX + "range_size",
         new ByteSizeValue(32, ByteSizeUnit.MB),                 // default
-        new ByteSizeValue(4, ByteSizeUnit.KB),                  // min
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),  // max
+        MIN_SNAPSHOT_CACHE_RANGE_SIZE,                          // min
+        MAX_SNAPSHOT_CACHE_RANGE_SIZE,                          // max
         Setting.Property.NodeScope
     );
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -16,11 +16,7 @@ import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.store.IndexInputStats;
-import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -29,12 +25,9 @@ import java.io.InputStream;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import static com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomIntBetween;
-import static com.carrotsearch.randomizedtesting.generators.RandomPicks.randomFrom;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -42,27 +35,6 @@ import static org.mockito.Mockito.mock;
 
 public final class TestUtils {
     private TestUtils() {}
-
-    public static void noOpCacheCleaner() {}
-
-    public static CacheService createDefaultCacheService() {
-        return new CacheService(TestUtils::noOpCacheCleaner, Settings.EMPTY);
-    }
-
-    public static CacheService createCacheService(final Random random) {
-        final ByteSizeValue cacheSize = new ByteSizeValue(
-            randomIntBetween(random, 1, 100),
-            randomFrom(random, List.of(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB, ByteSizeUnit.GB))
-        );
-        return new CacheService(TestUtils::noOpCacheCleaner, cacheSize, randomCacheRangeSize(random));
-    }
-
-    public static ByteSizeValue randomCacheRangeSize(final Random random) {
-        return new ByteSizeValue(
-            randomIntBetween(random, 1, 100),
-            randomFrom(random, List.of(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB))
-        );
-    }
 
     public static long numberOfRanges(long fileSize, long rangeSize) {
         return numberOfRanges(toIntBytes(fileSize), toIntBytes(rangeSize));

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.indices.recovery.SearchableSnapshotRecoveryState;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTestCase {
+
+    protected ThreadPool threadPool;
+
+    @Before
+    public void setUpTest() {
+        threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
+    }
+
+    @After
+    public void tearDownTest() {
+        assertTrue(ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS));
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with default settings
+     */
+    protected CacheService defaultCacheService() {
+        return new CacheService(AbstractSearchableSnapshotsTestCase::noOpCacheCleaner, Settings.EMPTY);
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with random cache size and cache range size settings
+     */
+    protected CacheService randomCacheService() {
+        final Settings.Builder cacheSettings = Settings.builder();
+        if (randomBoolean()) {
+            cacheSettings.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), randomCacheSize());
+        }
+        if (randomBoolean()) {
+            cacheSettings.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), randomCacheRangeSize());
+        }
+        return new CacheService(AbstractSearchableSnapshotsTestCase::noOpCacheCleaner, cacheSettings.build());
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with the given cache size and cache range size settings
+     */
+    protected CacheService createCacheService(final ByteSizeValue cacheSize, final ByteSizeValue cacheRangeSize) {
+        return new CacheService(
+            AbstractSearchableSnapshotsTestCase::noOpCacheCleaner,
+            Settings.builder()
+                .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
+                .put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), cacheRangeSize)
+                .build()
+        );
+    }
+
+    protected static void noOpCacheCleaner() {}
+
+    /**
+     * @return a random {@link ByteSizeValue} that can be used to set {@link CacheService#SNAPSHOT_CACHE_SIZE_SETTING}.
+     * Note that it can return a cache size of 0.
+     */
+    protected static ByteSizeValue randomCacheSize() {
+        return new ByteSizeValue(randomNonNegativeLong());
+    }
+
+    /**
+     * @return a random {@link ByteSizeValue} that can be used to set {@link CacheService#SNAPSHOT_CACHE_RANGE_SIZE_SETTING}
+     */
+    protected static ByteSizeValue randomCacheRangeSize() {
+        return new ByteSizeValue(
+            randomLongBetween(CacheService.MIN_SNAPSHOT_CACHE_RANGE_SIZE.getBytes(), CacheService.MAX_SNAPSHOT_CACHE_RANGE_SIZE.getBytes())
+        );
+    }
+
+    protected static SearchableSnapshotRecoveryState createRecoveryState() {
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(
+            new ShardId(randomAlphaOfLength(10), randomAlphaOfLength(10), 0),
+            randomAlphaOfLength(10),
+            true,
+            ShardRoutingState.INITIALIZING,
+            new RecoverySource.SnapshotRecoverySource(
+                UUIDs.randomBase64UUID(),
+                new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
+                Version.CURRENT,
+                new IndexId("some_index", UUIDs.randomBase64UUID(random()))
+            )
+        );
+        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        SearchableSnapshotRecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
+
+        recoveryState.setStage(RecoveryState.Stage.INIT)
+            .setStage(RecoveryState.Stage.INDEX)
+            .setStage(RecoveryState.Stage.VERIFY_INDEX)
+            .setStage(RecoveryState.Stage.TRANSLOG);
+        recoveryState.getIndex().setFileDetailsComplete();
+        recoveryState.setStage(RecoveryState.Stage.FINALIZE).setStage(RecoveryState.Stage.DONE);
+
+        return recoveryState;
+    }
+
+    /**
+     * Wait for all operations on the threadpool to complete
+     */
+    protected static void assertThreadPoolNotBusy(ThreadPool threadPool) throws Exception {
+        assertBusy(() -> {
+            for (ThreadPoolStats.Stats stat : threadPool.stats()) {
+                assertEquals(stat.getActive(), 0);
+                assertEquals(stat.getQueue(), 0);
+            }
+        });
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -42,7 +42,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
 
     @After
     public void tearDownTest() {
-        assertTrue(ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS));
+        assertTrue(ThreadPool.terminate(threadPool, 30L, TimeUnit.SECONDS));
     }
 
     /**
@@ -133,6 +133,6 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
                 assertEquals(stat.getActive(), 0);
                 assertEquals(stat.getQueue(), 0);
             }
-        });
+        }, 30L, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
This pull request centralizes the creation of `CacheService` instances in Searchable Snapshot tests. It cleans up a bit the tests and it will make the tests more easily adaptable when the creation of `CacheService` will be more complex due to the future persistent cache.