### PR TITLE
[DOCS] Improve docs for Windows DOS/UNC paths in `path.*` settings

### DIFF
--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -7,9 +7,8 @@ For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
 respective `data` and `logs` subdirectories of `$ES_HOME` by default. However,
 files in `$ES_HOME` risk deletion during an upgrade.
 
-In production, we strongly recommend you use the `path.data` and `path.logs`
-settings in `elasticsearch.yml` to write data and logs to locations outside of
-`$ES_HOME`.
+In production, we strongly recommend you set the `path.data` and `path.logs` in
+`elasticsearch.yml` to locations outside of `$ES_HOME`.
 
 TIP: <<docker,Docker>>, <<deb,Debian>>, <<rpm,RPM>>, <<brew,macOS Homebrew>>,
 and <<windows,Windows `.msi`>> installations write data and log to locations

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -4,7 +4,7 @@
 
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
 <<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
-respective `data` and `logs` subdirectories of `$ES_HOME` or by default.
+respective `data` and `logs` subdirectories of `$ES_HOME` by default.
 However, files in `$ES_HOME` risk deletion during an upgrade.
 
 In production, we strongly recommend you set the `path.data` and `path.logs` in
@@ -24,9 +24,9 @@ If needed, you can specify multiple paths in `path.data`. {es} stores the node's
 data across all provided paths but keeps each shard's data on the same path.
 
 WARNING: {es} does not balance shards across a node's data paths. High disk
-usage in a single path can trigger a <<disk-based-shard-allocation, related
-watermark>> for the entire node. If triggered, {es} will not add shards to the
-node, even if the node’s other paths have available disk space. If you need
+usage in a single path can trigger a <<disk-based-shard-allocation,high disk
+usage watermark>> for the entire node. If triggered, {es} will not add shards to
+the node, even if the node’s other paths have available disk space. If you need
 additional disk space, we recommend you add a new node rather than additional
 data paths. 
 

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -2,32 +2,31 @@
 [discrete]
 === Path settings
 
-If you are using the `.zip` or `.tar.gz` archives, the `data` and `logs`
-directories are sub-folders of `$ES_HOME`. If these important folders are left
-in their default locations, there is a high risk of them being deleted while
-upgrading {es} to a new version.
+For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
+<<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
+respective `data` and `logs` subdirectories of `$ES_HOME` by default. However,
+these files risk deletion during an upgrade.
 
-In production use, you will almost certainly want to change the locations of the
-`path.data` and `path.logs` folders:
+In production, we strongly recommend you use the `path.data` and `path.logs`
+settings in `elasticsearch.yml` to write data and logs to locations outside of
+`$ES_HOME`.
 
-[source,yaml]
---------------------------------------------------
-path:
-  logs: /var/log/elasticsearch
-  data: /var/data/elasticsearch
---------------------------------------------------
+TIP: <<docker,Docker>>, <<deb,Debian>>, <<rpm,RPM>>, <<brew,macOS Homebrew>>,
+and <<windows,Windows `.msi`>> installations already use data and log locations
+outside of `$ES_HOME` by default.
 
-The RPM and Debian distributions already use custom paths for `data` and `logs`.
+include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
-The `path.data` settings can be set to multiple paths, in which case all paths
-will be used to store data. However, the files belonging to a single shard will
-all be stored on the same data path:
+include::{es-repo-dir}/tab-widgets/customize-data-log-path-widget.asciidoc[]
 
-[source,yaml]
---------------------------------------------------
-path:
-  data:
-    - /mnt/elasticsearch_1
-    - /mnt/elasticsearch_2
-    - /mnt/elasticsearch_3
---------------------------------------------------
+If needed, you can specify multiple paths in `path.data`. {es} stores the node's
+data across all provided paths but keeps each shard's data on the same path.
+
+WARNING: {es} does not balance shards across a node's data paths. High disk
+usage in a single path can trigger a <<disk-based-shard-allocation, related
+watermark>> for the entire node. If triggered, {es} will not add shards to the
+node, even if the node’s other paths have available disk space. If you need
+additional disk space, we recommend you add a new node rather than additional
+data paths. 
+
+include::{es-repo-dir}/tab-widgets/multi-data-path-widget.asciidoc[]

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -5,14 +5,14 @@
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
 <<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
 respective `data` and `logs` subdirectories of `$ES_HOME` by default. However,
