### PR TITLE
Fix autoscaling delete policy rest test

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
@@ -92,3 +92,7 @@
   - do:
       autoscaling.get_autoscaling_policy:
         name: my_autoscaling_policy_keep
+
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: my_autoscaling_policy_keep


### PR DESCRIPTION
Test did not cleanup, now removes the last policy too.
