### PR TITLE
Review retrying persister audit messages

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -161,7 +161,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
                 renormalizer,
                 new JobResultsPersister(originSettingClient, resultsPersisterService,
                     new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class))),
-                new AnnotationPersister(resultsPersisterService, auditor),
+                new AnnotationPersister(resultsPersisterService),
                 process,
                 new ModelSizeStats.Builder(JOB_ID).build(),
                 new TimingStats(JOB_ID)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -612,8 +612,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         this.dataFrameAnalyticsAuditor.set(dataFrameAnalyticsAuditor);
         OriginSettingClient originSettingClient = new OriginSettingClient(client, ClientHelper.ML_ORIGIN);
         ResultsPersisterService resultsPersisterService = new ResultsPersisterService(originSettingClient, clusterService, settings);
-        AnnotationPersister anomalyDetectionAnnotationPersister =
-            new AnnotationPersister(resultsPersisterService, anomalyDetectionAuditor);
+        AnnotationPersister anomalyDetectionAnnotationPersister = new AnnotationPersister(resultsPersisterService);
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings, indexNameExpressionResolver);
         JobResultsPersister jobResultsPersister =
             new JobResultsPersister(originSettingClient, resultsPersisterService, anomalyDetectionAuditor);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersister.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.xpack.core.common.notifications.AbstractAuditor;
 import org.elasticsearch.xpack.core.ml.annotations.Annotation;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
@@ -35,20 +34,19 @@ public class AnnotationPersister {
     private static final int DEFAULT_BULK_LIMIT = 10_000;
 
     private final ResultsPersisterService resultsPersisterService;
-    private final AbstractAuditor<?> auditor;
+
     /**
      * Execute bulk requests when they reach this size
      */
     private final int bulkLimit;
 
-    public AnnotationPersister(ResultsPersisterService resultsPersisterService, AbstractAuditor<?> auditor) {
-        this(resultsPersisterService, auditor, DEFAULT_BULK_LIMIT);
+    public AnnotationPersister(ResultsPersisterService resultsPersisterService) {
+        this(resultsPersisterService, DEFAULT_BULK_LIMIT);
     }
 
     // For testing
-    AnnotationPersister(ResultsPersisterService resultsPersisterService, AbstractAuditor<?> auditor, int bulkLimit) {
+    AnnotationPersister(ResultsPersisterService resultsPersisterService, int bulkLimit) {
         this.resultsPersisterService = Objects.requireNonNull(resultsPersisterService);
-        this.auditor = Objects.requireNonNull(auditor);
         this.bulkLimit = bulkLimit;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersister.java
@@ -114,7 +114,8 @@ public class AnnotationPersister {
             logger.trace("[{}] ES API CALL: bulk request with {} actions", () -> jobId, () -> bulkRequest.numberOfActions());
             BulkResponse bulkResponse =
                 resultsPersisterService.bulkIndexWithRetry(
-                    bulkRequest, jobId, shouldRetry, msg -> auditor.warning(jobId, "Bulk indexing of annotations failed " + msg));
+                    bulkRequest, jobId, shouldRetry,
+                    retryMessage -> logger.debug("[{}] Bulk indexing of annotations failed {}", jobId, retryMessage));
             bulkRequest = new BulkRequest(AnnotationIndex.WRITE_ALIAS_NAME);
             return bulkResponse;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -160,6 +160,6 @@ public class InferenceRunner {
             bulkRequest,
             config.getId(),
             () -> isCancelled == false,
-            errorMsg -> {});
+            retryMsg -> {});
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -160,6 +160,6 @@ public class InferenceRunner {
             bulkRequest,
             config.getId(),
             () -> isCancelled == false,
-            retryMsg -> {});
+            retryMessage -> {});
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -109,7 +109,7 @@ class DataFrameRowsJoiner implements AutoCloseable {
             bulkRequest,
             analyticsId,
             () -> isCancelled == false,
-            retryMsg -> {});
+            retryMessage -> {});
     }
 
     private void checkChecksumsMatch(DataFrameDataExtractor.Row row, RowResults result) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -109,7 +109,7 @@ class DataFrameRowsJoiner implements AutoCloseable {
             bulkRequest,
             analyticsId,
             () -> isCancelled == false,
-            errorMsg -> {});
+            retryMsg -> {});
     }
 
     private void checkChecksumsMatch(DataFrameDataExtractor.Row row, RowResults result) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