-these files risk deletion during an upgrade.
+files in `$ES_HOME` risk deletion during an upgrade.
 
 In production, we strongly recommend you use the `path.data` and `path.logs`
 settings in `elasticsearch.yml` to write data and logs to locations outside of
 `$ES_HOME`.
 
 TIP: <<docker,Docker>>, <<deb,Debian>>, <<rpm,RPM>>, <<brew,macOS Homebrew>>,
-and <<windows,Windows `.msi`>> installations already use data and log locations
+and <<windows,Windows `.msi`>> installations write data and log to locations
 outside of `$ES_HOME` by default.
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -4,8 +4,8 @@
 
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
 <<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
-respective `data` and `logs` subdirectories of `$ES_HOME` by default. However,
-files in `$ES_HOME` risk deletion during an upgrade.
+respective `data` and `logs` subdirectories of `$ES_HOME` or by default.
+However, files in `$ES_HOME` risk deletion during an upgrade.
 
 In production, we strongly recommend you set the `path.data` and `path.logs` in
 `elasticsearch.yml` to locations outside of `$ES_HOME`.

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -15,6 +15,8 @@ TIP: <<docker,Docker>>, <<deb,Debian>>, <<rpm,RPM>>, <<brew,macOS Homebrew>>,
 and <<windows,Windows `.msi`>> installations write data and log to locations
 outside of `$ES_HOME` by default.
 
+Supported `path.data` and `path.logs` values vary by platform:
+
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/customize-data-log-path-widget.asciidoc[]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -109,6 +109,8 @@ parent directory to the `path.repo` setting in `elasticsearch.yml` for each
 master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.
 
+Supported `path.repo` values vary by platform:
+
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/register-fs-repo-widget.asciidoc[]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -100,46 +100,18 @@ are left untouched and in place.
 [[snapshots-filesystem-repository]]
 === Shared file system repository
 
-The shared file system repository (`"type": "fs"`) uses the shared file system to store snapshots. In order to register
-the shared file system repository it is necessary to mount the same shared filesystem to the same location on all
-master and data nodes. This location (or one of its parent directories) must be registered in the `path.repo`
-setting on all master and data nodes.
+Use a shared file system repository (`"type": "fs"`) to store snapshots on a
+shared file system.
 
-Assuming that the shared filesystem is mounted to `/mount/backups/my_fs_backup_location`, the following setting should
-be added to `elasticsearch.yml` file:
+To register a shared file system repository, first mount the file system to the
+same location on all master and data nodes. Next steps vary slightly based on
+your platform:
 
-[source,yaml]
---------------
-path.repo: ["/mount/backups", "/mount/longterm_backups"]
---------------
+include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
-If running {es} directly on Windows, you can specify UNC paths in `path.repo`.
-Provide the server name and share as a prefix and escape any backslashes:
+include::{es-repo-dir}/tab-widgets/register-fs-repo-widget.asciidoc[]
 
-[source,yaml]
---------------
-path.repo: ["\\\\MY_SERVER\\Snapshots"]
---------------
-
-After all nodes are restarted, the following command can be used to register the shared file system repository with
-the name `my_fs_backup`:
-
-[source,console]
------------------------------------
-PUT /_snapshot/my_fs_backup
-{
-  "type": "fs",
-  "settings": {
-    "location": "/mount/backups/my_fs_backup_location",
-    "compress": true
-  }
-}
------------------------------------
-// TEST[skip:no access to absolute path]
-
-If the repository location is specified as a relative path this path will be resolved against the first path specified
-in `path.repo`:
-
+////
 [source,console]
 -----------------------------------
 PUT /_snapshot/my_fs_backup
@@ -152,19 +124,7 @@ PUT /_snapshot/my_fs_backup
 }
 -----------------------------------
 // TEST[continued]
