### PR TITLE
Move index analyzer management to FieldMapper/MapperService (#63937)

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -91,7 +91,6 @@ public class RankFeatureFieldMapper extends FieldMapper {
         public RankFeatureFieldType(String name, Map<String, String> meta, boolean positiveScoreImpact) {
             super(name, true, false, false, TextSearchInfo.NONE, meta);
             this.positiveScoreImpact = positiveScoreImpact;
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -136,7 +135,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
 
     private RankFeatureFieldMapper(String simpleName, MappedFieldType mappedFieldType,
                                    MultiFields multiFields, CopyTo copyTo, boolean positiveScoreImpact) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
         this.positiveScoreImpact = positiveScoreImpact;
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -68,7 +68,6 @@ public class RankFeaturesFieldMapper extends FieldMapper {
 
         public RankFeaturesFieldType(String name, Map<String, String> meta) {
             super(name, false, false, false, TextSearchInfo.NONE, meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -99,7 +98,7 @@ public class RankFeaturesFieldMapper extends FieldMapper {
 
     private RankFeaturesFieldMapper(String simpleName, MappedFieldType mappedFieldType,
                                     MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
     }
 
     @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -62,6 +62,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -180,12 +181,12 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         assertRootFieldMapper(rootMapper, 3, "default");
 
         PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(defaultMapper, "field._index_prefix");
-        assertPrefixFieldType(prefixFieldMapper.fieldType(), 3, "default");
+        assertPrefixFieldType(prefixFieldMapper, rootMapper.indexAnalyzers(), 3, "default");
 
-        assertShingleFieldType(
-            getShingleFieldMapper(defaultMapper, "field._2gram").fieldType(), 2, "default", prefixFieldMapper.fieldType());
-        assertShingleFieldType(
-            getShingleFieldMapper(defaultMapper, "field._3gram").fieldType(), 3, "default", prefixFieldMapper.fieldType());
+        assertShingleFieldType(getShingleFieldMapper(defaultMapper, "field._2gram"),
+            rootMapper.indexAnalyzers(), 2, "default", prefixFieldMapper.fieldType());
+        assertShingleFieldType(getShingleFieldMapper(defaultMapper, "field._3gram"),
+            rootMapper.indexAnalyzers(), 3, "default", prefixFieldMapper.fieldType());
    }
 
     public void testConfiguration() throws IOException {
@@ -201,14 +202,14 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         assertRootFieldMapper(rootMapper, maxShingleSize, analyzerName);
 
         PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(defaultMapper, "field._index_prefix");
-        assertPrefixFieldType(prefixFieldMapper.fieldType(), maxShingleSize, analyzerName);
+        assertPrefixFieldType(prefixFieldMapper, rootMapper.indexAnalyzers(), maxShingleSize, analyzerName);
 
-        assertShingleFieldType(
-            getShingleFieldMapper(defaultMapper, "field._2gram").fieldType(), 2, analyzerName, prefixFieldMapper.fieldType());
-        assertShingleFieldType(
-            getShingleFieldMapper(defaultMapper, "field._3gram").fieldType(), 3, analyzerName, prefixFieldMapper.fieldType());
-        assertShingleFieldType(
-            getShingleFieldMapper(defaultMapper, "field._4gram").fieldType(), 4, analyzerName, prefixFieldMapper.fieldType());
+        assertShingleFieldType(getShingleFieldMapper(defaultMapper, "field._2gram"),
+            rootMapper.indexAnalyzers(), 2, analyzerName, prefixFieldMapper.fieldType());
+        assertShingleFieldType(getShingleFieldMapper(defaultMapper, "field._3gram"),
+            rootMapper.indexAnalyzers(), 3, analyzerName, prefixFieldMapper.fieldType());
+        assertShingleFieldType(getShingleFieldMapper(defaultMapper, "field._4gram"),
+            rootMapper.indexAnalyzers(), 4, analyzerName, prefixFieldMapper.fieldType());
     }
 
     public void testSimpleMerge() throws IOException {
@@ -600,47 +601,53 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         assertThat(mapper.maxShingleSize(), equalTo(maxShingleSize));
         assertThat(mapper.fieldType(), notNullValue());
-        assertSearchAsYouTypeFieldType(mapper.fieldType(), maxShingleSize, analyzerName, mapper.prefixField().fieldType());
+        assertSearchAsYouTypeFieldType(mapper, mapper.fieldType(), maxShingleSize, analyzerName, mapper.prefixField().fieldType());
 
         assertThat(mapper.prefixField(), notNullValue());
         assertThat(mapper.prefixField().fieldType().parentField, equalTo(mapper.name()));
-        assertPrefixFieldType(mapper.prefixField().fieldType(), maxShingleSize, analyzerName);
+        assertPrefixFieldType(mapper.prefixField(), mapper.indexAnalyzers, maxShingleSize, analyzerName);
 
 
         for (int shingleSize = 2; shingleSize <= maxShingleSize; shingleSize++) {
             final ShingleFieldMapper shingleFieldMapper = mapper.shingleFields()[shingleSize - 2];
             assertThat(shingleFieldMapper, notNullValue());
-            assertShingleFieldType(shingleFieldMapper.fieldType(), shingleSize, analyzerName, mapper.prefixField().fieldType());
+            assertShingleFieldType(shingleFieldMapper, mapper.indexAnalyzers, shingleSize,
+                analyzerName, mapper.prefixField().fieldType());
         }
 
         final int numberOfShingleSubfields = (maxShingleSize - 2) + 1;
         assertThat(mapper.shingleFields().length, equalTo(numberOfShingleSubfields));
     }
 
-    private static void assertSearchAsYouTypeFieldType(SearchAsYouTypeFieldType fieldType, int maxShingleSize,
+    private static void assertSearchAsYouTypeFieldType(SearchAsYouTypeFieldMapper mapper,
+                                                       SearchAsYouTypeFieldType fieldType,
+                                                       int maxShingleSize,
                                                        String analyzerName,
                                                        PrefixFieldType prefixFieldType) {
 
         assertThat(fieldType.shingleFields.length, equalTo(maxShingleSize - 1));
-        for (NamedAnalyzer analyzer : asList(fieldType.indexAnalyzer(), fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+        NamedAnalyzer indexAnalyzer = mapper.indexAnalyzers().get(fieldType.name());
+        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().getSearchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
         }
         int shingleSize = 2;
-        for (ShingleFieldType shingleField : fieldType.shingleFields) {
-            assertShingleFieldType(shingleField, shingleSize++, analyzerName, prefixFieldType);
+        for (ShingleFieldMapper shingleField : mapper.shingleFields()) {
+            assertShingleFieldType(shingleField, mapper.indexAnalyzers(), shingleSize++, analyzerName, prefixFieldType);
         }
 
         assertThat(fieldType.prefixField, equalTo(prefixFieldType));
     }
 
-    private static void assertShingleFieldType(ShingleFieldType fieldType,
+    private static void assertShingleFieldType(ShingleFieldMapper mapper,
+                                               Map<String, NamedAnalyzer> indexAnalyzers,
                                                int shingleSize,
                                                String analyzerName,
                                                PrefixFieldType prefixFieldType) {
 
+        ShingleFieldType fieldType = mapper.fieldType();
         assertThat(fieldType.shingleSize, equalTo(shingleSize));
 
-        for (NamedAnalyzer analyzer : asList(fieldType.indexAnalyzer(), fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+        for (NamedAnalyzer analyzer : asList(indexAnalyzers.get(fieldType.name()), fieldType.getTextSearchInfo().getSearchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
             if (shingleSize > 1) {
                 final SearchAsYouTypeAnalyzer wrappedAnalyzer = (SearchAsYouTypeAnalyzer) analyzer.analyzer();
@@ -653,12 +660,15 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
     }
 
-    private static void assertPrefixFieldType(PrefixFieldType fieldType, int shingleSize, String analyzerName) {
-        for (NamedAnalyzer analyzer : asList(fieldType.indexAnalyzer(), fieldType.getTextSearchInfo().getSearchAnalyzer())) {
+    private static void assertPrefixFieldType(PrefixFieldMapper mapper, Map<String, NamedAnalyzer> indexAnalyzers,
+                                              int shingleSize, String analyzerName) {
+        PrefixFieldType fieldType = mapper.fieldType();
+        NamedAnalyzer indexAnalyzer = indexAnalyzers.get(fieldType.name());
+        for (NamedAnalyzer analyzer : asList(indexAnalyzer, fieldType.getTextSearchInfo().getSearchAnalyzer())) {
             assertThat(analyzer.name(), equalTo(analyzerName));
         }
 
-        final SearchAsYouTypeAnalyzer wrappedIndexAnalyzer = (SearchAsYouTypeAnalyzer) fieldType.indexAnalyzer().analyzer();
+        final SearchAsYouTypeAnalyzer wrappedIndexAnalyzer = (SearchAsYouTypeAnalyzer) indexAnalyzer.analyzer();
         final SearchAsYouTypeAnalyzer wrappedSearchAnalyzer
             = (SearchAsYouTypeAnalyzer) fieldType.getTextSearchInfo().getSearchAnalyzer().analyzer();
         for (SearchAsYouTypeAnalyzer analyzer : asList(wrappedIndexAnalyzer, wrappedSearchAnalyzer)) {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldTypeTests.java
@@ -113,7 +113,6 @@ public class SearchAsYouTypeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         SearchAsYouTypeFieldType fieldType = createFieldType();
-        fieldType.setIndexAnalyzer(Lucene.STANDARD_ANALYZER);
 
         assertEquals(org.elasticsearch.common.collect.List.of("value"), fetchSourceValue(fieldType, "value"));
         assertEquals(org.elasticsearch.common.collect.List.of("42"), fetchSourceValue(fieldType, 42L));

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -60,7 +60,6 @@ public final class ParentIdFieldMapper extends FieldMapper {
     public static final class ParentIdFieldType extends StringFieldType {
         public ParentIdFieldType(String name, boolean eagerGlobalOrdinals) {
             super(name, true, false, true, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             setEagerGlobalOrdinals(eagerGlobalOrdinals);
         }
 
@@ -91,7 +90,7 @@ public final class ParentIdFieldMapper extends FieldMapper {
     }
 
     protected ParentIdFieldMapper(String name, boolean eagerGlobalOrdinals) {
-        super(name, new ParentIdFieldType(name, eagerGlobalOrdinals), MultiFields.empty(), CopyTo.empty());
+        super(name, new ParentIdFieldType(name, eagerGlobalOrdinals), Lucene.KEYWORD_ANALYZER, MultiFields.empty(), CopyTo.empty());
     }
 
     @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -144,7 +144,6 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
         private JoinFieldType(String name, Joiner joiner, Map<String, String> meta) {
             super(name, true, false, true, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.joiner = joiner;
         }
 
@@ -194,7 +193,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
                                     MetaJoinFieldMapper uniqueFieldMapper,
                                     Map<String, ParentIdFieldMapper> parentIdFields,
                                     boolean eagerGlobalOrdinals, List<Relations> relations) {
-        super(simpleName, mappedFieldType, MultiFields.empty(), CopyTo.empty());
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, MultiFields.empty(), CopyTo.empty());
         this.parentIdFields = parentIdFields;
         this.uniqueFieldMapper = uniqueFieldMapper;
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -63,7 +63,6 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         public CollationFieldType(String name, boolean isSearchable, boolean isStored, boolean hasDocValues,
                                   Collator collator, String nullValue, int ignoreAbove, Map<String, String> meta) {
             super(name, isSearchable, isStored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.collator = collator;
             this.nullValue = nullValue;
             this.ignoreAbove = ignoreAbove;
@@ -419,7 +418,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
                                              MappedFieldType mappedFieldType,
                                              MultiFields multiFields, CopyTo copyTo,
                                              Collator collator, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
         assert collator.isFrozen();
         this.fieldType = fieldType;
         this.params = builder.collatorParams();

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -35,7 +35,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextParams;
@@ -72,10 +71,14 @@ import java.util.regex.Pattern;
 public class AnnotatedTextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "annotated_text";
-    private static final int POSITION_INCREMENT_GAP_USE_ANALYZER = -1;
 
     private static Builder builder(FieldMapper in) {
         return ((AnnotatedTextFieldMapper)in).builder;
+    }
+
+    private static NamedAnalyzer wrapAnalyzer(NamedAnalyzer in) {
+        return new NamedAnalyzer(in.name(), AnalyzerScope.INDEX,
+            new AnnotationAnalyzerWrapper(in.analyzer()), in.getPositionIncrementGap(""));
     }
 
     public static class Builder extends FieldMapper.Builder {
@@ -90,56 +93,33 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.getValue());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.getValue());
 
-        final Parameter<Integer> positionIncrementGap = Parameter.intParam("position_increment_gap", false,
-            m -> builder(m).positionIncrementGap.getValue(), POSITION_INCREMENT_GAP_USE_ANALYZER)
-            .setValidator(v -> {
-                if (v != POSITION_INCREMENT_GAP_USE_ANALYZER && v < 0) {
-                    throw new MapperParsingException("[positions_increment_gap] must be positive, got [" + v + "]");
-                }
-            });
-
         private final Parameter<Float> boost = Parameter.boostParam();
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         public Builder(String name, Supplier<NamedAnalyzer> defaultAnalyzer) {
             super(name);
-            this.analyzers = new TextParams.Analyzers(defaultAnalyzer);
+            this.analyzers = new TextParams.Analyzers(defaultAnalyzer, m -> builder(m).analyzers);
         }
 
         @Override
         protected List<Parameter<?>> getParameters() {
             return Arrays.asList(store, indexOptions, norms, termVectors, similarity,
-                analyzers.indexAnalyzer, analyzers.searchAnalyzer, analyzers.searchQuoteAnalyzer, positionIncrementGap,
+                analyzers.indexAnalyzer, analyzers.searchAnalyzer, analyzers.searchQuoteAnalyzer,
+                analyzers.positionIncrementGap,
                 boost, meta);
         }
 
-        private NamedAnalyzer wrapAnalyzer(NamedAnalyzer in, int positionIncrementGap) {
-            return new NamedAnalyzer(in.name(), AnalyzerScope.INDEX,
-                new AnnotationAnalyzerWrapper(in.analyzer()), positionIncrementGap);
-        }
-
         private AnnotatedTextFieldType buildFieldType(FieldType fieldType, BuilderContext context) {
-            int posGap;
-            if (positionIncrementGap.get() == POSITION_INCREMENT_GAP_USE_ANALYZER) {
-                posGap = TextFieldMapper.Defaults.POSITION_INCREMENT_GAP;
-            } else {
-                if (fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) < 0) {
-                    throw new IllegalArgumentException("Cannot set position_increment_gap on field [" + name()
-                        + "] without positions enabled");
-                }
-                posGap = positionIncrementGap.get();
-            }
             TextSearchInfo tsi = new TextSearchInfo(
                 fieldType,
                 similarity.get(),
-                wrapAnalyzer(analyzers.getSearchAnalyzer(), posGap),
-                wrapAnalyzer(analyzers.getSearchQuoteAnalyzer(), posGap));
+                wrapAnalyzer(analyzers.getSearchAnalyzer()),
+                wrapAnalyzer(analyzers.getSearchQuoteAnalyzer()));
             AnnotatedTextFieldType ft = new AnnotatedTextFieldType(
                 buildFullName(context),
                 store.getValue(),
                 tsi,
                 meta.getValue());
-            ft.setIndexAnalyzer(wrapAnalyzer(analyzers.getIndexAnalyzer(), posGap));
             ft.setBoost(boost.getValue());
             return ft;
         }
@@ -149,6 +129,12 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
             FieldType fieldType = TextParams.buildFieldType(() -> true, store, indexOptions, norms, termVectors);
             if (fieldType.indexOptions() == IndexOptions.NONE ) {
                 throw new IllegalArgumentException("[" + CONTENT_TYPE + "] fields must be indexed");
+            }
+            if (analyzers.positionIncrementGap.get() != TextParams.POSITION_INCREMENT_GAP_USE_ANALYZER) {
+                if (fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) < 0) {
+                    throw new IllegalArgumentException("Cannot set position_increment_gap on field ["
+                        + name + "] without positions enabled");
+                }
             }
             return new AnnotatedTextFieldMapper(
                     name, fieldType, buildFieldType(fieldType, context),
@@ -530,7 +516,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
 
     protected AnnotatedTextFieldMapper(String simpleName, FieldType fieldType, AnnotatedTextFieldType mappedFieldType,
                                 MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, wrapAnalyzer(builder.analyzers.getIndexAnalyzer()), multiFields, copyTo);
         assert fieldType.tokenized();
         this.fieldType = fieldType;
         this.builder = builder;

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -298,9 +298,12 @@ public class FlushIT extends ESIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(between(2, 3));
         final int numberOfReplicas = internalCluster().numDataNodes() - 1;
         assertAcked(
-            prepareCreate("test").setSettings(Settings.builder()
+            prepareCreate("test")
+                .setSettings(Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas)).get()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas))
+                .addMapping("doc", "value", "type=text")
+                .get()
         );
         ensureGreen();
         final Index index = clusterService().state().metadata().index("test").getIndex();

--- a/server/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
@@ -48,4 +48,20 @@ public final class FieldNameAnalyzer extends DelegatingAnalyzerWrapper {
         // Fields need to be explicitly added
         throw new IllegalArgumentException("Field [" + fieldName + "] has no associated analyzer");
     }
+
+    public boolean containsBrokenAnalysis(String field) {
+        Analyzer analyzer = getWrappedAnalyzer(field);
+        if (analyzer instanceof NamedAnalyzer) {
+            analyzer = ((NamedAnalyzer) analyzer).analyzer();
+        }
+        if (analyzer instanceof AnalyzerComponentsProvider) {
+            final TokenFilterFactory[] tokenFilters = ((AnalyzerComponentsProvider) analyzer).getComponents().getTokenFilters();
+            for (TokenFilterFactory tokenFilterFactory : tokenFilters) {
+                if (tokenFilterFactory.breaksFastVectorHighlighter()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.MapXContentParser;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -151,14 +152,22 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
     private final Parser<Parsed> parser;
 
     protected AbstractGeometryFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                                          Map<String, NamedAnalyzer> indexAnalyzers,
                                           Explicit<Boolean> ignoreMalformed, Explicit<Boolean> ignoreZValue,
                                           MultiFields multiFields, CopyTo copyTo,
                                           Indexer<Parsed, Processed> indexer, Parser<Parsed> parser) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
         this.ignoreZValue = ignoreZValue;
         this.indexer = indexer;
         this.parser = parser;
+    }
+
+    protected AbstractGeometryFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                                          Explicit<Boolean> ignoreMalformed, Explicit<Boolean> ignoreZValue,
+                                          MultiFields multiFields, CopyTo copyTo,
+                                          Indexer<Parsed, Processed> indexer, Parser<Parsed> parser) {
+        this(simpleName, mappedFieldType, Collections.emptyMap(), ignoreMalformed, ignoreZValue, multiFields, copyTo, indexer, parser);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -21,7 +21,9 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -61,13 +63,23 @@ public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extend
     protected Explicit<Orientation> orientation;
 
     protected AbstractShapeGeometryFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                                               Map<String, NamedAnalyzer> indexAnalyzers,
                                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                                Explicit<Boolean> ignoreZValue, Explicit<Orientation> orientation,
                                                MultiFields multiFields, CopyTo copyTo,
                                                Indexer<Parsed, Processed> indexer, Parser<Parsed> parser) {
-        super(simpleName, mappedFieldType, ignoreMalformed, ignoreZValue, multiFields, copyTo, indexer, parser);
+        super(simpleName, mappedFieldType, indexAnalyzers, ignoreMalformed, ignoreZValue, multiFields, copyTo, indexer, parser);
         this.coerce = coerce;
         this.orientation = orientation;
+    }
+
+    protected AbstractShapeGeometryFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                                               Explicit<Boolean> ignoreZValue, Explicit<Orientation> orientation,
+                                               MultiFields multiFields, CopyTo copyTo,
+                                               Indexer<Parsed, Processed> indexer, Parser<Parsed> parser) {
+        this(simpleName, mappedFieldType, Collections.emptyMap(),
+            ignoreMalformed, coerce, ignoreZValue, orientation, multiFields, copyTo, indexer, parser);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -223,7 +224,7 @@ public class BooleanFieldMapper extends FieldMapper {
 
     protected BooleanFieldMapper(String simpleName, MappedFieldType mappedFieldType,
                                  MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
         this.nullValue = builder.nullValue.getValue();
         this.stored = builder.stored.getValue();
         this.indexed = builder.indexed.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -87,7 +87,7 @@ public class CompletionFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), defaultAnalyzer, indexVersionCreated).init(this);
+        return new Builder(simpleName(), builder.defaultAnalyzer, builder.indexVersionCreated).init(this);
     }
 
     public static class Defaults {
@@ -112,8 +112,8 @@ public class CompletionFieldMapper extends FieldMapper {
         public static final String CONTENT_FIELD_NAME_CONTEXTS = "contexts";
     }
 
-    private static CompletionFieldMapper toType(FieldMapper in) {
-        return (CompletionFieldMapper) in;
+    private static Builder builder(FieldMapper in) {
+        return ((CompletionFieldMapper)in).builder;
     }
 
     /**
@@ -124,13 +124,13 @@ public class CompletionFieldMapper extends FieldMapper {
         private final Parameter<NamedAnalyzer> analyzer;
         private final Parameter<NamedAnalyzer> searchAnalyzer;
         private final Parameter<Boolean> preserveSeparators = Parameter.boolParam("preserve_separators", false,
-            m -> toType(m).preserveSeparators, Defaults.DEFAULT_PRESERVE_SEPARATORS)
+            m -> builder(m).preserveSeparators.get(), Defaults.DEFAULT_PRESERVE_SEPARATORS)
             .alwaysSerialize();
         private final Parameter<Boolean> preservePosInc = Parameter.boolParam("preserve_position_increments", false,
-            m -> toType(m).preservePosInc, Defaults.DEFAULT_POSITION_INCREMENTS)
+            m -> builder(m).preservePosInc.get(), Defaults.DEFAULT_POSITION_INCREMENTS)
             .alwaysSerialize();
         private final Parameter<ContextMappings> contexts = new Parameter<>("contexts", false, () -> null,
-            (n, c, o) -> ContextMappings.load(o, c.indexVersionCreated()), m -> toType(m).contexts)
+            (n, c, o) -> ContextMappings.load(o, c.indexVersionCreated()), m -> builder(m).contexts.get())
             .setSerializer((b, n, c) -> {
                 if (c == null) {
                     return;
@@ -140,7 +140,7 @@ public class CompletionFieldMapper extends FieldMapper {
                 b.endArray();
             }, Objects::toString);
         private final Parameter<Integer> maxInputLength = Parameter.intParam("max_input_length", true,
-            m -> toType(m).maxInputLength, Defaults.DEFAULT_MAX_INPUT_LENGTH)
+            m -> builder(m).maxInputLength.get(), Defaults.DEFAULT_MAX_INPUT_LENGTH)
             .addDeprecatedName("max_input_len")
             .setValidator(Builder::validateInputLength)
             .alwaysSerialize();
@@ -158,10 +158,10 @@ public class CompletionFieldMapper extends FieldMapper {
             super(name);
             this.defaultAnalyzer = defaultAnalyzer;
             this.indexVersionCreated = indexVersionCreated;
-            this.analyzer = Parameter.analyzerParam("analyzer", false, m -> toType(m).analyzer, () -> defaultAnalyzer)
+            this.analyzer = Parameter.analyzerParam("analyzer", false, m -> builder(m).analyzer.get(), () -> defaultAnalyzer)
                 .alwaysSerialize();
             this.searchAnalyzer
-                = Parameter.analyzerParam("search_analyzer", true, m -> toType(m).searchAnalyzer, analyzer::getValue);
+                = Parameter.analyzerParam("search_analyzer", true, m -> builder(m).searchAnalyzer.get(), analyzer::getValue);
         }
 
         private static void validateInputLength(int maxInputLength) {
@@ -175,6 +175,11 @@ public class CompletionFieldMapper extends FieldMapper {
             return Arrays.asList(analyzer, searchAnalyzer, preserveSeparators, preservePosInc, maxInputLength, contexts, meta);
         }
 
+        NamedAnalyzer buildAnalyzer() {
+            return new NamedAnalyzer(analyzer.get().name(), AnalyzerScope.INDEX,
+                new CompletionAnalyzer(analyzer.get(), preserveSeparators.get(), preservePosInc.get()));
+        }
+
         @Override
         public CompletionFieldMapper build(BuilderContext context) {
             checkCompletionContextsLimit(context);
@@ -184,11 +189,8 @@ public class CompletionFieldMapper extends FieldMapper {
             CompletionFieldType ft
                 = new CompletionFieldType(buildFullName(context), completionAnalyzer, meta.getValue());
             ft.setContextMappings(contexts.getValue());
-            ft.setPreservePositionIncrements(preservePosInc.getValue());
-            ft.setPreserveSep(preserveSeparators.getValue());
-            ft.setIndexAnalyzer(analyzer.getValue());
-            return new CompletionFieldMapper(name, ft, defaultAnalyzer,
-                multiFieldsBuilder.build(this, context), copyTo.build(), indexVersionCreated, this);
+            return new CompletionFieldMapper(name, ft,
+                multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
 
         private void checkCompletionContextsLimit(BuilderContext context) {
@@ -213,35 +215,14 @@ public class CompletionFieldMapper extends FieldMapper {
 
         private static PostingsFormat postingsFormat;
 
-        private boolean preserveSep = Defaults.DEFAULT_PRESERVE_SEPARATORS;
-        private boolean preservePositionIncrements = Defaults.DEFAULT_POSITION_INCREMENTS;
         private ContextMappings contextMappings = null;
 
         public CompletionFieldType(String name, NamedAnalyzer searchAnalyzer, Map<String, String> meta) {
             super(name, true, false, false, new TextSearchInfo(Defaults.FIELD_TYPE, null, searchAnalyzer, searchAnalyzer), meta);
         }
 
-        public void setPreserveSep(boolean preserveSep) {
-            this.preserveSep = preserveSep;
-        }
-
-        public void setPreservePositionIncrements(boolean preservePositionIncrements) {
-            this.preservePositionIncrements = preservePositionIncrements;
-        }
-
         public void setContextMappings(ContextMappings contextMappings) {
             this.contextMappings = contextMappings;
-        }
-
-        @Override
-        public NamedAnalyzer indexAnalyzer() {
-            final NamedAnalyzer indexAnalyzer = super.indexAnalyzer();
-            if (indexAnalyzer != null && !(indexAnalyzer.analyzer() instanceof CompletionAnalyzer)) {
-                return new NamedAnalyzer(indexAnalyzer.name(), AnalyzerScope.INDEX,
-                        new CompletionAnalyzer(indexAnalyzer, preserveSep, preservePositionIncrements));
-
-            }
-            return indexAnalyzer;
         }
 
         /**
@@ -322,25 +303,13 @@ public class CompletionFieldMapper extends FieldMapper {
     }
 
     private final int maxInputLength;
-    private final boolean preserveSeparators;
-    private final boolean preservePosInc;
-    private final NamedAnalyzer defaultAnalyzer;
-    private final NamedAnalyzer analyzer;
-    private final NamedAnalyzer searchAnalyzer;
-    private final ContextMappings contexts;
-    private final Version indexVersionCreated;
+    private final Builder builder;
 
-    public CompletionFieldMapper(String simpleName, MappedFieldType mappedFieldType, NamedAnalyzer defaultAnalyzer,
-                                 MultiFields multiFields, CopyTo copyTo, Version indexVersionCreated, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
-        this.defaultAnalyzer = defaultAnalyzer;
+    public CompletionFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                                 MultiFields multiFields, CopyTo copyTo, Builder builder) {
+        super(simpleName, mappedFieldType, builder.buildAnalyzer(), multiFields, copyTo);
+        this.builder = builder;
         this.maxInputLength = builder.maxInputLength.getValue();
-        this.preserveSeparators = builder.preserveSeparators.getValue();
-        this.preservePosInc = builder.preservePosInc.getValue();
-        this.analyzer = builder.analyzer.getValue();
-        this.searchAnalyzer = builder.searchAnalyzer.getValue();
-        this.contexts = builder.contexts.getValue();
-        this.indexVersionCreated = indexVersionCreated;
     }
 
     @Override
@@ -354,7 +323,7 @@ public class CompletionFieldMapper extends FieldMapper {
     }
 
     int getMaxInputLength() {
-        return maxInputLength;
+        return builder.maxInputLength.get();
     }
 
     /**
@@ -398,7 +367,7 @@ public class CompletionFieldMapper extends FieldMapper {
             }
             // truncate input
             if (input.length() > maxInputLength) {
-                int len = Math.min(maxInputLength, input.length());
+                int len = maxInputLength;
                 if (Character.isHighSurrogate(input.charAt(len - 1))) {
                     assert input.length() >= len + 1 && Character.isLowSurrogate(input.charAt(len));
                     len += 1;
@@ -504,7 +473,7 @@ public class CompletionFieldMapper extends FieldMapper {
                         ContextMappings contextMappings = fieldType().getContextMappings();
                         XContentParser.Token currentToken = parser.currentToken();
                         if (currentToken == XContentParser.Token.START_OBJECT) {
-                            ContextMapping contextMapping = null;
+                            ContextMapping<?> contextMapping = null;
                             String fieldName = null;
                             while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                                 if (currentToken == XContentParser.Token.FIELD_NAME) {
@@ -564,7 +533,7 @@ public class CompletionFieldMapper extends FieldMapper {
     public void doValidate(MappingLookup mappers) {
         if (fieldType().hasContextMappings()) {
             for (ContextMapping<?> contextMapping : fieldType().getContextMappings()) {
-                contextMapping.validateReferences(indexVersionCreated, s -> mappers.fieldTypes().get(s));
+                contextMapping.validateReferences(builder.indexVersionCreated, s -> mappers.fieldTypes().get(s));
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -121,7 +121,7 @@ public class DocumentMapper implements ToXContentFragment {
         this.documentParser = documentParser;
         this.indexSettings = indexSettings;
         this.indexAnalyzers = indexAnalyzers;
-        this.fieldMappers = MappingLookup.fromMapping(this.mapping, indexAnalyzers.getDefaultIndexAnalyzer());
+        this.fieldMappers = MappingLookup.fromMapping(this.mapping);
 
         try {
             mappingSource = new CompressedXContent(this, XContentType.JSON, ToXContent.EMPTY_PARAMS);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldMapper.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+
 /**
  * A field mapper that supports lookup of dynamic sub-keys. If the field mapper is named 'my_field',
  * then a user is able to search on the field in both of the following ways:
@@ -41,8 +43,9 @@ public abstract class DynamicKeyFieldMapper extends FieldMapper {
 
     public DynamicKeyFieldMapper(String simpleName,
                                  MappedFieldType defaultFieldType,
+                                 NamedAnalyzer indexAnalyzer,
                                  CopyTo copyTo) {
-        super(simpleName, defaultFieldType, MultiFields.empty(), copyTo);
+        super(simpleName, defaultFieldType, indexAnalyzer, MultiFields.empty(), copyTo);
     }
 
     public abstract MappedFieldType keyedFieldType(String key);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -65,17 +65,55 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FieldMapper.class);
 
-    protected MappedFieldType mappedFieldType;
-    protected MultiFields multiFields;
-    protected CopyTo copyTo;
+    protected final MappedFieldType mappedFieldType;
+    protected final Map<String, NamedAnalyzer> indexAnalyzers;
+    protected final MultiFields multiFields;
+    protected final CopyTo copyTo;
 
+    /**
+     * Create a FieldMapper with no index analyzers
+     * @param simpleName        the leaf name of the mapper
+     * @param mappedFieldType   the MappedFieldType associated with this mapper
+     * @param multiFields       sub fields of this mapper
+     * @param copyTo            copyTo fields of this mapper
+     */
     protected FieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                          MultiFields multiFields, CopyTo copyTo) {
+        this(simpleName, mappedFieldType, Collections.emptyMap(), multiFields, copyTo);
+    }
+
+    /**
+     * Create a FieldMapper with a single associated index analyzer
+     * @param simpleName        the leaf name of the mapper
+     * @param mappedFieldType   the MappedFieldType associated with this mapper
+     * @param indexAnalyzer     the index-time analyzer to use for this field
+     * @param multiFields       sub fields of this mapper
+     * @param copyTo            copyTo fields of this mapper
+     */
+    protected FieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                          NamedAnalyzer indexAnalyzer,
+                          MultiFields multiFields, CopyTo copyTo) {
+        this(simpleName, mappedFieldType, Collections.singletonMap(mappedFieldType.name(), indexAnalyzer), multiFields, copyTo);
+    }
+
+    /**
+     * Create a FieldMapper that indexes into multiple analyzed fields
+     * @param simpleName        the leaf name of the mapper
+     * @param mappedFieldType   the MappedFieldType associated with this mapper
+     * @param indexAnalyzers    a map of field names to analyzers, one for each analyzed field
+     *                          the mapper will add
+     * @param multiFields       sub fields of this mapper
+     * @param copyTo            copyTo fields of this mapper
+     */
+    protected FieldMapper(String simpleName, MappedFieldType mappedFieldType,
+                          Map<String, NamedAnalyzer> indexAnalyzers,
                           MultiFields multiFields, CopyTo copyTo) {
         super(simpleName);
         if (mappedFieldType.name().isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty string");
         }
         this.mappedFieldType = mappedFieldType;
+        this.indexAnalyzers = indexAnalyzers;
         this.multiFields = multiFields;
         this.copyTo = Objects.requireNonNull(copyTo);
     }
@@ -272,6 +310,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     }
 
     protected abstract String contentType();
+
+    public final Map<String, NamedAnalyzer> indexAnalyzers() {
+        return indexAnalyzers;
+    }
 
     public static class MultiFields implements Iterable<Mapper> {
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -105,7 +105,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
         IdFieldType(BooleanSupplier fieldDataEnabled) {
             super(NAME, true, true, false, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
             this.fieldDataEnabled = fieldDataEnabled;
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -156,11 +155,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
                     + IndicesService.INDICES_ID_FIELD_DATA_ENABLED_SETTING.getKey());
             }
             final IndexFieldData.Builder fieldDataBuilder = new PagedBytesIndexFieldData.Builder(
-                    name(),
-                    TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
-                    TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
-                    TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE,
-                    CoreValuesSourceType.BYTES);
+                name(),
+                TextFieldMapper.Defaults.FIELDDATA_MIN_FREQUENCY,
+                TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
+                TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE,
+                CoreValuesSourceType.BYTES);
             return new IndexFieldData.Builder() {
                 @Override
                 public IndexFieldData<?> build(
@@ -199,7 +198,8 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
                         @Override
                         public BucketedSort newBucketedSort(BigArrays bigArrays, Object missingValue, MultiValueMode sortMode,
-                                Nested nested, SortOrder sortOrder, DocValueFormat format, int bucketSize, BucketedSort.ExtraData extra) {
+                                                            Nested nested, SortOrder sortOrder, DocValueFormat format,
+                                                            int bucketSize, BucketedSort.ExtraData extra) {
                             throw new UnsupportedOperationException("can't sort on the [" + CONTENT_TYPE + "] field");
                         }
                     };
@@ -235,7 +235,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
                     public BytesRef nextValue() throws IOException {
                         BytesRef encoded = inValues.nextValue();
                         return new BytesRef(Uid.decodeId(
-                                Arrays.copyOfRange(encoded.bytes, encoded.offset, encoded.offset + encoded.length)));
+                            Arrays.copyOfRange(encoded.bytes, encoded.offset, encoded.offset + encoded.length)));
                     }
 
                     @Override
@@ -257,7 +257,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
     }
 
     private IdFieldMapper(BooleanSupplier fieldDataEnabled) {
-        super(new IdFieldType(fieldDataEnabled));
+        super(new IdFieldType(fieldDataEnabled), Lucene.KEYWORD_ANALYZER);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -434,4 +434,5 @@ public class IpFieldMapper extends FieldMapper {
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(simpleName(), ignoreMalformedByDefault, indexCreatedVersion).init(this);
     }
+
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -180,6 +180,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private final int ignoreAbove;
         private final String nullValue;
+        private final NamedAnalyzer normalizer;
 
         public KeywordFieldType(String name, FieldType fieldType,
                                 NamedAnalyzer normalizer, NamedAnalyzer searchAnalyzer, Builder builder) {
@@ -190,15 +191,15 @@ public final class KeywordFieldMapper extends FieldMapper {
                 new TextSearchInfo(fieldType, builder.similarity.getValue(), searchAnalyzer, searchAnalyzer),
                 builder.meta.getValue());
             setEagerGlobalOrdinals(builder.eagerGlobalOrdinals.getValue());
-            setIndexAnalyzer(normalizer);
             setBoost(builder.boost.getValue());
+            this.normalizer = normalizer;
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
         }
 
         public KeywordFieldType(String name, boolean isSearchable, boolean hasDocValues, Map<String, String> meta) {
             super(name, isSearchable, false, hasDocValues, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
+            this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
         }
@@ -212,12 +213,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                 false, false,
                 new TextSearchInfo(fieldType, null, Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER),
                 Collections.emptyMap());
+            this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
         }
 
         public KeywordFieldType(String name, NamedAnalyzer analyzer) {
             super(name, true, false, true, new TextSearchInfo(Defaults.FIELD_TYPE, null, analyzer, analyzer), Collections.emptyMap());
+            this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
         }
@@ -228,7 +231,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         NamedAnalyzer normalizer() {
-            return indexAnalyzer();
+            return normalizer;
         }
 
         @Override
@@ -314,9 +317,9 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private final IndexAnalyzers indexAnalyzers;
 
-    protected KeywordFieldMapper(String simpleName, FieldType fieldType, MappedFieldType mappedFieldType,
+    protected KeywordFieldMapper(String simpleName, FieldType fieldType, KeywordFieldType mappedFieldType,
                                  MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, mappedFieldType.normalizer, multiFields, copyTo);
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -451,7 +452,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
                                      MultiFields multiFields, CopyTo copyTo,
                                      LegacyGeoShapeIndexer indexer, LegacyGeoShapeParser parser,
                                      Builder builder) {
-        super(simpleName, mappedFieldType,
+        super(simpleName, mappedFieldType, Collections.singletonMap(mappedFieldType.name(), Lucene.KEYWORD_ANALYZER),
             builder.ignoreMalformed.get(), builder.coerce.get(), builder.ignoreZValue.get(), builder.orientation.get(),
             multiFields, copyTo, indexer, parser);
         this.indexCreatedVersion = builder.indexCreatedVersion;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -133,14 +133,6 @@ public abstract class MappedFieldType {
         return docValues;
     }
 
-    public NamedAnalyzer indexAnalyzer() {
-        return indexAnalyzer;
-    }
-
-    public void setIndexAnalyzer(NamedAnalyzer analyzer) {
-        this.indexAnalyzer = analyzer;
-    }
-
     /**
      * Returns the collapse type of the field
      * CollapseType.NONE means the field can'be used for collapsing.

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -42,14 +42,7 @@ public final class MappingLookup implements Iterable<Mapper> {
     private final int metadataFieldCount;
     private final FieldNameAnalyzer indexAnalyzer;
 
-    private static void put(Map<String, Analyzer> analyzers, String key, Analyzer value, Analyzer defaultValue) {
-        if (value == null) {
-            value = defaultValue;
-        }
-        analyzers.put(key, value);
-    }
-
-    public static MappingLookup fromMapping(Mapping mapping, Analyzer defaultIndex) {
+    public static MappingLookup fromMapping(Mapping mapping) {
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
         List<FieldMapper> newFieldMappers = new ArrayList<>();
         List<FieldAliasMapper> newFieldAliasMappers = new ArrayList<>();
@@ -59,7 +52,7 @@ public final class MappingLookup implements Iterable<Mapper> {
             }
         }
         collect(mapping.root, newObjectMappers, newFieldMappers, newFieldAliasMappers);
-        return new MappingLookup(newFieldMappers, newObjectMappers, newFieldAliasMappers, mapping.metadataMappers.length, defaultIndex);
+        return new MappingLookup(newFieldMappers, newObjectMappers, newFieldAliasMappers, mapping.metadataMappers.length);
     }
 
     private static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers,
@@ -86,8 +79,7 @@ public final class MappingLookup implements Iterable<Mapper> {
     public MappingLookup(Collection<FieldMapper> mappers,
                          Collection<ObjectMapper> objectMappers,
                          Collection<FieldAliasMapper> aliasMappers,
-                         int metadataFieldCount,
-                         Analyzer defaultIndex) {
+                         int metadataFieldCount) {
         Map<String, Mapper> fieldMappers = new HashMap<>();
         Map<String, Analyzer> indexAnalyzers = new HashMap<>();
         Map<String, ObjectMapper> objects = new HashMap<>();
@@ -110,8 +102,7 @@ public final class MappingLookup implements Iterable<Mapper> {
             if (fieldMappers.put(mapper.name(), mapper) != null) {
                 throw new MapperParsingException("Field [" + mapper.name() + "] is defined more than once");
             }
-            MappedFieldType fieldType = mapper.fieldType();
-            put(indexAnalyzers, fieldType.name(), fieldType.indexAnalyzer(), defaultIndex);
+            indexAnalyzers.putAll(mapper.indexAnalyzers());
         }
         this.metadataFieldCount = metadataFieldCount;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 
 import java.io.IOException;
 import java.util.Map;
@@ -132,6 +133,10 @@ public abstract class MetadataFieldMapper extends FieldMapper {
 
     protected MetadataFieldMapper(MappedFieldType mappedFieldType) {
         super(mappedFieldType.name(), mappedFieldType, MultiFields.empty(), CopyTo.empty());
+    }
+
+    protected MetadataFieldMapper(MappedFieldType mappedFieldType, NamedAnalyzer indexAnalyzer) {
+        super(mappedFieldType.name(), mappedFieldType, indexAnalyzer, MultiFields.empty(), CopyTo.empty());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -38,7 +38,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Numbers;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -901,7 +900,6 @@ public class NumberFieldMapper extends FieldMapper {
             this.type = Objects.requireNonNull(type);
             this.coerce = coerce;
             this.nullValue = nullValue;
-            this.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);     // allows number fields in significant text aggs - do we need this?
         }
 
         NumberFieldType(String name, Builder builder) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -168,7 +167,6 @@ public class RangeFieldMapper extends FieldMapper {
             this.rangeType = Objects.requireNonNull(type);
             dateTimeFormatter = null;
             dateMathParser = null;
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.coerce = coerce;
         }
 
@@ -182,7 +180,6 @@ public class RangeFieldMapper extends FieldMapper {
             this.rangeType = RangeType.DATE;
             this.dateTimeFormatter = Objects.requireNonNull(formatter);
             this.dateMathParser = dateTimeFormatter.toDateMathParser();
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.coerce = coerce;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -86,7 +86,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
         private RoutingFieldType() {
             super(NAME, true, true, false, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -103,7 +102,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     private final boolean required;
 
     private RoutingFieldMapper(boolean required) {
-        super(RoutingFieldType.INSTANCE);
+        super(RoutingFieldType.INSTANCE, Lucene.KEYWORD_ANALYZER);
         this.required = required;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -79,6 +79,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +91,6 @@ import java.util.function.Supplier;
 public class TextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "text";
-    private static final int POSITION_INCREMENT_GAP_USE_ANALYZER = -1;
     private static final String FAST_PHRASE_SUFFIX = "._index_phrase";
 
     public static class Defaults {
@@ -251,9 +251,6 @@ public class TextFieldMapper extends FieldMapper {
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.getValue());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.getValue());
 
-        final Parameter<Integer> positionIncrementGap = Parameter.intParam("position_increment_gap", false,
-            m -> builder(m).positionIncrementGap.getValue(), POSITION_INCREMENT_GAP_USE_ANALYZER);
-
         final Parameter<Boolean> fieldData
             = Parameter.boolParam("fielddata", true, m -> builder(m).fieldData.getValue(), false);
         final Parameter<FielddataFrequencyFilter> freqFilter = new Parameter<>("fielddata_frequency_filter", true,
@@ -278,7 +275,7 @@ public class TextFieldMapper extends FieldMapper {
         public Builder(String name, Version indexCreatedVersion, Supplier<NamedAnalyzer> defaultAnalyzer) {
             super(name);
             this.indexCreatedVersion = indexCreatedVersion;
-            this.analyzers = new TextParams.Analyzers(defaultAnalyzer);
+            this.analyzers = new TextParams.Analyzers(defaultAnalyzer, m -> builder(m).analyzers);
         }
 
         public Builder index(boolean index) {
@@ -310,28 +307,23 @@ public class TextFieldMapper extends FieldMapper {
         protected List<Parameter<?>> getParameters() {
             return Arrays.asList(index, store, indexOptions, norms, termVectors,
                 analyzers.indexAnalyzer, analyzers.searchAnalyzer, analyzers.searchQuoteAnalyzer, similarity,
-                positionIncrementGap,
+                analyzers.positionIncrementGap,
                 fieldData, freqFilter, eagerGlobalOrdinals,
                 indexPhrases, indexPrefixes,
                 boost, meta);
         }
 
         private TextFieldType buildFieldType(FieldType fieldType, BuilderContext context) {
-            NamedAnalyzer indexAnalyzer = analyzers.getIndexAnalyzer();
             NamedAnalyzer searchAnalyzer = analyzers.getSearchAnalyzer();
             NamedAnalyzer searchQuoteAnalyzer = analyzers.getSearchQuoteAnalyzer();
-            if (positionIncrementGap.get() != POSITION_INCREMENT_GAP_USE_ANALYZER) {
+            if (analyzers.positionIncrementGap.get() != TextParams.POSITION_INCREMENT_GAP_USE_ANALYZER) {
                 if (fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) < 0) {
                     throw new IllegalArgumentException("Cannot set position_increment_gap on field ["
                         + name + "] without positions enabled");
                 }
-                indexAnalyzer = new NamedAnalyzer(indexAnalyzer, positionIncrementGap.get());
-                searchAnalyzer = new NamedAnalyzer(searchAnalyzer, positionIncrementGap.get());
-                searchQuoteAnalyzer = new NamedAnalyzer(searchQuoteAnalyzer, positionIncrementGap.get());
             }
             TextSearchInfo tsi = new TextSearchInfo(fieldType, similarity.getValue(), searchAnalyzer, searchQuoteAnalyzer);
             TextFieldType ft = new TextFieldType(buildFullName(context), index.getValue(), store.getValue(), tsi, meta.getValue());
-            ft.setIndexAnalyzer(indexAnalyzer);
             ft.setEagerGlobalOrdinals(eagerGlobalOrdinals.getValue());
             ft.setBoost(boost.getValue());
             if (fieldData.getValue()) {
@@ -369,9 +361,12 @@ public class TextFieldMapper extends FieldMapper {
                 pft.setStoreTermVectorOffsets(true);
             }
             PrefixFieldType prefixFieldType = new PrefixFieldType(tft, fullName + "._index_prefix", indexPrefixes.get());
-            prefixFieldType.setAnalyzer(analyzers.getIndexAnalyzer());
             tft.setPrefixFieldType(prefixFieldType);
-            return new PrefixFieldMapper(pft, prefixFieldType);
+            return new PrefixFieldMapper(pft, prefixFieldType, new PrefixWrappedAnalyzer(
+                analyzers.getIndexAnalyzer().analyzer(),
+                analyzers.positionIncrementGap.get(),
+                prefixFieldType.minChars,
+                prefixFieldType.maxChars));
         }
 
         private PhraseFieldMapper buildPhraseMapper(FieldType fieldType, TextFieldType parent) {
@@ -386,15 +381,39 @@ public class TextFieldMapper extends FieldMapper {
             }
             FieldType phraseFieldType = new FieldType(fieldType);
             parent.setIndexPhrases();
-            return new PhraseFieldMapper(phraseFieldType, new PhraseFieldType(parent));
+            PhraseWrappedAnalyzer a
+                = new PhraseWrappedAnalyzer(analyzers.getIndexAnalyzer().analyzer(), analyzers.positionIncrementGap.get());
+            return new PhraseFieldMapper(phraseFieldType, new PhraseFieldType(parent), a);
+        }
+
+        public Map<String, NamedAnalyzer> indexAnalyzers(String name,
+                                                         PhraseFieldMapper phraseFieldMapper,
+                                                         PrefixFieldMapper prefixFieldMapper) {
+            Map<String, NamedAnalyzer> analyzers = new HashMap<>();
+            NamedAnalyzer main = this.analyzers.getIndexAnalyzer();
+            analyzers.put(name, main);
+            if (phraseFieldMapper != null) {
+                analyzers.put(
+                    phraseFieldMapper.name(),
+                    new NamedAnalyzer(main.name() + "_phrase", AnalyzerScope.INDEX, phraseFieldMapper.analyzer));
+            }
+            if (prefixFieldMapper != null) {
+                analyzers.put(
+                    prefixFieldMapper.name(),
+                    new NamedAnalyzer(main.name() + "_prefix", AnalyzerScope.INDEX, prefixFieldMapper.analyzer));
+            }
+            return analyzers;
         }
 
         @Override
         public TextFieldMapper build(BuilderContext context) {
             FieldType fieldType = TextParams.buildFieldType(index, store, indexOptions, norms, termVectors);
             TextFieldType tft = buildFieldType(fieldType, context);
+            PhraseFieldMapper phraseFieldMapper = buildPhraseMapper(fieldType, tft);
+            PrefixFieldMapper prefixFieldMapper = buildPrefixMapper(context, fieldType, tft);
             return new TextFieldMapper(name, fieldType, tft,
-                buildPrefixMapper(context, fieldType, tft), buildPhraseMapper(fieldType, tft),
+                indexAnalyzers(tft.name(), phraseFieldMapper, prefixFieldMapper),
+                prefixFieldMapper, phraseFieldMapper,
                 multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
     }
@@ -405,10 +424,17 @@ public class TextFieldMapper extends FieldMapper {
     private static class PhraseWrappedAnalyzer extends AnalyzerWrapper {
 
         private final Analyzer delegate;
+        private final int posIncGap;
 
-        PhraseWrappedAnalyzer(Analyzer delegate) {
+        PhraseWrappedAnalyzer(Analyzer delegate, int posIncGap) {
             super(delegate.getReuseStrategy());
             this.delegate = delegate;
+            this.posIncGap = posIncGap;
+        }
+
+        @Override
+        public int getPositionIncrementGap(String fieldName) {
+            return posIncGap;
         }
 
         @Override
@@ -426,11 +452,13 @@ public class TextFieldMapper extends FieldMapper {
 
         private final int minChars;
         private final int maxChars;
+        private final int posIncGap;
         private final Analyzer delegate;
 
-        PrefixWrappedAnalyzer(Analyzer delegate, int minChars, int maxChars) {
+        PrefixWrappedAnalyzer(Analyzer delegate, int posIncGap, int minChars, int maxChars) {
             super(delegate.getReuseStrategy());
             this.delegate = delegate;
+            this.posIncGap = posIncGap;
             this.minChars = minChars;
             this.maxChars = maxChars;
         }
@@ -438,6 +466,11 @@ public class TextFieldMapper extends FieldMapper {
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
             return delegate;
+        }
+
+        @Override
+        public int getPositionIncrementGap(String fieldName) {
+            return posIncGap;
         }
 
         @Override
@@ -453,12 +486,7 @@ public class TextFieldMapper extends FieldMapper {
 
         PhraseFieldType(TextFieldType parent) {
             super(parent.name() + FAST_PHRASE_SUFFIX, true, false, false, parent.getTextSearchInfo(), Collections.emptyMap());
-            setAnalyzer(parent.indexAnalyzer().name(), parent.indexAnalyzer().analyzer());
             this.parent = parent;
-        }
-
-        void setAnalyzer(String name, Analyzer delegate) {
-            setIndexAnalyzer(new NamedAnalyzer(name, AnalyzerScope.INDEX, new PhraseWrappedAnalyzer(delegate)));
         }
 
         @Override
@@ -501,11 +529,6 @@ public class TextFieldMapper extends FieldMapper {
             // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
             return SourceValueFetcher.toString(name(), mapperService, format);
-        }
-
-        void setAnalyzer(NamedAnalyzer delegate) {
-            setIndexAnalyzer(new NamedAnalyzer(delegate.name(), AnalyzerScope.INDEX,
-                new PrefixWrappedAnalyzer(delegate.analyzer(), minChars, maxChars)));
         }
 
         boolean accept(int length) {
@@ -575,11 +598,13 @@ public class TextFieldMapper extends FieldMapper {
 
     private static final class PhraseFieldMapper extends FieldMapper {
 
+        private final Analyzer analyzer;
         private final FieldType fieldType;
 
-        PhraseFieldMapper(FieldType fieldType, PhraseFieldType mappedFieldType) {
+        PhraseFieldMapper(FieldType fieldType, PhraseFieldType mappedFieldType, PhraseWrappedAnalyzer analyzer) {
             super(mappedFieldType.name(), mappedFieldType, MultiFields.empty(), CopyTo.empty());
             this.fieldType = fieldType;
+            this.analyzer = analyzer;
         }
 
         @Override
@@ -600,10 +625,12 @@ public class TextFieldMapper extends FieldMapper {
 
     private static final class PrefixFieldMapper extends FieldMapper {
 
+        private final Analyzer analyzer;
         private final FieldType fieldType;
 
-        protected PrefixFieldMapper(FieldType fieldType, PrefixFieldType mappedFieldType) {
+        protected PrefixFieldMapper(FieldType fieldType, PrefixFieldType mappedFieldType, Analyzer analyzer) {
             super(mappedFieldType.name(), mappedFieldType, MultiFields.empty(), CopyTo.empty());
+            this.analyzer = analyzer;
             this.fieldType = fieldType;
         }
 
@@ -846,10 +873,11 @@ public class TextFieldMapper extends FieldMapper {
 
     protected TextFieldMapper(String simpleName, FieldType fieldType,
                               TextFieldType mappedFieldType,
+                              Map<String, NamedAnalyzer> indexAnalyzers,
                               PrefixFieldMapper prefixFieldMapper,
                               PhraseFieldMapper phraseFieldMapper,
                               MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, indexAnalyzers, multiFields, copyTo);
         assert mappedFieldType.getTextSearchInfo().isTokenized();
         assert mappedFieldType.hasDocValues() == false;
         if (fieldType.indexOptions() == IndexOptions.NONE && fieldType().fielddata()) {
@@ -1053,7 +1081,7 @@ public class TextFieldMapper extends FieldMapper {
         this.builder.analyzers.searchQuoteAnalyzer.toXContent(builder, includeDefaults);
         this.builder.similarity.toXContent(builder, includeDefaults);
         this.builder.eagerGlobalOrdinals.toXContent(builder, includeDefaults);
-        this.builder.positionIncrementGap.toXContent(builder, includeDefaults);
+        this.builder.analyzers.positionIncrementGap.toXContent(builder, includeDefaults);
         this.builder.fieldData.toXContent(builder, includeDefaults);
         this.builder.freqFilter.toXContent(builder, includeDefaults);
         this.builder.indexPrefixes.toXContent(builder, includeDefaults);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -363,6 +363,14 @@ public class QueryShardContext extends QueryRewriteContext {
         return Arrays.asList(types);
     }
 
+    /**
+     * Does the index analyzer for this field have token filters that may produce
+     * backwards offsets in term vectors
+     */
+    public boolean containsBrokenAnalysis(String field) {
+        return mapperService.containsBrokenAnalysis(field);
+    }
+
     private SearchLookup lookup = null;
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -225,17 +225,11 @@ public class TermVectorsService  {
 
     private static Analyzer getAnalyzerAtField(IndexShard indexShard, String field, @Nullable Map<String, String> perFieldAnalyzer) {
         MapperService mapperService = indexShard.mapperService();
-        Analyzer analyzer;
         if (perFieldAnalyzer != null && perFieldAnalyzer.containsKey(field)) {
-            analyzer = mapperService.getIndexAnalyzers().get(perFieldAnalyzer.get(field));
+            return mapperService.getIndexAnalyzers().get(perFieldAnalyzer.get(field));
         } else {
-            MappedFieldType fieldType = mapperService.fieldType(field);
-            analyzer = fieldType.indexAnalyzer();
+            return mapperService.indexAnalyzer();
         }
-        if (analyzer == null) {
-            analyzer = mapperService.getIndexAnalyzers().getDefaultIndexAnalyzer();
-        }
-        return analyzer;
     }
 
     private static Set<String> getFieldsToGenerate(Map<String, String> perAnalyzerField, Fields fieldsObject) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -131,6 +131,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
             context.lookup().source(),
             context.bigArrays(),
             fieldType,
+            searchContext.getQueryShardContext().getIndexAnalyzer(),
             sourceFieldNames,
             filterDuplicateText
         );
@@ -157,6 +158,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
         private final SourceLookup sourceLookup;
         private final BigArrays bigArrays;
         private final MappedFieldType fieldType;
+        private final Analyzer analyzer;
         private final String[] sourceFieldNames;
         private ObjectArray<DuplicateByteSequenceSpotter> dupSequenceSpotters;
 
@@ -164,12 +166,14 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
             SourceLookup sourceLookup,
             BigArrays bigArrays,
             MappedFieldType fieldType,
+            Analyzer analyzer,
             String[] sourceFieldNames,
             boolean filterDuplicateText
         ) {
             this.sourceLookup = sourceLookup;
             this.bigArrays = bigArrays;
             this.fieldType = fieldType;
+            this.analyzer = analyzer;
             this.sourceFieldNames = sourceFieldNames;
             dupSequenceSpotters = filterDuplicateText ? bigArrays.newObjectArray(1) : null;
         }
@@ -223,7 +227,6 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
                                     return obj.toString();
                                 })
                                 .iterator();
-                            Analyzer analyzer = fieldType.indexAnalyzer();
                             while (itr.hasNext()) {
                                 TokenStream ts = analyzer.tokenStream(fieldType.name(), itr.next());
                                 processTokenStream(doc, owningBucketOrd, ts, inDocTerms, spotter);

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -167,6 +167,14 @@ public class FetchContext {
     }
 
     /**
+     * Does the index analyzer for this field have token filters that may produce
+     * backwards offsets in term vectors
+     */
+    public boolean containsBrokenAnalysis(String field) {
+        return searchContext.getQueryShardContext().containsBrokenAnalysis(field);
+    }
+
+    /**
      * Should the response include scores, even if scores were not calculated in the original query
      */
     public boolean fetchScores() {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -72,6 +72,7 @@ public class FastVectorHighlighter implements Highlighter {
         FetchSubPhase.HitContext hitContext = fieldContext.hitContext;
         MappedFieldType fieldType = fieldContext.fieldType;
         boolean forceSource = fieldContext.forceSource;
+        boolean fixBrokenAnalysis = fieldContext.context.containsBrokenAnalysis(fieldContext.fieldName);
 
         if (canHighlight(fieldType) == false) {
             throw new IllegalArgumentException("the field [" + fieldContext.fieldName +
@@ -95,10 +96,10 @@ public class FastVectorHighlighter implements Highlighter {
                 fragListBuilder = new SingleFragListBuilder();
 
                 if (!forceSource && fieldType.isStored()) {
-                    fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, field.fieldOptions().preTags(),
+                    fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, field.fieldOptions().preTags(),
                         field.fieldOptions().postTags(), boundaryScanner);
                 } else {
-                    fragmentsBuilder = new SourceSimpleFragmentsBuilder(fieldType, hitContext.sourceLookup(),
+                    fragmentsBuilder = new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
                         field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                 }
             } else {
@@ -109,16 +110,16 @@ public class FastVectorHighlighter implements Highlighter {
                         fragmentsBuilder = new ScoreOrderFragmentsBuilder(field.fieldOptions().preTags(),
                             field.fieldOptions().postTags(), boundaryScanner);
                     } else {
-                        fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(fieldType, hitContext.sourceLookup(),
+                        fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
                             field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                     }
                 } else {
                     if (!forceSource && fieldType.isStored()) {
-                        fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, field.fieldOptions().preTags(),
+                        fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, field.fieldOptions().preTags(),
                             field.fieldOptions().postTags(), boundaryScanner);
                     } else {
                         fragmentsBuilder =
-                            new SourceSimpleFragmentsBuilder(fieldType, hitContext.sourceLookup(),
+                            new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
                                 field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
@@ -29,20 +29,26 @@ import org.elasticsearch.index.mapper.MappedFieldType;
  * that corrects offsets for broken analysis chains.
  */
 public class SimpleFragmentsBuilder extends org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder {
+
     protected final MappedFieldType fieldType;
+    private final boolean fixBrokenAnalysis;
 
     public SimpleFragmentsBuilder(MappedFieldType fieldType,
+                                  boolean fixBrokenAnalysis,
                                   String[] preTags,
                                   String[] postTags,
                                   BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
         this.fieldType = fieldType;
+        this.fixBrokenAnalysis = fixBrokenAnalysis;
     }
 
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
-            String[] preTags, String[] postTags, Encoder encoder ){
-        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
-        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
+            String[] preTags, String[] postTags, Encoder encoder) {
+        if (fixBrokenAnalysis) {
+            fragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fragInfo);
+        }
+        return super.makeFragment(buffer, index, values, fragInfo, preTags, postTags, encoder);
    }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
@@ -35,8 +35,10 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
 
     private final MappedFieldType fieldType;
     private final SourceLookup sourceLookup;
+    private final boolean fixBrokenAnalysis;
 
     public SourceScoreOrderFragmentsBuilder(MappedFieldType fieldType,
+                                            boolean fixBrokenAnalysis,
                                             SourceLookup sourceLookup,
                                             String[] preTags,
                                             String[] postTags,
@@ -44,6 +46,7 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
         super(preTags, postTags, boundaryScanner);
         this.fieldType = fieldType;
         this.sourceLookup = sourceLookup;
+        this.fixBrokenAnalysis = fixBrokenAnalysis;
     }
 
     @Override
@@ -59,8 +62,10 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
 
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
-            String[] preTags, String[] postTags, Encoder encoder ){
-        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
-        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
+            String[] preTags, String[] postTags, Encoder encoder) {
+        if (fixBrokenAnalysis) {
+            fragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fragInfo);
+        }
+        return super.makeFragment(buffer, index, values, fragInfo, preTags, postTags, encoder);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
@@ -33,11 +33,12 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
     private final SourceLookup sourceLookup;
 
     public SourceSimpleFragmentsBuilder(MappedFieldType fieldType,
+                                        boolean fixBrokenAnalysis,
                                         SourceLookup sourceLookup,
                                         String[] preTags,
                                         String[] postTags,
                                         BoundaryScanner boundaryScanner) {
-        super(fieldType, preTags, postTags, boundaryScanner);
+        super(fieldType, fixBrokenAnalysis, preTags, postTags, boundaryScanner);
         this.sourceLookup = sourceLookup;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
@@ -59,7 +58,6 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -557,15 +555,16 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             DateFieldMapper dateFieldMapper
                 = new DateFieldMapper.Builder("@timestamp", DateFieldMapper.Resolution.MILLISECONDS, null, false, Version.CURRENT)
                 .build(builderContext);
-            MetadataFieldMapper mockedTimestampField = mock(MetadataFieldMapper.class);
-            when(mockedTimestampField.name()).thenReturn("_data_stream_timestamp");
             MappedFieldType mockedTimestampFieldType = mock(MappedFieldType.class);
             when(mockedTimestampFieldType.name()).thenReturn("_data_stream_timestamp");
-            when(mockedTimestampField.fieldType()).thenReturn(mockedTimestampFieldType);
-            when(mockedTimestampField.copyTo()).thenReturn(FieldMapper.CopyTo.empty());
-            when(mockedTimestampField.multiFields()).thenReturn(FieldMapper.MultiFields.empty());
+            MetadataFieldMapper mockedTimestampField = new MetadataFieldMapper(mockedTimestampFieldType) {
+                @Override
+                protected String contentType() {
+                    return null;
+                }
+            };
             MappingLookup mappingLookup = new MappingLookup(Arrays.asList(mockedTimestampField, dateFieldMapper),
-                Collections.emptyList(), Collections.emptyList(), 0, new StandardAnalyzer());
+                Collections.emptyList(), Collections.emptyList(), 0);
 
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -125,7 +125,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
         MappedFieldType completionFieldType = ((CompletionFieldMapper) fieldMapper).fieldType();
 
-        NamedAnalyzer indexAnalyzer = completionFieldType.indexAnalyzer();
+        NamedAnalyzer indexAnalyzer = (NamedAnalyzer) ((CompletionFieldMapper) fieldMapper).indexAnalyzers().values().iterator().next();
         assertThat(indexAnalyzer.name(), equalTo("simple"));
         assertThat(indexAnalyzer.analyzer(), instanceOf(CompletionAnalyzer.class));
         CompletionAnalyzer analyzer = (CompletionAnalyzer) indexAnalyzer.analyzer();
@@ -154,7 +154,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
         MappedFieldType completionFieldType = ((CompletionFieldMapper) fieldMapper).fieldType();
 
-        NamedAnalyzer indexAnalyzer = completionFieldType.indexAnalyzer();
+        NamedAnalyzer indexAnalyzer = (NamedAnalyzer) ((CompletionFieldMapper) fieldMapper).indexAnalyzers().values().iterator().next();
         assertThat(indexAnalyzer.name(), equalTo("simple"));
         assertThat(indexAnalyzer.analyzer(), instanceOf(CompletionAnalyzer.class));
         CompletionAnalyzer analyzer = (CompletionAnalyzer) indexAnalyzer.analyzer();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -47,10 +47,10 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         protected TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new Tokenizer() {
                 boolean incremented = false;
-                CharTermAttribute term = addAttribute(CharTermAttribute.class);
+                final CharTermAttribute term = addAttribute(CharTermAttribute.class);
 
                 @Override
-                public boolean incrementToken() throws IOException {
+                public boolean incrementToken() {
                     if (incremented) {
                         return false;
                     }
@@ -83,8 +83,13 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
 
     static class FakeFieldMapper extends FieldMapper {
 
-        FakeFieldMapper(FakeFieldType fieldType) {
-            super(fieldType.name(), fieldType, MultiFields.empty(), CopyTo.empty());
+        final String indexedValue;
+
+        FakeFieldMapper(FakeFieldType fieldType, String indexedValue) {
+            super(fieldType.name(), fieldType,
+                new NamedAnalyzer("fake", AnalyzerScope.INDEX, new FakeAnalyzer(indexedValue)),
+                MultiFields.empty(), CopyTo.empty());
+            this.indexedValue = indexedValue;
         }
 
         @Override
@@ -104,23 +109,20 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
 
     public void testAnalyzers() throws IOException {
         FakeFieldType fieldType1 = new FakeFieldType("field1");
-        fieldType1.setIndexAnalyzer(new NamedAnalyzer("foo", AnalyzerScope.INDEX, new FakeAnalyzer("index")));
-        FieldMapper fieldMapper1 = new FakeFieldMapper(fieldType1);
+        FieldMapper fieldMapper1 = new FakeFieldMapper(fieldType1, "index1");
 
         FakeFieldType fieldType2 = new FakeFieldType("field2");
-        FieldMapper fieldMapper2 = new FakeFieldMapper(fieldType2);
-
-        Analyzer defaultIndex = new FakeAnalyzer("default_index");
+        FieldMapper fieldMapper2 = new FakeFieldMapper(fieldType2, "index2");
 
         MappingLookup mappingLookup = new MappingLookup(
             Arrays.asList(fieldMapper1, fieldMapper2),
             Collections.emptyList(),
             Collections.emptyList(),
-            0, defaultIndex);
+            0);
 
-        assertAnalyzes(mappingLookup.indexAnalyzer(), "field1", "index");
-
-        assertAnalyzes(mappingLookup.indexAnalyzer(), "field2", "default_index");
+        assertAnalyzes(mappingLookup.indexAnalyzer(), "field1", "index1");
+        assertAnalyzes(mappingLookup.indexAnalyzer(), "field2", "index2");
+        expectThrows(IllegalArgumentException.class, () -> mappingLookup.indexAnalyzer().tokenStream("field3", "blah"));
     }
 
     private void assertAnalyzes(Analyzer analyzer, String field, String output) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -67,7 +67,6 @@ public class FakeStringFieldMapper extends FieldMapper {
 
         private FakeStringFieldType(String name, boolean stored, TextSearchInfo textSearchInfo) {
             super(name, true, stored, true, textSearchInfo, Collections.emptyMap());
-            setIndexAnalyzer(Lucene.STANDARD_ANALYZER);
         }
 
         @Override
@@ -83,7 +82,7 @@ public class FakeStringFieldMapper extends FieldMapper {
 
     protected FakeStringFieldMapper(MappedFieldType mappedFieldType,
                                     MultiFields multiFields, CopyTo copyTo) {
-        super(mappedFieldType.name(), mappedFieldType, multiFields, copyTo);
+        super(mappedFieldType.name(), mappedFieldType, Lucene.STANDARD_ANALYZER, multiFields, copyTo);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
@@ -42,7 +41,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             new MappingLookup(
                 Collections.emptyList(),
                 singletonList(objectMapper),
-                singletonList(aliasMapper), 0, Lucene.STANDARD_ANALYZER));
+                singletonList(aliasMapper), 0));
         assertEquals("Alias [some.path] is defined both as an object and an alias", e.getMessage());
     }
 
@@ -55,7 +54,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             new MappingLookup(
                 Arrays.asList(field, invalidField),
                 emptyList(),
-                singletonList(invalidAlias), 0, Lucene.STANDARD_ANALYZER));
+                singletonList(invalidAlias), 0));
 
         assertEquals("Alias [invalid] is defined both as an alias and a concrete field", e.getMessage());
     }
@@ -68,7 +67,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
         MappingLookup mappers = new MappingLookup(
             singletonList(field),
             emptyList(),
-            Arrays.asList(alias, invalidAlias), 0, Lucene.STANDARD_ANALYZER);
+            Arrays.asList(alias, invalidAlias), 0);
         alias.validate(mappers);
 
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> invalidAlias.validate(mappers));
@@ -84,7 +83,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             MappingLookup mappers = new MappingLookup(
                 emptyList(),
                 emptyList(),
-                singletonList(invalidAlias), 0, null);
+                singletonList(invalidAlias), 0);
             invalidAlias.validate(mappers);
         });
 
@@ -99,7 +98,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             MappingLookup mappers = new MappingLookup(
                 emptyList(),
                 emptyList(),
-                singletonList(invalidAlias), 0, Lucene.STANDARD_ANALYZER);
+                singletonList(invalidAlias), 0);
             invalidAlias.validate(mappers);
         });
 
@@ -115,7 +114,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             singletonList(createFieldMapper("nested", "field")),
             singletonList(objectMapper),
             singletonList(aliasMapper),
-            0, Lucene.STANDARD_ANALYZER);
+            0);
         aliasMapper.validate(mappers);
     }
 
@@ -127,7 +126,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
             singletonList(createFieldMapper("object1", "field")),
             Arrays.asList(createObjectMapper("object1"), createObjectMapper("object2")),
             singletonList(aliasMapper),
-            0, Lucene.STANDARD_ANALYZER);
+            0);
         aliasMapper.validate(mappers);
     }
 
@@ -140,7 +139,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
                 singletonList(createFieldMapper("nested", "field")),
                 Collections.singletonList(objectMapper),
                 singletonList(aliasMapper),
-                0, Lucene.STANDARD_ANALYZER);
+                0);
             aliasMapper.validate(mappers);
         });
 
@@ -158,7 +157,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
                 singletonList(createFieldMapper("nested1", "field")),
                 Arrays.asList(createNestedObjectMapper("nested1"), createNestedObjectMapper("nested2")),
                 singletonList(aliasMapper),
-                0, Lucene.STANDARD_ANALYZER);
+                0);
             aliasMapper.validate(mappers);
         });
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -36,7 +36,6 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
@@ -165,7 +164,6 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         TextFieldType fieldType = createFieldType();
-        fieldType.setIndexAnalyzer(Lucene.STANDARD_ANALYZER);
 
         assertEquals(org.elasticsearch.common.collect.List.of("value"), fetchSourceValue(fieldType, "value"));
         assertEquals(org.elasticsearch.common.collect.List.of("42"), fetchSourceValue(fieldType, 42L));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -37,8 +37,6 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.analysis.AnalyzerScope;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -108,9 +106,8 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     public void testSignificance() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
         textFieldType.setFielddata(true);
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
 