@@ -46,13 +46,13 @@ public class StatsPersister {
                 docIdSupplier.apply(jobId),
                 true,
                 () -> true,
-                errorMsg -> auditor.error(jobId,
-                    "failed to persist result with id [" + docIdSupplier.apply(jobId) + "]; " + errorMsg)
+                retryMessage -> LOGGER.debug("[{}] failed to persist result with id [{}]; {}", jobId, docIdSupplier.apply(jobId), retryMessage)
             );
         } catch (IOException ioe) {
             LOGGER.error(() -> new ParameterizedMessage("[{}] Failed serializing stats result", jobId), ioe);
         } catch (Exception e) {
             LOGGER.error(() -> new ParameterizedMessage("[{}] Failed indexing stats result", jobId), e);
+            auditor.error(jobId, "Failed indexing stats result with id [" + docIdSupplier.apply(jobId) + "]; " + e.getMessage());
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
@@ -46,7 +46,8 @@ public class StatsPersister {
                 docIdSupplier.apply(jobId),
                 true,
                 () -> true,
-                retryMessage -> LOGGER.debug("[{}] failed to persist result with id [{}]; {}", jobId, docIdSupplier.apply(jobId), retryMessage)
+                retryMessage ->
+                    LOGGER.debug("[{}] failed to persist result with id [{}]; {}", jobId, docIdSupplier.apply(jobId), retryMessage)
             );
         } catch (IOException ioe) {
             LOGGER.error(() -> new ParameterizedMessage("[{}] Failed serializing stats result", jobId), ioe);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -67,11 +67,12 @@ public class JobDataCountsPersister {
                 DataCounts.documentId(jobId),
                 true,
                 () -> true,
-                (msg) -> auditor.warning(jobId, "Job data_counts " + msg));
+                retryMessage -> logger.debug("[{}] Job data_counts {}", jobId, retryMessage));
         } catch (IOException ioe) {
             logger.error(() -> new ParameterizedMessage("[{}] Failed writing data_counts stats", jobId), ioe);
         } catch (Exception ex) {
             logger.error(() -> new ParameterizedMessage("[{}] Failed persisting data_counts stats", jobId), ex);
+            auditor.error(jobId, "Failed persisting data_counts stats: " + ex.getMessage());
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -242,9 +242,9 @@ public class JobResultsPersister {
                 return;
             }
             logger.trace("[{}] ES API CALL: bulk request with {} actions", jobId, bulkRequest.numberOfActions());
-            resultsPersisterService.bulkIndexWithRetry(bulkRequest, jobId, shouldRetry, (msg) -> {
-                auditor.warning(jobId, "Bulk indexing of results failed " + msg);
-            });
+            resultsPersisterService.bulkIndexWithRetry(bulkRequest, jobId, shouldRetry,
+                retryMessage -> logger.debug("[{}] Bulk indexing of results failed {}", jobId, retryMessage)
+            );
             bulkRequest = new BulkRequest();
         }
 
@@ -283,7 +283,7 @@ public class JobResultsPersister {
                 searchRequest,
                 jobId,
                 shouldRetry,
-                (msg) -> auditor.warning(jobId, quantilesDocId + " " + msg));
+                retryMessage -> logger.debug("[{}] {} {}", jobId, quantilesDocId, retryMessage));
         String indexOrAlias =
             searchResponse.getHits().getHits().length > 0
                 ? searchResponse.getHits().getHits()[0].getIndex()
