### PR TITLE
[ML] Increase timeout for RegressionIT.testAliasFields job to run

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -570,7 +570,10 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertProgressIsZero(jobId);
 
         startAnalytics(jobId);
-        waitUntilAnalyticsIsStopped(jobId);
+
+        // This seems to some times take a bit longer than 30 seconds on CI
+        // so we give it a minute.
+        waitUntilAnalyticsIsStopped(jobId, TimeValue.timeValueMinutes(1));
 
         double predictionErrorSum = 0.0;
 


### PR DESCRIPTION
I looked into the failures for this test as reported in #63268.
Nothing seems odd. The tests failed because the job did not complete
within the 30 seconds we provide. This seems to be happening on
CI workers occasionally. As the test is useful, I think it is ok
to increase the timeout a bit and see how it goes.

Fixes #63268
