### PR TITLE
[7.x] Update deprecation version for _cat/shards

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -53,7 +53,7 @@
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)",
         "deprecated":{
-          "version":"8.0.0",
+          "version":"7.11.0",
           "description":"This parameter does not affect the request. It will be removed in a future release."
         }
       },


### PR DESCRIPTION
Completes the backport of #62197
