### PR TITLE
Fix NPE in toString of FailedShard

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/FailedShard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/FailedShard.java
@@ -43,7 +43,7 @@ public class FailedShard {
     @Override
     public String toString() {
         return "failed shard, shard " + routingEntry + ", message [" + message + "], markAsStale [" + markAsStale + "], failure ["
-            + failure == null ? "null" : ExceptionsHelper.stackTrace(failure) + "]";
+            + (failure == null ? "null" : ExceptionsHelper.stackTrace(failure)) + "]";
     }
 
     /**


### PR DESCRIPTION
The concatenation took precedence over the null check, leading to an NPE
because `null` was passed to `ExceptionsHelper.stackTrace(failure))`.

Just saw this in a test failure and it might be the cause because this kills the execution of `AllocationService#applyFailedShards` 