### PR TITLE
Fix incorrect setContextClassLoader permissions

### DIFF
--- a/modules/transport-netty4/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/transport-netty4/src/main/plugin-metadata/plugin-security.policy
@@ -25,7 +25,7 @@ grant codeBase "${codebase.netty-common}" {
    permission java.net.SocketPermission "*", "accept,connect";
 
    // Netty sets custom classloader for some of its internal threads
-   permission java.lang.RuntimePermission "*", "setContextClassLoader";
+   permission java.lang.RuntimePermission "setContextClassLoader";
 };
 
 grant codeBase "${codebase.netty-transport}" {

--- a/plugins/transport-nio/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/transport-nio/src/main/plugin-metadata/plugin-security.policy
@@ -27,5 +27,5 @@ grant codeBase "${codebase.netty-common}" {
    // netty makes and accepts socket connections
    permission java.net.SocketPermission "*", "accept,connect";
    // Netty sets custom classloader for some of its internal threads
-   permission java.lang.RuntimePermission "*", "setContextClassLoader";
+   permission java.lang.RuntimePermission "setContextClassLoader";
 };

--- a/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.policy
@@ -20,7 +20,7 @@ grant codeBase "${codebase.netty-common}" {
    // for reading the system-wide configuration for the backlog of established sockets
    permission java.io.FilePermission "/proc/sys/net/core/somaxconn", "read";
    // Netty sets custom classloader for some of its internal threads
-   permission java.lang.RuntimePermission "*", "setContextClassLoader";
+   permission java.lang.RuntimePermission "setContextClassLoader";
 };
 
 grant codeBase "${codebase.netty-transport}" {

--- a/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security.policy
@@ -10,7 +10,7 @@ grant codeBase "${codebase.netty-common}" {
    // for reading the system-wide configuration for the backlog of established sockets
    permission java.io.FilePermission "/proc/sys/net/core/somaxconn", "read";
    // Netty sets custom classloader for some of its internal threads
-   permission java.lang.RuntimePermission "*", "setContextClassLoader";
+   permission java.lang.RuntimePermission "setContextClassLoader";
 };
 
 grant codeBase "${codebase.netty-transport}" {


### PR DESCRIPTION
Netty requires the setContextClassLoader permission. However, many of
our policy files incorrectly use `*` as the name, thinking
`setContextClassLoader` is the actions element of the permission (it
looks like a copy paste error that was then itself copy pasted through
several policy files). This commit corrects these permissions, which had
actually granted all RuntimePermissions.