### PR TITLE
Dry up TransportResponseHandler (#64395)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -485,11 +485,6 @@ public class CancellableTasksIT extends ESIntegTestCase {
                                 }
 
                                 @Override
-                                public String executor() {
-                                    return ThreadPool.Names.SAME;
-                                }
-
-                                @Override
                                 public TestResponse read(StreamInput in) throws IOException {
                                     return new TestResponse(in);
                                 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -272,11 +272,6 @@ public class TransportFieldCapabilitiesIndexAction
                         }
 
                         @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
-                        }
-
-                        @Override
                         public void handleResponse(final FieldCapabilitiesIndexResponse response) {
                             if (response.canMatch()) {
                                 listener.onResponse(response);

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -54,7 +54,7 @@ import java.util.stream.Stream;
 public class TransportResyncReplicationAction extends TransportWriteAction<ResyncReplicationRequest,
     ResyncReplicationRequest, ResyncReplicationResponse> implements PrimaryReplicaSyncer.SyncAction {
 
-    private static String ACTION_NAME = "internal:index/seq_no/resync";
+    private static final String ACTION_NAME = "internal:index/seq_no/resync";
     private static final Function<IndexShard, String> EXECUTOR_NAME_FUNCTION = shard -> {
         if (shard.indexSettings().getIndexMetadata().isSystem()) {
             return Names.SYSTEM_WRITE;
@@ -167,11 +167,6 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                 @Override
                 public ResyncReplicationResponse read(StreamInput in) throws IOException {
                     return newResponseInstance(in);
-                }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -184,11 +184,6 @@ public abstract class TransportBroadcastAction<
                                 }
 
                                 @Override
-                                public String executor() {
-                                    return ThreadPool.Names.SAME;
-                                }
-
-                                @Override
                                 public void handleResponse(ShardResponse response) {
                                     onOperation(shard, shardIndex, response);
                                 }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -44,7 +44,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NodeShouldNotConnectException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -335,11 +334,6 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                     @Override
                     public void handleException(TransportException exp) {
                         onNodeFailure(node, nodeIndex, exp);
-                    }
-
-                    @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
                     }
                 });
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -230,11 +230,6 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                                 public void handleException(TransportException exp) {
                                     onFailure(idx, node.getId(), exp);
                                 }
-
-                                @Override
-                                public String executor() {
-                                    return ThreadPool.Names.SAME;
-                                }
                             });
                 } catch (Exception e) {
                     onFailure(idx, nodeId, e);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -803,11 +803,6 @@ public abstract class TransportReplicationAction<
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
-
-                @Override
                 public void handleResponse(Response response) {
                     finishOnSuccess(response);
                 }

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -199,11 +199,6 @@ public abstract class TransportInstanceSingleOperationAction<
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
-
-                @Override
                 public void handleResponse(Response response) {
                     listener.onResponse(response);
                 }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -183,11 +183,6 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
                     public void handleResponse(final Response response) {
                         listener.onResponse(response);
                     }
@@ -249,11 +244,6 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
                         @Override
                         public Response read(StreamInput in) throws IOException {
                             return reader.read(in);
-                        }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
                         }
 
                         @Override

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NodeShouldNotConnectException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -276,11 +275,6 @@ public abstract class TransportTasksAction<
                                     @Override
                                     public void handleException(TransportException exp) {
                                         onFailure(idx, node.getId(), exp);
-                                    }
-
-                                    @Override
-                                    public String executor() {
-                                        return ThreadPool.Names.SAME;
                                     }
                                 });
                         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -45,6 +45,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -316,14 +317,10 @@ public class FollowersChecker {
             }
             transportService.sendRequest(discoveryNode, actionName, transportRequest,
                 TransportRequestOptions.builder().withTimeout(followerCheckTimeout).withType(Type.PING).build(),
-                new TransportResponseHandler<Empty>() {
-                    @Override
-                    public Empty read(StreamInput in) {
-                        return Empty.INSTANCE;
-                    }
+                new TransportResponseHandler.Empty() {
 
                     @Override
-                    public void handleResponse(Empty response) {
+                    public void handleResponse(TransportResponse.Empty response) {
                         if (running() == false) {
                             logger.trace("{} no longer running", FollowerChecker.this);
                             return;
@@ -361,12 +358,6 @@ public class FollowersChecker {
                         }
 
                         failNode(reason);
-                    }
-
-
-                    @Override
-                    public String executor() {
-                        return Names.SAME;
                     }
                 });
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -247,16 +247,10 @@ public class LeaderChecker {
             // TransportResponse.Empty here.
             transportService.sendRequest(leader, actionName, transportRequest,
                 TransportRequestOptions.builder().withTimeout(leaderCheckTimeout).withType(Type.PING).build(),
-
-                new TransportResponseHandler<TransportResponse.Empty>() {
-
-                    @Override
-                    public Empty read(StreamInput in) {
-                        return Empty.INSTANCE;
-                    }
+                new TransportResponseHandler.Empty() {
 
                     @Override
-                    public void handleResponse(Empty response) {
+                    public void handleResponse(TransportResponse.Empty response) {
                         if (isClosed.get()) {
                             logger.debug("closed check scheduler received a response, doing nothing");
                             return;
@@ -297,11 +291,6 @@ public class LeaderChecker {
                         logger.debug(new ParameterizedMessage("{} consecutive failures (limit [{}] is {}) with leader [{}]",
                             failureCount, LEADER_CHECK_RETRY_COUNT_SETTING.getKey(), leaderCheckRetryCount, leader), exp);
                         scheduleNextWakeUp();
-                    }
-
-                    @Override
-                    public String executor() {
-                        return Names.SAME;
                     }
                 });
         }

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -119,11 +119,6 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
                     public void handleResponse(ReplicationResponse response) {
                         task.setPhase("finished");
                         taskManager.unregister(task);

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -121,11 +121,6 @@ public class RetentionLeaseSyncAction extends
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
                     public void handleResponse(ReplicationResponse response) {
                         task.setPhase("finished");
                         taskManager.unregister(task);

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -264,11 +264,6 @@ public class IndicesStore implements ClusterStateListener, Closeable {
             }
         }
 
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
-
         private void allNodesResponded() {
             if (activeCopies.get() != expectedActiveCopies) {
                 logger.trace("not deleting shard {}, expected {} active copies, but only {} found active copies",

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -467,11 +467,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     public void handleException(TransportException exp) {
                         reqListener.onFailure(exp);
                     }
-
-                    @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
                 })
         );
     }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -146,11 +146,6 @@ final class RemoteClusterConnection implements Closeable {
                         public void handleException(TransportException exp) {
                             contextPreservingActionListener.onFailure(exp);
                         }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
-                        }
                     });
             }
         };

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -92,11 +92,6 @@ public final class TransportActionProxy {
                 throw new UncheckedIOException(e);
             }
         }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
     }
 
     static class ProxyRequest<T extends TransportRequest> extends TransportRequest {

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -150,11 +150,6 @@ final class TransportHandshaker {
                 listener.onFailure(e);
             }
         }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
     }
 
     static final class HandshakeRequest extends TransportRequest {

--- a/server/src/main/java/org/elasticsearch/transport/TransportResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportResponseHandler.java
@@ -21,6 +21,7 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -31,7 +32,9 @@ public interface TransportResponseHandler<T extends TransportResponse> extends W
 
     void handleException(TransportException exp);
 
-    String executor();
+    default String executor() {
+        return ThreadPool.Names.SAME;
+    }
 
     default <Q extends TransportResponse> TransportResponseHandler<Q> wrap(Function<Q, T> converter, Writeable.Reader<Q> reader) {
         final TransportResponseHandler<T> self = this;
@@ -56,5 +59,15 @@ public interface TransportResponseHandler<T extends TransportResponse> extends W
                 return reader.read(in);
             }
         };
