### PR TITLE
Use no-kpi subdomains for tests downloading artifacts (#64502)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -603,7 +603,7 @@ class BuildPlugin implements Plugin<Project> {
         }
         repos.maven {
             name "elastic"
-            url "https://artifacts.elastic.co/maven"
+            url "https://artifacts-no-kpi.elastic.co/maven"
         }
         repos.jcenter()
         String luceneVersion = VersionProperties.lucene

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -166,7 +166,7 @@ class VagrantTestPlugin implements Plugin<Project> {
           is fine with that */
         repos.ivy {
             name "elasticsearch"
-            artifactPattern "https://artifacts.elastic.co/downloads/elasticsearch/[module]-[revision].[ext]"
+            artifactPattern "https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/[module]-[revision].[ext]"
         }
     }
 

--- a/client/sniffer/src/test/resources/create_test_nodes_info.bash
+++ b/client/sniffer/src/test/resources/create_test_nodes_info.bash
@@ -22,8 +22,8 @@ pushd ${work} >> /dev/null
 echo Working in ${work}
 
 wget https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0/elasticsearch-2.0.0.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
+wget https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
+wget https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
 sha1sum -c - << __SHAs
 e369d8579bd3a2e8b5344278d5043f19f14cac88 elasticsearch-2.0.0.tar.gz
 d25f6547bccec9f0b5ea7583815f96a6f50849e0 elasticsearch-5.0.0.tar.gz

--- a/dev-tools/get-bwc-version.py
+++ b/dev-tools/get-bwc-version.py
@@ -67,7 +67,7 @@ def main():
   elif c.version.startswith('0.') or c.version.startswith('1.') or c.version.startswith('2.'):
     url = 'https://download.elasticsearch.org/elasticsearch/elasticsearch/%s' % filename
   else:
-    url = 'https://artifacts.elastic.co/downloads/elasticsearch/%s' % filename
+    url = 'https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/%s' % filename
   print('Downloading %s' % url)
   urllib.request.urlretrieve(url, filename)
 

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -26,7 +26,7 @@ ext.expansions = { oss, local ->
     'jdkUrl'              : 'https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.1%2B9/OpenJDK15U-jdk_x64_linux_hotspot_15.0.1_9.tar.gz',
     'jdkVersion'          : '15.0.1+9',
     'license'             : oss ? 'Apache-2.0' : 'Elastic-License',
-    'source_elasticsearch': local ? "COPY $elasticsearch /opt/" : "RUN cd /opt && curl --retry 8 -s -L -O https://artifacts.elastic.co/downloads/elasticsearch/${elasticsearch} && cd -",
+    'source_elasticsearch': local ? "COPY $elasticsearch /opt/" : "RUN cd /opt && curl --retry 8 -s -L -O https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/${elasticsearch} && cd -",
     'version'             : VersionProperties.elasticsearch
   ]
 }

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -13,11 +13,11 @@ subprojects { Project subproj ->
         repositories {
           maven {
             name "elastic"
-            url "https://artifacts.elastic.co/maven"
+            url "https://artifacts-no-kpi.elastic.co/maven"
           }
           maven {
             name "elastic-snapshots"
-            url "https://snapshots.elastic.co/maven"
+            url "https://snapshots-no-kpi.elastic.co/maven"
           }
         }
       }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -309,10 +309,10 @@ subprojects {
 
   repositories {
     maven {
-      url "https://artifacts.elastic.co/maven"
+      url "https://artifacts-no-kpi.elastic.co/maven"
     }
     maven {
-      url "https://snapshots.elastic.co/maven"
+      url "https://snapshots-no-kpi.elastic.co/maven"
     }
   }
 }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -383,10 +383,10 @@ subprojects {
 
   repositories {
     maven {
-      url "https://artifacts.elastic.co/maven"
+      url "https://artifacts-no-kpi.elastic.co/maven"
     }
     maven {
-      url "https://snapshots.elastic.co/maven"
+      url "https://snapshots-no-kpi.elastic.co/maven"
     }
   }
 }


### PR DESCRIPTION
This commit converts build code that downloads distributions or other
artifacts to use the new no-kpi subdomain, and removes the formerly used
no-kpi header.