### PR TITLE
Fix DataTiersUsageTransportActionTests testCalculateMAD

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -26,10 +26,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DataTiersUsageTransportActionTests extends ESTestCase {
+
     public void testCalculateMAD() {
         assertThat(DataTiersUsageTransportAction.computeMedianAbsoluteDeviation(new TDigestState(10)), equalTo(0L));
 
-        TDigestState sketch = new TDigestState(randomDoubleBetween(0, 1000, false));
+        TDigestState sketch = new TDigestState(randomDoubleBetween(1, 1000, false));
         sketch.add(1);
         sketch.add(1);
         sketch.add(2);


### PR DESCRIPTION
Random the compression factor starting with 1 (to elimitinate nearly 0 values)
which will only use one centroid (and yield 0 for MAD as the aproximate median
is the same as the single centroid mean value)

Fixes #64149 