### PR TITLE
[DOC] Fix small typo in fields doc

### DIFF
--- a/docs/reference/mapping/fields.asciidoc
+++ b/docs/reference/mapping/fields.asciidoc
@@ -29,7 +29,7 @@ fields can be customized when a mapping is created.
     The size of the `_source` field in bytes, provided by the
     {plugins}/mapper-size.html[`mapper-size` plugin].
 
-q[discrete]
+[discrete]
 === Doc count metadata field
 
 <<mapping-doc-count-field,`_doc_count`>>::


### PR DESCRIPTION
Fix typo in documentation page for fields