### PR TITLE
[ML] Truncate long audit messages

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
@@ -28,10 +28,11 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
     public static final ParseField NODE_NAME = new ParseField("node_name");
     public static final ParseField JOB_TYPE = new ParseField("job_type");
 
+    private static final String TRUNCATED_SUFFIX = "... (truncated)";
     /**
      * The max length of an audit message in characters is 32766 / 4 = 8191
      * where 32766 is the limit in bytes Lucene sets for a term field
-     * and 4 is the max number of bytes required to represent a UTF8 character
+     * and 4 is the max number of bytes required to represent a UTF8 character.
      */
     public static final int MAX_AUDIT_MESSAGE_CHARS = 8191;
 
@@ -95,7 +96,13 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
         if (resourceId != null) {
             builder.field(getResourceField(), resourceId);
         }
-        builder.field(MESSAGE.getPreferredName(), message.substring(0, Math.min(message.length(), MAX_AUDIT_MESSAGE_CHARS)));
+
+        if (message.length() > MAX_AUDIT_MESSAGE_CHARS) {
+            assert message.length() > MAX_AUDIT_MESSAGE_CHARS : "Audit message is unexpectedly large";
+            builder.field(MESSAGE.getPreferredName(), truncateMessage(message, MAX_AUDIT_MESSAGE_CHARS));
+        } else {
+            builder.field(MESSAGE.getPreferredName(), message);
+        }
         builder.field(LEVEL.getPreferredName(), level);
         builder.field(TIMESTAMP.getPreferredName(), timestamp.getTime());
         if (nodeName != null) {
@@ -141,4 +148,29 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
      * @return resource id field name used when storing a new message
      */
     protected abstract String getResourceField();
+
+    /**
+     * Truncate the message and append {@value #TRUNCATED_SUFFIX} so
+     * that the resulting string does not exceed {@code maxLength} characters
+     *
+     * {@code message} must be at least {@code maxLength} long
+     *
+     * @param message The message to truncate. Must have length of at least maxLength
+     * @param maxLength The length to truncate to
+     * @return The truncated string ending int {@value #TRUNCATED_SUFFIX}
+     */
+    static String truncateMessage(String message, int maxLength) {
+        StringBuilder sb = new StringBuilder(maxLength);
+        sb.append(message, 0, maxLength - TRUNCATED_SUFFIX.length());
+        int lastWhitespace = sb.lastIndexOf(" ");
+        if (lastWhitespace < 0) {
+            // no space char
+            lastWhitespace = maxLength - TRUNCATED_SUFFIX.length();
+        } else {
+            lastWhitespace++; // point to next char which is a non-space char
+        }
+        sb.replace(lastWhitespace, lastWhitespace + TRUNCATED_SUFFIX.length(), TRUNCATED_SUFFIX);
+        sb.delete(lastWhitespace + TRUNCATED_SUFFIX.length(), sb.length());
+        return sb.toString();
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
@@ -28,6 +28,13 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
     public static final ParseField NODE_NAME = new ParseField("node_name");
     public static final ParseField JOB_TYPE = new ParseField("job_type");
 
+    /**
+     * The max length of an audit message in characters is 32766 / 4 = 8191
+     * where 32766 is the limit in bytes Lucene sets for a term field
+     * and 4 is the max number of bytes required to represent a UTF8 character
+     */
+    public static final int MAX_AUDIT_MESSAGE_CHARS = 8191;
+
     protected static final <T extends AbstractAuditMessage> ConstructingObjectParser<T, Void> createParser(
             String name, AbstractAuditMessageFactory<T> messageFactory, ParseField resourceField) {
 
@@ -88,7 +95,7 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
         if (resourceId != null) {
             builder.field(getResourceField(), resourceId);
         }
-        builder.field(MESSAGE.getPreferredName(), message);
+        builder.field(MESSAGE.getPreferredName(), message.substring(0, Math.min(message.length(), MAX_AUDIT_MESSAGE_CHARS)));
         builder.field(LEVEL.getPreferredName(), level);
         builder.field(TIMESTAMP.getPreferredName(), timestamp.getTime());
         if (nodeName != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
@@ -120,12 +120,15 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
         String truncated = AbstractAuditMessage.truncateMessage(message, 20);
         assertEquals("a ... (truncated)", truncated);
         assertThat(truncated.length(), lessThanOrEqualTo(20));
+
         truncated = AbstractAuditMessage.truncateMessage(message, 23);
         assertEquals("a short ... (truncated)", truncated);
         assertThat(truncated.length(), lessThanOrEqualTo(23));
+
         truncated = AbstractAuditMessage.truncateMessage(message, 31);
         assertEquals("a short message ... (truncated)", truncated);
         assertThat(truncated.length(), lessThanOrEqualTo(31));
+
         truncated = AbstractAuditMessage.truncateMessage(message, 32);
         assertEquals("a short message ... (truncated)", truncated);
         assertThat(truncated.length(), lessThanOrEqualTo(32));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
@@ -6,13 +6,20 @@
 package org.elasticsearch.xpack.core.common.notifications;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
+import java.io.IOException;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class AbstractAuditMessageTests extends AbstractXContentTestCase<AbstractAuditMessageTests.TestAuditMessage> {
 
@@ -77,6 +84,67 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
         assertThat(message.getLevel(), equalTo(Level.ERROR));
         assertThat(message.getTimestamp(), equalTo(TIMESTAMP));
         assertThat(message.getNodeName(), equalTo(NODE_NAME));
+    }
+
+    public void testLongMessageIsTruncated() throws IOException {
+        AbstractAuditMessage longMessage = new AbstractAuditMessage(
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            "thisis17charslong".repeat(490),
+            randomFrom(Level.values()),
+            new Date(),
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20)
+        ) {
+            @Override
+            public String getJobType() {
+                return "unused";
+            }
+
+            @Override
+            protected String getResourceField() {
+                return "unused";
+            }
+        };
+
+        assertThat(longMessage.getMessage().length(), greaterThan(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
+
+        // serialise the message and check the new message is truncated
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalXContent = XContentHelper.toXContent(longMessage, xContentType, randomBoolean());
+        XContentParser parser = createParser(XContentFactory.xContent(xContentType), originalXContent);
+        AbstractAuditMessage parsed = doParseInstance(parser);
+        assertThat(parsed.getMessage().length(), equalTo(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
+    }
+
+    public void testTruncateString() {
+        String message = "a short message short message short message short message short message";
+        String truncated = AbstractAuditMessage.truncateMessage(message, 20);
+        assertEquals("a ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(20));
+        truncated = AbstractAuditMessage.truncateMessage(message, 23);
+        assertEquals("a short ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(23));
+        truncated = AbstractAuditMessage.truncateMessage(message, 31);
+        assertEquals("a short message ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(31));
+        truncated = AbstractAuditMessage.truncateMessage(message, 32);
+        assertEquals("a short message ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(32));
+    }
+
+    public void testTruncateString_noSpaceChar() {
+        String message = "ashortmessageshortmessageshortmessageshortmessageshortmessage";
+        String truncated = AbstractAuditMessage.truncateMessage(message, 20);
+        assertEquals("ashor... (truncated)", truncated);
+        assertEquals(20, truncated.length());
+        truncated = AbstractAuditMessage.truncateMessage(message, 25);
+        assertEquals("ashortmess... (truncated)", truncated);
+        assertEquals(25, truncated.length());
+    }
+
+    public void testTruncateString_tabsInsteadOfSpaces() {
+        String truncated = AbstractAuditMessage.truncateMessage("a\tshort\tmessage\tshort\tmessage", 25);
+        assertEquals("a\tshort\tme... (truncated)", truncated);
+        assertEquals(25, truncated.length());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessageTests.java
@@ -5,11 +5,21 @@
  */
 package org.elasticsearch.xpack.core.ml.notifications;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
+import org.elasticsearch.xpack.core.common.notifications.Level;
 
+
+import java.io.IOException;
+import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public abstract class AuditMessageTests<T extends AbstractAuditMessage> extends AbstractXContentTestCase<T> {
 
@@ -23,5 +33,34 @@ public abstract class AuditMessageTests<T extends AbstractAuditMessage> extends 
     @Override
     protected boolean supportsUnknownFields() {
         return true;
+    }
+
+    public void testLongMessageIsTruncated() throws IOException {
+        AbstractAuditMessage longMessage = new AbstractAuditMessage(
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            "thisis17charslong".repeat(490),
+            randomFrom(Level.values()),
+            new Date(),
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20)
+        ) {
+            @Override
+            public String getJobType() {
+                return "unused";
+            }
+
+            @Override
+            protected String getResourceField() {
+                return "unused";
+            }
+        };
+
+        assertThat(longMessage.getMessage().length(), greaterThan(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
+
+        // serialise the message and check the new message is truncated
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalXContent = XContentHelper.toXContent(longMessage, xContentType, randomBoolean());
+        XContentParser parser = createParser(XContentFactory.xContent(xContentType), originalXContent);
+        AbstractAuditMessage parsed = doParseInstance(parser);
+        assertThat(parsed.getMessage().length(), equalTo(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessageTests.java
@@ -5,21 +5,11 @@
  */
 package org.elasticsearch.xpack.core.ml.notifications;
 
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
-import org.elasticsearch.xpack.core.common.notifications.Level;
 
-
-import java.io.IOException;
-import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 
 public abstract class AuditMessageTests<T extends AbstractAuditMessage> extends AbstractXContentTestCase<T> {
 
@@ -33,34 +23,5 @@ public abstract class AuditMessageTests<T extends AbstractAuditMessage> extends 
     @Override
     protected boolean supportsUnknownFields() {
         return true;
-    }
-
-    public void testLongMessageIsTruncated() throws IOException {
-        AbstractAuditMessage longMessage = new AbstractAuditMessage(
-            randomBoolean() ? null : randomAlphaOfLength(10),
-            "thisis17charslong".repeat(490),
-            randomFrom(Level.values()),
-            new Date(),
-            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20)
-        ) {
-            @Override
-            public String getJobType() {
-                return "unused";
-            }
-
-            @Override
-            protected String getResourceField() {
-                return "unused";
-            }
-        };
-
-        assertThat(longMessage.getMessage().length(), greaterThan(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
-
-        // serialise the message and check the new message is truncated
-        XContentType xContentType = randomFrom(XContentType.values());
-        BytesReference originalXContent = XContentHelper.toXContent(longMessage, xContentType, randomBoolean());
-        XContentParser parser = createParser(XContentFactory.xContent(xContentType), originalXContent);
-        AbstractAuditMessage parsed = doParseInstance(parser);
-        assertThat(parsed.getMessage().length(), equalTo(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
     }
 }


### PR DESCRIPTION
ML notification indices that do not have the `ignore_above` parameter added in #64570 are susceptible to an issue where the keyword field can be longer than the 32766 bytes allowed by Lucene. This change limits the length of the message so that bug is never triggered.

## For discussion
This approach isn't the only way to fix the problem -the existing index mappings could be updated- and is not required for new indices with the `ignore_above` parameter so is truncating the best solution?

I argue that an audit message probably isn't worth reading past 8191 chars as the useful information is at the start of the message and the remainder will be computer generated. 

For context english words contain on average 4.7 characters so 8191 chars ~ 1742 words, longer than most of the reports I wrote at university and you wouldn't want to read them to the end. 