### PR TITLE
[DOCS] Adds more information about skip in REST API spec tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -114,6 +114,13 @@ For instance:
        ... test definitions ...
 ....
 
+The value for version can also be `all`, to skip in any version of
+Elasticsearch. This can be used for example when a feature is being implemented
+or awaiting a fix.
+
+`skip` can also be used at the top level of the file in the `setup` block, so
+all the tests in a file will be skipped if the condition applies.
+
 The skip section can also be used to list new features that need to be
 supported in order to run a test. This way the up-to-date runners will
 run the test, while the ones that don't support the feature yet can


### PR DESCRIPTION
Adds more information about using `skip` in the REST API spec tests, based on failing tests from [this file](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/50_script_values.yml#L3).
