### PR TITLE
[7.4] [DOCS] POST /_aliases remove_index action only works on concrete indices (#64616)

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -63,8 +63,8 @@ Adds an alias to an index.
 Removes an alias from an index.
 
 `remove_index`::
-Deletes an index or index alias,
-like the <<indices-delete-index,delete index API>>.
+Deletes a concrete index, similar to the <<indices-delete-index, delete index
+API>>. Attempts to remove an index alias will fail.
 
 You can perform these actions on alias objects.
 Valid parameters for alias objects include:
@@ -276,7 +276,7 @@ POST /_aliases
 // CONSOLE
 <1> An index we've added by mistake
 <2> The index we should have added
-<3> `remove_index` is just like <<indices-delete-index>>
+<3> `remove_index` is just like <<indices-delete-index>> but will only remove a concrete index.
 
 [[filtered]]
 ===== Filtered aliases


### PR DESCRIPTION
Backports the following commits to 7.4:
 - [DOCS] POST /_aliases remove_index action only works on concrete indices (#64616)