### PR TITLE
Enable ML dataframe analytics tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -29,10 +29,6 @@
 
 ---
 "Start and stop old outlier_detection job":
-  - skip:
-      version: " - 7.99.99"
-      reason: "_doc_count field is currently implemented only in 8.x"
-
   - do:
       ml.start_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
@@ -122,10 +118,6 @@
 
 ---
 "Put an outlier_detection job on the mixed cluster":
-  - skip:
-      version: " - 7.99.99"
-      reason: "_doc_count field is currently implemented only in 8.x"
-
   - do:
       ml.put_data_frame_analytics:
         id: "mixed_cluster_outlier_detection_job"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/90_ml_data_frame_analytics_crud.yml
@@ -81,9 +81,6 @@
 
 ---
 "Get mixed cluster outlier_detection job":
-  - skip:
-      version: " - 8.00.00"
-      reason: "_doc_count field is currently implemented only in 8.x"
   - do:
       ml.get_data_frame_analytics:
         id: "mixed_cluster_outlier_detection_job"
@@ -102,9 +99,6 @@
 
 ---
 "Get mixed cluster outlier_detection job stats":
-  - skip:
-      version: " - 8.00.00"
-      reason: "_doc_count field is currently implemented only in 8.x"
   - do:
       ml.get_data_frame_analytics_stats:
         id: "mixed_cluster_outlier_detection_job"


### PR DESCRIPTION
After merging the `_doc_count` PR in branch 7.x (#64594), we can enablethe skipped ML dataframe analytics.

Those tests had been broken after merging #64503 in master.
