### PR TITLE
Unmute testFullPolicySnapshot

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -96,7 +96,6 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/50358")
     public void testFullPolicySnapshot() throws Exception {
         final String indexName = "test";
         final String policyName = "full-policy";

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -110,6 +110,9 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         // Create a snapshot repo
         initializeRepo(repoId);
 
+        // allow arbitrarily frequent slm snapshots
+        disableSLMMinimumIntervalValidation();
+
         createSnapshotPolicy(policyName, "snap", "*/1 * * * * ?", repoId, indexName, true);
 
         // A test for whether the repository's snapshots have any snapshots starting with "snap-"
@@ -185,15 +188,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         initializeRepo(repoName);
 
         // allow arbitrarily frequent slm snapshots
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();
-        req.transientSettings(Settings.builder().put(LifecycleSettings.SLM_MINIMUM_INTERVAL, "0s"));
-        try (XContentBuilder builder = jsonBuilder()) {
-            req.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            Request r = new Request("PUT", "/_cluster/settings");
-            r.setJsonEntity(Strings.toString(builder));
-            Response updateSettingsResp = client().performRequest(r);
-            assertAcked(updateSettingsResp);
-        }
+        disableSLMMinimumIntervalValidation();
 
         // Create a policy with ignore_unavailable: false and an index that doesn't exist
         createSnapshotPolicy(policyName, "snap", "*/1 * * * * ?", repoName, indexPattern, false);
@@ -721,6 +716,18 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         putLifecycle.setJsonEntity(Strings.toString(lifecycleBuilder));
         final Response response = client().performRequest(putLifecycle);
         assertAcked(response);
+    }
+
+    private void disableSLMMinimumIntervalValidation() throws IOException {
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();
+        req.transientSettings(Settings.builder().put(LifecycleSettings.SLM_MINIMUM_INTERVAL, "0s"));
+        try (XContentBuilder builder = jsonBuilder()) {
+            req.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            Request r = new Request("PUT", "/_cluster/settings");
+            r.setJsonEntity(Strings.toString(builder));
+            Response updateSettingsResp = client().performRequest(r);
+            assertAcked(updateSettingsResp);
+        }
     }
 
     private void initializeRepo(String repoName) throws IOException {


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/50358, followup to #64452

While backporting #64452 to 7.x, I ran into an unexpected test failure. That made me realize this test was muted on master, but not 7.x, and then that the issue that resulted in this being muted had already been closed. Seems to me like we should unmute it.