### PR TITLE
Remove provider permissions from ingest-attachment plugin

### DIFF
--- a/plugins/ingest-attachment/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/ingest-attachment/src/main/plugin-metadata/plugin-security.policy
@@ -22,9 +22,6 @@ grant {
   // needed to apply additional sandboxing to tika parsing
   permission java.security.SecurityPermission "createAccessControlContext";
 
-  // TODO: fix PDFBox not to actually install bouncy castle like this
-  permission java.security.SecurityPermission "putProviderProperty.BC";
-  permission java.security.SecurityPermission "insertProvider";
   // TODO: fix POI XWPF to not do this: https://bz.apache.org/bugzilla/show_bug.cgi?id=58597
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed by xmlbeans, as part of POI for MS xml docs


### PR DESCRIPTION
At some point the the past, PDFBox setup the bouncycastle security
provider explicitly. However, since then it looks like they have moved
away from that and no longer force that provider
(https://issues.apache.org/jira/browse/PDFBOX-2963), which means we no
longer need to grant those security provider permissions. This commit
removes these legacy permissions.