+    }
+
+    /**
+     * Implementations of {@link TransportResponseHandler} that handles the empty response {@link TransportResponse.Empty}.
+     */
+    abstract class Empty implements TransportResponseHandler<TransportResponse.Empty> {
+        @Override
+        public final TransportResponse.Empty read(StreamInput in) {
+            return TransportResponse.Empty.INSTANCE;
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -46,7 +46,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -536,11 +535,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
             @Override
             public void handleException(TransportException exp) {
                 onException.accept(exp);
-            }
-
-            @Override
-            public String executor() {
-                return Names.SAME;
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -40,7 +40,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -198,11 +197,6 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
             @Override
             public void handleException(TransportException exp) {
                 onException.accept(exp);
-            }
-
-            @Override
-            public String executor() {
-                return Names.SAME;
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -203,11 +203,6 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                         public void handleException(TransportException exp) {
                             getResponseHandler().handleException(exp);
                         }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
-                        }
                     });
             }
         };

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.coordination.FollowersChecker.FollowerCheckRequ
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.monitor.NodeHealthService;
@@ -36,7 +35,6 @@ import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.MockTransport;
-import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -424,12 +422,7 @@ public class FollowersCheckerTests extends ESTestCase {
         followersChecker.updateFastResponseState(followerTerm, Mode.FOLLOWER);
         final AtomicReference<TransportException> receivedException = new AtomicReference<>();
         transportService.sendRequest(follower, FOLLOWER_CHECK_ACTION_NAME, new FollowerCheckRequest(leaderTerm, leader),
-            new TransportResponseHandler<TransportResponse.Empty>() {
-                @Override
-                public TransportResponse.Empty read(StreamInput in) {
-                    return TransportResponse.Empty.INSTANCE;
-                }
-
+            new TransportResponseHandler.Empty() {
                 @Override
                 public void handleResponse(TransportResponse.Empty response) {
                     fail("unexpected success");
@@ -439,11 +432,6 @@ public class FollowersCheckerTests extends ESTestCase {
                 public void handleException(TransportException exp) {
                     assertThat(exp, not(nullValue()));
                     assertTrue(receivedException.compareAndSet(null, exp));
-                }
-
-                @Override
-                public String executor() {
-                    return Names.SAME;
                 }
             });
         deterministicTaskQueue.runAllTasks();
@@ -503,12 +491,7 @@ public class FollowersCheckerTests extends ESTestCase {
 
             final AtomicReference<TransportException> receivedException = new AtomicReference<>();
             transportService.sendRequest(follower, FOLLOWER_CHECK_ACTION_NAME, new FollowerCheckRequest(leaderTerm, leader),
-                new TransportResponseHandler<TransportResponse.Empty>() {
-                    @Override
-                    public TransportResponse.Empty read(StreamInput in) {
-                        return TransportResponse.Empty.INSTANCE;
-                    }
-
+                new TransportResponseHandler.Empty() {
                     @Override
                     public void handleResponse(TransportResponse.Empty response) {
                         fail("unexpected success");
@@ -518,11 +501,6 @@ public class FollowersCheckerTests extends ESTestCase {
                     public void handleException(TransportException exp) {
                         assertThat(exp, not(nullValue()));
                         assertTrue(receivedException.compareAndSet(null, exp));
-                    }
-
-                    @Override
-                    public String executor() {
-                        return Names.SAME;
                     }
                 });
             deterministicTaskQueue.runAllTasks();
@@ -567,12 +545,7 @@ public class FollowersCheckerTests extends ESTestCase {
 
             final AtomicReference<TransportException> receivedException = new AtomicReference<>();
             transportService.sendRequest(follower, FOLLOWER_CHECK_ACTION_NAME, new FollowerCheckRequest(term, leader),
-                new TransportResponseHandler<TransportResponse.Empty>() {
-                    @Override
-                    public TransportResponse.Empty read(StreamInput in) {
-                        return TransportResponse.Empty.INSTANCE;
-                    }
-
+                new TransportResponseHandler.Empty() {
                     @Override
                     public void handleResponse(TransportResponse.Empty response) {
                         fail("unexpected success");
@@ -582,11 +555,6 @@ public class FollowersCheckerTests extends ESTestCase {
                     public void handleException(TransportException exp) {
                         assertThat(exp, not(nullValue()));
                         assertTrue(receivedException.compareAndSet(null, exp));
-                    }
-
-                    @Override
-                    public String executor() {
-                        return Names.SAME;
                     }
                 });
             deterministicTaskQueue.runAllTasks();
@@ -652,11 +620,11 @@ public class FollowersCheckerTests extends ESTestCase {
         return settingsBuilder.build();
     }
 
-    private static class ExpectsSuccess implements TransportResponseHandler<Empty> {
+    private static class ExpectsSuccess extends TransportResponseHandler.Empty {
         private final AtomicBoolean responseReceived = new AtomicBoolean();
 
         @Override
-        public void handleResponse(Empty response) {
+        public void handleResponse(TransportResponse.Empty response) {
             assertTrue(responseReceived.compareAndSet(false, true));
         }
 
@@ -665,18 +633,8 @@ public class FollowersCheckerTests extends ESTestCase {
             throw new AssertionError("unexpected", exp);
         }
 
-        @Override
-        public String executor() {
-            return Names.SAME;
-        }
-
         public boolean succeeded() {
             return responseReceived.get();
-        }
-
-        @Override
-        public TransportResponse.Empty read(StreamInput in) {
-            return TransportResponse.Empty.INSTANCE;
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -463,13 +463,13 @@ public class LeaderCheckerTests extends ESTestCase {
         }
     }
 
-    private class CapturingTransportResponseHandler implements TransportResponseHandler<Empty> {
+    private class CapturingTransportResponseHandler implements TransportResponseHandler<TransportResponse.Empty> {
 
         TransportException transportException;
         boolean successfulResponseReceived;
 
         @Override
-        public void handleResponse(Empty response) {
+        public void handleResponse(TransportResponse.Empty response) {
             successfulResponseReceived = true;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
@@ -50,7 +50,6 @@ import static org.elasticsearch.cluster.coordination.PreVoteCollector.REQUEST_PR
 import static org.elasticsearch.monitor.StatusInfo.Status.HEALTHY;
 import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
-import static org.elasticsearch.threadpool.ThreadPool.Names.SAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -296,11 +295,6 @@ public class PreVoteCollectorTests extends ESTestCase {
                 @Override
                 public void handleException(TransportException exp) {
                     exceptionRef.set(exp);
-                }
-
-                @Override
-                public String executor() {
-                    return SAME;
                 }
             });
 

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.CapturingTransport.CapturedRequest;
 import org.elasticsearch.test.transport.StubbableConnectionManager;
-import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.ConnectionManager;
 import org.elasticsearch.transport.TransportException;
@@ -506,11 +505,6 @@ public class PeerFinderTests extends ESTestCase {
                 @Override
                 public void handleException(TransportException exp) {
                     throw new AssertionError("unexpected", exp);
-                }
-
-                @Override
-                public String executor() {
-                    return Names.SAME;
                 }
             });
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -123,11 +123,6 @@ public class InboundHandlerTests extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
-            }
-
-            @Override
             public TestResponse read(StreamInput in) throws IOException {
                 return new TestResponse(in);
             }

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -133,11 +133,6 @@ public class TransportActionProxyTests extends ESTestCase {
                         latch.countDown();
                     }
                 }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
             });
         latch.await();
     }
@@ -191,11 +186,6 @@ public class TransportActionProxyTests extends ESTestCase {
                     } finally {
                         latch.countDown();
                     }
-                }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
                 }
             });
         latch.await();

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -92,11 +92,6 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
                         }
 
                         @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
-                        }
-
-                        @Override
                         public TransportResponse.Empty read(StreamInput in) {
                             throw new AssertionError("should not be called");
                         }
@@ -139,11 +134,6 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
                         @Override
                         public void handleException(TransportException exp) {
                             fail("should not be called");
-                        }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
                         }
 
                         @Override

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1046,11 +1046,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             @Override
             public void handleException(TransportException exp) {
             }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
-            }
         };
 
         serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, StringMessageRequest::new, handler);
@@ -1318,11 +1313,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     logger.error("Unexpected failure", exp);
                     fail("got exception instead of a response: " + exp.getMessage());
                 }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
             }).txGet();
 
         assertThat(version0Response.value1, equalTo(1));
