### PR TITLE
Do not wrap can_match searchers

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -115,6 +115,8 @@ public abstract class Engine implements Closeable {
     public static final String HISTORY_UUID_KEY = "history_uuid";
     public static final String MIN_RETAINED_SEQNO = "min_retained_seq_no";
     public static final String MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID = "max_unsafe_auto_id_timestamp";
+    public static final String CAN_MATCH_SEARCH_SOURCE = "can_match";
+
 
     protected final ShardId shardId;
     protected final String allocationId;

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1270,8 +1270,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             != null : "DirectoryReader must be an instance or ElasticsearchDirectoryReader";
         boolean success = false;
         try {
-            final Engine.Searcher wrappedSearcher = searcherWrapper == null ? searcher : searcherWrapper.wrap(searcher);
-            assert wrappedSearcher != null;
+            final Engine.Searcher wrappedSearcher;
+            if (searcherWrapper != null && Engine.CAN_MATCH_SEARCH_SOURCE.equals(source) == false) {
+                wrappedSearcher = searcherWrapper.wrap(searcher);
+            } else {
+                wrappedSearcher = searcher;
+            }
             success = true;
             return wrappedSearcher;
         } catch (IOException ex) {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1062,7 +1062,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      */
     public boolean canMatch(ShardSearchRequest request) throws IOException {
         assert request.searchType() == SearchType.QUERY_THEN_FETCH : "unexpected search type: " + request.searchType();
-        try (DefaultSearchContext context = createSearchContext(request, defaultSearchTimeout, false, "can_match")) {
+        try (DefaultSearchContext context = createSearchContext(request, defaultSearchTimeout, false, Engine.CAN_MATCH_SEARCH_SOURCE)) {
             SearchSourceBuilder source = context.request().source();
             if (canRewriteToMatchNone(source)) {
                 QueryBuilder queryBuilder = source.query();

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -28,8 +28,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.FilterDirectoryReader;
-import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -39,20 +37,15 @@ import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ReferenceManager;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TotalHitCountCollector;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterModule;
@@ -111,7 +104,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -1166,61 +1158,6 @@ public abstract class EngineTestCase extends ESTestCase {
         @Override
         public long getAsLong() {
             return get();
-        }
-    }
-
-    public static final class MatchingDirectoryReader extends FilterDirectoryReader {
-        private final Query query;
-
-        public MatchingDirectoryReader(DirectoryReader in, Query query) throws IOException {
-            super(in, new SubReaderWrapper() {
-                @Override
-                public LeafReader wrap(LeafReader leaf) {
-                    try {
-                        final IndexSearcher searcher = new IndexSearcher(leaf);
-                        final Weight weight = searcher.createWeight(query, randomBoolean(), 1.0f);
-                        final Scorer scorer = weight.scorer(leaf.getContext());
-                        final DocIdSetIterator iterator = scorer != null ? scorer.iterator() : null;
-                        final FixedBitSet liveDocs = new FixedBitSet(leaf.maxDoc());
-                        if (iterator != null) {
-                            for (int docId = iterator.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = iterator.nextDoc()) {
-                                if (leaf.getLiveDocs() == null || leaf.getLiveDocs().get(docId)) {
-                                    liveDocs.set(docId);
-                                }
-                            }
-                        }
-                        return new FilterLeafReader(leaf) {
-                            @Override
-                            public Bits getLiveDocs() {
-                                return liveDocs;
-                            }
-
-                            @Override
-                            public CacheHelper getCoreCacheHelper() {
-                                return leaf.getCoreCacheHelper();
-                            }
-
-                            @Override
-                            public CacheHelper getReaderCacheHelper() {
-                                return null; // modify liveDocs
-                            }
-                        };
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-            });
-            this.query = query;
-        }
-
-        @Override
-        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
-            return new MatchingDirectoryReader(in, query);
-        }
-
-        @Override
-        public CacheHelper getReaderCacheHelper() {
-            return in.getReaderCacheHelper();
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -49,7 +49,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -222,7 +222,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
                 case "segments":
                 case "segments_stats":
                 case "completion_stats":
-                case "can_match": // special case for can_match phase - we use the cached point values reader
+                case CAN_MATCH_SEARCH_SOURCE: // special case for can_match phase - we use the cached point values reader
                     maybeOpenReader = false;
                     break;
                 default:
@@ -235,7 +235,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
                 // we just hand out a searcher on top of an empty reader that we opened for the ReadOnlyEngine in the #open(IndexCommit)
                 // method. this is the case when we don't have a reader open right now and we get a stats call any other that falls in
                 // the category that doesn't trigger a reopen
-                if ("can_match".equals(source)) {
+                if (CAN_MATCH_SEARCH_SOURCE.equals(source)) {
                     canMatchReader.incRef();
                     return new Searcher(source, new IndexSearcher(canMatchReader), canMatchReader::decRef);
                 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenEngineTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenEngineTests.java
@@ -301,7 +301,7 @@ public class FrozenEngineTests extends EngineTestCase {
                 listener.reset();
                 try (FrozenEngine frozenEngine = new FrozenEngine(engine.engineConfig)) {
                     DirectoryReader reader;
-                    try (Engine.Searcher searcher = frozenEngine.acquireSearcher("can_match")) {
+                    try (Engine.Searcher searcher = frozenEngine.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
                         assertNotNull(ElasticsearchDirectoryReader.getElasticsearchDirectoryReader(searcher.getDirectoryReader()));
                         assertEquals(config.getShardId(), ElasticsearchDirectoryReader.getElasticsearchDirectoryReader(searcher
                             .getDirectoryReader()).shardId());
@@ -313,7 +313,7 @@ public class FrozenEngineTests extends EngineTestCase {
                         assertNotNull(ElasticsearchDirectoryReader.getElasticsearchDirectoryReader(searcher.getDirectoryReader()));
                     }
 
-                    try (Engine.Searcher searcher = frozenEngine.acquireSearcher("can_match")) {
+                    try (Engine.Searcher searcher = frozenEngine.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
                         assertSame(reader, searcher.getDirectoryReader());
                         assertNotEquals(reader, Matchers.instanceOf(FrozenEngine.LazyDirectoryReader.class));
                         assertEquals(0, listener.afterRefresh.get());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -6,8 +6,6 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.FilterDirectoryReader;
-import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -53,7 +51,6 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
@@ -274,21 +275,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
 
     public void testCanMatch() throws ExecutionException, InterruptedException, IOException {
         if (randomBoolean()) {
-            readerWrapper.set(reader -> new FilterDirectoryReader(reader, new FilterDirectoryReader.SubReaderWrapper() {
-                @Override
-                public LeafReader wrap(LeafReader reader) {
-                    return reader;
-                }
-            }) {
-                @Override
-                protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
-                    return in;
-                }
-
-                @Override
-                public CacheHelper getReaderCacheHelper() {
-                    return in.getReaderCacheHelper();
-                }
+            readerWrapper.set(reader -> {
+                throw new AssertionError("can_match must not wrap the reader");
             });
         }
         createIndex("index");


### PR DESCRIPTION
The can_match phase does not work with frozen indices that have document-level security enabled. Also, we should not wrap can_match searchers to reduce the load during the can_match phase.

We already fixed this in 7.10 or later in https://github.com/elastic/elasticsearch/blob/6a92b3ec7ce8f32a97f741720cd61b8be3242bb7/server/src/main/java/org/elasticsearch/index/engine/Engine.java#L1195.