### PR TITLE
SQL:Fix the return type problem in the sign function

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
@@ -80,7 +80,7 @@ public class MathProcessor implements Processor {
                 return (int) Math.signum((Double) l);
             }
             if (l instanceof Float) {
-                return (int)Math.signum((Float) l);
+                return (int) Math.signum((Float) l);
             }
 
             return Long.signum(((Number) l).longValue());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
@@ -77,7 +77,7 @@ public class MathProcessor implements Processor {
                 Randomness.get().nextDouble(), true),
         SIGN((Object l) -> {
             if (l instanceof Double) {
-                return (int)Math.signum((Double) l);
+                return (int) Math.signum((Double) l);
             }
             if (l instanceof Float) {
                 return (int)Math.signum((Float) l);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
@@ -77,26 +77,13 @@ public class MathProcessor implements Processor {
                 Randomness.get().nextDouble(), true),
         SIGN((Object l) -> {
             if (l instanceof Double) {
-                return Math.signum((Double) l);
+                return (int)Math.signum((Double) l);
             }
             if (l instanceof Float) {
-                return Math.signum((Float) l);
+                return (int)Math.signum((Float) l);
             }
 
-            long lo = Long.signum(((Number) l).longValue());
-
-            if (l instanceof Integer) {
-                return DataTypeConverter.safeToInt(lo);
-            }
-            if (l instanceof Short) {
-                return DataTypeConverter.safeToShort(lo);
-            }
-            if (l instanceof Byte) {
-                return DataTypeConverter.safeToByte(lo);
-            }
-
-            //fallback to generic double
-            return lo;
+            return Long.signum(((Number) l).longValue());
         }),
         SIN(Math::sin),
         SINH(Math::sinh),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
@@ -42,7 +42,7 @@ public class MathOperationTests extends ESTestCase {
     public void testSignIntegerType() {
         List<Number> negative = Arrays.asList((byte) -42, (short) -42, -42, Long.valueOf(-42), Float.valueOf(-42.0f), Double.valueOf(-42.0d));
         List<Number> zero = Arrays.asList((byte) 0, (short) 0, 0, Long.valueOf(0), Float.valueOf(0.0f), Double.valueOf(0.0d));
-        List<Number> positive = Arrays.asList((byte) 42, (short)42, 42, Long.valueOf(42), Float.valueOf(42.0f), Double.valueOf(42.0d));
+        List<Number> positive = Arrays.asList((byte) 42, (short) 42, 42, Long.valueOf(42), Float.valueOf(42.0f), Double.valueOf(42.0d));
 
         for (Number number : negative) {
             Number result = MathOperation.SIGN.apply(number);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
@@ -35,4 +35,25 @@ public class MathOperationTests extends ESTestCase {
         assertEquals(42f, MathOperation.ABS.apply(-42f));
         assertEquals(42d, MathOperation.ABS.apply(-42d));
     }
+
+    public void testSignIntegerType() {
+        assertEquals(-1, MathOperation.SIGN.apply((byte) -42));
+        assertEquals( -1, MathOperation.SIGN.apply((short) -42));
+        assertEquals(-1, MathOperation.SIGN.apply(-42));
+        assertEquals( -1, MathOperation.SIGN.apply((long) -42));
+        assertEquals(-1, MathOperation.SIGN.apply(-42.0f));
+        assertEquals(-1, MathOperation.SIGN.apply(-42.0d));
+        assertEquals( 1, MathOperation.SIGN.apply((byte) 42));
+        assertEquals( 1, MathOperation.SIGN.apply((short) 42));
+        assertEquals(1, MathOperation.SIGN.apply(42));
+        assertEquals( 1, MathOperation.SIGN.apply((long) 42));
+        assertEquals(1, MathOperation.SIGN.apply(42.0f));
+        assertEquals(1, MathOperation.SIGN.apply(42.0d));
+        assertEquals(0, MathOperation.SIGN.apply((byte) 0));
+        assertEquals( 0, MathOperation.SIGN.apply((short) 0));
+        assertEquals(0, MathOperation.SIGN.apply(0));
+        assertEquals( 0, MathOperation.SIGN.apply((long) 0));
+        assertEquals(0, MathOperation.SIGN.apply(-0.0f));
+        assertEquals(0, MathOperation.SIGN.apply(-0.0d));
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathOperationTests.java
@@ -10,6 +10,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.MathProcessor.MathOperation;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class MathOperationTests extends ESTestCase {
 
     public void testAbsLongMax() {
@@ -37,23 +40,26 @@ public class MathOperationTests extends ESTestCase {
     }
 
     public void testSignIntegerType() {
-        assertEquals(-1, MathOperation.SIGN.apply((byte) -42));
-        assertEquals( -1, MathOperation.SIGN.apply((short) -42));
-        assertEquals(-1, MathOperation.SIGN.apply(-42));
-        assertEquals( -1, MathOperation.SIGN.apply((long) -42));
-        assertEquals(-1, MathOperation.SIGN.apply(-42.0f));
-        assertEquals(-1, MathOperation.SIGN.apply(-42.0d));
-        assertEquals( 1, MathOperation.SIGN.apply((byte) 42));
-        assertEquals( 1, MathOperation.SIGN.apply((short) 42));
-        assertEquals(1, MathOperation.SIGN.apply(42));
-        assertEquals( 1, MathOperation.SIGN.apply((long) 42));
-        assertEquals(1, MathOperation.SIGN.apply(42.0f));
-        assertEquals(1, MathOperation.SIGN.apply(42.0d));
-        assertEquals(0, MathOperation.SIGN.apply((byte) 0));
-        assertEquals( 0, MathOperation.SIGN.apply((short) 0));
-        assertEquals(0, MathOperation.SIGN.apply(0));
-        assertEquals( 0, MathOperation.SIGN.apply((long) 0));
-        assertEquals(0, MathOperation.SIGN.apply(-0.0f));
-        assertEquals(0, MathOperation.SIGN.apply(-0.0d));
+        List<Number> negative = Arrays.asList((byte) -42, (short) -42, -42, Long.valueOf(-42), Float.valueOf(-42.0f), Double.valueOf(-42.0d));
+        List<Number> zero = Arrays.asList((byte) 0, (short) 0, 0, Long.valueOf(0), Float.valueOf(0.0f), Double.valueOf(0.0d));
+        List<Number> positive = Arrays.asList((byte) 42, (short)42, 42, Long.valueOf(42), Float.valueOf(42.0f), Double.valueOf(42.0d));
+
+        for (Number number : negative) {
+            Number result = MathOperation.SIGN.apply(number);
+            assertEquals(Integer.class, result.getClass());
+            assertEquals(-1, result);
+        }
+
+        for (Number number : zero) {
+            Number result = MathOperation.SIGN.apply(number);
+            assertEquals(Integer.class, result.getClass());
+            assertEquals(0, result);
+        }
+
+        for (Number number : positive) {
+            Number result = MathOperation.SIGN.apply(number);
+            assertEquals(Integer.class, result.getClass());
+            assertEquals(1, result);
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: mantuliu <240951888@qq.com>


In the Class Sign, DataType is DataTypes.INTEGER. The source code is as follows：
```
    @Override
    public DataType dataType() {
        return DataTypes.INTEGER;
    }
```
But In the Class MathProcessor, the source code of SIGN((Object l),  Parameter and return value types are the same.Therefore, when using double or float parameters to test, there is a little problem, the test method is like the following curl :
```
curl -XPOST 127.0.0.1:9200/_sql -d "{\"query\":\"select  SIGN(1.0) \"}" -H 'Content-Type: application/json'

```
The result is:
```
{"columns":[{"name":"SIGN(1.0)","type":"integer"}],"rows":[[1.0]]}
```
The result value is "1.0", but the type is "integer".  The above test is based on the master branch