### PR TITLE
Fix NPE in toString of FailedShard (#64770)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/FailedShard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/FailedShard.java
@@ -43,7 +43,7 @@ public class FailedShard {
     @Override
     public String toString() {
         return "failed shard, shard " + routingEntry + ", message [" + message + "], failure [" +
-            failure == null ? "null" : ExceptionsHelper.detailedMessage(failure) + "], markAsStale [" + markAsStale + "]";
+                (failure == null ? "null" : ExceptionsHelper.detailedMessage(failure)) + "], markAsStale [" + markAsStale + "]";
     }
 
     /**


### PR DESCRIPTION
The concatenation took precedence over the null check, leading to an NPE
because `null` was passed to `ExceptionsHelper.stackTrace(failure))`.

backport of #64770 