### PR TITLE
Centralize cache service instances creation in tests

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -42,11 +42,13 @@ public class CacheService extends AbstractLifecycleComponent {
         Setting.Property.NodeScope
     );
 
+    public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(4, ByteSizeUnit.KB);
+    public static final ByteSizeValue MAX_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES);
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_RANGE_SIZE_SETTING = Setting.byteSizeSetting(
         SETTINGS_PREFIX + "range_size",
         new ByteSizeValue(32, ByteSizeUnit.MB),                 // default
-        new ByteSizeValue(4, ByteSizeUnit.KB),                  // min
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),  // max
+        MIN_SNAPSHOT_CACHE_RANGE_SIZE,                          // min
+        MAX_SNAPSHOT_CACHE_RANGE_SIZE,                          // max
         Setting.Property.NodeScope
     );
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
-import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -34,9 +33,7 @@ import org.elasticsearch.indices.recovery.SearchableSnapshotRecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
+import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 
 import java.io.IOException;
@@ -49,7 +46,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static org.elasticsearch.index.store.cache.TestUtils.assertCounter;
-import static org.elasticsearch.index.store.cache.TestUtils.createCacheService;
 import static org.elasticsearch.index.store.cache.TestUtils.singleBlobContainer;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING;
@@ -64,7 +60,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase {
+public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSnapshotsTestCase {
 
     private static final int MAX_FILE_LENGTH = 10_000;
 
@@ -73,7 +69,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
      */
     private static final long FAKE_CLOCK_ADVANCE_NANOS = TimeValue.timeValueMillis(100).nanos();
 
-    public void testOpenCount() {
+    public void testOpenCount() throws Exception {
         executeTestCase((fileName, fileContent, directory) -> {
             try {
                 for (long i = 0L; i < randomLongBetween(1L, 20L); i++) {
@@ -91,7 +87,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testCloseCount() {
+    public void testCloseCount() throws Exception {
         executeTestCase((fileName, fileContent, directory) -> {
             try {
                 for (long i = 0L; i < randomLongBetween(1L, 20L); i++) {
@@ -110,9 +106,9 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testCachedBytesReadsAndWrites() {
+    public void testCachedBytesReadsAndWrites() throws Exception {
         // a cache service with a low range size but enough space to not evict the cache file
-        final ByteSizeValue rangeSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
+        final ByteSizeValue rangeSize = randomCacheRangeSize();
         final ByteSizeValue cacheSize = new ByteSizeValue(1, ByteSizeUnit.GB);
 
         executeTestCaseWithCache(cacheSize, rangeSize, (fileName, fileContent, directory) -> {
@@ -165,7 +161,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testCachedBytesReadsAndWritesNoCache() {
+    public void testCachedBytesReadsAndWritesNoCache() throws Exception {
         final ByteSizeValue uncachedChunkSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             try (IndexInput input = directory.openInput(fileName, newIOContext(random()))) {
@@ -189,9 +185,9 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testDirectBytesReadsWithCache() {
+    public void testDirectBytesReadsWithCache() throws Exception {
         // Cache service always evicts files
-        executeTestCaseWithCache(ByteSizeValue.ZERO, ByteSizeValue.ZERO, (fileName, fileContent, directory) -> {
+        executeTestCaseWithCache(ByteSizeValue.ZERO, randomCacheRangeSize(), (fileName, fileContent, directory) -> {
             assertThat(directory.getStats(fileName), nullValue());
 
             final IOContext ioContext = newIOContext(random());
@@ -242,7 +238,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testDirectBytesReadsWithoutCache() {
+    public void testDirectBytesReadsWithoutCache() throws Exception {
         final ByteSizeValue uncachedChunkSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             assertThat(directory.getStats(fileName), nullValue());
@@ -278,7 +274,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testOptimizedBytesReads() {
+    public void testOptimizedBytesReads() throws Exception {
         // use a large uncached chunk size that allows to read the file in a single operation
         final ByteSizeValue uncachedChunkSize = new ByteSizeValue(1, ByteSizeUnit.GB);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
@@ -315,7 +311,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testReadBytesContiguously() {
+    public void testReadBytesContiguously() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
             final IOContext ioContext = newIOContext(random());
 
@@ -366,7 +362,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testReadBytesNonContiguously() {
+    public void testReadBytesNonContiguously() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
             final IOContext ioContext = newIOContext(random());
 
@@ -417,7 +413,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testForwardSeeks() {
+    public void testForwardSeeks() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
             final IOContext ioContext = newIOContext(random());
             try (IndexInput indexInput = cacheDirectory.openInput(fileName, ioContext)) {
@@ -475,7 +471,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    public void testBackwardSeeks() {
+    public void testBackwardSeeks() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
             final IOContext ioContext = newIOContext(random());
             try (IndexInput indexInput = cacheDirectory.openInput(fileName, ioContext)) {
@@ -537,9 +533,9 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         });
     }
 
-    private static void executeTestCase(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) {
+    private void executeTestCase(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) throws Exception {
         executeTestCase(
-            createCacheService(random()),
+            randomCacheService(),
             Settings.builder()
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), randomBoolean())
                 .put(SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false) // disable prewarming as it impacts the stats
@@ -548,12 +544,12 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         );
     }
 
-    private static void executeTestCaseWithoutCache(
+    private void executeTestCaseWithoutCache(
         final ByteSizeValue uncachedChunkSize,
         final TriConsumer<String, byte[], SearchableSnapshotDirectory> test
-    ) {
+    ) throws Exception {
         executeTestCase(
-            createCacheService(random()),
+            defaultCacheService(),
             Settings.builder()
                 .put(SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING.getKey(), uncachedChunkSize)
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), false)
@@ -562,7 +558,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         );
     }
 
-    private static void executeTestCaseWithDefaultCache(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) {
+    private void executeTestCaseWithDefaultCache(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) throws Exception {
         executeTestCaseWithCache(
             CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getDefault(Settings.EMPTY),
             CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getDefault(Settings.EMPTY),
@@ -570,13 +566,13 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         );
     }
 
-    private static void executeTestCaseWithCache(
+    private void executeTestCaseWithCache(
         final ByteSizeValue cacheSize,
         final ByteSizeValue cacheRangeSize,
         final TriConsumer<String, byte[], SearchableSnapshotDirectory> test
-    ) {
+    ) throws Exception {
         executeTestCase(
-            new CacheService(TestUtils::noOpCacheCleaner, cacheSize, cacheRangeSize),
+            createCacheService(cacheSize, cacheRangeSize),
             Settings.builder()
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
                 .put(SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false) // disable prewarming as it impacts the stats
@@ -585,11 +581,11 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         );
     }
 
-    private static void executeTestCase(
+    private void executeTestCase(
         final CacheService cacheService,
         final Settings indexSettings,
         final TriConsumer<String, byte[], SearchableSnapshotDirectory> test
-    ) {
+    ) throws Exception {
 
         final byte[] fileContent = randomUnicodeOfLength(randomIntBetween(10, MAX_FILE_LENGTH)).getBytes(StandardCharsets.UTF_8);
         final String fileExtension = randomAlphaOfLength(3);
@@ -599,7 +595,6 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
         final ShardId shardId = new ShardId("_name", "_uuid", 0);
         final AtomicLong fakeClock = new AtomicLong();
         final LongSupplier statsCurrentTimeNanos = () -> fakeClock.addAndGet(FAKE_CLOCK_ADVANCE_NANOS);
-        final ThreadPool threadPool = new TestThreadPool(getTestClass().getSimpleName(), SearchableSnapshots.executorBuilders());
 
         final Long seekingThreshold = randomBoolean() ? randomLongBetween(1L, fileContent.length) : null;
 
@@ -615,7 +610,6 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
             throw new UncheckedIOException(e);
         }
         final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
-        final DiscoveryNode discoveryNode = new DiscoveryNode("_id", buildNewFakeTransportAddress(), Version.CURRENT);
         final Path cacheDir = createTempDir();
 
         try (
@@ -668,7 +662,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
 
             test.apply(fileName, fileContent, directory);
         } finally {
-            terminate(threadPool);
+            assertThreadPoolNotBusy(threadPool);
         }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -40,11 +40,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.RecoverySource;
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
-import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.UUIDs;
@@ -86,15 +81,10 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.fs.FsRepository;
-import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.DummyShardLock;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPoolStats;
-import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
+import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.hamcrest.Matcher;
 
@@ -121,7 +111,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -146,7 +135,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class SearchableSnapshotDirectoryTests extends ESTestCase {
+public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshotsTestCase {
 
     public void testListAll() throws Exception {
         testDirectories(
@@ -484,7 +473,6 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
         final ShardId shardId = new ShardId(indexSettings.getIndex(), randomIntBetween(0, 10));
         final List<Releasable> releasables = new ArrayList<>();
 
-        final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
         try (Directory directory = newDirectory()) {
             final IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
             try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
@@ -595,7 +583,7 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
                 }
                 final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
                 final Path cacheDir = createTempDir();
-                final CacheService cacheService = TestUtils.createDefaultCacheService();
+                final CacheService cacheService = defaultCacheService();
                 releasables.add(cacheService);
                 cacheService.start();
 
@@ -631,7 +619,7 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
                 Releasables.close(releasables);
             }
         } finally {
-            terminateSafely(threadPool);
+            assertThreadPoolNotBusy(threadPool);
         }
     }
 
@@ -657,7 +645,7 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
     }
 
     public void testClearCache() throws Exception {
-        try (CacheService cacheService = TestUtils.createDefaultCacheService()) {
+        try (CacheService cacheService = defaultCacheService()) {
             cacheService.start();
 
             final int nbRandomFiles = randomIntBetween(3, 10);
@@ -697,7 +685,6 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
             }
             final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
             final Path cacheDir = createTempDir();
-            final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
             try (
                 SearchableSnapshotDirectory directory = new SearchableSnapshotDirectory(
                     () -> blobContainer,
@@ -748,7 +735,7 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
                     }
                 }
             } finally {
-                terminateSafely(threadPool);
+                assertThreadPoolNotBusy(threadPool);
             }
         }
     }
@@ -916,43 +903,6 @@ public class SearchableSnapshotDirectoryTests extends ESTestCase {
                 .put(IndexMetadata.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT)
                 .build()
         );
-    }
-
-    private SearchableSnapshotRecoveryState createRecoveryState() {
-        ShardRouting shardRouting = TestShardRouting.newShardRouting(
-            new ShardId(randomAlphaOfLength(10), randomAlphaOfLength(10), 0),
-            randomAlphaOfLength(10),
-            true,
-            ShardRoutingState.INITIALIZING,
-            new RecoverySource.SnapshotRecoverySource(
-                UUIDs.randomBase64UUID(),
-                new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
-                Version.CURRENT,
-                new IndexId("some_index", UUIDs.randomBase64UUID(random()))
-            )
-        );
-        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
-        SearchableSnapshotRecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
-
-        recoveryState.setStage(RecoveryState.Stage.INIT)
-            .setStage(RecoveryState.Stage.INDEX)
-            .setStage(RecoveryState.Stage.VERIFY_INDEX)
-            .setStage(RecoveryState.Stage.TRANSLOG);
-        recoveryState.getIndex().setFileDetailsComplete();
-        recoveryState.setStage(RecoveryState.Stage.FINALIZE).setStage(RecoveryState.Stage.DONE);
-
-        return recoveryState;
-    }
-
-    // Wait for all operations on the threadpool to complete to make sure we don't leak any reference count releasing and then shut it down
-    public static void terminateSafely(ThreadPool threadPool) throws Exception {
-        assertBusy(() -> {
-            for (ThreadPoolStats.Stats stat : threadPool.stats()) {
-                assertEquals(stat.getActive(), 0);
-                assertEquals(stat.getQueue(), 0);
-            }
-        });
-        assertTrue(ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS));
     }
 
     private static class FaultyReadsFileSystem extends FilterFileSystemProvider {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
-import static org.elasticsearch.index.store.cache.TestUtils.createCacheService;
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.index.store.cache.TestUtils.singleBlobContainer;
 import static org.elasticsearch.index.store.cache.TestUtils.singleSplitBlobContainer;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING;

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -7,15 +7,8 @@ package org.elasticsearch.index.store.cache;
 
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.RecoverySource;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
-import org.elasticsearch.cluster.routing.TestShardRouting;
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.support.FilterBlobContainer;
-import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.NodeEnvironment;
@@ -23,17 +16,12 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.SearchableSnapshotDirectory;
-import org.elasticsearch.index.store.SearchableSnapshotDirectoryTests;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.store.cache.TestUtils.NoopBlobStoreCacheService;
 import org.elasticsearch.indices.recovery.RecoveryState;
-import org.elasticsearch.indices.recovery.SearchableSnapshotRecoveryState;
 import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
+import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 
 import java.io.EOFException;
@@ -48,7 +36,6 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
-import static java.util.Collections.singletonList;
 import static org.elasticsearch.index.store.cache.TestUtils.createCacheService;
 import static org.elasticsearch.index.store.cache.TestUtils.singleBlobContainer;
 import static org.elasticsearch.index.store.cache.TestUtils.singleSplitBlobContainer;
@@ -59,11 +46,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
+public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
     public void testRandomReads() throws Exception {
-        final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
-        try (CacheService cacheService = createCacheService(random())) {
+        try (CacheService cacheService = randomCacheService()) {
             cacheService.start();
 
             SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
@@ -164,12 +150,12 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                 }
             }
         } finally {
-            SearchableSnapshotDirectoryTests.terminateSafely(threadPool);
+            assertThreadPoolNotBusy(threadPool);
         }
     }
 
     public void testThrowsEOFException() throws Exception {
-        try (CacheService cacheService = createCacheService(random())) {
+        try (CacheService cacheService = randomCacheService()) {
             cacheService.start();
 
             SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
@@ -192,7 +178,6 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
             );
 
             final BlobContainer blobContainer = singleBlobContainer(blobName, input);
-            final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
             final Path shardDir;
             try {
                 shardDir = new NodeEnvironment.NodePath(createTempDir()).resolve(shardId);
@@ -232,7 +217,7 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                     }
                 }
             } finally {
-                SearchableSnapshotDirectoryTests.terminateSafely(threadPool);
+                assertThreadPoolNotBusy(threadPool);
             }
         }
     }
@@ -250,23 +235,6 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
             }
         }
         return containsEOFException(throwable.getCause(), seenThrowables);
-    }
-
-    private SearchableSnapshotRecoveryState createRecoveryState() {
-        ShardRouting shardRouting = TestShardRouting.newShardRouting(
-            new ShardId(randomAlphaOfLength(10), randomAlphaOfLength(10), 0),
-            randomAlphaOfLength(10),
-            true,
-            ShardRoutingState.INITIALIZING,
-            new RecoverySource.SnapshotRecoverySource(
-                UUIDs.randomBase64UUID(),
-                new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
-                Version.CURRENT,
-                new IndexId("some_index", UUIDs.randomBase64UUID(random()))
-            )
-        );
-        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
-        return new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -15,11 +15,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.store.IndexInputStats;
-import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -27,11 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomIntBetween;
 import static com.carrotsearch.randomizedtesting.generators.RandomPicks.randomFrom;
-import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,27 +36,6 @@ import static org.mockito.Mockito.when;
 
 public final class TestUtils {
     private TestUtils() {}
-
-    public static void noOpCacheCleaner() {}
-
-    public static CacheService createDefaultCacheService() {
-        return new CacheService(TestUtils::noOpCacheCleaner, Settings.EMPTY);
-    }
-
-    public static CacheService createCacheService(final Random random) {
-        final ByteSizeValue cacheSize = new ByteSizeValue(
-            randomIntBetween(random, 1, 100),
-            randomFrom(random, asList(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB, ByteSizeUnit.GB))
-        );
-        return new CacheService(TestUtils::noOpCacheCleaner, cacheSize, randomCacheRangeSize(random));
-    }
-
-    public static ByteSizeValue randomCacheRangeSize(final Random random) {
-        return new ByteSizeValue(
-            randomIntBetween(random, 1, 100),
-            randomFrom(random, asList(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB))
-        );
-    }
 
     public static long numberOfRanges(long fileSize, long rangeSize) {
         return numberOfRanges(toIntBytes(fileSize), toIntBytes(rangeSize));

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.store.IndexInputStats;
 
 import java.io.ByteArrayInputStream;
@@ -23,11 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
-import static com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomIntBetween;
-import static com.carrotsearch.randomizedtesting.generators.RandomPicks.randomFrom;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.indices.recovery.SearchableSnapshotRecoveryState;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTestCase {
+
+    protected ThreadPool threadPool;
+
+    @Before
+    public void setUpTest() {
+        threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilders());
+    }
+
+    @After
+    public void tearDownTest() {
+        assertTrue(ThreadPool.terminate(threadPool, 30L, TimeUnit.SECONDS));
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with default settings
+     */
+    protected CacheService defaultCacheService() {
+        return new CacheService(AbstractSearchableSnapshotsTestCase::noOpCacheCleaner, Settings.EMPTY);
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with random cache size and cache range size settings
+     */
+    protected CacheService randomCacheService() {
+        final Settings.Builder cacheSettings = Settings.builder();
+        if (randomBoolean()) {
+            cacheSettings.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), randomCacheSize());
+        }
+        if (randomBoolean()) {
+            cacheSettings.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), randomCacheRangeSize());
+        }
+        return new CacheService(AbstractSearchableSnapshotsTestCase::noOpCacheCleaner, cacheSettings.build());
+    }
+
+    /**
+     * @return a new {@link CacheService} instance configured with the given cache size and cache range size settings
+     */
+    protected CacheService createCacheService(final ByteSizeValue cacheSize, final ByteSizeValue cacheRangeSize) {
+        return new CacheService(
+            AbstractSearchableSnapshotsTestCase::noOpCacheCleaner,
+            Settings.builder()
+                .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
+                .put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), cacheRangeSize)
+                .build()
+        );
+    }
+
+    protected static void noOpCacheCleaner() {}
+
+    /**
+     * @return a random {@link ByteSizeValue} that can be used to set {@link CacheService#SNAPSHOT_CACHE_SIZE_SETTING}.
+     * Note that it can return a cache size of 0.
+     */
+    protected static ByteSizeValue randomCacheSize() {
+        return new ByteSizeValue(randomNonNegativeLong());
+    }
+
+    /**
+     * @return a random {@link ByteSizeValue} that can be used to set {@link CacheService#SNAPSHOT_CACHE_RANGE_SIZE_SETTING}
+     */
+    protected static ByteSizeValue randomCacheRangeSize() {
+        return new ByteSizeValue(
+            randomLongBetween(CacheService.MIN_SNAPSHOT_CACHE_RANGE_SIZE.getBytes(), CacheService.MAX_SNAPSHOT_CACHE_RANGE_SIZE.getBytes())
+        );
+    }
+
+    protected static SearchableSnapshotRecoveryState createRecoveryState() {
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(
+            new ShardId(randomAlphaOfLength(10), randomAlphaOfLength(10), 0),
+            randomAlphaOfLength(10),
+            true,
+            ShardRoutingState.INITIALIZING,
+            new RecoverySource.SnapshotRecoverySource(
+                UUIDs.randomBase64UUID(),
+                new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
+                Version.CURRENT,
+                new IndexId("some_index", UUIDs.randomBase64UUID(random()))
+            )
+        );
+        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        SearchableSnapshotRecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
+
+        recoveryState.setStage(RecoveryState.Stage.INIT)
+            .setStage(RecoveryState.Stage.INDEX)
+            .setStage(RecoveryState.Stage.VERIFY_INDEX)
+            .setStage(RecoveryState.Stage.TRANSLOG);
+        recoveryState.getIndex().setFileDetailsComplete();
+        recoveryState.setStage(RecoveryState.Stage.FINALIZE).setStage(RecoveryState.Stage.DONE);
+
+        return recoveryState;
+    }
+
+    /**
+     * Wait for all operations on the threadpool to complete
+     */
+    protected static void assertThreadPoolNotBusy(ThreadPool threadPool) throws Exception {
+        assertBusy(() -> {
+            for (ThreadPoolStats.Stats stat : threadPool.stats()) {
+                assertEquals(stat.getActive(), 0);
+                assertEquals(stat.getQueue(), 0);
+            }
+        }, 30L, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
This commit centralizes the creation of CacheService instances in
Searchable Snapshot tests. It cleans up a bit the tests and it will
make the tests more easily adaptable when the creation of
CacheService will be more complex due to the future persistent
cache.

Backport of #64591
