### PR TITLE
Fail with a better error when providing null as processor config. 

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -334,7 +334,11 @@ public final class ConfigurationUtils {
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
                     try {
-                        processors.add(readProcessor(processorFactories, scriptService, entry.getKey(), entry.getValue()));
+                        if (entry.getValue() == null) {
+                            throw newConfigurationException(entry.getKey(), null, null, "processor config cannot be [null]");
+                        } else {
+                            processors.add(readProcessor(processorFactories, scriptService, entry.getKey(), entry.getValue()));
+                        }
                     } catch (Exception e) {
                         exception = ExceptionsHelper.useOrSuppress(exception, e);
                     }

--- a/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
@@ -166,6 +166,13 @@ public class ConfigurationUtilsTests extends ESTestCase {
         assertThat(e2.getMetadata("es.processor_tag"), equalTo(Collections.singletonList("my_second_unknown")));
         assertThat(e2.getMetadata("es.processor_type"), equalTo(Collections.singletonList("second_unknown_processor")));
         assertThat(e2.getMetadata("es.property_name"), is(nullValue()));
+
+        List<Map<String, Object>> config3 = new ArrayList<>();
+        config3.add(Collections.singletonMap("test_processor", null));
+        ElasticsearchParseException e3 = expectThrows(ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readProcessorConfigs(config3, scriptService, registry));
+        assertThat(e3.getMetadata("es.processor_type"), equalTo(Collections.singletonList("test_processor")));
+        assertThat(e3.getMessage(), equalTo("processor config cannot be [null]"));
     }
 
     public void testReadProcessorNullDescription() throws Exception {


### PR DESCRIPTION
Backporting #64565 to 7.x branch.

When executing PUT pipeline API, if the config of one processor is null, then NPE is throwed. This PR fix the NPE and add a test for the change.

Relates to #57793