-
-The following settings are supported:
-
-`location`:: Location of the snapshots. Mandatory.
-`compress`:: Turns on compression of the snapshot files. Compression is applied only to metadata files (index mapping and settings). Data files are not compressed. Defaults to `true`.
-`chunk_size`:: Big files can be broken down into chunks during snapshotting if needed. Specify the chunk size as a value and
-unit, for example: `1GB`, `10MB`, `5KB`, `500B`. Defaults to `null` (unlimited chunk size).
-`max_restore_bytes_per_sec`:: Throttles per node restore rate. Defaults to unlimited. Note that restores are also throttled through <<recovery,recovery settings>>.
-`max_snapshot_bytes_per_sec`:: Throttles per node snapshot rate. Defaults to `40mb` per second.
-`readonly`:: Makes repository read-only.  Defaults to `false`.
-`max_number_of_snapshots`:: Limits the maximum number of snapshots that the repository may contain. Defaults to `500`. Note that snapshot repositories do not
-scale indefinitely in size and might lead to master node performance and stability issues if they grow past a certain size. We do not recommend increasing this setting.
-Instead you should delete older snapshots or use multiple repositories.
+////
 
 [discrete]
 [[snapshots-read-only-repository]]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -104,7 +104,7 @@ Use a shared file system repository (`"type": "fs"`) to store snapshots on a
 shared file system.
 
 To register a shared file system repository, first mount the file system to the
-same location on the cluster's master and data nodes. Then add the file system's
+same location on all master and data nodes. Then add the file system's
 path or parent directory to the `path.repo` setting in `elasticsearch.yml` for
 each master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -104,27 +104,14 @@ Use a shared file system repository (`"type": "fs"`) to store snapshots on a
 shared file system.
 
 To register a shared file system repository, first mount the file system to the
-same location on all master and data nodes. Next steps vary slightly based on
-your platform:
+same location on all master and data nodes. Then add the file system's path or
+parent directory to the `path.repo` setting in `elasticsearch.yml` for each
+master and data node. For running clusters, this requires a
+<<restart-cluster-rolling,rolling restart>> of each node.
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/register-fs-repo-widget.asciidoc[]
-
-////
-[source,console]
------------------------------------
-PUT /_snapshot/my_fs_backup
-{
-  "type": "fs",
-  "settings": {
-    "location": "my_fs_backup_location",
-    "compress": true
-  }
-}
------------------------------------
-// TEST[continued]
-////
 
 [discrete]
 [[snapshots-read-only-repository]]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -104,9 +104,9 @@ Use a shared file system repository (`"type": "fs"`) to store snapshots on a
 shared file system.
 
 To register a shared file system repository, first mount the file system to the
-same location on all master and data nodes. Then add the file system's path or
-parent directory to the `path.repo` setting in `elasticsearch.yml` for each
-master and data node. For running clusters, this requires a
+same location on the cluster's master and data nodes. Then add the file system's
+path or parent directory to the `path.repo` setting in `elasticsearch.yml` for
+each master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.
 
 Supported `path.repo` values vary by platform:

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -113,8 +113,8 @@ be added to `elasticsearch.yml` file:
 path.repo: ["/mount/backups", "/mount/longterm_backups"]
 --------------
 
-The `path.repo` setting supports Microsoft Windows UNC paths as long as at least server name and share are specified as
-a prefix and back slashes are properly escaped:
+If running {es} directly on Windows, you can specify UNC paths in `path.repo`.
+Provide the server name and share as a prefix and escape any backslashes:
 
 [source,yaml]
 --------------

--- a/docs/reference/tab-widgets/customize-data-log-path-widget.asciidoc
+++ b/docs/reference/tab-widgets/customize-data-log-path-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="data-log-path">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="unix-tab-data-log-path"
+            id="unix-data-log-path">
+      Unix-like systems
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-data-log-path"
+            id="win-data-log-path">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="unix-tab-data-log-path"
+       aria-labelledby="unix-data-log-path">
+++++
+
+include::customize-data-log-path.asciidoc[tag=unix]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-data-log-path"
+       aria-labelledby="win-data-log-path"
+       hidden="">
+++++
+
+include::customize-data-log-path.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/customize-data-log-path.asciidoc
+++ b/docs/reference/tab-widgets/customize-data-log-path.asciidoc
@@ -11,22 +11,12 @@ path:
 
 
 // tag::win[]
-Windows installations support both traditional DOS and Microsoft UNC paths. The
-following example uses traditional DOS paths with escaped backslashes:
+Windows installations support DOS paths with escaped backslashes:
 
 [source,yaml]
 ----
 path:
   data: "C:\\Elastic\\Elasticsearch\\data"
   logs: "C:\\Elastic\\Elasticsearch\\logs"
