### PR TITLE
Simplify triangle tree writer (#64572)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
@@ -7,8 +7,10 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -20,36 +22,43 @@ import java.util.List;
  */
 class TriangleTreeWriter {
 
-    private final TriangleTreeNode node;
-    private final Extent extent;
-
-    TriangleTreeWriter(List<ShapeField.DecodedTriangle> triangles) {
-        this.extent = new Extent();
-        this.node = build(triangles);
+    private TriangleTreeWriter() {
     }
 
     /*** Serialize the interval tree in the provided data output */
-    public void writeTo(ByteBuffersDataOutput out) throws IOException {
+    public static void writeTo(ByteBuffersDataOutput out, List<IndexableField> fields) throws IOException {
+        final Extent extent = new Extent();
+        final TriangleTreeNode node = build(fields, extent); ;
         extent.writeCompressed(out);
         node.writeTo(out);
     }
 
-    private TriangleTreeNode build(List<ShapeField.DecodedTriangle> triangles) {
-        if (triangles.size() == 1) {
-            TriangleTreeNode triangleTreeNode =  new TriangleTreeNode(triangles.get(0));
+    private static TriangleTreeNode build(List<IndexableField> fields, Extent extent) {
+        final byte[] scratch = new byte[7 * Integer.BYTES];
+        if (fields.size() == 1) {
+            final TriangleTreeNode triangleTreeNode =  new TriangleTreeNode(toDecodedTriangle(fields.get(0), scratch));
             extent.addRectangle(triangleTreeNode.minX, triangleTreeNode.minY, triangleTreeNode.maxX, triangleTreeNode.maxY);
             return triangleTreeNode;
         }
-        TriangleTreeNode[] nodes = new TriangleTreeNode[triangles.size()];
-        for (int i = 0; i < triangles.size(); i++) {
-            nodes[i] = new TriangleTreeNode(triangles.get(i));
+        final TriangleTreeNode[] nodes = new TriangleTreeNode[fields.size()];
+        for (int i = 0; i < fields.size(); i++) {
+            nodes[i] = new TriangleTreeNode(toDecodedTriangle(fields.get(i), scratch));
             extent.addRectangle(nodes[i].minX, nodes[i].minY, nodes[i].maxX, nodes[i].maxY);
         }
-        return createTree(nodes, 0, triangles.size() - 1, true);
+        return createTree(nodes, 0, fields.size() - 1, true);
+    }
+
+    private static ShapeField.DecodedTriangle toDecodedTriangle(IndexableField field, byte[] scratch) {
+        final BytesRef bytesRef = field.binaryValue();
+        assert bytesRef.length == 7 * Integer.BYTES;
+        System.arraycopy(bytesRef.bytes, bytesRef.offset, scratch, 0, 7 * Integer.BYTES);
+        final ShapeField.DecodedTriangle decodedTriangle = new ShapeField.DecodedTriangle();
+        ShapeField.decodeTriangle(scratch, decodedTriangle);
+        return decodedTriangle;
     }
 
     /** Creates tree from sorted components (with range low and high inclusive) */
-    private TriangleTreeNode createTree(TriangleTreeNode[] components, int low, int high, boolean splitX) {
+    private static TriangleTreeNode createTree(TriangleTreeNode[] components, int low, int high, boolean splitX) {
         if (low > high) {
             return null;
         }
@@ -95,8 +104,6 @@ class TriangleTreeWriter {
         private TriangleTreeNode right;
         /** root node of edge tree */
         private final ShapeField.DecodedTriangle component;
-        /** component type */
-        private final ShapeField.DecodedTriangle.TYPE type;
 
         private TriangleTreeNode(ShapeField.DecodedTriangle component) {
             this.minY = Math.min(Math.min(component.aY, component.bY), component.cY);
@@ -104,7 +111,6 @@ class TriangleTreeWriter {
             this.minX = Math.min(Math.min(component.aX, component.bX), component.cX);
             this.maxX = Math.max(Math.max(component.aX, component.bX), component.cX);
             this.component = component;
-            this.type = component.type;
         }
 
         private void writeTo(ByteBuffersDataOutput out) throws IOException {
@@ -141,9 +147,9 @@ class TriangleTreeWriter {
             byte metadata = 0;
             metadata |= (left != null) ? (1 << 0) : 0;
             metadata |= (right != null) ? (1 << 1) : 0;
-            if (type == ShapeField.DecodedTriangle.TYPE.POINT) {
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
                 metadata |= (1 << 2);
-            } else if (type == ShapeField.DecodedTriangle.TYPE.LINE) {
+            } else if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
                 metadata |= (1 << 3);
                 metadata |= (component.ab) ? (1 << 4) : 0;
             } else {
@@ -157,12 +163,12 @@ class TriangleTreeWriter {
         private void writeComponent(ByteBuffersDataOutput out) throws IOException {
             out.writeVLong((long) maxX - component.aX);
             out.writeVLong((long) maxY - component.aY);
-            if (type == ShapeField.DecodedTriangle.TYPE.POINT) {
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
                return;
             }
             out.writeVLong((long) maxX - component.bX);
             out.writeVLong((long) maxY - component.bY);
-            if (type == ShapeField.DecodedTriangle.TYPE.LINE) {
+            if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
                 return;
             }
             out.writeVLong((long) maxX - component.cX);
@@ -196,10 +202,10 @@ class TriangleTreeWriter {
 
         private int componentSize(ByteBuffersDataOutput scratchBuffer) throws IOException {
             scratchBuffer.reset();
-            if (type == ShapeField.DecodedTriangle.TYPE.POINT) {
+            if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
                 scratchBuffer.writeVLong((long) maxX - component.aX);
                 scratchBuffer.writeVLong((long) maxY - component.aY);
-            } else if (type == ShapeField.DecodedTriangle.TYPE.LINE) {
+            } else if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
                 scratchBuffer.writeVLong((long) maxX - component.aX);
                 scratchBuffer.writeVLong((long) maxY - component.aY);
                 scratchBuffer.writeVLong((long) maxX - component.bX);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/BinaryGeoShapeDocValuesField.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/BinaryGeoShapeDocValuesField.java
@@ -6,8 +6,7 @@
 
 package org.elasticsearch.xpack.spatial.index.mapper;
 
-import org.apache.lucene.document.ShapeField;
-import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.index.mapper.CustomDocValuesField;
@@ -17,33 +16,29 @@ import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueWriter;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class BinaryGeoShapeDocValuesField extends CustomDocValuesField {
 
-    private final List<ShapeField.DecodedTriangle> triangles;
+    private final List<IndexableField> fields;
     private final CentroidCalculator centroidCalculator;
 
-    public BinaryGeoShapeDocValuesField(String name, ShapeField.DecodedTriangle[] triangles, CentroidCalculator centroidCalculator) {
+    public BinaryGeoShapeDocValuesField(String name, List<IndexableField> fields, CentroidCalculator centroidCalculator) {
         super(name);
-        this.triangles = new ArrayList<>(triangles.length);
+        this.fields = new ArrayList<>(fields.size());
         this.centroidCalculator = centroidCalculator;
-        this.triangles.addAll(Arrays.asList(triangles));
+        this.fields.addAll(fields);
     }
 
-    public void add(ShapeField.DecodedTriangle[] triangles, CentroidCalculator centroidCalculator) {
-        this.triangles.addAll(Arrays.asList(triangles));
+    public void add( List<IndexableField> fields, CentroidCalculator centroidCalculator) {
+        this.fields.addAll(fields);
         this.centroidCalculator.addFrom(centroidCalculator);
     }
 
     @Override
     public BytesRef binaryValue() {
         try {
-            final GeometryDocValueWriter writer = new GeometryDocValueWriter(triangles, CoordinateEncoder.GEO, centroidCalculator);
-            final ByteBuffersDataOutput output = new ByteBuffersDataOutput();
-            writer.writeTo(output);
-            return new BytesRef(output.toArrayCopy(), 0, Math.toIntExact(output.size()));
+            return GeometryDocValueWriter.write(fields, CoordinateEncoder.GEO, centroidCalculator);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to encode shape", e);
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
 import org.elasticsearch.xpack.spatial.index.fielddata.DimensionalShapeType;
-import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
@@ -159,7 +158,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
             for (Geometry geometry : geometries) {
                 Document document = new Document();
                 CentroidCalculator calculator = new CentroidCalculator(geometry);
-                document.add(new BinaryGeoShapeDocValuesField("field", GeoTestUtils.toDecodedTriangles(geometry), calculator));
+                document.add(GeoTestUtils.binaryGeoShapeDocValuesField("field", geometry));
                 w.addDocument(document);
                 if (targetShapeType.compareTo(calculator.getDimensionalShapeType()) == 0) {
                     double weight = calculator.sumWeight();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueTests.java
@@ -94,7 +94,7 @@ public class GeometryDocValueTests extends ESTestCase {
             int minY = randomIntBetween(-40, -1);
             int maxY = randomIntBetween(1, 40);
             Geometry rectangle = new Rectangle(minX, maxX, maxY, minY);
-            GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(rectangle, CoordinateEncoder.GEO);
+            GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(rectangle, CoordinateEncoder.GEO);
 
             Extent expectedExtent  = getExtentFromBox(minX, minY, maxX, maxY);
             assertThat(expectedExtent, equalTo(reader.getExtent()));
@@ -115,7 +115,7 @@ public class GeometryDocValueTests extends ESTestCase {
     }
 
     private static void assertDimensionalShapeType(Geometry geometry, DimensionalShapeType expected) throws IOException {
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         assertThat(reader.getDimensionalShapeType(), equalTo(expected));
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
@@ -42,7 +42,7 @@ public class Tile2DVisitorTests extends ESTestCase {
 
         // test cell crossing poly
         Polygon pacMan = new Polygon(new LinearRing(py, px), Collections.emptyList());
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(pacMan, TestCoordinateEncoder.INSTANCE);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(pacMan, TestCoordinateEncoder.INSTANCE);
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
@@ -54,7 +54,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         Polygon polyWithHole = new Polygon(new LinearRing(new double[]{-50, 50, 50, -50, -50}, new double[]{-50, -50, 50, 50, -50}),
             Collections.singletonList(new LinearRing(new double[]{-10, 10, 10, -10, -10}, new double[]{-10, -10, 10, 10, -10})));
 
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
 
         assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(6, -6, 6, -6)); // in the hole
         assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(25, -25, 25, -25)); // on the mainland
@@ -72,7 +72,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         double[] hy = {1, 20, 20, 1, 1};
 
         Polygon polyWithHole = new Polygon(new LinearRing(px, py), Collections.singletonList(new LinearRing(hx, hy)));
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(polyWithHole, CoordinateEncoder.GEO);
         // test cell crossing poly
         assertRelation(GeoRelation.QUERY_INSIDE, reader, getExtentFromBox(5, 10, 5, 10));
         assertRelation(GeoRelation.QUERY_DISJOINT, reader, getExtentFromBox(15, 10, 15, 10));
@@ -85,7 +85,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5, 0};
 
         // test cell crossing poly
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
@@ -98,7 +98,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         double[] py = {0, 5, 9, 10, 9, 0, -9, -10, -9, -5};
 
         // test cell crossing poly
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(new Line(px, py), CoordinateEncoder.GEO);
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(2, -1, 11, 1));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-12, -12, 12, 12));
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(-2, -1, 2, 0));
@@ -128,7 +128,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         int yMax = 9;
 
         // test cell crossing poly
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(new MultiPoint(points), CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(new MultiPoint(points), CoordinateEncoder.GEO);
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(xMin, yMin, xMax, yMax));
     }
 
@@ -136,11 +136,11 @@ public class Tile2DVisitorTests extends ESTestCase {
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         MultiLine geometry = randomMultiLine(false);
         geometry = (MultiLine) indexer.prepareForIndexing(geometry);
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = GeoTestUtils.geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         Extent readerExtent = reader.getExtent();
 
         for (Line line : geometry) {
-            Extent lineExtent = GeoTestUtils.GeometryDocValueReader(line, CoordinateEncoder.GEO).getExtent();
+            Extent lineExtent = GeoTestUtils.geometryDocValueReader(line, CoordinateEncoder.GEO).getExtent();
             if (lineExtent.minX() != Integer.MIN_VALUE && lineExtent.maxX() != Integer.MAX_VALUE
                 && lineExtent.minY() != Integer.MIN_VALUE && lineExtent.maxY() != Integer.MAX_VALUE) {
                 assertRelation(GeoRelation.QUERY_CROSSES, reader, Extent.fromPoints(lineExtent.minX() - 1, lineExtent.minY() - 1,
@@ -202,7 +202,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         Extent bufferBounds = bufferedExtentFromGeoPoint(p.getX(), p.getY(), extentSize);
         Tile2DVisitor tile2DVisitor = new Tile2DVisitor();
         tile2DVisitor.reset(bufferBounds.minX(), bufferBounds.minY(), bufferBounds.maxX(), bufferBounds.maxY());
-        GeoTestUtils.GeometryDocValueReader(g, CoordinateEncoder.GEO).visit(tile2DVisitor);
+        GeoTestUtils.geometryDocValueReader(g, CoordinateEncoder.GEO).visit(tile2DVisitor);
         return tile2DVisitor.relation() == GeoRelation.QUERY_CROSSES || tile2DVisitor.relation() == GeoRelation.QUERY_INSIDE;
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
@@ -6,13 +6,16 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -20,11 +23,18 @@ public class TriangleTreeTests extends ESTestCase {
 
     public void testVisitAllTriangles() throws IOException {
         Geometry geometry = GeometryTestUtils.randomGeometryWithoutCircle(randomIntBetween(1, 10), false);
-        ShapeField.DecodedTriangle[] triangles = GeoTestUtils.toDecodedTriangles(geometry);
-        GeometryDocValueReader reader = GeoTestUtils.GeometryDocValueReader(geometry, TestCoordinateEncoder.INSTANCE);
+        // write tree
+        GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
+        List<IndexableField> fieldList = indexer.indexShape(null, indexer.prepareForIndexing(geometry));
+        ByteBuffersDataOutput output = new ByteBuffersDataOutput();
+        TriangleTreeWriter.writeTo(output, fieldList);
+        // read tree
+        ByteArrayDataInput input = new ByteArrayDataInput(output.toArrayCopy());
+        Extent extent = new Extent();
+        Extent.readFromCompressed(input, extent);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();
-        reader.visit(visitor);
-        assertThat(triangles.length, equalTo(visitor.counter));
+        TriangleTreeReader.visit(input, visitor, extent.maxX(), extent.maxY());
+        assertThat(fieldList.size(), equalTo(visitor.counter));
     }
 
     private static class TriangleCounterVisitor implements TriangleTreeReader.Visitor  {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils.
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.encodeDecodeLat;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.encodeDecodeLon;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.randomBBox;
-import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.GeometryDocValueReader;
+import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geometryDocValueReader;
 import static org.hamcrest.Matchers.equalTo;
 
 public class GeoGridTilerTests extends ESTestCase {
@@ -63,7 +63,7 @@ public class GeoGridTilerTests extends ESTestCase {
         Rectangle tile = GeoTileUtils.toBoundingBox(1309, 3166, 13);
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
-        GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = geometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
         GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         // test shape within tile bounds
         {
@@ -115,7 +115,7 @@ public class GeoGridTilerTests extends ESTestCase {
                 }
             }, () -> boxToGeo(randomBBox())));
 
-            GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+            GeometryDocValueReader reader = geometryDocValueReader(geometry, CoordinateEncoder.GEO);
             GeoBoundingBox geoBoundingBox = randomBBox();
             GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues cellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
@@ -142,7 +142,7 @@ public class GeoGridTilerTests extends ESTestCase {
                 }
             }, () -> boxToGeo(randomBBox())));
 
-            GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+            GeometryDocValueReader reader = geometryDocValueReader(geometry, CoordinateEncoder.GEO);
             GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
@@ -175,7 +175,7 @@ public class GeoGridTilerTests extends ESTestCase {
             if (point.getX() == GeoUtils.MAX_LON || point.getY() == -LATITUDE_MASK) {
                 continue;
             }
-            GeometryDocValueReader reader = GeometryDocValueReader(point, CoordinateEncoder.GEO);
+            GeometryDocValueReader reader = geometryDocValueReader(point, CoordinateEncoder.GEO);
             GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
@@ -196,7 +196,7 @@ public class GeoGridTilerTests extends ESTestCase {
 
         Rectangle shapeRectangle = new Rectangle(tile.getMinX() + 0.00001, tile.getMaxX() - 0.00001,
             tile.getMaxY() - 0.00001,  tile.getMinY() + 0.00001);
-        GeometryDocValueReader reader = GeometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = geometryDocValueReader(shapeRectangle, CoordinateEncoder.GEO);
         GeoShapeValues.GeoShapeValue value =  new GeoShapeValues.GeoShapeValue(reader);
 
         // test shape within tile bounds
@@ -315,7 +315,7 @@ public class GeoGridTilerTests extends ESTestCase {
         int precision = randomIntBetween(1, 4);
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
-        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOTILE, NOOP_BREAKER);
         int recursiveCount;
@@ -345,7 +345,7 @@ public class GeoGridTilerTests extends ESTestCase {
         int precision = randomIntBetween(1, 3);
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         geometry = indexer.prepareForIndexing(geometry);
-        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
         GeoShapeCellValues recursiveValues = new GeoShapeCellValues(null, precision, GEOHASH, NOOP_BREAKER);
         int recursiveCount;
@@ -466,7 +466,7 @@ public class GeoGridTilerTests extends ESTestCase {
     private void testCircuitBreaker(GeoGridTiler tiler) throws IOException {
         Geometry geometry = GeometryTestUtils.randomPolygon(false);
         int precision = randomIntBetween(0, 3);
-        GeometryDocValueReader reader = GeometryDocValueReader(geometry, CoordinateEncoder.GEO);
+        GeometryDocValueReader reader = geometryDocValueReader(geometry, CoordinateEncoder.GEO);
         GeoShapeValues.GeoShapeValue value =  new GeoShapeValues.GeoShapeValue(reader);
 
         List<Long> byteChangeHistory = new ArrayList<>();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
-import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
 import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeometryDocValueReader;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
@@ -58,7 +57,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.GeometryDocValueReader;
+import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.binaryGeoShapeDocValuesField;
+import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geometryDocValueReader;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>> extends AggregatorTestCase {
@@ -119,9 +119,9 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
 
     public void testUnmapped() throws IOException {
         testCase(new MatchAllDocsQuery(), "wrong_field", randomPrecision(), null, iw -> {
-            iw.addDocument(Collections.singleton(
-                new BinaryGeoShapeDocValuesField(FIELD_NAME, GeoTestUtils.toDecodedTriangles(new Point(10D, 10D)),
-                    new CentroidCalculator(new Point(10D, 10D)))));
+            iw.addDocument(
+                Collections.singleton(GeoTestUtils.binaryGeoShapeDocValuesField(FIELD_NAME, new Point(10D, 10D)))
+            );
         }, geoGrid -> {
             assertEquals(0, geoGrid.getBuckets().size());
         });
@@ -135,9 +135,9 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             .missing("-34.0,53.4");
         testCase(new MatchAllDocsQuery(), 1, null,
             iw -> {
-                iw.addDocument(Collections.singleton(
-                    new BinaryGeoShapeDocValuesField(FIELD_NAME, GeoTestUtils.toDecodedTriangles(new Point(10D, 10D)),
-                        new CentroidCalculator(new Point(10D, 10D)))));
+                iw.addDocument(
+                    Collections.singleton(GeoTestUtils.binaryGeoShapeDocValuesField(FIELD_NAME, new Point(10D, 10D)))
+                );
             },
             geoGrid -> assertEquals(1, geoGrid.getBuckets().size()), builder);
     }
@@ -192,7 +192,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             double y = GeoTestUtils.encodeDecodeLat(p.getY());
             Rectangle pointTile = getTile(x, y, precision);
 
-            GeometryDocValueReader reader = GeometryDocValueReader(p, CoordinateEncoder.GEO);
+            GeometryDocValueReader reader = geometryDocValueReader(p, CoordinateEncoder.GEO);
             GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue(reader);
             GeoRelation tileRelation =  value.relate(pointTile);
             boolean intersectsBounds = boundsTop >= pointTile.getMinY() && boundsBottom <= pointTile.getMaxY()
@@ -203,8 +203,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             }
 
             points.add(p);
-            docs.add(new BinaryGeoShapeDocValuesField(FIELD_NAME,
-                GeoTestUtils.toDecodedTriangles(p), new CentroidCalculator(p)));
+            docs.add(binaryGeoShapeDocValuesField(FIELD_NAME, p));
         }
 
         final long numDocsInBucket = numDocsWithin;
@@ -252,8 +251,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
                 distinctHashesPerDoc.add(hash);
                 if (usually()) {
                     Geometry geometry = new MultiPoint(new ArrayList<>(shapes));
-                    document.add(new BinaryGeoShapeDocValuesField(FIELD_NAME,
-                        GeoTestUtils.toDecodedTriangles(geometry), new CentroidCalculator(geometry)));
+                    document.add(binaryGeoShapeDocValuesField(FIELD_NAME, geometry));
                     iw.addDocument(document);
                     shapes.clear();
                     distinctHashesPerDoc.clear();
@@ -262,8 +260,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
             }
             if (shapes.size() != 0) {
                 Geometry geometry = new MultiPoint(new ArrayList<>(shapes));
-                document.add(new BinaryGeoShapeDocValuesField(FIELD_NAME,
-                    GeoTestUtils.toDecodedTriangles(geometry), new CentroidCalculator(geometry)));
+                document.add(binaryGeoShapeDocValuesField(FIELD_NAME, geometry));
                 iw.addDocument(document);
             }
         }, geoHashGrid -> {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -30,8 +30,6 @@ import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
-import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
-import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
@@ -193,8 +191,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                     }
                 }
                 Geometry geometry = new MultiPoint(points);
-                doc.add(new BinaryGeoShapeDocValuesField("field", GeoTestUtils.toDecodedTriangles(geometry),
-                    new CentroidCalculator(geometry)));
+                doc.add(GeoTestUtils.binaryGeoShapeDocValuesField("field", geometry));
                 w.addDocument(doc);
             }
             GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")


### PR DESCRIPTION
This change delays the decoding of the indexed triangles to the tree writer so we do not need to do it up front. In addition it changes the tree writing classes to static methods.

backport #64572