@@ -1361,11 +1351,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     logger.error("Unexpected failure", exp);
                     fail("got exception instead of a response: " + exp.getMessage());
                 }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
             }).txGet();
 
         assertThat(version1Response.value1, equalTo(1));
@@ -1403,11 +1388,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     logger.error("Unexpected failure", exp);
                     fail("got exception instead of a response: " + exp.getMessage());
                 }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
             }).txGet();
 
         assertThat(version1Response.value1, equalTo(1));
@@ -1441,11 +1421,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 public void handleException(TransportException exp) {
                     logger.error("Unexpected failure", exp);
                     fail("got exception instead of a response: " + exp.getMessage());
-                }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
                 }
             }).txGet();
 
@@ -1586,11 +1561,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             public void handleException(TransportException exp) {
                 latch.countDown();
             }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
-            }
         });
 
         if (!latch.await(10, TimeUnit.SECONDS)) {
@@ -1633,11 +1603,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                         public void handleException(TransportException exp) {
                             latch.countDown();
                         }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
-                        }
                     });
 
                 latch.await();
@@ -1662,11 +1627,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                         @Override
                         public void handleException(TransportException exp) {
                             latch2.countDown();
-                        }
-
-                        @Override
-                        public String executor() {
-                            return ThreadPool.Names.SAME;
                         }
                     });
 
