### PR TITLE
Remove unnecessary classloader permissions in xpack

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RestorableContextClassLoader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RestorableContextClassLoader.java
@@ -22,7 +22,11 @@ public class RestorableContextClassLoader implements AutoCloseable {
     private ClassLoader restore;
 
     public RestorableContextClassLoader(Class<?> fromClass) throws PrivilegedActionException {
-        this(Thread.currentThread(), fromClass.getClassLoader());
+        this(Thread.currentThread(), getClassLoader(fromClass));
+    }
+
+    private static ClassLoader getClassLoader(Class<?> fromClass) throws PrivilegedActionException {
+        return AccessController.doPrivileged((PrivilegedExceptionAction<ClassLoader>) fromClass::getClassLoader);
     }
 
     public RestorableContextClassLoader(Thread thread, ClassLoader setClassLoader) throws PrivilegedActionException {

--- a/x-pack/plugin/identity-provider/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/identity-provider/src/main/plugin-metadata/plugin-security.policy
@@ -4,10 +4,6 @@ grant {
   // ApacheXMLSecurityInitializer
   permission java.util.PropertyPermission "org.apache.xml.security.ignoreLineBreaks", "read,write";
 
-  // needed because of SAML (cf. o.e.x.c.s.s.RestorableContextClassLoader)
-  permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.RuntimePermission "setContextClassLoader";
-
   // needed during initialization of OpenSAML library where xml security algorithms are registered
   // see https://github.com/apache/santuario-java/blob/e79f1fe4192de73a975bc7246aee58ed0703343d/src/main/java/org/apache/xml/security/utils/JavaUtils.java#L205-L220
   // and https://git.shibboleth.net/view/?p=java-opensaml.git;a=blob;f=opensaml-xmlsec-impl/src/main/java/org/opensaml/xmlsec/signature/impl/SignatureMarshaller.java;hb=db0eaa64210f0e32d359cd6c57bedd57902bf811#l52

--- a/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
@@ -4,10 +4,6 @@ grant {
   // needed because of problems in unbound LDAP library
   permission java.util.PropertyPermission "*", "read,write";
 
-  // needed because of SAML (cf. o.e.x.c.s.s.RestorableContextClassLoader)
-  permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.RuntimePermission "setContextClassLoader";
-
   // needed during initialization of OpenSAML library where xml security algorithms are registered
   // see https://github.com/apache/santuario-java/blob/e79f1fe4192de73a975bc7246aee58ed0703343d/src/main/java/org/apache/xml/security/utils/JavaUtils.java#L205-L220
   // and https://git.shibboleth.net/view/?p=java-opensaml.git;a=blob;f=opensaml-xmlsec-impl/src/main/java/org/opensaml/xmlsec/signature/impl/SignatureMarshaller.java;hb=db0eaa64210f0e32d359cd6c57bedd57902bf811#l52


### PR DESCRIPTION
Xpack core contains a utility class for setting and restoring the
context class loader when entering certain libraries which depend on the
context classloader. The permissions for getting and setting the
classloader are only needed within this core class,
RestorableContextClassLoader, yet thes permissions (along with the
comment) have been copied to a few other security policy files. This
commit removes those unnecessary permissions from modules outside of
xpack core.