### PR TITLE
[DOCS] Adds #63097 to release notes

### DIFF
--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -36,7 +36,8 @@ Mapping::
 Cluster Coordination::
 * Deprecate and ignore join timeout {es-pull}60872[#60872] (issue: {es-issue}60873[#60873])
 
-
+Machine learning::
+* Renames \*/inference* APIs to \*/trained_models* {es-pull}63097[#63097]
 
 [[feature-7.10.0]]
 [float]


### PR DESCRIPTION
Adds https://github.com/elastic/elasticsearch/pull/63097 to the 7.10 Elasticsearch release notes. It was omitted due to the "refactoring" label.