-----
-
-For UNC paths, provide the server name or share as a prefix:
-
-[source,yaml]
-----
-path:
-  data: "\\\\MY_SERVER\\Elastic\\Elasticsearch\\data"
-  logs: "\\\\MY_SERVER\\Elastic\\Elasticsearch\\logs"
 ----
 // end::win[]

--- a/docs/reference/tab-widgets/customize-data-log-path.asciidoc
+++ b/docs/reference/tab-widgets/customize-data-log-path.asciidoc
@@ -1,5 +1,5 @@
 // tag::unix[]
-macOS and Linux, including Debian and RPM, support Unix-style paths:
+Linux and macOS installations support Unix-style paths:
 
 [source,yaml]
 ----
@@ -11,10 +11,8 @@ path:
 
 
 // tag::win[]
-If running {es} directly on Windows, both traditional DOS and Microsoft UNC
-paths are supported.
-
-The following example uses traditional DOS paths with escaped backslashes:
+Windows installations support both traditional DOS and Microsoft UNC paths. The
+following example uses traditional DOS paths with escaped backslashes:
 
 [source,yaml]
 ----

--- a/docs/reference/tab-widgets/customize-data-log-path.asciidoc
+++ b/docs/reference/tab-widgets/customize-data-log-path.asciidoc
@@ -1,0 +1,33 @@
+// tag::unix[]
+
+[source,yaml]
+----
+path:
+  data: /var/data/elasticsearch
+  logs: /var/log/elasticsearch
+----
+// end::unix[]
+
+
+// tag::win[]
+If running {es} directly on Windows, both traditional DOS and Microsoft UNC
+paths are supported.
+
+The following example uses traditional DOS paths with escaped backslashes:
+
+[source,yaml]
+----
+path:
+  data: "C:\\Elastic\\Elasticsearch\\data"
+  logs: "C:\\Elastic\\Elasticsearch\\logs"
+----
+
+For UNC paths, provide the server name or share as a prefix:
+
+[source,yaml]
+----
+path:
+  data: "\\\\MY_SERVER\\Elastic\\Elasticsearch\\data"
+  logs: "\\\\MY_SERVER\\Elastic\\Elasticsearch\\logs"
+----
+// end::win[]

--- a/docs/reference/tab-widgets/customize-data-log-path.asciidoc
+++ b/docs/reference/tab-widgets/customize-data-log-path.asciidoc
@@ -1,4 +1,5 @@
 // tag::unix[]
+macOS and Linux, including Debian and RPM, support Unix-style paths:
 
 [source,yaml]
 ----

--- a/docs/reference/tab-widgets/logging-widget.asciidoc
+++ b/docs/reference/tab-widgets/logging-widget.asciidoc
@@ -25,7 +25,7 @@
             aria-controls="mac-tab-logs"
             id="mac-logs"
             tabindex="-1">
-      MacOS
+      macOS
     </button>
     <button role="tab"
             aria-selected="false"

--- a/docs/reference/tab-widgets/logging.asciidoc
+++ b/docs/reference/tab-widgets/logging.asciidoc
@@ -16,8 +16,8 @@ For <<targz,macOS `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
 Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
-recommend you use the `path.logs` setting to write logs to a location outside of
-`$ES_HOME`. See <<path-settings>>.
+recommend you set `path.logs` to write logs to a location outside of `$ES_HOME`.
+See <<path-settings>>.
 // end::mac[]
 
 // tag::brew[]
@@ -30,17 +30,17 @@ For <<targz,Linux `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
 Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
-recommend you use the `path.logs` setting to write logs to a location outside of
-`$ES_HOME`. See <<path-settings>>.
+recommend you set `path.logs` to write logs to a location outside of `$ES_HOME`.
+See <<path-settings>>.
 // end::linux[]
 
 // tag::win-zip[]
 For <<zip-windows,Windows `.zip`>> installations, {es} writes logs to
 `%ES_HOME%\logs`.
 
-Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
-recommend you use the `path.logs` setting to write logs to a location outside of
-`$ES_HOME`. See <<path-settings>>.
+Files in `%ES_HOME%` risk deletion during an upgrade. In production, we strongly
+recommend you set `path.logs` to write logs to a location outside of `%ES_HOME%``.
+See <<path-settings>>.
 // end::win-zip[]
 
 // tag::win-msi[]

--- a/docs/reference/tab-widgets/logging.asciidoc
+++ b/docs/reference/tab-widgets/logging.asciidoc
@@ -15,9 +15,9 @@ For <<rpm,RPM installations>>, {es} writes logs to `/var/log/elasticsearch`.
 For <<targz,macOS `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
-Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
-strongly recommend you use the `path.logs` setting to write logs to a location
-outside of `$ES_HOME`. See <<path-settings>>.
+Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
+recommend you use the `path.logs` setting to write logs to a location outside of
+`$ES_HOME`. See <<path-settings>>.
 // end::mac[]
 
 // tag::brew[]
@@ -29,18 +29,18 @@ For <<brew,macOS Homebrew>> installations, {es} writes logs to
 For <<targz,Linux `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
-Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
-strongly recommend you use the `path.logs` setting to write logs to a location
-outside of `$ES_HOME`. See <<path-settings>>.
+Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
+recommend you use the `path.logs` setting to write logs to a location outside of
+`$ES_HOME`. See <<path-settings>>.
 // end::linux[]
 
 // tag::win-zip[]
 For <<zip-windows,Windows `.zip`>> installations, {es} writes logs to
 `%ES_HOME%\logs`.
 
-Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
-strongly recommend you use the `path.logs` setting to write logs to a location
-outside of `$ES_HOME`. See <<path-settings>>.
+Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
+recommend you use the `path.logs` setting to write logs to a location outside of
+`$ES_HOME`. See <<path-settings>>.
 // end::win-zip[]
 
 // tag::win-msi[]

--- a/docs/reference/tab-widgets/logging.asciidoc
+++ b/docs/reference/tab-widgets/logging.asciidoc
@@ -16,7 +16,7 @@ For <<targz,macOS `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
 Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
-recommend you set `path.logs` to write logs to a location outside of `$ES_HOME`.
+recommend you set `path.logs` to a location outside of `$ES_HOME`.
 See <<path-settings>>.
 // end::mac[]
 
@@ -30,7 +30,7 @@ For <<targz,Linux `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
 
 Files in `$ES_HOME` risk deletion during an upgrade. In production, we strongly
-recommend you set `path.logs` to write logs to a location outside of `$ES_HOME`.
+recommend you set `path.logs` to a location outside of `$ES_HOME`.
 See <<path-settings>>.
 // end::linux[]
 
@@ -39,7 +39,7 @@ For <<zip-windows,Windows `.zip`>> installations, {es} writes logs to
 `%ES_HOME%\logs`.
 
 Files in `%ES_HOME%` risk deletion during an upgrade. In production, we strongly
-recommend you set `path.logs` to write logs to a location outside of `%ES_HOME%``.
+recommend you set `path.logs` to a location outside of `%ES_HOME%``.
 See <<path-settings>>.
 // end::win-zip[]
 

--- a/docs/reference/tab-widgets/logging.asciidoc
+++ b/docs/reference/tab-widgets/logging.asciidoc
@@ -12,23 +12,35 @@ For <<rpm,RPM installations>>, {es} writes logs to `/var/log/elasticsearch`.
 // end::rpm[]
 
 // tag::mac[]
-For <<targz,MacOS `.tar.gz`>> installations, {es} writes logs to
+For <<targz,macOS `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
+
+Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
+strongly recommend you use the `path.logs` setting to write logs to a location
+outside of `$ES_HOME`. See <<path-settings>>.
 // end::mac[]
 
 // tag::brew[]
-For <<brew,MacOS Homebrew>> installations, {es} writes logs to
+For <<brew,macOS Homebrew>> installations, {es} writes logs to
 `/usr/local/var/log/elasticsearch`.
 // end::brew[]
 
 // tag::linux[]
 For <<targz,Linux `.tar.gz`>> installations, {es} writes logs to
 `$ES_HOME/logs`.
+
+Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
+strongly recommend you use the `path.logs` setting to write logs to a location
+outside of `$ES_HOME`. See <<path-settings>>.
 // end::linux[]
 
 // tag::win-zip[]
 For <<zip-windows,Windows `.zip`>> installations, {es} writes logs to
 `%ES_HOME%\logs`.
