### PR TITLE
[7.x] Disable ILM history in DataStreamRestIT (#64840)

### DIFF
--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -16,4 +16,6 @@ testClusters.javaRestTest {
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
+  //disabling ILM history as it disturbs testDSXpackUsage test
+  setting 'indices.lifecycle.history_index_enabled', 'false'
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable ILM history in DataStreamRestIT (#64840)