@@ -253,9 +250,8 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     public void testUnmapped() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
         textFieldType.setFielddata(true);
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -321,9 +317,8 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     public void testFieldAlias() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
         textFieldType.setFielddata(true);
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -34,10 +34,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.analysis.AnalyzerScope;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
-import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
@@ -80,14 +77,16 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
-        return Collections.singletonList(CoreValuesSourceType.BYTES);
+        return Arrays.asList(
+            CoreValuesSourceType.BOOLEAN,
+            CoreValuesSourceType.BYTES
+        );
     }
 
     @Override
     protected List<String> unsupportedMappedFieldTypes() {
-        return Arrays.asList(
-            BinaryFieldMapper.CONTENT_TYPE, // binary fields are not supported because they do not have analyzers
-            GeoPointFieldMapper.CONTENT_TYPE // geopoint fields cannot use term queries
+        return Collections.singletonList(
+            BinaryFieldMapper.CONTENT_TYPE // binary fields are not supported because they do not have analyzers
         );
     }
 
@@ -96,9 +95,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
      */
     public void testSignificance() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -147,9 +145,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
      */
     public void testIncludeExcludes() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
-
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -203,7 +199,6 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     public void testMissingField() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
         indexWriterConfig.setMaxBufferedDocs(100);
@@ -233,9 +228,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     public void testFieldAlias() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -284,9 +278,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     public void testInsideTermsAgg() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
@@ -343,9 +336,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
      */
     public void testSignificanceOnTextArrays() throws IOException {
         TextFieldType textFieldType = new TextFieldType("text");
-        textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
-        IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(new StandardAnalyzer());
         indexWriterConfig.setMaxBufferedDocs(100);
         indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -286,6 +286,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
         when(mapperService.hasNested()).thenReturn(false);
         when(mapperService.indexAnalyzer()).thenReturn(new StandardAnalyzer()); // for significant text
+        when(searchContext.mapperService()).thenReturn(mapperService);
         QueryShardContext queryShardContext =
             queryShardContextMock(contextIndexSearcher, mapperService, indexSettings, circuitBreakerService, bigArrays);
         when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -285,7 +285,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         MapperService mapperService = mapperServiceMock();
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
         when(mapperService.hasNested()).thenReturn(false);
-        when(searchContext.mapperService()).thenReturn(mapperService);
+        when(mapperService.indexAnalyzer()).thenReturn(new StandardAnalyzer()); // for significant text
         QueryShardContext queryShardContext =
             queryShardContextMock(contextIndexSearcher, mapperService, indexSettings, circuitBreakerService, bigArrays);
         when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
@@ -169,7 +169,6 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
             super(name, indexed, false, hasDocValues,
                 splitQueriesOnWhitespace ? TextSearchInfo.WHITESPACE_MATCH_ONLY : TextSearchInfo.SIMPLE_MATCH_ONLY,
                 meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.key = key;
         }
 
@@ -386,7 +385,6 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
             super(name, indexed, false, hasDocValues,
                 splitQueriesOnWhitespace ? TextSearchInfo.WHITESPACE_MATCH_ONLY : TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
             this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -421,7 +419,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
     private FlattenedFieldMapper(String simpleName,
                                  MappedFieldType mappedFieldType,
                                  Builder builder) {
-        super(simpleName, mappedFieldType, CopyTo.empty());
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, CopyTo.empty());
         this.builder = builder;
         this.fieldParser = new FlattenedFieldParser(mappedFieldType.name(), keyedFieldName(),
             mappedFieldType, builder.depthLimit.get(), builder.ignoreAbove.get(), builder.nullValue.get());

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -123,7 +123,6 @@ public class VersionStringFieldMapper extends FieldMapper {
 
         private VersionStringFieldType(String name, FieldType fieldType, Map<String, String> meta) {
             super(name, true, false, true, new TextSearchInfo(fieldType, null, Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER), meta);
-            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override
@@ -310,7 +309,7 @@ public class VersionStringFieldMapper extends FieldMapper {
         MultiFields multiFields,
         CopyTo copyTo
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, Lucene.KEYWORD_ANALYZER, multiFields, copyTo);
         this.fieldType = fieldType;
     }
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -249,14 +249,15 @@ public class WildcardFieldMapper extends FieldMapper {
 
         private final String nullValue;
         private final int ignoreAbove;
+        private final NamedAnalyzer analyzer;
 
         private WildcardFieldType(String name, String nullValue, int ignoreAbove,
                                   Version version, Map<String, String> meta) {
             super(name, true, false, true, Defaults.TEXT_SEARCH_INFO, meta);
             if (version.onOrAfter(Version.V_7_10_0)) {
-                setIndexAnalyzer(WILDCARD_ANALYZER_7_10);
+                this.analyzer = WILDCARD_ANALYZER_7_10;
             } else {
-                setIndexAnalyzer(WILDCARD_ANALYZER_7_9);
+                this.analyzer = WILDCARD_ANALYZER_7_9;
             }
             this.nullValue = nullValue;
             this.ignoreAbove = ignoreAbove;
@@ -640,7 +641,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 return;
             }
             // Break fragment into multiple Ngrams
-            TokenStream tokenizer = indexAnalyzer().tokenStream(name(), fragment);
+            TokenStream tokenizer = analyzer.tokenStream(name(), fragment);
             CharTermAttribute termAtt = tokenizer.addAttribute(CharTermAttribute.class);
             int foundTokens = 0;
             try {
@@ -659,7 +660,7 @@ public class WildcardFieldMapper extends FieldMapper {
             if (foundTokens == 0 && fragment.length() > 0) {
                 // fragment must have been less than NGRAM_SIZE - add a placeholder which may be used in a prefix query e.g. ab*
                 fragment = toLowerCase(fragment);
-                if (indexAnalyzer() == WILDCARD_ANALYZER_7_10) {
+                if (analyzer == WILDCARD_ANALYZER_7_10) {
                     fragment = PunctuationFoldingFilter.normalize(fragment);
                 }
                 tokens.add(fragment);
@@ -785,7 +786,7 @@ public class WildcardFieldMapper extends FieldMapper {
                     }
                 }
                 // Tokenize all content after the prefix
-                TokenStream tokenizer = indexAnalyzer().tokenStream(name(), postPrefixString);
+                TokenStream tokenizer = analyzer.tokenStream(name(), postPrefixString);
                 CharTermAttribute termAtt = tokenizer.addAttribute(CharTermAttribute.class);
                 ArrayList<String> postPrefixTokens = new ArrayList<>();
                 String firstToken = null;
@@ -929,10 +930,10 @@ public class WildcardFieldMapper extends FieldMapper {
     private final FieldType ngramFieldType;
     private final Version indexVersionCreated;
 
-    private WildcardFieldMapper(String simpleName, MappedFieldType mappedFieldType,
+    private WildcardFieldMapper(String simpleName, WildcardFieldType mappedFieldType,
                                 int ignoreAbove, MultiFields multiFields, CopyTo copyTo,
                                 String nullValue, Version indexVersionCreated) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, mappedFieldType.analyzer, multiFields, copyTo);
         this.nullValue = nullValue;
         this.ignoreAbove = ignoreAbove;
         this.indexVersionCreated = indexVersionCreated;


### PR DESCRIPTION
Index-time analyzers are currently specified on the MappedFieldType. This
has a number of unfortunate consequences; for example, field mappers that
index data into implementation sub-fields, such as prefix or phrase
accelerators on text fields, need to expose these sub-fields as MappedFieldTypes,
which means that they then appear in field caps, are externally searchable,
etc. It also adds index-time logic to a class that should only be concerned
with search-time behaviour.

This commit removes references to the index analyzer from MappedFieldType.
Instead, FieldMappers that use the terms index can pass either a single analyzer
or a Map of fields to analyzers to their super constructor, which are then
exposed via a new FieldMapper#indexAnalyzers() method; all index-time analysis
is mediated through the delegating analyzer wrapper on MapperService.
In a follow-up, this will make it possible to register multiple field analyzers from
a single FieldMapper, removing the need for 'hidden' mapper implementations
on text field, parent joins, and elsewhere.
