### PR TITLE
[DOCS] EQL: Fix tiebreaker field docs

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -250,8 +250,8 @@ Field used to sort events with the same
 If no tiebreaker field is specified or the events also share the same tiebreaker
 field value, {es} uses <<sort-search-results,`_doc` order>>.
 +
-If you use {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker
-field.
+If you use {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
+`event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -247,10 +247,11 @@ this value.
 (Optional, string)
 Field used to sort events with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
-If no tiebreaker field is specified or the events also share the same tiebreaker
-field value, {es} uses <<sort-search-results,`_doc` order>>.
+For basic queries, {es} uses <<sort-search-results,`_doc` order>> if no
+tiebreaker field is specified or the events also share the same tiebreaker value.
 +
-If you use the {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
+If you specify a tiebreaker field, all documents in the searched index or data
+stream must contain the field. If you use the {ecs-ref}[ECS], we recommend using
 `event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -252,8 +252,8 @@ indices must contain the field. For basic queries, {es} uses
 <<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
 events also share the same tiebreaker value.
 +
-If you use the {ecs-ref}[ECS], we recommend using `event.sequence` as the
-tiebreaker field.
+If you use the {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
+`event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -245,7 +245,7 @@ this value.
 [[eql-search-api-tiebreaker-field]]
 `tiebreaker_field`::
 (Optional, string)
-Field used to sort events with the same
+Field used to sort hits with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
 If you specify a tiebreaker field for a sequence query, all documents in the
 searched data streams or indices must contain the field. For basic queries, {es}

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -252,7 +252,7 @@ indices must contain the field. For basic queries, {es} uses
 <<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
 events also share the same tiebreaker value.
 +
- If you use the {ecs-ref}[ECS], we recommend using
+If you use the {ecs-ref}[ECS], we recommend using
 `event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -247,11 +247,12 @@ this value.
 (Optional, string)
 Field used to sort events with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
-For basic queries, {es} uses <<sort-search-results,`_doc` order>> if no
-tiebreaker field is specified or the events also share the same tiebreaker value.
+If you specify a tiebreaker field, all documents in the searched data streams or
+indices must contain the field. For basic queries, {es} uses
+<<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
+events also share the same tiebreaker value.
 +
-If you specify a tiebreaker field, all documents in the searched index or data
-stream must contain the field. If you use the {ecs-ref}[ECS], we recommend using
+ If you use the {ecs-ref}[ECS], we recommend using
 `event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -247,13 +247,7 @@ this value.
 (Optional, string)
 Field used to sort hits with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
-If you specify a tiebreaker field for a sequence query, all documents in the
-searched data streams or indices must contain the field. For basic queries, {es}
-uses <<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
-events also share the same tiebreaker value.
-+
-If you use the {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
-`event.sequence` as the tiebreaker field.
+See <<eql-search-specify-a-sort-tiebreaker>>.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::
@@ -311,7 +305,7 @@ This search ID is only provided if one of the following conditions is met:
 * A search request does not return complete results during the
   <<eql-search-api-wait-for-completion-timeout,`wait_for_completion_timeout`>>
   parameter's timeout period, becoming an <<eql-search-async,async search>>.
-  
+
 * The search request's <<eql-search-api-keep-on-completion,`keep_on_completion`>>
   parameter is `true`.
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -250,7 +250,7 @@ Field used to sort events with the same
 If no tiebreaker field is specified or the events also share the same tiebreaker
 field value, {es} uses <<sort-search-results,`_doc` order>>.
 +
-If you use {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
+If you use the {ecs-ref}[Elastic Common Schema (ECS)], we recommend using
 `event.sequence` as the tiebreaker field.
 
 [[eql-search-api-timestamp-field]]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -246,14 +246,9 @@ this value.
 `tiebreaker_field`::
 (Optional, string)
 Field used to sort events with the same
-<<eql-search-api-timestamp-field,timestamp field>> value. Defaults to
-`event.sequence`, as defined in the {ecs-ref}/ecs-event.html[Elastic Common
-Schema (ECS)].
-+
-By default, matching events in the search response are sorted by timestamp,
-converted to milliseconds since the {wikipedia}/Unix_time[Unix
-epoch], in ascending order. If two or more events share the same timestamp, this
-field is used to sort the events in ascending, lexicographic order.
+<<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
+If no tiebreaker field is specified or the events also share the same tiebreaker
+field value, {es} uses <<sort-search-results,`_doc` order>>.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -247,9 +247,9 @@ this value.
 (Optional, string)
 Field used to sort events with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
-If you specify a tiebreaker field, all documents in the searched data streams or
-indices must contain the field. For basic queries, {es} uses
-<<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
+If you specify a tiebreaker field for a sequence query, all documents in the
+searched data streams or indices must contain the field. For basic queries, {es}
+uses <<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
 events also share the same tiebreaker value.
 +
 If you use the {ecs-ref}[Elastic Common Schema (ECS)], we recommend using

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -252,8 +252,8 @@ indices must contain the field. For basic queries, {es} uses
 <<sort-search-results,`_doc` order>> if no tiebreaker field is specified or
 events also share the same tiebreaker value.
 +
-If you use the {ecs-ref}[ECS], we recommend using
-`event.sequence` as the tiebreaker field.
+If you use the {ecs-ref}[ECS], we recommend using `event.sequence` as the
+tiebreaker field.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -249,6 +249,9 @@ Field used to sort events with the same
 <<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
 If no tiebreaker field is specified or the events also share the same tiebreaker
 field value, {es} uses <<sort-search-results,`_doc` order>>.
++
+If you use {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker
+field.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -388,12 +388,14 @@ or event category field.
 [[eql-search-specify-a-sort-tiebreaker]]
 === Specify a sort tiebreaker
 
-By default, the EQL search API returns matching events by timestamp. If two or
-more events share the same timestamp, {es} uses a tiebreaker field value to sort
-the events in ascending, lexicographic order.
+The EQL search API returns hits in ascending, lexicographic order using the
+following precedence:
 
-`event.sequence` is the default tiebreaker field. To specify another tiebreaker
-field, use the `tiebreaker_field` parameter:
+. <<eql-search-api-timestamp-field,timestamp>>
+. Tiebreaker field, if specified
+. <<sort-search-results,`_doc` order>>
+
+To specify a tiebreaker field, use the `tiebreaker_field` parameter:
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -393,10 +393,12 @@ following precedence:
 
 . <<eql-search-api-timestamp-field,Timestamp>>
 . Tiebreaker field, if specified
-. <<sort-search-results,`_doc` order>>
+. For basic queries, the <<sort-search-results,`_doc` order>>
 
-To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
-the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.
+To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
+specify a tiebreaker field, all documents in the searched index or data stream
+must contain the field. If you use the {ecs-ref}[ECS], we recommend using
+`event.sequence` as the tiebreaker field.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -396,9 +396,9 @@ following precedence:
 . For basic queries, the <<sort-search-results,`_doc` order>>
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
-specify a tiebreaker field, all documents in the searched data streams or
-indices must contain the field. If you use the {ecs-ref}[ECS], we recommend
-using `event.sequence` as the tiebreaker field.
+specify a tiebreaker field for a sequence query, all documents in the searched
+data streams or indices must contain the field. If you use the {ecs-ref}[ECS],
+we recommend using `event.sequence` as the tiebreaker field.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -391,7 +391,7 @@ or event category field.
 The EQL search API returns hits in ascending, lexicographic order using the
 following precedence:
 
-. <<eql-search-api-timestamp-field,timestamp>>
+. <<eql-search-api-timestamp-field,Timestamp>>
 . Tiebreaker field, if specified
 . <<sort-search-results,`_doc` order>>
 

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -399,8 +399,8 @@ be part of the same sequence and may not be returned in a consistent sort order.
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
 specify a tiebreaker field for a sequence query, all events in the searched data
 streams or indices must contain a tiebreaker field value. For basic queries,
-{es} orders events with no tiebreaker value after events with a tiebreaker
-value.
+{es} orders matching events with no tiebreaker value after events with a
+tiebreaker value.
 
 If you use the {ecs-ref}[ECS], we recommend using `event.sequence` as the
 tiebreaker field.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -389,8 +389,8 @@ or event category field.
 === Specify a sort tiebreaker
 
 By default, the EQL search API returns matching hits by timestamp. If two or
-more events share the same timestamp, Elasticsearch uses a tiebreaker field
-value to sort the events in ascending, lexicographic order.
+more events share the same timestamp, {es} uses a tiebreaker field value to sort
+the events in ascending, lexicographic order.
 
 If you don't specify a tiebreaker field or the events also share the same
 tiebreaker value, {es} considers the events concurrent. Concurrent events cannot

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -395,13 +395,14 @@ following precedence:
 . Tiebreaker field, if specified
 . <<sort-search-results,`_doc` order>>
 
-To specify a tiebreaker field, use the `tiebreaker_field` parameter:
+To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
+{ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.
 
 [source,console]
 ----
 GET /my-index-000001/_eql/search
 {
-  "tiebreaker_field": "event.id",
+  "tiebreaker_field": "event.sequence",
   "query": """
     process where process.name == "cmd.exe" and stringContains(process.executable, "System32")
   """

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -396,9 +396,9 @@ following precedence:
 . For basic queries, the <<sort-search-results,`_doc` order>>
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
-specify a tiebreaker field, all documents in the searched index or data stream
-must contain the field. If you use the {ecs-ref}[ECS], we recommend using
-`event.sequence` as the tiebreaker field.
+specify a tiebreaker field, all documents in the searched data streams or
+indices must contain the field. If you use the {ecs-ref}[ECS], we recommend
+using `event.sequence` as the tiebreaker field.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -141,7 +141,7 @@ GET /my-index-000001/_eql/search
 === Search for a sequence of events
 
 Use EQL's <<eql-sequences,sequence syntax>> to search for a series of
-ordered events. List the event items in ascending chronological order, 
+ordered events. List the event items in ascending chronological order,
 with the most recent event listed last:
 
 [source,console]
@@ -388,17 +388,22 @@ or event category field.
 [[eql-search-specify-a-sort-tiebreaker]]
 === Specify a sort tiebreaker
 
-The EQL search API returns hits in ascending, lexicographic order using the
-following precedence:
+By default, the EQL search API returns matching hits by timestamp. If two or
+more events share the same timestamp, Elasticsearch uses a tiebreaker field
+value to sort the events in ascending, lexicographic order.
 
-. <<eql-search-api-timestamp-field,Timestamp>>
-. Tiebreaker field, if specified
-. For basic queries, the <<sort-search-results,`_doc` order>>
+If you don't specify a tiebreaker field or the events also share the same
+tiebreaker value, {es} considers the events concurrent. Concurrent events cannot
+be part of the same sequence and may not be returned in a consistent sort order.
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
-specify a tiebreaker field for a sequence query, all documents in the searched
-data streams or indices must contain the field. If you use the {ecs-ref}[ECS],
-we recommend using `event.sequence` as the tiebreaker field.
+specify a tiebreaker field for a sequence query, all events in the searched data
+streams or indices must contain a tiebreaker field value. For basic queries,
+{es} orders events with no tiebreaker value after events with a tiebreaker
+value.
+
+If you use the {ecs-ref}[ECS], we recommend using `event.sequence` as the
+tiebreaker field.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -396,7 +396,7 @@ following precedence:
 . <<sort-search-results,`_doc` order>>
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
-{ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.
+the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.
 
 [source,console]
 ----


### PR DESCRIPTION
Corrects the EQL docs to remove `event.sequence` as the default `tiebreaker_field` value.
Documents `_doc` order as the fallback for matching tiebreaker field values or when
no tiebreaker is specified.

### Preview
EQL overview:
https://elasticsearch_64671.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#eql-search-specify-a-sort-tiebreaker

EQL API reference:
https://elasticsearch_64671.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html#eql-search-api-tiebreaker-field