### PR TITLE
[7.8] [DOCS] Fix put repository API docs (#64811) (#64819)

### DIFF
--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -150,11 +150,11 @@ plugins:
 +
 --
 (Required, object)
-Contains settings for the repository. Valid properties for the `settings` object
-depend on the repository type, set using the
-<<put-snapshot-repo-api-request-type,`type`>> parameter.
+Contains settings for the repository.
 
-.Valid `settings` properties for `fs` repositories
+The following `settings` properties are valid for all repository types:
+
+.Properties of `settings`
 [%collapsible%open]
 ====
 `chunk_size`::
@@ -167,12 +167,6 @@ file size).
 (Optional, boolean)
 If `true`, metadata files, such as index mappings and settings, are compressed
 in snapshots. Data files are not compressed. Defaults to `true`.
-
-`location`::
-(Required, string)
-Location of the shared filesystem used to store and retrieve snapshots. This
-location must be registered in the `path.repo` setting on all master and data
-nodes in the cluster.
 
 `max_restore_bytes_per_sec`::
 (Optional, <<byte-units,byte value>>)
@@ -203,6 +197,19 @@ other clusters connected to the repository should have the `readonly` parameter
 set to `true`. This means those clusters can retrieve or restore snapshots from
 the repository but not create snapshots in it.
 =====
+====
+
+Other accepted `settings` properties depend on the repository type, set using the
+<<put-snapshot-repo-api-request-type,`type`>> parameter.
+
+.Valid `settings` properties for `fs` repositories
+[%collapsible%open]
+====
+`location`::
+(Required, string)
+Location of the shared filesystem used to store and retrieve snapshots. This
+location must be registered in the `path.repo` setting on all master and data
+nodes in the cluster.
 ====
 
 .Valid `settings` properties for `source` repositories


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Fix put repository API docs (#64811) (#64819)