@@ -2244,25 +2204,15 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceC.start();
         serviceC.acceptIncomingRequests();
         CountDownLatch responseLatch = new CountDownLatch(1);
-        TransportResponseHandler<TransportResponse> transportResponseHandler = new TransportResponseHandler<TransportResponse>() {
+        TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
             @Override
-            public TransportResponse read(StreamInput in) {
-                return TransportResponse.Empty.INSTANCE;
-            }
-
-            @Override
-            public void handleResponse(TransportResponse response) {
+            public void handleResponse(TransportResponse.Empty response) {
                 responseLatch.countDown();
             }
 
             @Override
             public void handleException(TransportException exp) {
                 responseLatch.countDown();
-            }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
             }
         };
 
@@ -2312,25 +2262,15 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceC.start();
         serviceC.acceptIncomingRequests();
         CountDownLatch responseLatch = new CountDownLatch(1);
-        TransportResponseHandler<TransportResponse> transportResponseHandler = new TransportResponseHandler<TransportResponse>() {
+        TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
             @Override
-            public TransportResponse read(StreamInput in) {
-                return TransportResponse.Empty.INSTANCE;
-            }
-
-            @Override
-            public void handleResponse(TransportResponse response) {
+            public void handleResponse(TransportResponse.Empty response) {
                 responseLatch.countDown();
             }
 
             @Override
             public void handleException(TransportException exp) {
                 responseLatch.countDown();
-            }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
             }
         };
 
