### PR TITLE
[7.9] [DOCS] Document get pipeline API as multi-target (#64816)

### DIFF
--- a/docs/reference/ingest/apis/get-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/get-pipeline.asciidoc
@@ -45,8 +45,12 @@ GET /_ingest/pipeline/my-pipeline-id
 [[get-pipeline-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=path-pipeline]
-
+`<pipeline>`::
+(Optional, string)
+Comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions are
+supported.
++
+To get all ingest pipelines, omit this parameter or use `*`.
 
 
 [[get-pipeline-api-query-params]]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -655,12 +655,6 @@ The number of search or bulk index operations processed. Documents are
 processed in batches instead of individually.
 end::pages-processed[]
 
-tag::path-pipeline[]
-`<pipeline>`::
-(Optional, string) Comma-separated list or wildcard expression of pipeline IDs
-used to limit the request.
-end::path-pipeline[]
-
 tag::pivot[]
 The method for transforming the data. These objects define the pivot function
 `group by` fields and the aggregation to reduce the data.


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Document get pipeline API as multi-target (#64816)