### PR TITLE
[DOCS] Document off-heap swaps under mlocks

### DIFF
--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -52,8 +52,14 @@ http://opengroup.org/onlinepubs/007908799/xsh/mlockall.html[mlockall] on
 Linux/Unix systems, or
 https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895%28v=vs.85%29.aspx[VirtualLock]
 on Windows, to try to lock the process address space into RAM, preventing any
-Elasticsearch memory from being swapped out. This can be done, by adding this
-line to the `config/elasticsearch.yml` file:
+{es} heap memory from being swapped out.
+
+NOTE: Some platforms still swap off-heap memory when using a memory lock. To
+prevent off-heap memory swaps, <<disable-swap-files,disable all swap files>>
+instead.
+
+To enable a memory lock, set `bootstrap.memory_lock` to `true` in
+`elasticsearch.yml`:
 
 [source,yaml]
 --------------


### PR DESCRIPTION
Notes that some platforms still swap off-heap memory when using a memory lock.
If users want to prevent this, they should disable all swaps instead.

Closes #58092

### Preview

https://elasticsearch_64667.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/setup-configuration-memory.html#bootstrap-memory_lock

<img width="746" alt="Screen Shot 2020-11-05 at 1 56 03 PM" src="https://user-images.githubusercontent.com/40268737/98284173-ba749c00-1f6e-11eb-95b7-d65e6a059483.PNG">
