### PR TITLE
[7.10] Tests: fix testBulkProcessorConcurrentRequestsReadOnlyIndex (#64633)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
@@ -248,7 +248,8 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
                 .setFlushInterval(TimeValue.timeValueHours(24)).setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB)).build()) {
 
             for (int i = 1; i <= numDocs; i++) {
-                if (randomBoolean()) {
+                // let's make sure we get at least 1 item in the MultiGetRequest regardless of the randomising roulette
+                if (randomBoolean() || multiGetRequest.getItems().size() == 0) {
                     testDocs++;
                     processor.add(new IndexRequest("test").id(Integer.toString(testDocs))
                             .source(XContentType.JSON, "field", "value"));


### PR DESCRIPTION
Executing a MultiGetRequest with no items will fail. This makes sure there
is always at least one item in the request.

(cherry picked from commit bd4703250fe331296b8613b277ea25c8bef1dcd9)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #64633 