### PR TITLE
[ML] Increase log level for forecast disk storage problems

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
@@ -69,7 +69,7 @@ public class NativeStorageProvider {
     public Path tryGetLocalTmpStorage(String uniqueIdentifier, ByteSizeValue requestedSize) {
         Path path = allocatedStorage.get(uniqueIdentifier);
         if (path != null && localTmpStorageHasEnoughSpace(path, requestedSize) == false) {
-            LOGGER.debug("Previous tmp storage for [{}] run out, returning null", uniqueIdentifier);
+            LOGGER.warn("Previous tmp storage for [{}] run out, returning null", uniqueIdentifier);
             return null;
         } else {
             path = tryAllocateStorage(uniqueIdentifier, requestedSize);
@@ -87,10 +87,10 @@ public class NativeStorageProvider {
                     return tmpDirectory;
                 }
             } catch (IOException e) {
-                LOGGER.debug("Failed to obtain information about path [{}]: {}", path, e);
+                LOGGER.warn("Failed to obtain information about path [{}]: {}", path, e);
             }
         }
-        LOGGER.debug("Failed to find native storage for [{}], returning null", uniqueIdentifier);
+        LOGGER.warn("Failed to find native storage for [{}], returning null", uniqueIdentifier);
         return null;
     }
 
@@ -102,7 +102,7 @@ public class NativeStorageProvider {
                     return getUsableSpace(p) >= requestedSize.getBytes() + minLocalStorageAvailable.getBytes();
                 }
             } catch (IOException e) {
-                LOGGER.debug("Failed to optain information about path [{}]: {}", path, e);
+                LOGGER.warn("Failed to obtain information about path [{}]: {}", path, e);
             }
         }
 


### PR DESCRIPTION
Originally these errors were logged at the DEBUG level,
to avoid log spam.  However, investigating #58806 has
shown that we are making our code hard to support by hiding
problems at the default log level.  If a user is making
extensive use of ML forecasting and doesn't have enough
disk space then they will see many log messages following
this change, but the alternative is that things don't work
and we don't have information to diagnose the problem.
If they don't have enough disk space for forecasting then
they should get more or stop using forecasting.