### PR TITLE
Remove legacy xpack extension permissions

### DIFF
--- a/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.policy
@@ -6,12 +6,6 @@ grant {
   permission java.lang.RuntimePermission "getClassLoader";
   permission java.lang.RuntimePermission "setContextClassLoader";
 
-  // needed for x-pack security extension
-  permission java.security.SecurityPermission "createPolicy.JavaPolicy";
-  permission java.security.SecurityPermission "getPolicy";
-  permission java.security.SecurityPermission "setPolicy";
-  permission java.util.PropertyPermission "*", "read,write";
-
   // needed for multiple server implementations used in tests
   permission java.net.SocketPermission "*", "accept,connect";
 };


### PR DESCRIPTION
The first implement of xpack extensions implemented them completely
within xpack. In order to support extensions adding additional
permissions to those used by xpack, the extension mechanism needed broad
policy permissions. However, since then xpack extension apis were moved
to SPI and can now be done as any other plugin. This commit removes the
permissions that are no longer used from the xpack security policy.