### PR TITLE
[7.x] Add supports for upper and lower values on boxplot based on the IQR value (#63617)

### DIFF
--- a/docs/reference/aggregations/metrics/boxplot-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/boxplot-aggregation.asciidoc
@@ -59,12 +59,20 @@ The response will look like this:
       "max": 990.0,
       "q1": 165.0,
       "q2": 445.0,
-      "q3": 725.0
+      "q3": 725.0,
+      "lower": 0.0,
+      "upper": 990.0
     }
   }
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
+
+In this case, the lower and upper whisker values are equal to the min and max.  In general, these values are the 1.5 *
+IQR range, which is to say the nearest values to `q1 - (1.5 * IQR)` and `q3 + (1.5 * IQR)`.  Since this is an approximation, the given values
+may not actually be observed values from the data, but should be within a reasonable error bound of them.  While the Boxplot aggregation
+doesn't directly return outlier points, you can check if `lower > min` or `upper < max` to see if outliers exist on either side, and then
+query for them directly.
 
 ==== Script
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -116,7 +116,8 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
     public void testIQR() {
         double epsilon = 0.00001; // tolerance on equality for doubles
         TDigestState state = new TDigestState(100);
-        for (double value : List.of(52, 57, 57, 58, 63, 66, 66, 67, 67, 68, 69, 70, 70, 70, 70, 72, 73, 75, 75, 76, 76, 78, 79, 89)) {
+        for (double value : org.elasticsearch.common.collect.List.of(52, 57, 57, 58, 63, 66, 66, 67, 67, 68, 69, 70, 70, 70, 70, 72, 73, 75,
+                                                                     75, 76, 76, 78, 79, 89)) {
             state.add(value);
         }
         double[] actual = InternalBoxplot.whiskers(state);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -113,15 +113,34 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
         return extendedNamedXContents;
     }
 
+    public void testIQR() {
+        double epsilon = 0.00001; // tolerance on equality for doubles
+        TDigestState state = new TDigestState(100);
+        for (double value : List.of(52, 57, 57, 58, 63, 66, 66, 67, 67, 68, 69, 70, 70, 70, 70, 72, 73, 75, 75, 76, 76, 78, 79, 89)) {
+            state.add(value);
+        }
+        double[] actual = InternalBoxplot.whiskers(state);
+        assertEquals(57.0, actual[0], epsilon);
+        assertEquals(79.0, actual[1], epsilon);
+
+        // Test null state
+        actual = InternalBoxplot.whiskers(null);
+        assertNotNull(actual);
+        assertTrue(Double.isNaN(actual[0]));
+        assertTrue(Double.isNaN(actual[1]));
+    }
+
     public void testIterator() {
         InternalBoxplot aggregation = createTestInstance("test", emptyMap());
         List<String> names = StreamSupport.stream(aggregation.valueNames().spliterator(), false).collect(Collectors.toList());
 
-        assertEquals(5, names.size());
+        assertEquals(7, names.size());
         assertTrue(names.contains("min"));
         assertTrue(names.contains("max"));
         assertTrue(names.contains("q1"));
         assertTrue(names.contains("q2"));
         assertTrue(names.contains("q3"));
+        assertTrue(names.contains("lower"));
+        assertTrue(names.contains("upper"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add supports for upper and lower values on boxplot based on the IQR value (#63617)