### PR TITLE
SQL: Remove constant_keyword from SQL docs

### DIFF
--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -24,7 +24,6 @@ s|SQL precision
 | <<number, `half_float`>>                 | half_float      | FLOAT       | 3
 | <<number, `scaled_float`>>               | scaled_float    | DOUBLE      | 15
 | <<keyword, `keyword`>>                   | keyword         | VARCHAR     | 32,766
-| <<constant-keyword-field-type, `constant_keyword`>> | constant_keyword| VARCHAR     | 32,766
 | <<text, `text`>>                         | text            | VARCHAR     | 2,147,483,647
 | <<binary, `binary`>>                     | binary          | VARBINARY   | 2,147,483,647
 | <<date, `date`>>                         | datetime        | TIMESTAMP   | 29

--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -23,7 +23,7 @@ s|SQL precision
 | <<number, `float`>>                      | float           | REAL        | 7
 | <<number, `half_float`>>                 | half_float      | FLOAT       | 3
 | <<number, `scaled_float`>>               | scaled_float    | DOUBLE      | 15
-| <<keyword, `keyword`>>                   | keyword         | VARCHAR     | 32,766
+| <<keyword, keyword type family>>         | keyword         | VARCHAR     | 32,766
 | <<text, `text`>>                         | text            | VARCHAR     | 2,147,483,647
 | <<binary, `binary`>>                     | binary          | VARBINARY   | 2,147,483,647
 | <<date, `date`>>                         | datetime        | TIMESTAMP   | 29
@@ -133,4 +133,3 @@ SELECT first_name FROM index WHERE first_name.raw = 'John'
 ----
 
 as {es-sql} automatically _picks_ up the `raw` multi-field from `raw` for exact matching.
-


### PR DESCRIPTION
`constant_keyword` removed as distinct type from SQL in #60524.
