### PR TITLE
Fix inconsistent excludes in IndexNameExpressionResolver

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -849,7 +849,6 @@ public class IndexNameExpressionResolver {
 
         private Set<String> innerResolve(Context context, List<String> expressions, IndicesOptions options, Metadata metadata) {
             Set<String> result = null;
-            boolean wildcardSeen = false;
             for (int i = 0; i < expressions.size(); i++) {
                 String expression = expressions.get(i);
                 if (Strings.isEmpty(expression)) {
@@ -863,7 +862,7 @@ public class IndexNameExpressionResolver {
                     continue;
                 }
                 final boolean add;
-                if (expression.charAt(0) == '-' && wildcardSeen) {
+                if (expression.charAt(0) == '-' && i > 0) {
                     add = false;
                     expression = expression.substring(1);
                 } else {
@@ -904,9 +903,6 @@ public class IndexNameExpressionResolver {
                 }
                 if (options.allowNoIndices() == false && matches.isEmpty()) {
                     throw indexNotFoundException(expression);
-                }
-                if (Regex.isSimpleMatchPattern(expression)) {
-                    wildcardSeen = true;
                 }
             }
             return result;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -88,6 +88,26 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         indexNameExpressionResolver = createIndexNameExpressionResolver(threadContext);
     }
 
+    public void testExcludePattern() {
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .put(indexBuilder("foo"));
+
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
+            IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN, false);
+        String[] names = indexNameExpressionResolver.concreteIndexNames(context, "foo", "-f*");
+        assertEquals(0, names.length);
+
+        names = indexNameExpressionResolver.concreteIndexNames(context, "foo", "-a*","-f*");
+        assertEquals(0, names.length);
+
+        names = indexNameExpressionResolver.concreteIndexNames(context, "foo", "-a*");
+        assertArrayEquals(new String[]{"foo"}, names);
+
+        names = indexNameExpressionResolver.concreteIndexNames(context, "-a*");
+        assertEquals(0, names.length);
+    }
+
     public void testIndexOptionsStrict() {
         Metadata.Builder mdBuilder = Metadata.builder()
                 .put(indexBuilder("foo").putAlias(AliasMetadata.builder("foofoobar")))


### PR DESCRIPTION
Currently we only apply exclude patterns after first wildcard. This lead to inconsistent behaviour.
After this change exclude pattern is applied always unless it's defined on first position to avoid implicit `*` and potentially dangerous behaviours.

Closes #64752 