### PR TITLE
Treat all xpack as modules

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -65,7 +65,7 @@ public class RestTestUtil {
                 if (project.getPath().contains("modules:") || project.getPath().startsWith(":x-pack:plugin")) {
                     testTask.getClusters().forEach(c -> c.module(bundle.getArchiveFile()));
                 } else {
-                    testTask.getClusters().forEach(c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile())));
+                    testTask.getClusters().forEach(c -> c.plugin(bundle.getArchiveFile()));
                 }
             });
         });

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestTestUtil.java
@@ -62,7 +62,7 @@ public class RestTestUtil {
             project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
                 Zip bundle = (Zip) project.getTasks().getByName("bundlePlugin");
                 testTask.dependsOn(bundle);
-                if (project.getPath().contains("modules:")) {
+                if (project.getPath().contains("modules:") || project.getPath().startsWith(":x-pack:plugin")) {
                     testTask.getClusters().forEach(c -> c.module(bundle.getArchiveFile()));
                 } else {
                     testTask.getClusters().forEach(c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile())));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -617,27 +617,23 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private void installModules() {
-        if (testDistribution == TestDistribution.INTEG_TEST) {
-            logToProcessStdout("Installing " + modules.size() + "modules");
-            for (Provider<File> module : modules) {
-                Path destination = getDistroDir().resolve("modules")
-                    .resolve(module.get().getName().replace(".zip", "").replace("-" + getVersion(), "").replace("-SNAPSHOT", ""));
-                // only install modules that are not already bundled with the integ-test distribution
-                if (Files.exists(destination) == false) {
-                    fileSystemOperations.copy(spec -> {
-                        if (module.get().getName().toLowerCase().endsWith(".zip")) {
-                            spec.from(archiveOperations.zipTree(module));
-                        } else if (module.get().isDirectory()) {
-                            spec.from(module);
-                        } else {
-                            throw new IllegalArgumentException("Not a valid module " + module + " for " + this);
-                        }
-                        spec.into(destination);
-                    });
-                }
+        logToProcessStdout("Installing " + modules.size() + "modules");
+        for (Provider<File> module : modules) {
+            Path destination = getDistroDir().resolve("modules")
+                .resolve(module.get().getName().replace(".zip", "").replace("-" + getVersion(), "").replace("-SNAPSHOT", ""));
+            // only install modules that are not already bundled with the integ-test distribution
+            if (Files.exists(destination) == false) {
+                fileSystemOperations.copy(spec -> {
+                    if (module.get().getName().toLowerCase().endsWith(".zip")) {
+                        spec.from(archiveOperations.zipTree(module));
+                    } else if (module.get().isDirectory()) {
+                        spec.from(module);
+                    } else {
+                        throw new IllegalArgumentException("Not a valid module " + module + " for " + this);
+                    }
+                    spec.into(destination);
+                });
             }
-        } else {
-            LOGGER.info("Not installing " + modules.size() + "(s) since the " + distributions + " distribution already has them");
         }
     }
 

--- a/x-pack/plugin/async-search/qa/rest/build.gradle
+++ b/x-pack/plugin/async-search/qa/rest/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 esplugin {
+  name 'test-deprecated-query'
   description 'Deprecated query plugin'
   classname 'org.elasticsearch.query.DeprecatedQueryPlugin'
 }


### PR DESCRIPTION
When rest tests install plugins, they currently treat xpack as plugins
instead of modules. This was a side effect of splitting the rest test
plugin out from PluginBuildPlugin. However, that means xpack modules are
being run through the elasticsearch plugin installer, which is not
guaranteed to work. This commit reworks rest tests to treat anything
under xpack as a module. A side effect of this is that QA plugins under
xpack get treated as modules. This is ok because they are just for
testing, we don't need to validate them in the same way we do actual
plugins. Additionally, this commit relaxes the expection that modules
are only added for the integ test distribution. There is already a check
to not overwrite an existing module, so this wasn't a useful
optimization anyways.