### PR TITLE
[7.10] Fix DataTiersUsageTransportActionTests testCalculateMAD (#64596)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersFeatureSetTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersFeatureSetTests.java
@@ -29,7 +29,7 @@ public class DataTiersFeatureSetTests extends ESTestCase {
     public void testCalculateMAD() {
         assertThat(DataTiersFeatureSet.computeMedianAbsoluteDeviation(new TDigestState(10)), equalTo(0L));
 
-        TDigestState sketch = new TDigestState(randomDoubleBetween(0, 1000, false));
+        TDigestState sketch = new TDigestState(randomDoubleBetween(1, 1000, false));
         sketch.add(1);
         sketch.add(1);
         sketch.add(2);


### PR DESCRIPTION
Random the compression factor starting with 1 (to elimitinate nearly 0 values)
which will only use one centroid (and yield 0 for MAD as the aproximate median
is the same as the single centroid mean value)

(cherry picked from commit 940e0f1fde0f40f99af117dd03ab0891c9eedae6)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #64596 