### PR TITLE
[ML] Refactor gathering of context necessary to run datafeed

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -698,14 +698,12 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 anomalyDetectionAuditor,
                 anomalyDetectionAnnotationPersister,
                 System::currentTimeMillis,
-                jobConfigProvider,
-                jobResultsProvider,
-                datafeedConfigProvider,
                 jobResultsPersister,
                 settings,
                 clusterService.getNodeName());
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,
-                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager);
+                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager, jobConfigProvider, datafeedConfigProvider,
+                jobResultsProvider);
         this.datafeedManager.set(datafeedManager);
 
         // Inference components

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
@@ -61,7 +61,7 @@ class DatafeedContext {
             return this;
         }
 
-        public Job getJob() {
+        Job getJob() {
             return job;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
+
+import java.util.Objects;
+
+class DatafeedContext {
+
+    private final DatafeedConfig datafeedConfig;
+    private final Job job;
+    private final RestartTimeInfo restartTimeInfo;
+    private final DatafeedTimingStats timingStats;
+
+    DatafeedContext(DatafeedConfig datafeedConfig, Job job, RestartTimeInfo restartTimeInfo,
+                           DatafeedTimingStats timingStats) {
+        this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
+        this.job = Objects.requireNonNull(job);
+        this.restartTimeInfo = Objects.requireNonNull(restartTimeInfo);
+        this.timingStats = Objects.requireNonNull(timingStats);
+    }
+
+
+    DatafeedConfig getDatafeedConfig() {
+        return datafeedConfig;
+    }
+
+    Job getJob() {
+        return job;
+    }
+
+    RestartTimeInfo getRestartTimeInfo() {
+        return restartTimeInfo;
+    }
+
+    DatafeedTimingStats getTimingStats() {
+        return timingStats;
+    }
+
+    static class Builder {
+        private volatile DatafeedConfig datafeedConfig;
+        private volatile Job job;
+        private volatile RestartTimeInfo restartTimeInfo;
+        private volatile DatafeedTimingStats timingStats;
+
+        Builder setDatafeedConfig(DatafeedConfig datafeedConfig) {
+            this.datafeedConfig = datafeedConfig;
+            return this;
+        }
+
+        Builder setJob(Job job) {
+            this.job = job;
+            return this;
+        }
+
+        public Job getJob() {
+            return job;
+        }
+
+        Builder setRestartTimeInfo(RestartTimeInfo restartTimeInfo) {
+            this.restartTimeInfo = restartTimeInfo;
+            return this;
+        }
+
+        Builder setTimingStats(DatafeedTimingStats timingStats) {
+            this.timingStats = timingStats;
+            return this;
+        }
+
+        DatafeedContext build() {
+            return new DatafeedContext(datafeedConfig, job, restartTimeInfo, timingStats);
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -61,7 +61,7 @@ public class DatafeedJobBuilder {
         final Job job = context.getJob();
         final long latestFinalBucketEndMs = context.getRestartTimeInfo().getLatestFinalBucketTimeMs() == null ?
             -1 : context.getRestartTimeInfo().getLatestFinalBucketTimeMs() + job.getAnalysisConfig().getBucketSpan().millis() - 1;
-        long latestRecordTimeMs = context.getRestartTimeInfo().getLatestRecordTimeMs() == null ?
+        final long latestRecordTimeMs = context.getRestartTimeInfo().getLatestRecordTimeMs() == null ?
             -1 : context.getRestartTimeInfo().getLatestRecordTimeMs();
         final DatafeedTimingStatsReporter timingStatsReporter = new DatafeedTimingStatsReporter(context.getTimingStats(),
             jobResultsPersister::persistDatafeedTimingStats);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -13,29 +13,22 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
-import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
-import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.action.TransportStartDatafeedAction;
 import org.elasticsearch.xpack.ml.annotations.AnnotationPersister;
 import org.elasticsearch.xpack.ml.datafeed.delayeddatacheck.DelayedDataDetector;
 import org.elasticsearch.xpack.ml.datafeed.delayeddatacheck.DelayedDataDetectorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
-import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
-import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
-import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
-import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class DatafeedJobBuilder {
@@ -45,147 +38,102 @@ public class DatafeedJobBuilder {
     private final AnomalyDetectionAuditor auditor;
     private final AnnotationPersister annotationPersister;
     private final Supplier<Long> currentTimeSupplier;
-    private final JobConfigProvider jobConfigProvider;
-    private final JobResultsProvider jobResultsProvider;
-    private final DatafeedConfigProvider datafeedConfigProvider;
     private final JobResultsPersister jobResultsPersister;
     private final boolean remoteClusterClient;
     private final String nodeName;
 
     public DatafeedJobBuilder(Client client, NamedXContentRegistry xContentRegistry, AnomalyDetectionAuditor auditor,
                               AnnotationPersister annotationPersister, Supplier<Long> currentTimeSupplier,
-                              JobConfigProvider jobConfigProvider, JobResultsProvider jobResultsProvider,
-                              DatafeedConfigProvider datafeedConfigProvider, JobResultsPersister jobResultsPersister, Settings settings,
-                              String nodeName) {
+                              JobResultsPersister jobResultsPersister, Settings settings, String nodeName) {
         this.client = client;
         this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
         this.auditor = Objects.requireNonNull(auditor);
         this.annotationPersister = Objects.requireNonNull(annotationPersister);
         this.currentTimeSupplier = Objects.requireNonNull(currentTimeSupplier);
-        this.jobConfigProvider = Objects.requireNonNull(jobConfigProvider);
-        this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
-        this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
         this.jobResultsPersister = Objects.requireNonNull(jobResultsPersister);
         this.remoteClusterClient = DiscoveryNode.isRemoteClusterClient(settings);
         this.nodeName = nodeName;
     }
 
-    void build(String datafeedId, TaskId parentTaskId, ActionListener<DatafeedJob> listener) {
-        AtomicReference<Job> jobHolder = new AtomicReference<>();
-        AtomicReference<DatafeedConfig> datafeedConfigHolder = new AtomicReference<>();
-        final ParentTaskAssigningClient parentTaskAssigningClient = new ParentTaskAssigningClient(client, parentTaskId);
+    void build(TransportStartDatafeedAction.DatafeedTask task, DatafeedContext context, ActionListener<DatafeedJob> listener) {
+        final ParentTaskAssigningClient parentTaskAssigningClient = new ParentTaskAssigningClient(client, task.getParentTaskId());
+        final DatafeedConfig datafeedConfig = context.getDatafeedConfig();
+        final Job job = context.getJob();
+        final long latestFinalBucketEndMs = context.getRestartTimeInfo().getLatestFinalBucketTimeMs() == null ?
+            -1 : context.getRestartTimeInfo().getLatestFinalBucketTimeMs() + job.getAnalysisConfig().getBucketSpan().millis() - 1;
+        long latestRecordTimeMs = context.getRestartTimeInfo().getLatestRecordTimeMs() == null ?
+            -1 : context.getRestartTimeInfo().getLatestRecordTimeMs();
+        final DatafeedTimingStatsReporter timingStatsReporter = new DatafeedTimingStatsReporter(context.getTimingStats(),
+            jobResultsPersister::persistDatafeedTimingStats);
 
-        // Build datafeed job object
-        Consumer<Context> contextHanlder = context -> {
-            TimeValue frequency = getFrequencyOrDefault(datafeedConfigHolder.get(), jobHolder.get(), xContentRegistry);
-            TimeValue queryDelay = datafeedConfigHolder.get().getQueryDelay();
-            DelayedDataDetector delayedDataDetector = DelayedDataDetectorFactory.buildDetector(jobHolder.get(),
-                    datafeedConfigHolder.get(), parentTaskAssigningClient, xContentRegistry);
-            DatafeedJob datafeedJob =
-                new DatafeedJob(
-                    jobHolder.get().getId(),
-                    buildDataDescription(jobHolder.get()),
-                    frequency.millis(),
-                    queryDelay.millis(),
-                    context.dataExtractorFactory,
-                    context.timingStatsReporter,
-                    parentTaskAssigningClient,
-                    auditor,
-                    annotationPersister,
-                    currentTimeSupplier,
-                    delayedDataDetector,
-                    datafeedConfigHolder.get().getMaxEmptySearches(),
-                    context.latestFinalBucketEndMs,
-                    context.latestRecordTimeMs,
-                    context.haveSeenDataPreviously);
+        // Validate remote indices are available and get the job
+        try {
+            checkRemoteIndicesAreAvailable(datafeedConfig);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
 
-            listener.onResponse(datafeedJob);
-        };
-
-        final Context context = new Context();
-
-        // Context building complete - invoke final listener
-        ActionListener<DataExtractorFactory> dataExtractorFactoryHandler = ActionListener.wrap(
-                dataExtractorFactory -> {
-                    context.dataExtractorFactory = dataExtractorFactory;
-                    contextHanlder.accept(context);
-                }, e -> {
-                    auditor.error(jobHolder.get().getId(), e.getMessage());
-                    listener.onFailure(e);
-                }
-        );
-
-        // Create data extractor factory
-        Consumer<DatafeedTimingStats> datafeedTimingStatsHandler = initialTimingStats -> {
-            context.timingStatsReporter =
-                new DatafeedTimingStatsReporter(initialTimingStats, jobResultsPersister::persistDatafeedTimingStats);
-            DataExtractorFactory.create(
-                parentTaskAssigningClient,
-                datafeedConfigHolder.get(),
-                jobHolder.get(),
-                xContentRegistry,
-                context.timingStatsReporter,
-                dataExtractorFactoryHandler);
-        };
-
-        ActionListener<RestartTimeInfo> restartTimeInfoListener = ActionListener.wrap(
-            restartTimeInfo -> {
-                if (restartTimeInfo.getLatestFinalBucketTimeMs() != null) {
-                    TimeValue bucketSpan = jobHolder.get().getAnalysisConfig().getBucketSpan();
-                    context.latestFinalBucketEndMs = restartTimeInfo.getLatestFinalBucketTimeMs() + bucketSpan.millis() - 1;
-                }
-                if (restartTimeInfo.getLatestRecordTimeMs() != null) {
-                    context.latestRecordTimeMs = restartTimeInfo.getLatestRecordTimeMs();
-                }
-                context.haveSeenDataPreviously = restartTimeInfo.haveSeenDataPreviously();
-                jobResultsProvider.datafeedTimingStats(jobHolder.get().getId(), datafeedTimingStatsHandler, listener::onFailure);
-            },
-            listener::onFailure
-        );
-
-        // Get the job config and re-validate
         // Re-validation is required as the config has been re-read since
         // the previous validation
-        // Finally, get restart info
-        ActionListener<Job.Builder> jobConfigListener = ActionListener.wrap(
-                jobBuilder -> {
-                    try {
-                        jobHolder.set(jobBuilder.build());
-                        DatafeedJobValidator.validate(datafeedConfigHolder.get(), jobHolder.get(), xContentRegistry);
-                    } catch (Exception e) {
-                        listener.onFailure(e);
-                    }
-                    jobResultsProvider.getRestartTimeInfo(jobHolder.get().getId(), restartTimeInfoListener);
-                },
-                listener::onFailure
+        try {
+            DatafeedJobValidator.validate(datafeedConfig, job, xContentRegistry);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        ActionListener<DataExtractorFactory> dataExtractorFactoryHandler = ActionListener.wrap(
+            dataExtractorFactory -> {
+                TimeValue frequency = getFrequencyOrDefault(datafeedConfig, job, xContentRegistry);
+                TimeValue queryDelay = datafeedConfig.getQueryDelay();
+                DelayedDataDetector delayedDataDetector = DelayedDataDetectorFactory.buildDetector(job,
+                    datafeedConfig, parentTaskAssigningClient, xContentRegistry);
+                DatafeedJob datafeedJob =
+                    new DatafeedJob(
+                        job.getId(),
+                        buildDataDescription(job),
+                        frequency.millis(),
+                        queryDelay.millis(),
+                        dataExtractorFactory,
+                        timingStatsReporter,
+                        parentTaskAssigningClient,
+                        auditor,
+                        annotationPersister,
+                        currentTimeSupplier,
+                        delayedDataDetector,
+                        datafeedConfig.getMaxEmptySearches(),
+                        latestFinalBucketEndMs,
+                        latestRecordTimeMs,
+                        context.getRestartTimeInfo().haveSeenDataPreviously());
+
+                listener.onResponse(datafeedJob);
+            }, e -> {
+                auditor.error(job.getId(), e.getMessage());
+                listener.onFailure(e);
+            }
         );
 
-        // Get the datafeed config
-        ActionListener<DatafeedConfig.Builder> datafeedConfigListener = ActionListener.wrap(
-                configBuilder -> {
-                    try {
-                        datafeedConfigHolder.set(configBuilder.build());
-                        if (remoteClusterClient == false) {
-                            List<String> remoteIndices = RemoteClusterLicenseChecker.remoteIndices(datafeedConfigHolder.get().getIndices());
-                            if (remoteIndices.isEmpty() == false) {
-                                listener.onFailure(
-                                    ExceptionsHelper.badRequestException(Messages.getMessage(
-                                        Messages.DATAFEED_NEEDS_REMOTE_CLUSTER_SEARCH,
-                                        configBuilder.getId(),
-                                        remoteIndices,
-                                        nodeName)));
-                                return;
-                            }
-                        }
-                        jobConfigProvider.getJob(datafeedConfigHolder.get().getJobId(), jobConfigListener);
-                    } catch (Exception e) {
-                        listener.onFailure(e);
-                    }
-                },
-                listener::onFailure
-        );
+        DataExtractorFactory.create(
+            parentTaskAssigningClient,
+            datafeedConfig,
+            job,
+            xContentRegistry,
+            timingStatsReporter,
+            dataExtractorFactoryHandler);
+    }
 
-        datafeedConfigProvider.getDatafeedConfig(datafeedId, datafeedConfigListener);
+    private void checkRemoteIndicesAreAvailable(DatafeedConfig datafeedConfig) {
+        if (remoteClusterClient == false) {
+            List<String> remoteIndices = RemoteClusterLicenseChecker.remoteIndices(datafeedConfig.getIndices());
+            if (remoteIndices.isEmpty() == false) {
+                throw ExceptionsHelper.badRequestException(Messages.getMessage(
+                        Messages.DATAFEED_NEEDS_REMOTE_CLUSTER_SEARCH,
+                        datafeedConfig.getId(),
+                        remoteIndices,
+                        nodeName));
+            }
+        }
     }
 
     private static TimeValue getFrequencyOrDefault(DatafeedConfig datafeed, Job job, NamedXContentRegistry xContentRegistry) {
@@ -207,11 +155,4 @@ public class DatafeedJobBuilder {
         return dataDescription.build();
     }
 
-    private static class Context {
-        volatile long latestFinalBucketEndMs = -1L;
-        volatile long latestRecordTimeMs = -1L;
-        volatile boolean haveSeenDataPreviously;
-        volatile DataExtractorFactory dataExtractorFactory;
-        volatile DatafeedTimingStatsReporter timingStatsReporter;
-    }
 }


### PR DESCRIPTION
This groups together the context necessary to build a datafeed
job into a method of the `DatafeedManager`. This method can
be reused in the future in order to determine whether the
job needs to be reverted to its loaded model snapshot in
case the latter is out dated.
