### PR TITLE
Make filter variables static in FilterAllocationDecider

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -81,9 +81,9 @@ public class FilterAllocationDecider extends AllocationDecider {
         Setting.prefixKeySetting(CLUSTER_ROUTING_EXCLUDE_GROUP_PREFIX + ".", key ->
             Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.NodeScope));
 
-    private volatile DiscoveryNodeFilters clusterRequireFilters;
-    private volatile DiscoveryNodeFilters clusterIncludeFilters;
-    private volatile DiscoveryNodeFilters clusterExcludeFilters;
+    private static volatile DiscoveryNodeFilters clusterRequireFilters;
+    private static volatile DiscoveryNodeFilters clusterIncludeFilters;
+    private static volatile DiscoveryNodeFilters clusterExcludeFilters;
 
     public FilterAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
         setClusterRequireFilters(CLUSTER_ROUTING_REQUIRE_GROUP_SETTING.getAsMap(settings));


### PR DESCRIPTION
Relates to #64529.

Currently the cluster filter variables `clusterRequireFilters` , `clusterIncludeFilters` and `clusterExcludeFilters` are non-static, so the new instance of `FilterAllocationDecider` inited in `SetSingleNodeAllocateStep ` in ILM cannot see the changes when updating the `cluster.routing.allocation.exclude._x` settings, and finally ILM will stuck in the shrink action.

This PR makes the  cluster filter variables static to fix the bug and add a test for that.