+
+Logs in `$ES_HOME/logs` risk deletion during an upgrade. In production, we
+strongly recommend you use the `path.logs` setting to write logs to a location
+outside of `$ES_HOME`. See <<path-settings>>.
 // end::win-zip[]
 
 // tag::win-msi[]

--- a/docs/reference/tab-widgets/multi-data-path-widget.asciidoc
+++ b/docs/reference/tab-widgets/multi-data-path-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="multi-data-path">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="unix-tab-multi-data-path"
+            id="unix-multi-data-path">
+      Unix-like systems
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-multi-data-path"
+            id="win-multi-data-path">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="unix-tab-multi-data-path"
+       aria-labelledby="unix-multi-data-path">
+++++
+
+include::multi-data-path.asciidoc[tag=unix]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-multi-data-path"
+       aria-labelledby="win-multi-data-path"
+       hidden="">
+++++
+
+include::multi-data-path.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/multi-data-path.asciidoc
+++ b/docs/reference/tab-widgets/multi-data-path.asciidoc
@@ -1,4 +1,6 @@
 // tag::unix[]
+Linux and macOS installations support multiple Unix-style paths in `path.data`:
+
 [source,yaml]
 ----
 path:
@@ -11,12 +13,14 @@ path:
 
 
 // tag::win[]
+Windows installations support multiple traditional DOS and Microsoft UNC paths in `path.data`:
+
 [source,yaml]
 ----
 path:
   data:
     - "C:\\Elastic\\Elasticsearch_1"
-    - "C:\\Elastic\\Elasticsearch_2"
-    - "C:\\Elastic\\Elasticsearch_3"
+    - "\\\\MY_SERVER\\Elastic\\Elasticsearch_2"
+    - "E:\\Elastic\\Elasticsearch_3"
 ----
 // end::win[]

--- a/docs/reference/tab-widgets/multi-data-path.asciidoc
+++ b/docs/reference/tab-widgets/multi-data-path.asciidoc
@@ -1,0 +1,22 @@
+// tag::unix[]
+[source,yaml]
+----
+path:
+  data:
+    - /mnt/elasticsearch_1
+    - /mnt/elasticsearch_2
+    - /mnt/elasticsearch_3
+----
+// end::unix[]
+
+
+// tag::win[]
+[source,yaml]
+----
+path:
+  data:
+    - "C:\\Elastic\\Elasticsearch_1"
+    - "C:\\Elastic\\Elasticsearch_2"
+    - "C:\\Elastic\\Elasticsearch_3"
+----
+// end::win[]

--- a/docs/reference/tab-widgets/multi-data-path.asciidoc
+++ b/docs/reference/tab-widgets/multi-data-path.asciidoc
@@ -13,14 +13,14 @@ path:
 
 
 // tag::win[]
-Windows installations support multiple traditional DOS and Microsoft UNC paths in `path.data`:
+Windows installations support multiple DOS paths in `path.data`:
 
 [source,yaml]
 ----
 path:
   data:
     - "C:\\Elastic\\Elasticsearch_1"
-    - "\\\\MY_SERVER\\Elastic\\Elasticsearch_2"
-    - "E:\\Elastic\\Elasticsearch_3"
+    - "E:\\Elastic\\Elasticsearch_1"
+    - "F:\\Elastic\\Elasticsearch_3"
 ----
 // end::win[]

--- a/docs/reference/tab-widgets/register-fs-repo-widget.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="fs-repo">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="unix-tab-fs-repo"
+            id="unix-fs-repo">
+      Unix-like systems
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-fs-repo"
+            id="win-fs-repo">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="unix-tab-fs-repo"
+       aria-labelledby="unix-fs-repo">
+++++
+
+include::register-fs-repo.asciidoc[tag=unix]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-fs-repo"
+       aria-labelledby="win-fs-repo"
+       hidden="">
+++++
+
+include::register-fs-repo.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -50,7 +50,7 @@ relative path, `my_fs_backup_location`, resolves to
 
 // tag::win[]
 Windows installations support both DOS and Microsoft UNC paths. Escaped any
