### PR TITLE
[Transform] add support for median absolute deviation

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -666,6 +666,7 @@ supported:
 * <<search-aggregations-metrics-geobounds-aggregation,Geo bounds>>
 * <<search-aggregations-metrics-geocentroid-aggregation,Geo centroid>>
 * <<search-aggregations-metrics-max-aggregation,Max>>
+* <<search-aggregations-metrics-median-absolute-deviation-aggregation,Median absolute deviation>>
 * <<search-aggregations-metrics-min-aggregation,Min>>
 * <<search-aggregations-bucket-missing-aggregation,Missing>>
 * <<search-aggregations-metrics-percentile-aggregation,Percentiles>>

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -654,6 +654,10 @@ public class TransformPivotRestIT extends TransformRestTestCase {
             + "       \"avg\": {"
             + "         \"field\": \"stars\""
             + " } },"
+            + "     \"variability_rating\": {"
+            + "       \"median_absolute_deviation\": {"
+            + "         \"field\": \"stars\""
+            + " } },"
             + "     \"sum_rating\": {"
             + "       \"sum\": {"
             + "         \"field\": \"stars\""
@@ -694,6 +698,8 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
         assertEquals(3.878048780, actual.doubleValue(), 0.000001);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.variability_rating", searchResult)).get(0);
+        assertEquals(0.0, actual.doubleValue(), 0.000001);
         actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.sum_rating", searchResult)).get(0);
         assertEquals(159, actual.longValue());
         actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.cardinality_business", searchResult)).get(0);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -65,7 +65,6 @@ public final class TransformAggregations {
         "histogram",
         "ip_range",
         "matrix_stats",
-        "median_absolute_deviation",
         "nested",
         "percentile_ranks",
         "range",
@@ -95,6 +94,7 @@ public final class TransformAggregations {
      */
     enum AggregationType {
         AVG("avg", DOUBLE),
+        MEDIAN_ABSOLUTE_DEVIATION("median_absolute_deviation", DOUBLE),
         CARDINALITY("cardinality", LONG),
         VALUE_COUNT("value_count", LONG),
         MAX("max", SOURCE),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -32,6 +32,10 @@ public class TransformAggregationsTests extends ESTestCase {
         assertEquals("double", TransformAggregations.resolveTargetMapping("avg", "int"));
         assertEquals("double", TransformAggregations.resolveTargetMapping("avg", "double"));
 
+        // median_absolute_deviation
+        assertEquals("double", TransformAggregations.resolveTargetMapping("median_absolute_deviation", "int"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("median_absolute_deviation", "double"));
+
         // cardinality
         assertEquals("long", TransformAggregations.resolveTargetMapping("cardinality", "int"));
         assertEquals("long", TransformAggregations.resolveTargetMapping("cardinality", "double"));


### PR DESCRIPTION
add `median_absolute_deviation` to the list of supported aggs in transform

docs preview: https://elasticsearch_64634.docs-preview.app.elstc.co/diff