### PR TITLE
Disable ILM history in DataStreamRestIT

### DIFF
--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -16,4 +16,6 @@ testClusters.javaRestTest {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
+  //disabling ILM history as it disturbes testDSXpackUsage test
+  setting 'indices.lifecycle.history_index_enabled', 'false'
 }

--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -16,6 +16,6 @@ testClusters.javaRestTest {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
-  //disabling ILM history as it disturbes testDSXpackUsage test
+  //disabling ILM history as it disturbs testDSXpackUsage test
   setting 'indices.lifecycle.history_index_enabled', 'false'
 }


### PR DESCRIPTION
Disabling ILM history in `x-pack:plugin:data-streams:qa:multi-node` because it disturbs data streams count in `DataStreamRestIT#testDSXpackUsage`