### PR TITLE
[DOCS] [7.10] Remove typo (#64760)

### DIFF
--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -886,7 +886,7 @@ authentication proxy handling the authentication of end users (more correctly,
 APIs require authentication and the necessary authorization level for the authenticated
 user. For this reason, you must create a Service Account user and assign it a role
 that gives it the `manage_saml` cluster privilege. The use of the `manage_token`
-cluster privilege will be necessary after the authentication takes place, so that the
+cluster privilege will be necessary after the authentication takes place, so that
 the service account user can maintain access in order refresh access tokens on
 behalf of the authenticated users or to subsequently log them out.
 


### PR DESCRIPTION
Applies changes from #64760 to 7.10 to correct a typo.