### PR TITLE
Prevent some BigArray leaking (backport of #64744)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -41,7 +41,14 @@ public final class LongHash extends AbstractHash {
     //Constructor with configurable capacity and load factor.
     public LongHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
-        keys = bigArrays.newLongArray(capacity, false);
+        try {
+            // `super` allocates a big array so we have to `close` if we fail here or we'll leak it.
+            keys = bigArrays.newLongArray(capacity, false);
+        } finally {
+            if (keys == null) {
+                close();
+            }
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -48,7 +48,14 @@ public final class LongLongHash extends AbstractHash {
     //Constructor with configurable capacity and load factor.
     public LongLongHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
-        keys = bigArrays.newLongArray(2 * capacity, false);
+        try {
+            // `super` allocates a big array so we have to `close` if we fail here or we'll leak it.
+            keys = bigArrays.newLongArray(2 * capacity, false);
+        } finally {
+            if (keys == null) {
+                close();
+            }
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -41,8 +41,17 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
 
     public LongObjectPagedHashMap(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
-        keys = bigArrays.newLongArray(capacity(), false);
-        values = bigArrays.newObjectArray(capacity());
+        boolean success = false;
+        try {
+            // `super` allocates a big array so we have to `close` if we fail here or we'll leak it.
+            keys = bigArrays.newLongArray(capacity(), false);
+            values = bigArrays.newObjectArray(capacity());
+            success = true;
+        } finally {
+            if (false == success) {
+                close();
+            }
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
@@ -36,62 +37,51 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 public class BytesRefHashTests extends ESTestCase {
-
-    BytesRefHash hash;
-
-    private BigArrays randomBigArrays() {
+    private BigArrays mockBigArrays() {
         return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
     }
 
-    private void newHash() {
-        if (hash != null) {
-            hash.close();
-        }
+    private BytesRefHash randomHash() {
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
-        hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, randomBigArrays());
-    }
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        newHash();
+        return new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, mockBigArrays());
     }
 
     public void testDuel() {
-        final int len = randomIntBetween(1, 100000);
-        final BytesRef[] values = new BytesRef[len];
-        for (int i = 0; i < values.length; ++i) {
-            values[i] = new BytesRef(randomAlphaOfLength(5));
-        }
-        final ObjectLongMap<BytesRef> valueToId = new ObjectLongHashMap<>();
-        final BytesRef[] idToValue = new BytesRef[values.length];
-        final int iters = randomInt(1000000);
-        for (int i = 0; i < iters; ++i) {
-            final BytesRef value = randomFrom(values);
-            if (valueToId.containsKey(value)) {
-                assertEquals(- 1 - valueToId.get(value), hash.add(value, value.hashCode()));
-            } else {
-                assertEquals(valueToId.size(), hash.add(value, value.hashCode()));
-                idToValue[valueToId.size()] = value;
-                valueToId.put(value, valueToId.size());
+        try (BytesRefHash hash = randomHash()) {
+            final int len = randomIntBetween(1, 100000);
+            final BytesRef[] values = new BytesRef[len];
+            for (int i = 0; i < values.length; ++i) {
+                values[i] = new BytesRef(randomAlphaOfLength(5));
+            }
+            final ObjectLongMap<BytesRef> valueToId = new ObjectLongHashMap<>();
+            final BytesRef[] idToValue = new BytesRef[values.length];
+            final int iters = randomInt(1000000);
+            for (int i = 0; i < iters; ++i) {
+                final BytesRef value = randomFrom(values);
+                if (valueToId.containsKey(value)) {
+                    assertEquals(- 1 - valueToId.get(value), hash.add(value, value.hashCode()));
+                } else {
+                    assertEquals(valueToId.size(), hash.add(value, value.hashCode()));
+                    idToValue[valueToId.size()] = value;
+                    valueToId.put(value, valueToId.size());
+                }
+            }
+
+            assertEquals(valueToId.size(), hash.size());
+            for (final ObjectLongCursor<BytesRef> next : valueToId) {
+                assertEquals(next.value, hash.find(next.key, next.key.hashCode()));
+            }
+
+            for (long i = 0; i < hash.capacity(); ++i) {
+                final long id = hash.id(i);
+                BytesRef spare = new BytesRef();
+                if (id >= 0) {
+                    hash.get(id, spare);
+                    assertEquals(idToValue[(int) id], spare);
+                }
             }
         }
-
-        assertEquals(valueToId.size(), hash.size());
-        for (final ObjectLongCursor<BytesRef> next : valueToId) {
-            assertEquals(next.value, hash.find(next.key, next.key.hashCode()));
-        }
-
-        for (long i = 0; i < hash.capacity(); ++i) {
-            final long id = hash.id(i);
-            BytesRef spare = new BytesRef();
-            if (id >= 0) {
-                hash.get(id, spare);
-                assertEquals(idToValue[(int) id], spare);
-            }
-        }
-        hash.close();
     }
 
     // START - tests borrowed from LUCENE
@@ -100,6 +90,7 @@ public class BytesRefHashTests extends ESTestCase {
      * Test method for {@link org.apache.lucene.util.BytesRefHash#size()}.
      */
     public void testSize() {
+        BytesRefHash hash = randomHash();
         BytesRefBuilder ref = new BytesRefBuilder();
         int num = scaledRandomIntBetween(2, 20);
         for (int j = 0; j < num; j++) {
@@ -112,12 +103,14 @@ public class BytesRefHashTests extends ESTestCase {
                 ref.copyChars(str);
                 long count = hash.size();
                 long key = hash.add(ref.get());
-                if (key < 0)
+                if (key < 0) {
                     assertEquals(hash.size(), count);
-                else
+                } else {
                     assertEquals(hash.size(), count + 1);
+                }
                 if(i % mod == 0) {
-                    newHash();
+                    hash.close();
+                    hash = randomHash();
                 }
             }
         }
@@ -130,6 +123,7 @@ public class BytesRefHashTests extends ESTestCase {
      * .
      */
     public void testGet() {
+        BytesRefHash hash = randomHash();
         BytesRefBuilder ref = new BytesRefBuilder();
         BytesRef scratch = new BytesRef();
         int num = scaledRandomIntBetween(2, 20);
@@ -158,7 +152,8 @@ public class BytesRefHashTests extends ESTestCase {
                 ref.copyChars(entry.getKey());
                 assertEquals(ref.get(), hash.get(entry.getValue(), scratch));
             }
-            newHash();
+            hash.close();
+            hash = randomHash();
         }
         hash.close();
     }
@@ -169,6 +164,7 @@ public class BytesRefHashTests extends ESTestCase {
      * .
      */
     public void testAdd() {
+        BytesRefHash hash = randomHash();
         BytesRefBuilder ref = new BytesRefBuilder();
         BytesRef scratch = new BytesRef();
         int num = scaledRandomIntBetween(2, 20);
@@ -198,12 +194,14 @@ public class BytesRefHashTests extends ESTestCase {
             }
 
             assertAllIn(strings, hash);
-            newHash();
+            hash.close();
+            hash = randomHash();
         }
         hash.close();
     }
 
     public void testFind() {
+        BytesRefHash hash = randomHash();
         BytesRefBuilder ref = new BytesRefBuilder();
         BytesRef scratch = new BytesRef();
         int num = scaledRandomIntBetween(2, 20);
@@ -233,7 +231,8 @@ public class BytesRefHashTests extends ESTestCase {
             }
 
             assertAllIn(strings, hash);
-            newHash();
+            hash.close();
+            hash = randomHash();
         }
         hash.close();
     }
@@ -254,4 +253,7 @@ public class BytesRefHashTests extends ESTestCase {
 
     // END - tests borrowed from LUCENE
 
+    public void testAllocation() {
+        MockBigArrays.assertFitsIn(new ByteSizeValue(512), bigArrays -> new BytesRefHash(1, bigArrays));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.util;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
@@ -98,6 +99,10 @@ public class LongLongHashTests extends ESTestCase {
                 assertEquals(key.key2, hash.getKey2(i));
             }
         }
+    }
+
+    public void testAllocation() {
+        MockBigArrays.assertFitsIn(new ByteSizeValue(256), bigArrays -> new LongLongHash(1, bigArrays));
     }
 
     class Key {

--- a/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
@@ -21,19 +21,20 @@ package org.elasticsearch.common.util;
 
 import com.carrotsearch.hppc.LongObjectHashMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
-public class LongObjectHashMapTests extends ESTestCase {
+public class LongObjectPagedHashMapTests extends ESTestCase {
 
-    private BigArrays randomBigArrays() {
+    private BigArrays mockBigArrays() {
         return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
     }
 
     public void testDuel() {
         final LongObjectHashMap<Object> map1 = new LongObjectHashMap<>();
         final LongObjectPagedHashMap<Object> map2 =
-            new LongObjectPagedHashMap<>(randomInt(42), 0.6f + randomFloat() * 0.39f, randomBigArrays());
+            new LongObjectPagedHashMap<>(randomInt(42), 0.6f + randomFloat() * 0.39f, mockBigArrays());
         final int maxKey = randomIntBetween(1, 10000);
         final int iters = scaledRandomIntBetween(10000, 100000);
         for (int i = 0; i < iters; ++i) {
@@ -59,6 +60,10 @@ public class LongObjectHashMapTests extends ESTestCase {
         }
         map2.close();
         assertEquals(map1, copy);
+    }
+
+    public void testAllocation() {
+        MockBigArrays.assertFitsIn(new ByteSizeValue(256), bigArrays -> new LongObjectPagedHashMap<Object>(1, bigArrays));
     }
 
 }


### PR DESCRIPTION
Its possible for us to fail to give bytes back to the circuit breaker if
we fail building some objects part way. Worse, if the object allocates a
whole page with of memory and *then* fails then it'll keep the memory
allocated forever.

This adds a test utility we can use to assert that it doesn't happen and
then applies it to a bunch of part of the aggregations framework,
catching a few bugs in the process.
