### PR TITLE
MetadataFieldMapper.Builder.build() doesn't need ContentPath

### DIFF
--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.mapper.size;
 
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -53,7 +52,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public SizeFieldMapper build(ContentPath contentPath) {
+        public SizeFieldMapper build() {
             return new SizeFieldMapper(enabled.getValue(), new NumberFieldType(NAME, NumberType.INTEGER));
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
@@ -91,8 +91,6 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
     public void testExternalValues() throws Exception {
         prepareCreate("test-idx").setMapping(
                 XContentFactory.jsonBuilder().startObject().startObject("_doc")
-                .startObject(ExternalMetadataMapper.CONTENT_TYPE)
-                .endObject()
                 .startObject("properties")
                     .startObject("field").field("type", ExternalMapperPlugin.EXTERNAL).endObject()
                 .endObject()

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 
 /** Mapper for the doc_count field. */
 public class DocCountFieldMapper extends MetadataFieldMapper {
@@ -38,26 +37,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
     public static final String NAME = "_doc_count";
     public static final String CONTENT_TYPE = "_doc_count";
 
-    public static final TypeParser PARSER = new ConfigurableTypeParser(
-        c -> new DocCountFieldMapper(),
-        c -> new DocCountFieldMapper.Builder());
-
-    static class Builder extends MetadataFieldMapper.Builder {
-
-        Builder() {
-            super(NAME);
-        }
-
-        @Override
-        protected List<Parameter<?>> getParameters() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public DocCountFieldMapper build(ContentPath contentPath) {
-            return new DocCountFieldMapper();
-        }
-    }
+    public static final TypeParser PARSER = new FixedTypeParser(c -> new DocCountFieldMapper());
 
     public static final class DocCountFieldType extends MappedFieldType {
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -93,7 +93,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public FieldNamesFieldMapper build(ContentPath contentPath) {
+        public FieldNamesFieldMapper build() {
             if (enabled.getValue().explicit()) {
                 if (indexVersionCreated.onOrAfter(Version.V_8_0_0)) {
                     throw new MapperParsingException("The `enabled` setting for the `_field_names` field has been deprecated and "

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -129,7 +129,11 @@ public abstract class MetadataFieldMapper extends FieldMapper {
         }
 
         @Override
-        public abstract MetadataFieldMapper build(ContentPath contentPath);
+        public final MetadataFieldMapper build(ContentPath path) {
+            return build();
+        }
+
+        public abstract MetadataFieldMapper build();
     }
 
     protected MetadataFieldMapper(MappedFieldType mappedFieldType) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -71,7 +71,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public RoutingFieldMapper build(ContentPath contentPath) {
+        public RoutingFieldMapper build() {
             return new RoutingFieldMapper(required.getValue());
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -91,7 +91,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public SourceFieldMapper build(ContentPath contentPath) {
+        public SourceFieldMapper build() {
             return new SourceFieldMapper(enabled.getValue(),
                 includes.getValue().toArray(String[]::new),
                 excludes.getValue().toArray(String[]::new));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -1575,7 +1574,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        public MetadataFieldMapper build(ContentPath contentPath) {
+        public MetadataFieldMapper build() {
             return new MetadataTimestampFieldMapper(enabled.getValue());
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMetadataMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMetadataMapper.java
@@ -22,11 +22,6 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
 public class ExternalMetadataMapper extends MetadataFieldMapper {
 
     static final String CONTENT_TYPE = "_external_root";
@@ -38,38 +33,15 @@ public class ExternalMetadataMapper extends MetadataFieldMapper {
     }
 
     @Override
-    public Iterator<Mapper> iterator() {
-        return Collections.emptyIterator();
-    }
-
-    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }
 
     @Override
-    public void postParse(ParseContext context) throws IOException {
+    public void postParse(ParseContext context) {
         context.doc().add(new StringField(FIELD_NAME, FIELD_VALUE, Store.YES));
     }
 
-    public static class Builder extends MetadataFieldMapper.Builder {
-
-        protected Builder() {
-            super(FIELD_NAME);
-        }
-
-        @Override
-        protected List<Parameter<?>> getParameters() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public ExternalMetadataMapper build(ContentPath contentPath) {
-            return new ExternalMetadataMapper();
-        }
-
-    }
-
-    public static final TypeParser PARSER = new ConfigurableTypeParser(c -> new ExternalMetadataMapper(), c -> new Builder());
+    public static final TypeParser PARSER = new FixedTypeParser(c -> new ExternalMetadataMapper());
 
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MockMetadataMapperPlugin.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MockMetadataMapperPlugin.java
@@ -27,8 +27,6 @@ import org.elasticsearch.plugins.Plugin;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -59,36 +57,11 @@ public class MockMetadataMapperPlugin extends Plugin implements MapperPlugin {
         }
 
         @Override
-        public Iterator<Mapper> iterator() {
-            return Collections.emptyIterator();
-        }
-
-        @Override
         protected String contentType() {
             return CONTENT_TYPE;
         }
 
-        public static class Builder extends MetadataFieldMapper.Builder {
-
-            protected Builder() {
-                super(FIELD_NAME);
-            }
-
-            @Override
-            protected List<Parameter<?>> getParameters() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public MockMetadataMapper build(ContentPath contentPath) {
-                return new MockMetadataMapper();
-            }
-        }
-
-        public static final TypeParser PARSER = new ConfigurableTypeParser(
-            c -> new MockMetadataMapper(),
-            c -> new MockMetadataMapper.Builder()) {
-        };
+        public static final TypeParser PARSER = new FixedTypeParser(c -> new MockMetadataMapper());
     }
 
     @Override

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -88,7 +87,7 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public MetadataFieldMapper build(ContentPath contentPath) {
+        public MetadataFieldMapper build() {
             return new DataStreamTimestampFieldMapper(new TimestampFieldType(), enabled.getValue());
         }
     }


### PR DESCRIPTION
Metadata fields are always instantiated at the root of a document,
so they don't need to take the ContentPath in their build() methods.

Also converts a couple of metadata parsers from Configurable to
Fixed, as they don't have any parameters.