### PR TITLE
fix `testOpenForOutputGivenPipeDoesNotExist` on multi language platform

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperTests.java
@@ -46,7 +46,8 @@ public class NamedPipeHelperTests extends ESTestCase {
                 NAMED_PIPE_HELPER.getDefaultPipeDirectoryPrefix(env) + "this pipe does not exist",
                 Duration.ofSeconds(1)));
 
-        assertTrue(ioe.getMessage(), ioe.getMessage().contains("No such file or directory") ||
+        assertTrue(ioe.getMessage(), ioe.getMessage().contains("this pipe does not exist") ||
+                ioe.getMessage().contains("No such file or directory") ||
                 ioe.getMessage().contains("The system cannot find the file specified"));
     }
 


### PR DESCRIPTION
My OS is: window10 2004 (19041.610) 
system language: zh-cn

On a OS that has a default language other than English, for example Chinese, this test will fail due err message no matching , because the exception message produced when running testing case are all in Chinese. So to reproduce this testcase failure you may need a environment that has a different language set than English and run this test again.