-backslashes in the path. For UNC paths, provide the server and share name as a
+backslashes in the paths. For UNC paths, provide the server and share name as a
 prefix.
 
 [source,yaml]

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -1,5 +1,5 @@
 // tag::unix[]
-Unix-style paths are supported:
+Linux and macOS installations support Unix-style paths:
 
 [source,yaml]
 ----
@@ -49,8 +49,8 @@ relative path, `my_fs_backup_location`, resolves to
 
 
 // tag::win[]
-Both traditional DOS and Microsoft UNC paths are supported. The following
-example uses traditional DOS paths with escaped backslashes:
+Windows installations support both traditional DOS and Microsoft UNC paths. The
+following example uses traditional DOS paths with escaped backslashes:
 
 [source,yaml]
 ----

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -1,4 +1,6 @@
 // tag::unix[]
+Unix-style paths are supported:
+
 [source,yaml]
 ----
 path:

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -49,26 +49,20 @@ relative path, `my_fs_backup_location`, resolves to
 
 
 // tag::win[]
-Windows installations support both DOS and Microsoft UNC paths. The following
-example uses DOS paths with escaped backslashes:
+Windows installations support both DOS and Microsoft UNC paths. Escaped any
+backslashes in the path. For UNC paths, provide the server and share name as a
+prefix.
 
 [source,yaml]
 ----
 path:
   repo:
-    - "E:\\Mount\\Backups"
-    - "F:\\Mount\\Long_term_backups"
+    - "E:\\Mount\\Backups"                      <1>
+    - "\\\\MY_SERVER\\Mount\\Long_term_backups" <2>
 ----
 
-For UNC paths, provide the server and share name as a prefix:
-
-[source,yaml]
-----
-path:
-  repo:
-    - "\\\\MY_SERVER\\Mount\\Backups"
-    - "\\\\MY_SERVER\\Mount\\Long_term_backups"
-----
+<1> DOS path
+<2> UNC path
 
 After restarting each node, use the <<put-snapshot-repo-api,put snapshot
 repository>> API to register the file system repository. Specify the file

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -51,13 +51,12 @@ relative path, `my_fs_backup_location`, resolves to
 
 
 // tag::win[]
-If running {es} directly on Windows, both traditional DOS and Microsoft UNC
-paths are supported. Add the file system's path or parent directory to the
-`path.repo` setting in `elasticsearch.yml` for each master and data node. For
-running clusters, this requires a <<restart-cluster-rolling,rolling restart>> of
-each node.
+Add the file system's path or parent directory to the `path.repo` setting in
+`elasticsearch.yml` for each master and data node. For running clusters, this
+requires a <<restart-cluster-rolling,rolling restart>> of each node.
 
-The following example uses traditional DOS paths with escaped backslashes:
+Both traditional DOS and Microsoft UNC paths are supported. The following
+example uses traditional DOS paths with escaped backslashes:
 
 [source,yaml]
 ----
