### PR TITLE
Mute ObjectMapperMergeTests.testMerge() test

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -117,6 +117,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         }));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/64607")
     public void testMerge() throws IOException {
         MergeReason reason = randomFrom(MergeReason.values());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));


### PR DESCRIPTION
Mute test `ObjectMapperMergeTests.testMerge()` for issue #64607