@@ -2426,14 +2366,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceC.acceptIncomingRequests();
         CountDownLatch responseLatch = new CountDownLatch(1);
         AtomicReference<TransportException> receivedException = new AtomicReference<>(null);
-        TransportResponseHandler<TransportResponse> transportResponseHandler = new TransportResponseHandler<TransportResponse>() {
+        TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
             @Override
-            public TransportResponse read(StreamInput in) {
-                return TransportResponse.Empty.INSTANCE;
-            }
-
-            @Override
-            public void handleResponse(TransportResponse response) {
+            public void handleResponse(TransportResponse.Empty response) {
                 responseLatch.countDown();
             }
 
@@ -2441,11 +2376,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             public void handleException(TransportException exp) {
                 receivedException.set(exp);
                 responseLatch.countDown();
-            }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
             }
         };
 
@@ -2792,25 +2722,15 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 "fail-to-send-action",
                 TransportRequest.Empty.INSTANCE,
                 TransportRequestOptions.EMPTY,
-                new TransportResponseHandler<TransportResponse>() {
+                new TransportResponseHandler.Empty() {
                     @Override
-                    public void handleResponse(final TransportResponse response) {
+                    public void handleResponse(final TransportResponse.Empty response) {
                         fail("handle response should not be invoked");
                     }
 
                     @Override
                     public void handleException(final TransportException exp) {
                         te.set(exp);
-                    }
-
-                    @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
-                    public TransportResponse read(final StreamInput in) {
-                        return TransportResponse.Empty.INSTANCE;
                     }
                 });
             assertThat(te.get(), not(nullValue()));

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
-import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
@@ -200,34 +199,19 @@ public class DisruptableMockTransportTests extends ESTestCase {
             public void handleException(TransportException exp) {
                 throw new AssertionError("should not be called");
             }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
-            }
         };
     }
 
