### PR TITLE
Run elasticsearch-node as the right user in package tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
+import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
@@ -392,7 +393,12 @@ public class ArchiveTests extends PackagingTestCase {
         startElasticsearch();
         stopElasticsearch();
 
-        Result result = sh.run("echo y | " + installation.executables().nodeTool + " unsafe-bootstrap");
+        String nodeTool = installation.executables().nodeTool.toString();
+        if (Platforms.WINDOWS == false) {
+            nodeTool = "sudo -E -u " + ARCHIVE_OWNER + " " + nodeTool;
+        }
+
+        Result result = sh.run("echo y | " + nodeTool + " unsafe-bootstrap");
         assertThat(result.stdout, containsString("Master node was successfully bootstrapped"));
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -394,7 +394,7 @@ public class Archives {
         assertThat(pid, is(not(emptyOrNullString())));
 
         final Shell sh = new Shell();
-        Platforms.onLinux(() -> sh.run("kill -SIGTERM " + pid + "; tail --pid=" + pid + " -f /dev/null"));
+        Platforms.onLinux(() -> sh.run("kill -SIGTERM " + pid + " && tail --pid=" + pid + " -f /dev/null"));
         Platforms.onWindows(() -> {
             sh.run("Get-Process -Id " + pid + " | Stop-Process -Force; Wait-Process -Id " + pid);
 


### PR DESCRIPTION
Closes #64735.

When running the `elasticsearch-node` tool in the archive packaging
tests with a non-standard data directory, make sure we run the tool as
the same user as Elasticsearch. Some systems place extra restrictions on
`/tmp` that prevent a different user being able to get write access
to `/tmp/node.lock`.