### PR TITLE
Autoscaling delete policy by simple pattern

### DIFF
--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -61,3 +61,20 @@ The API returns the following result:
   "acknowledged": true
 }
 --------------------------------------------------
+
+This example deletes all autoscaling policies.
+
+[source,console]
+--------------------------------------------------
+DELETE /_autoscaling/policy/*
+--------------------------------------------------
+// TEST
+
+The API returns the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "acknowledged": true
+}
+--------------------------------------------------

--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
@@ -31,3 +31,64 @@
       catch: /autoscaling policy with name \[does_not_exist\] does not exist/
       autoscaling.delete_autoscaling_policy:
         name: does_not_exist
+
+---
+"Test delete all non-existing autoscaling policies":
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: "*"
+
+---
+"Test delete all existing autoscaling policies":
+  - do:
+      autoscaling.put_autoscaling_policy:
+        name: my_autoscaling_policy_1
+        body:
+          roles: []
+
+  - do:
+      autoscaling.put_autoscaling_policy:
+        name: my_autoscaling_policy_2
+        body:
+          roles: []
+
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: "*"
+
+  - do:
+      catch: missing
+      autoscaling.get_autoscaling_policy:
+        name: my_autoscaling_policy_1
+
+  - do:
+      catch: missing
+      autoscaling.get_autoscaling_policy:
+        name: my_autoscaling_policy_2
+
+---
+"Test delete autoscaling policies by wildcard":
+  - do:
+      autoscaling.put_autoscaling_policy:
+        name: my_autoscaling_policy_delete
+        body:
+          roles: []
+
+  - do:
+      autoscaling.put_autoscaling_policy:
+        name: my_autoscaling_policy_keep
+        body:
+          roles: []
+
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: "my_autoscaling_policy_delete*"
+
+  - do:
+      catch: missing
+      autoscaling.get_autoscaling_policy:
+        name: my_autoscaling_policy_delete
+
+  - do:
+      autoscaling.get_autoscaling_policy:
+        name: my_autoscaling_policy_keep

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
@@ -30,7 +30,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         );
         assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, putRequest).actionGet());
         // we trust that the policy is in the cluster state since we have tests for putting policies
-        final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(policy.name());
+        String deleteName = randomFrom("*", policy.name(), policy.name().substring(0, between(0, policy.name().length())) + "*");
+        final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(deleteName);
         assertAcked(client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
         // now verify that the policy is not in the cluster state
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
@@ -56,4 +57,9 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         assertThat(e.getMessage(), containsString("autoscaling policy with name [" + name + "] does not exist"));
     }
 
+    public void testDeleteNonExistentPolicyByWildcard() {
+        final String name = randomFrom("*", randomAlphaOfLength(8) + "*");
+        final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(name);
+        assertAcked(client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
+    }
 }

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
@@ -15,7 +16,10 @@ import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.mutateAutoscalingDeciders;
+import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.randomAutoscalingDeciders;
 import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.randomAutoscalingPolicy;
+import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.randomRoles;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.sameInstance;
@@ -54,6 +58,18 @@ public class TransportPutAutoscalingPolicyActionIT extends AutoscalingIntegTestC
         assertThat(
             beforeState.metadata().custom(AutoscalingMetadata.NAME),
             sameInstance(afterState.metadata().custom(AutoscalingMetadata.NAME))
+        );
+    }
+
+    public void testPutPolicyIllegalName() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> putAutoscalingPolicy(new AutoscalingPolicy(randomAlphaOfLength(8) + "*", randomRoles(), randomAutoscalingDeciders()))
+        );
+
+        assertThat(
+            exception.getMessage(),
+            containsString("name must not contain the following characters " + Strings.INVALID_FILENAME_CHARS)
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
@@ -100,6 +101,40 @@ public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTest
             }
             assertThat(metadata.policies(), hasKey(entry.getKey()));
             assertThat(metadata.policies().get(entry.getKey()).policy(), equalTo(entry.getValue().policy()));
+        }
+    }
+
+    public void testDeletePolicyByWildcard() {
+        final ClusterState currentState;
+        {
+            final ClusterState.Builder builder = ClusterState.builder(new ClusterName(randomAlphaOfLength(8)));
+            builder.metadata(
+                Metadata.builder().putCustom(AutoscalingMetadata.NAME, randomAutoscalingMetadataOfPolicyCount(randomIntBetween(1, 8)))
+            );
+            currentState = builder.build();
+        }
+        final AutoscalingMetadata currentMetadata = currentState.metadata().custom(AutoscalingMetadata.NAME);
+        final String policyName = randomFrom(currentMetadata.policies().keySet());
+        final String deleteName = randomFrom(policyName.substring(0, between(0, policyName.length()))) + "*";
+        final Logger mockLogger = mock(Logger.class);
+        final ClusterState state = TransportDeleteAutoscalingPolicyAction.deleteAutoscalingPolicy(currentState, deleteName, mockLogger);
+
+        // ensure the policy is deleted from the cluster state
+        final AutoscalingMetadata metadata = state.metadata().custom(AutoscalingMetadata.NAME);
+        assertNotNull(metadata);
+        assertThat(metadata.policies(), not(hasKey(policyName)));
+
+        verify(mockLogger).info("deleting [{}] autoscaling policies", currentMetadata.policies().size() - metadata.policies().size());
+        verifyNoMoreInteractions(mockLogger);
+
+        // ensure that the right policies were preserved
+        for (final Map.Entry<String, AutoscalingPolicyMetadata> entry : currentMetadata.policies().entrySet()) {
+            if (Regex.simpleMatch(deleteName, entry.getKey())) {
+                assertFalse(metadata.policies().containsKey(entry.getKey()));
+            } else {
+                assertThat(metadata.policies(), hasKey(entry.getKey()));
+                assertThat(metadata.policies().get(entry.getKey()).policy(), equalTo(entry.getValue().policy()));
+            }
         }
     }
 


### PR DESCRIPTION
Added the capability to delete autoscaling policies by pattern, allowing
to for instance do:
```
DELETE _autoscaling/policy/*
```
to delete all autoscaling policies. If a wildcard is involved, no
matches are required.