@@ -87,7 +86,7 @@ PUT /_snapshot/my_fs_backup
 {
   "type": "fs",
   "settings": {
-    "location": "E:\\Mount\\Backups\My_fs_backup_location",
+    "location": "E:\\Mount\\Backups\\My_fs_backup_location",
     "compress": true
   }
 }

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -1,0 +1,116 @@
+// tag::unix[]
+Add the file system's path or parent directory to the `path.repo` setting in
+`elasticsearch.yml` for each master and data node. For running clusters, this
+requires a <<restart-cluster-rolling,rolling restart>> of each node.
+
+[source,yaml]
+----
+path:
+  repo:
+    - /mount/backups
+    - /mount/long_term_backups
+----
+
+After restarting each node, use the <<put-snapshot-repo-api,put snapshot
+repository>> API to register the file system repository. Specify the file
+system's path in `settings.location`:
+
+[source,console]
+----
+PUT /_snapshot/my_fs_backup
+{
+  "type": "fs",
+  "settings": {
+    "location": "/mount/backups/my_fs_backup_location",
+    "compress": true
+  }
+}
+----
+// TEST[skip:no access to path]
+
+If you specify a relative path in `settings.location`, {es} resolves the path
+using the first value in the `path.repo` setting.
+
+[source,console]
+----
+PUT /_snapshot/my_fs_backup
+{
+  "type": "fs",
+  "settings": {
+    "location": "my_fs_backup_location",       <1>
+    "compress": true
+  }
+}
+----
+// TEST[skip:no access to path]
+
+<1> The first value in the `path.repo` setting is `/mount/backups`. This
+relative path, `my_fs_backup_location`, resolves to
+`/mount/backups/my_fs_backup_location`.
+// end::unix[]
+
+
+// tag::win[]
+If running {es} directly on Windows, both traditional DOS and Microsoft UNC
+paths are supported. Add the file system's path or parent directory to the
+`path.repo` setting in `elasticsearch.yml` for each master and data node. For
+running clusters, this requires a <<restart-cluster-rolling,rolling restart>> of
+each node.
+
+The following example uses traditional DOS paths with escaped backslashes:
+
+[source,yaml]
+----
+path:
+  repo:
+    - "E:\\Mount\\Backups"
+    - "F:\\Mount\\Long_term_backups"
+----
+
+For UNC paths, provide the server or share name as a prefix:
+
+[source,yaml]
+----
+path:
+  repo:
+    - "\\\\MY_SERVER\\Mount\\Backups"
+    - "\\\\MY_SERVER\\Mount\\Long_term_backups"
+----
+
+After restarting each node, use the <<put-snapshot-repo-api,put snapshot
+repository>> API to register the file system repository. Specify the file
+system's path in `settings.location`:
+
+[source,console]
+----
+PUT /_snapshot/my_fs_backup
+{
+  "type": "fs",
+  "settings": {
+    "location": "E:\\Mount\\Backups\My_fs_backup_location",
+    "compress": true
+  }
+}
+----
+// TEST[skip:no access to path]
+
+If you specify a relative path in `settings.location`, {es} resolves the path
+using the first value in the `path.repo` setting.
+
+[source,console]
+----
+PUT /_snapshot/my_fs_backup
+{
+  "type": "fs",
+  "settings": {
+    "location": "My_fs_backup_location",       <1>
+    "compress": true
+  }
+}
+----
+// TEST[skip:no access to path]
+
+<1> The first value in the `path.repo` setting is `E:\Mount\Backups`. This
+relative path, `My_fs_backup_location`, resolves to
+`E:\Mount\Backups\My_fs_backup_location`.
+// end::win[]

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -1,8 +1,4 @@
 // tag::unix[]
-Add the file system's path or parent directory to the `path.repo` setting in
-`elasticsearch.yml` for each master and data node. For running clusters, this
-requires a <<restart-cluster-rolling,rolling restart>> of each node.
-
 [source,yaml]
 ----
 path:
@@ -51,10 +47,6 @@ relative path, `my_fs_backup_location`, resolves to
 
 
 // tag::win[]
-Add the file system's path or parent directory to the `path.repo` setting in
-`elasticsearch.yml` for each master and data node. For running clusters, this
-requires a <<restart-cluster-rolling,rolling restart>> of each node.
-
 Both traditional DOS and Microsoft UNC paths are supported. The following
 example uses traditional DOS paths with escaped backslashes:
 

--- a/docs/reference/tab-widgets/register-fs-repo.asciidoc
+++ b/docs/reference/tab-widgets/register-fs-repo.asciidoc
@@ -49,8 +49,8 @@ relative path, `my_fs_backup_location`, resolves to
 
 
 // tag::win[]
-Windows installations support both traditional DOS and Microsoft UNC paths. The
-following example uses traditional DOS paths with escaped backslashes:
+Windows installations support both DOS and Microsoft UNC paths. The following
+example uses DOS paths with escaped backslashes:
 
 [source,yaml]
 ----
@@ -60,7 +60,7 @@ path:
     - "F:\\Mount\\Long_term_backups"
 ----
 
-For UNC paths, provide the server or share name as a prefix:
+For UNC paths, provide the server and share name as a prefix:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Better delineates the paths supported by Windows and Unix-like systems.
Adds more examples for Windows DOS/UNC paths in `path.*` setting snippets.

Closes #57630

Closes #51211

### Preview

Register a snapshot repository: https://elasticsearch_64668.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshots-register-repository.html

Logging: https://elasticsearch_64668.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/logging.html

Path settings: https://elasticsearch_64668.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/important-settings.html#path-settings
