### PR TITLE
SQL: Remove the defensive copy from the AttributeMap

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
@@ -364,36 +364,22 @@ public class AttributeMap<E> implements Map<Attribute, E> {
     }
 
     public static class Builder<E> {
-        private AttributeMap<E> map = null;
-        private AttributeMap<E> previouslyBuiltMap = null;
+        private AttributeMap<E> map = new AttributeMap<>();
 
         private Builder() {}
 
-        private AttributeMap<E> map() {
-            if (map == null) {
-                map = new AttributeMap<>();
-                if (previouslyBuiltMap != null) {
-                    map.addAll(previouslyBuiltMap);
-                }
-            }
-            return map;
-        }
-
         public Builder<E> put(Attribute attr, E value) {
-            map().add(attr, value);
+            map.add(attr, value);
             return this;
         }
 
         public Builder<E> putAll(AttributeMap<E> m) {
-            map().addAll(m);
+            map.addAll(m);
             return this;
         }
 
         public AttributeMap<E> build() {
-            AttributeMap<E> m = map();
-            previouslyBuiltMap = m;
-            map = null;
-            return m;
+            return map;
         }
     }
 }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/AttributeMapTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/AttributeMapTests.java
@@ -90,15 +90,6 @@ public class AttributeMapTests extends ESTestCase {
         assertThat(m.containsValue("on"), is(false));
         assertThat(m.attributeNames(), contains("one", "two", "three"));
         assertThat(m.values(), contains("one", "two", "three"));
-
-        // defensive copying
-        builder.put(a("four"), "four");
-        AttributeMap<String> m2 = builder.build();
-        assertThat(m.size(), is(3));
-        assertThat(m.isEmpty(), is(false));
-        assertThat(m2.size(), is(4));
-        assertThat(m.isEmpty(), is(false));
-        assertThat(m2.attributeNames(), contains("one", "two", "three", "four"));
     }
 
     public void testSingleItemConstructor() {


### PR DESCRIPTION
Remove the defensive copy from the builder.