@@ -494,7 +494,7 @@ public class JobResultsPersister {
                     id,
                     requireAlias,
                     shouldRetry,
-                    (msg) -> auditor.warning(jobId, id + " " + msg));
+                    retryMessage -> logger.debug("[{}] {} {}", jobId, id, retryMessage));
             } catch (IOException e) {
                 logger.error(new ParameterizedMessage("[{}] Error writing [{}]", jobId, (id == null) ? "auto-generated ID" : id), e);
                 IndexResponse.Builder notCreatedResponse = new IndexResponse.Builder();
@@ -524,10 +524,12 @@ public class JobResultsPersister {
         }
 
         private void logCall(String indexName) {
-            if (id != null) {
-                logger.trace("[{}] ES API CALL: to index {} with ID [{}]", jobId, indexName, id);
-            } else {
-                logger.trace("[{}] ES API CALL: to index {} with auto-generated ID", jobId, indexName);
+            if (logger.isTraceEnabled()) {
+                if (id != null) {
+                    logger.trace("[{}] ES API CALL: to index {} with ID [{}]", jobId, indexName, id);
+                } else {
+                    logger.trace("[{}] ES API CALL: to index {} with auto-generated ID", jobId, indexName);
+                }
             }
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
@@ -147,7 +147,7 @@ public class IndexingStateProcessor implements StateProcessor {
                 resultsPersisterService.bulkIndexWithRetry(bulkRequest,
                     jobId,
                     () -> true,
-                    (msg) -> auditor.warning(jobId, "Bulk indexing of state failed " + msg));
+                    retryMessage -> LOGGER.debug("[{}] Bulk indexing of state failed {}", jobId, retryMessage));
             } catch (Exception ex) {
                 String msg = "failed indexing updated state docs";
                 LOGGER.error(() -> new ParameterizedMessage("[{}] {}", jobId, msg), ex);
@@ -161,7 +161,7 @@ public class IndexingStateProcessor implements StateProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    /**
+    /*
      * Extracts document id from the given {@code bytesRef}.
      * Only first non-blank line is parsed and document id is assumed to be a nested "index._id" field of type String.
      */
@@ -226,7 +226,7 @@ public class IndexingStateProcessor implements StateProcessor {
                 searchRequest,
                 jobId,
                 () -> true,
-                (msg) -> auditor.warning(jobId, documentId + " " + msg));
+                retryMessage -> LOGGER.debug("[{}] {} {}", jobId, documentId, retryMessage));
         return searchResponse.getHits().getHits().length > 0
             ? searchResponse.getHits().getHits()[0].getIndex()
             : AnomalyDetectorsIndex.jobStateIndexWriteAlias();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -491,7 +491,7 @@ public class DatafeedJobTests extends ESTestCase {
                                           long latestRecordTimeMs, boolean haveSeenDataPreviously) {
         Supplier<Long> currentTimeSupplier = () -> currentTime;
         return new DatafeedJob(jobId, dataDescription.build(), frequencyMs, queryDelayMs, dataExtractorFactory, timingStatsReporter,
-            client, auditor, new AnnotationPersister(resultsPersisterService, auditor), currentTimeSupplier,
+            client, auditor, new AnnotationPersister(resultsPersisterService), currentTimeSupplier,
             delayedDataDetector, null, latestFinalBucketEndTimeMs, latestRecordTimeMs, haveSeenDataPreviously);
     }
 


### PR DESCRIPTION
The ResultsPersisterService retries indexing/searches and takes a message handler function that is [triggered](https://github.com/elastic/elasticsearch/blob/a80a567a2ee0a4eba52e7ebaa33b67fd54847fb6/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java#L272) after a failure when a retry is queued.

```failed to {} after [{}] attempts. Will attempt again in [{}].```

In some cases the retry message was being audited at warning level. This isn't an operational message - the final failure is - the fact that the action is being retried can be a debug log message.

The retry message can easily be interpreted as the final failure message however, this is not the case as the final failure after N reties throws an exception. I've renamed the parameter `errorMsg` -> `retryMessage` in a effort to make that clear
