### PR TITLE
[docs] POST /_aliases remove_index action only works on concrete indices

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -62,7 +62,8 @@ Adds an alias to an index.
 Removes an alias from an index.
 
 `remove_index`::
-Deletes a concrete index. Similar to the <<indices-delete-index, delete index API>>, but if the provided index is an alias, the action will fail.
+Deletes a concrete index, similar to the <<indices-delete-index, delete index
+API>>. Attempts to remove an index alias will fail.
 
 You can perform these actions on alias objects.
 Valid parameters for alias objects include:

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -62,8 +62,7 @@ Adds an alias to an index.
 Removes an alias from an index.
 
 `remove_index`::
-Deletes an index or index alias,
-like the <<indices-delete-index,delete index API>>.
+Deletes a concrete index. Similar to the <<indices-delete-index, delete index API>>, but if the provided index is an alias, the action will fail.
 
 You can perform these actions on alias objects.
 Valid parameters for alias objects include:
@@ -287,7 +286,7 @@ POST /_aliases
 
 <1> An index we've added by mistake
 <2> The index we should have added
-<3> `remove_index` is just like <<indices-delete-index>>
+<3> `remove_index` is just like <<indices-delete-index>> but will only remove a concrete index.
 
 [[filtered]]
 ===== Filtered aliases


### PR DESCRIPTION
```
$ curl -X PUT "elastic:changeme@localhost:9200/.kibana_1"
{"acknowledged":true,"shards_acknowledged":true,"index":".kibana_1"}
$ curl -X PUT "elastic:changeme@localhost:9200/.kibana_1/_alias/.kibana"
{"acknowledged":true}
$ curl -X POST "elastic:changeme@localhost:9200/_aliases" -H 'Content-Type: application/json' -d'
{
  "actions" : [
    { "remove_index": { "indices": ".kibana" } }
  ]
}
'
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"The provided expression [.kibana] matches an alias, specify the corresponding concrete indices instead."}],"type":"illegal_argument_exception","reason":"The provided expression [.kibana] matches an alias, specify the corresponding concrete indices instead."},"status":400}
```