### PR TITLE
add the ability to retrieve the fieldnames an aggregation creates from the builder

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/StringStatsAggregationBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/StringStatsAggregationBuilder.java
@@ -128,4 +128,9 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
         StringStatsAggregationBuilder other = (StringStatsAggregationBuilder) obj;
         return showDistribution == other.showDistribution;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/TopMetricsAggregationBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/TopMetricsAggregationBuilder.java
@@ -109,4 +109,9 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
     protected AggregationBuilder shallowCopy(Builder factoriesBuilder, Map<String, Object> metadata) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return metrics;
+    }
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregationBuilder.java
@@ -93,4 +93,9 @@ public class MatrixStatsAggregationBuilder
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
@@ -100,6 +100,7 @@ public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<C
         return BucketCardinality.ONE;
     }
 
+    @Override
     protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
@@ -182,5 +183,10 @@ public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<C
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return ValuesSourceRegistry.UNREGISTERED_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
@@ -182,4 +182,9 @@ public class ParentAggregationBuilder extends ValuesSourceAggregationBuilder<Par
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return ValuesSourceRegistry.UNREGISTERED_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -532,6 +532,11 @@ public class TransportSearchIT extends ESIntegTestCase {
         public String getType() {
             return "test";
         }
+
+        @Override
+        public Iterable<String> getOutputFieldNames() {
+            return OutputFieldNames.UNKNOWN;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Base implementation of a {@link AggregationBuilder}.
@@ -34,8 +35,18 @@ import java.util.Objects;
 public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationBuilder<AB>>
     extends AggregationBuilder {
 
-    protected Map<String, Object> metadata;
+    // common sets for output generated
+    protected static class OutputFieldNames {
+        // special type when the output is unknown, e.g. because its the result of a script
+        public static final Set<String> UNKNOWN = Collections.emptySet();
+        public static final Set<String> DOC_COUNT_ONLY = Collections.singleton("doc_count");
+        public static final Set<String> SINGLE_VALUE = Collections.singleton("value");
+        public static final Set<String> KEY_AND_DOC_COUNT = Set.of("key", "doc_count");
+        public static final Set<String> RANGE = Set.of("key", "doc_count", "from", "to");
+        public static final Set<String> SIGNIFICANT = Set.of("key", "doc_count", "score", "bg_count");
+    }
 
+    protected Map<String, Object> metadata;
     /**
      * Constructs a new aggregation builder.
      *

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -65,6 +65,9 @@ public abstract class AggregationBuilder
         return name;
     }
 
+    /** Return the field names this aggregation creates*/
+    public abstract Iterable<String> getOutputFieldNames();
+
     /** Internal: build an {@link AggregatorFactory} based on the configuration of this builder. */
     protected abstract AggregatorFactory build(AggregationContext context, AggregatorFactory parent) throws IOException;
 
@@ -147,7 +150,7 @@ public abstract class AggregationBuilder
      * and pipeline aggregations. Just "zero", "one", and "many".
      * <p>
      * Unlike {@link CardinalityUpperBound} which is <strong>total</strong>
-     * instead of <strong>per parent bucket</strong>. 
+     * instead of <strong>per parent bucket</strong>.
      */
     public enum BucketCardinality {
         NONE, ONE, MANY;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
@@ -260,4 +260,9 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -279,4 +279,9 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
             Objects.equals(sources, other.sources) &&
             Objects.equals(after, other.after);
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -138,4 +138,9 @@ public class FilterAggregationBuilder extends AbstractAggregationBuilder<FilterA
     public QueryBuilder getFilter() {
         return filter;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
@@ -353,5 +354,14 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     @Override
     public String getType() {
         return NAME;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        List<String> keys = filters.stream().map(kf -> kf.key()).collect(Collectors.toList());
+        if (otherBucket) {
+            keys.add(otherBucketKey);
+        }
+        return keys;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
@@ -97,4 +97,9 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
@@ -95,4 +95,9 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregationBuilder.java
@@ -87,4 +87,9 @@ public class GlobalAggregationBuilder extends AbstractAggregationBuilder<GlobalA
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -246,6 +246,11 @@ public class AutoDateHistogramAggregationBuilder extends ValuesSourceAggregation
         return Objects.equals(numBuckets, other.numBuckets) && Objects.equals(minimumIntervalExpression, other.minimumIntervalExpression);
     }
 
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
+
     public static class RoundingInfo implements Writeable {
         final Rounding rounding;
         final int[] innerIntervals;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -173,6 +173,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     /** Get the current interval in milliseconds that is set on this builder. */
+    @Override
     @Deprecated
     public long interval() {
         return dateHistogramInterval.interval();
@@ -185,6 +186,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
      *  @deprecated use {@link #fixedInterval(DateHistogramInterval)} or {@link #calendarInterval(DateHistogramInterval)} instead
      *  @since 7.2.0
      */
+    @Override
     @Deprecated
     public DateHistogramAggregationBuilder interval(long interval) {
         dateHistogramInterval.interval(interval);
@@ -192,6 +194,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     /** Get the current date interval that is set on this builder. */
+    @Override
     @Deprecated
     public DateHistogramInterval dateHistogramInterval() {
        return dateHistogramInterval.dateHistogramInterval();
@@ -204,6 +207,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
      *  @deprecated use {@link #fixedInterval(DateHistogramInterval)} or {@link #calendarInterval(DateHistogramInterval)} instead
      *  @since 7.2.0
      */
+    @Override
     @Deprecated
     public DateHistogramAggregationBuilder dateHistogramInterval(DateHistogramInterval interval) {
         dateHistogramInterval.dateHistogramInterval(interval);
@@ -218,6 +222,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
      *
      * @param interval The calendar interval to use with the aggregation
      */
+    @Override
     public DateHistogramAggregationBuilder calendarInterval(DateHistogramInterval interval) {
         dateHistogramInterval.calendarInterval(interval);
         return this;
@@ -231,6 +236,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
      *
      * @param interval The fixed interval to use with the aggregation
      */
+    @Override
     public DateHistogramAggregationBuilder fixedInterval(DateHistogramInterval interval) {
         dateHistogramInterval.fixedInterval(interval);
         return this;
@@ -498,5 +504,10 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
                 && Objects.equals(offset, other.offset)
                 && Objects.equals(extendedBounds, other.extendedBounds)
                 && Objects.equals(hardBounds, other.hardBounds);
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -393,4 +393,9 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
             && Objects.equals(extendedBounds, other.extendedBounds)
             && Objects.equals(hardBounds, other.hardBounds);
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
@@ -219,4 +219,9 @@ public class VariableWidthHistogramAggregationBuilder extends ValuesSourceAggreg
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregationBuilder.java
@@ -97,6 +97,7 @@ public class MissingAggregationBuilder extends ValuesSourceAggregationBuilder<Mi
         return BucketCardinality.ONE;
     }
 
+    @Override
     protected ValuesSourceAggregatorFactory innerBuild(AggregationContext context,
                                                        ValuesSourceConfig config,
                                                        AggregatorFactory parent,
@@ -117,5 +118,10 @@ public class MissingAggregationBuilder extends ValuesSourceAggregationBuilder<Mi
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
@@ -168,4 +168,9 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregationBuilder.java
@@ -189,4 +189,9 @@ public class ReverseNestedAggregationBuilder extends AbstractAggregationBuilder<
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java
@@ -333,4 +333,9 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
         return new DateRangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metadata);
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.RANGE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -474,4 +474,8 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
                 && Objects.equals(unit, other.unit);
     }
 
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.RANGE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
@@ -416,4 +416,9 @@ public final class IpRangeAggregationBuilder extends ValuesSourceAggregationBuil
         return keyed == that.keyed
             && ranges.equals(that.ranges);
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.RANGE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
@@ -179,4 +179,9 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.RANGE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
@@ -202,4 +202,9 @@ public class DiversifiedAggregationBuilder extends ValuesSourceAggregationBuilde
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
@@ -148,4 +148,9 @@ public class SamplerAggregationBuilder extends AbstractAggregationBuilder<Sample
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.DOC_COUNT_ONLY;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -217,4 +217,9 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
@@ -137,6 +137,7 @@ public class SignificantTermsAggregationBuilder extends ValuesSourceAggregationB
         return new SignificantTermsAggregationBuilder(this, factoriesBuilder, metadata);
     }
 
+    @Override
     protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
         if (filterBuilder != null) {
             QueryBuilder rewrittenFilter = filterBuilder.rewrite(queryShardContext);
@@ -343,5 +344,10 @@ public class SignificantTermsAggregationBuilder extends ValuesSourceAggregationB
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SIGNIFICANT;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
@@ -387,4 +387,9 @@ public class SignificantTextAggregationBuilder extends AbstractAggregationBuilde
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SIGNIFICANT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -407,4 +407,9 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.KEY_AND_DOC_COUNT;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregationBuilder.java
@@ -104,4 +104,9 @@ public class AvgAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -169,4 +169,9 @@ public final class CardinalityAggregationBuilder
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregationBuilder.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -50,6 +51,8 @@ public class ExtendedStatsAggregationBuilder
         ValuesSourceAggregationBuilder.declareFields(PARSER, true, true, false);
         PARSER.declareDouble(ExtendedStatsAggregationBuilder::sigma, ExtendedStatsAggregator.SIGMA_FIELD);
     }
+
+    private static final List<String> OUTPUT_FIELDS = InternalExtendedStats.metricNames;
 
     public static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         ExtendedStatsAggregatorFactory.registerAggregators(builder);
@@ -136,5 +139,10 @@ public class ExtendedStatsAggregationBuilder
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OUTPUT_FIELDS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<GeoBoundsAggregationBuilder> {
     public static final String NAME = "geo_bounds";
@@ -52,6 +53,8 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
     public static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         GeoBoundsAggregatorFactory.registerAggregators(builder);
     }
+
+    private static final Set<String> OUTPUT_FIELDS = Set.of("top_left", "bottom_right");
 
     private boolean wrapLongitude = true;
 
@@ -144,5 +147,10 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OUTPUT_FIELDS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 public class GeoCentroidAggregationBuilder
         extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.GeoPoint, GeoCentroidAggregationBuilder> {
@@ -44,6 +45,8 @@ public class GeoCentroidAggregationBuilder
         NAME,
         MetricAggregatorSupplier.class
     );
+
+    private static final Set<String> OUTPUT_FIELDS = Set.of("location", "count");
 
     public static final ObjectParser<GeoCentroidAggregationBuilder, String> PARSER =
         ObjectParser.fromBuilder(NAME, GeoCentroidAggregationBuilder::new);
@@ -107,5 +110,10 @@ public class GeoCentroidAggregationBuilder
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OUTPUT_FIELDS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InternalExtendedStats extends InternalStats implements ExtendedStats {
     enum Metrics {
@@ -40,6 +42,8 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
             return Metrics.valueOf(name);
         }
     }
+
+    public static List<String> metricNames = Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toList());
 
     private final double sumOfSqrs;
     private final double sigma;
@@ -113,6 +117,11 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
             return getStdDeviationBound(Bounds.LOWER_SAMPLING);
         }
         return super.value(name);
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return metricNames;
     }
 
     public double getSigma() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
@@ -70,6 +70,11 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
     }
 
     @Override
+    public String getValueAsString(String name) {
+        return percentileAsString(Double.parseDouble(name));
+    }
+
+    @Override
     protected AbstractInternalHDRPercentiles createReduced(String name, double[] keys, DoubleHistogram merged, boolean keyed,
             Map<String, Object> metadata) {
         return new InternalHDRPercentiles(name, keys, merged, keyed, format, metadata);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -86,10 +86,16 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
             super(in);
         }
 
+        @Override
         public abstract double value(String name);
 
         public String valueAsString(String name) {
             return format.format(value(name)).toString();
+        }
+
+        @Override
+        public String getValueAsString(String name) {
+            return valueAsString(name);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregationBuilder.java
@@ -106,4 +106,9 @@ public class MaxAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
@@ -151,4 +151,9 @@ public class MedianAbsoluteDeviationAggregationBuilder extends LeafOnly<ValuesSo
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregationBuilder.java
@@ -106,4 +106,9 @@ public class MinAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregation.java
@@ -51,5 +51,13 @@ public interface NumericMetricsAggregation extends Aggregation {
          */
         double value(String name);
 
+        /**
+         * Return the result of 1 value by name as string
+         *
+         * @param name of the value
+         * @return the value as string
+         */
+        String getValueAsString(String name);
+
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
@@ -60,6 +60,11 @@ public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentil
     }
 
     @Override
+    public String getValueAsString(String name) {
+        return percentileAsString(Double.parseDouble(name));
+    }
+
+    @Override
     public Iterable<String> valueNames() {
         return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
@@ -39,6 +39,11 @@ abstract class ParsedPercentileRanks extends ParsedPercentiles implements Percen
     }
 
     @Override
+    public String getValueAsString(String name) {
+        return percentAsString(Double.parseDouble(name));
+    }
+
+    @Override
     public Iterable<String> valueNames() {
         return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
@@ -104,6 +104,20 @@ public class ParsedStats extends ParsedAggregation implements Stats {
     }
 
     @Override
+    public String getValueAsString(String name) {
+        Metrics metrics = Metrics.valueOf(name);
+        switch (metrics) {
+            case min: return getMinAsString();
+            case max: return getMaxAsString();
+            case avg: return getAvgAsString();
+            case count: return Long.toString(count);
+            case sum: return getSumAsString();
+            default:
+                throw new IllegalArgumentException("Unknown value [" + name + "] in common stats aggregation");
+        }
+    }
+
+    @Override
     public Iterable<String> valueNames() {
         return metricNames;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
@@ -48,6 +48,11 @@ public class ParsedTDigestPercentiles extends ParsedPercentiles implements Perce
     }
 
     @Override
+    public String getValueAsString(String name) {
+        return percentileAsString(Double.parseDouble(name));
+    }
+
+    @Override
     public Iterable<String> valueNames() {
         return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregationBuilder.java
@@ -33,7 +33,9 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PercentileRanksAggregationBuilder extends AbstractPercentilesAggregationBuilder<PercentileRanksAggregationBuilder> {
     public static final String NAME = PercentileRanks.TYPE_NAME;
@@ -104,5 +106,10 @@ public class PercentileRanksAggregationBuilder extends AbstractPercentilesAggreg
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return Arrays.stream(values).mapToObj(Double::toString).collect(Collectors.toSet());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PercentilesAggregationBuilder extends AbstractPercentilesAggregationBuilder<PercentilesAggregationBuilder> {
     public static final String NAME = Percentiles.TYPE_NAME;
@@ -146,5 +147,10 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return Arrays.stream(values).mapToObj(Double::toString).collect(Collectors.toSet());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -300,4 +300,9 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
             && Objects.equals(params, other.params);
     }
 
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.Numeric, StatsAggregationBuilder> {
@@ -49,6 +50,8 @@ public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.Leaf
     static {
         ValuesSourceAggregationBuilder.declareFields(PARSER, true, true, false);
     }
+
+    private static final List<String> OUTPUT_FIELDS = InternalStats.metricNames;
 
     public StatsAggregationBuilder(String name) {
         super(name);
@@ -105,5 +108,10 @@ public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.Leaf
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OUTPUT_FIELDS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregationBuilder.java
@@ -106,4 +106,9 @@ public class SumAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -846,4 +846,9 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregationBuilder.java
@@ -113,4 +113,9 @@ public class ValueCountAggregationBuilder extends ValuesSourceAggregationBuilder
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregationBuilder.java
@@ -128,4 +128,9 @@ public class WeightedAvgAggregationBuilder extends MultiValuesSourceAggregationB
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
@@ -63,6 +63,11 @@ public class ParsedPercentilesBucket extends ParsedPercentiles implements Percen
     }
 
     @Override
+    public String getValueAsString(String name) {
+        return percentileAsString(Double.parseDouble(name));
+    }
+
+    @Override
     public Iterable<String> valueNames() {
         return percentiles.keySet().stream().map(d -> d.toString()).collect(Collectors.toList());
     }

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -418,6 +418,11 @@ public class SearchModuleTests extends ESTestCase {
         private static TestAggregationBuilder fromXContent(String name, XContentParser p) {
             return null;
         }
+
+        @Override
+        public Iterable<String> getOutputFieldNames() {
+            return OutputFieldNames.UNKNOWN;
+        }
     }
 
     /**

--- a/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/search/aggregations/DelayedShardAggregationBuilder.java
+++ b/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/search/aggregations/DelayedShardAggregationBuilder.java
@@ -140,4 +140,9 @@ public class DelayedShardAggregationBuilder extends AbstractAggregationBuilder<D
     public int hashCode() {
         return Objects.hash(super.hashCode(), delay);
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -934,6 +934,11 @@ public abstract class AggregatorTestCase extends ESTestCase {
             throw new UnsupportedOperationException();
 
         }
+
+        @Override
+        public Iterable<String> getOutputFieldNames() {
+            return OutputFieldNames.UNKNOWN;
+        }
     }
 
     public static class InternalAggCardinality extends InternalAggregation {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
@@ -139,5 +139,10 @@ public class BoxplotAggregationBuilder extends ValuesSourceAggregationBuilder.Le
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return InternalBoxplot.metricNames;
+    }
 }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
@@ -5,10 +5,6 @@
  */
 package org.elasticsearch.xpack.analytics.rate;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Objects;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Rounding;
@@ -28,6 +24,10 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
 
 public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource, RateAggregationBuilder> {
     public static final String NAME = "rate";
@@ -194,5 +194,10 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.LeafO
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), rateUnit, rateMode);
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
@@ -137,4 +137,9 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
         StringStatsAggregationBuilder other = (StringStatsAggregationBuilder) obj;
         return showDistribution == other.showDistribution;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -160,5 +161,10 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
 
     List<MultiValuesSourceFieldConfig> getMetricFields() {
         return metricFields;
+    }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return metricFields.stream().map(mf -> mf.getFieldName()).collect(Collectors.toList());
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregationBuilder.java
@@ -159,4 +159,9 @@ public class TTestAggregationBuilder extends MultiValuesSourceAggregationBuilder
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.SINGLE_VALUE;
+    }
 }

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
@@ -99,4 +99,9 @@ public class CancellingAggregationBuilder extends AbstractAggregationBuilder<Can
     public BucketCardinality bucketCardinality() {
         return BucketCardinality.NONE;
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedAggregationBuilder.java
@@ -94,4 +94,9 @@ public class MockDeprecatedAggregationBuilder extends ValuesSourceAggregationBui
         deprecationLogger.deprecate("deprecated_mock", DEPRECATION_MESSAGE);
         return new MockDeprecatedAggregationBuilder();
     }
+
+    @Override
+    public Iterable<String> getOutputFieldNames() {
+        return OutputFieldNames.UNKNOWN;
+    }
 }


### PR DESCRIPTION
add a getOutputFieldNames method to aggregationbuilder to retrieve the names
of the fields the aggregation produces

@polyfractal @nik9000 @not-napoleon this is a follow up from the discussion about adding the ability to retrieve the output field names of an aggregation from a builder instance.

I mainly added:

```
    /** Return the field names this aggregation creates*/
    public abstract Iterable<String> getOutputFieldNames();
```

and a set of common ones in `AbstractAggregationBuilder`.

The PR is not complete, I took some shortcuts and did not add any tests. I want to get the design 1st before spending to much resources on it.

Open discussion points (beside the interface):

 - how to handle the unknown case, e.g. `scripted_metric`, `top_hits`, ... Only report the top level key: `value`/`hits`?
 - sub-aggs are ignored in this change, I think that makes sense, does it?
 - key_as_string are ignored because they just contain a normalized value of another field
 - `extended_stats` has nested outputs, should it return e.g. `std_deviation_bounds.upper`?

Again, no need to review it in detail. Let's discuss the interfaces and some details. I will fix the rest once we nailed it down. 