-    private TransportResponseHandler<TransportResponse> responseHandlerShouldBeCalledNormally(Runnable onCalled) {
-        return new TransportResponseHandler<TransportResponse>() {
+    private TransportResponseHandler<TransportResponse.Empty> responseHandlerShouldBeCalledNormally(Runnable onCalled) {
+        return new TransportResponseHandler.Empty() {
             @Override
-            public TransportResponse read(StreamInput in) {
-                return Empty.INSTANCE;
-            }
-
-            @Override
-            public void handleResponse(TransportResponse response) {
+            public void handleResponse(TransportResponse.Empty response) {
                 onCalled.run();
             }
 
             @Override
             public void handleException(TransportException exp) {
                 throw new AssertionError("should not be called");
-            }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
             }
         };
     }
@@ -248,11 +232,6 @@ public class DisruptableMockTransportTests extends ESTestCase {
             public void handleException(TransportException exp) {
                 onCalled.accept(exp);
             }
-
-            @Override
-            public String executor() {
-                return ThreadPool.Names.SAME;
-            }
         };
     }
 
@@ -261,7 +240,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
     }
 
     private void send(TransportService transportService, DiscoveryNode destinationNode,
-                      TransportResponseHandler<TransportResponse> responseHandler) {
+                      TransportResponseHandler<? extends TransportResponse> responseHandler) {
         transportService.sendRequest(destinationNode, "internal:dummy", TransportRequest.Empty.INSTANCE, responseHandler);
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -176,11 +175,6 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
                 public void handleException(TransportException exp) {
                     assertTrue(responded.compareAndSet(false, true));
                     latch.countDown();
-                }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
                 }
 
                 @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -369,15 +368,9 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
             threadContext.putTransient("foo", "different_bar");
             threadContext.putHeader("key", "value2");
             TransportResponseHandler<Empty> handler = new TransportService.ContextRestoreResponseHandler<>(
-                    threadContext.wrapRestorable(storedContext), new TransportResponseHandler<Empty>() {
-
+                    threadContext.wrapRestorable(storedContext), new TransportResponseHandler.Empty() {
                 @Override
-                public Empty read(StreamInput in) {
-                    return Empty.INSTANCE;
-                }
-
-                @Override
-                public void handleResponse(Empty response) {
+                public void handleResponse(TransportResponse.Empty response) {
                     assertEquals("bar", threadContext.getTransient("foo"));
                     assertEquals("value", threadContext.getHeader("key"));
                 }
@@ -386,11 +379,6 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 public void handleException(TransportException exp) {
                     assertEquals("bar", threadContext.getTransient("foo"));
                     assertEquals("value", threadContext.getHeader("key"));
-                }
-
-                @Override
-                public String executor() {
-                    return null;
                 }
             });
 
@@ -408,15 +396,9 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
             threadContext.putTransient("foo", "different_bar");
             threadContext.putHeader("key", "value2");
             handler = new TransportService.ContextRestoreResponseHandler<>(threadContext.newRestorableContext(true),
-                    new TransportResponseHandler<Empty>() {
-
+                    new TransportResponseHandler.Empty() {
                         @Override
-                        public Empty read(StreamInput in) {
-                            return Empty.INSTANCE;
-                        }
-
-                        @Override
-                        public void handleResponse(Empty response) {
+                        public void handleResponse(TransportResponse.Empty response) {
                             assertEquals("different_bar", threadContext.getTransient("foo"));
                             assertEquals("value2", threadContext.getHeader("key"));
                         }
@@ -425,11 +407,6 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                         public void handleException(TransportException exp) {
                             assertEquals("different_bar", threadContext.getTransient("foo"));
                             assertEquals("value2", threadContext.getHeader("key"));
-                        }
-
-                        @Override
-                        public String executor() {
-                            return null;
                         }
                     });
         }


### PR DESCRIPTION
The majority of implementations of this interface run on `SAME`.
Drying this up saves some duplication and also makes it a little
easier to understand what callbacks won't fork-off when reading the
code.

backport of #64395 