### PR TITLE
Ignore media ranges when parsing

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -33,11 +33,6 @@ import java.util.regex.Pattern;
  * @see MediaTypeRegistry
  */
 public class ParsedMediaType {
-    // TODO this should be removed once strict parsing is implemented https://github.com/elastic/elasticsearch/issues/63080
-    // sun.net.www.protocol.http.HttpURLConnection sets a default Accept header if it was not provided on a request.
-    // For this value Parsing returns null.
-    public static final String DEFAULT_ACCEPT_STRING = "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2";
-
     private final String type;
     private final String subType;
     private final Map<String, String> parameters;

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -70,7 +70,7 @@ public class ParsedMediaType {
      * @throws IllegalArgumentException if the header is malformed
      */
     public static ParsedMediaType parseMediaType(String headerValue) {
-        if (DEFAULT_ACCEPT_STRING.equals(headerValue) || "*/*".equals(headerValue)) {
+        if (isMediaRange(headerValue) || "*/*".equals(headerValue)) {
             return null;
         }
         if (headerValue != null) {
@@ -106,6 +106,11 @@ public class ParsedMediaType {
             }
         }
         return null;
+    }
+
+    // simplistic check for media ranges. do not validate if this is a correct header
+    private static boolean isMediaRange(String headerValue) {
+        return headerValue.contains(",");
     }
 
     /**

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -67,10 +67,10 @@ public class ParsedMediaType {
      * @throws IllegalArgumentException if the header is malformed
      */
     public static ParsedMediaType parseMediaType(String headerValue) {
-        if (isMediaRange(headerValue) || "*/*".equals(headerValue)) {
-            return null;
-        }
         if (headerValue != null) {
+            if (isMediaRange(headerValue) || "*/*".equals(headerValue)) {
+                return null;
+            }
             final String[] elements = headerValue.toLowerCase(Locale.ROOT).split("[\\s\\t]*;");
 
             final String[] splitMediaType = elements[0].split("/");

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ParsedMediaTypeTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ParsedMediaTypeTests.java
@@ -107,14 +107,21 @@ public class ParsedMediaTypeTests extends ESTestCase {
         assertThat(exception.getMessage(), equalTo("invalid parameters for header [application/foo; char=set=unknown]"));
     }
 
-    public void testDefaultAcceptHeader() {
+    public void testIgnoredMediaTypes() {
+        // When using curl */* is used a default Accept header when not specified by a user
+        assertThat(ParsedMediaType.parseMediaType("*/*"), is(nullValue()));
+
+
         // This media type is defined in sun.net.www.protocol.http.HttpURLConnection as a default Accept header
         // and used when a header was not set on a request
         // It should be treated as if a user did not specify a header value
         String mediaType = "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2";
         assertThat(ParsedMediaType.parseMediaType(mediaType), is(nullValue()));
 
-        // When using curl */* is used a default Accept header when not specified by a user
-        assertThat(ParsedMediaType.parseMediaType("*/*"), is(nullValue()));
+        //example accept header used by a browser
+        mediaType = "text/html,application/xhtml+xml,application/xml;q=0.9," +
+            "image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9";
+        ParsedMediaType parsedMediaType = ParsedMediaType.parseMediaType(mediaType);
+        assertThat(parsedMediaType, equalTo(null));
     }
 }


### PR DESCRIPTION
Browsers are sending media ranges with quality factors on Accept header.
We should ignore the value and respond with applicaiton/json

closes #64689
relates #51816

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
