### PR TITLE
[7.x] Update 7.10 release notes after respin (#64725)

### DIFF
--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -183,6 +183,7 @@ Search::
 * Add case insensitive support for regex queries {es-pull}59441[#59441]
 * Tweak toXContent implementation of ParametrizedFieldMapper {es-pull}59968[#59968]
 * Implement fields value fetching for the `text`, `search_as_you_type` and `token_count` field types {es-pull}63515[#63515]
+* Make term/prefix/wildcard/regex query parsing more lenient, with respect to the `case_insensitive` flag {es-pull}63926[#63926] (issue: {es-issue}63893[#63893])
 
 Snapshot/Restore::
 * Add repositories metering API {es-pull}60371[#60371]
@@ -206,6 +207,9 @@ Transform::
 
 Aggregations::
 * Fix AOOBE when setting min_doc_count to 0 in significant_terms {es-pull}60823[#60823] (issues: {es-issue}60683[#60683], {es-issue}60824[#60824])
+* Make sure non-collecting aggs include sub-aggs {es-pull}64214[#64214] (issue: {es-issue}64142[#64142])
+* Composite aggregation must check live docs when the index is sorted {es-pull}63864[#63864]
+* Fix broken parent and child aggregator {es-pull}63811[#63811]
 
 Allocation::
 * Fix scheduling of ClusterInfoService#refresh {es-pull}59880[#59880]
@@ -213,6 +217,7 @@ Allocation::
 Authorization::
 * Fix doc-update interceptor for indices with DLS and FLS {es-pull}61516[#61516]
 * Report anonymous roles in authenticate response {es-pull}61355[#61355] (issues: {es-issue}47195[#47195], {es-issue}53453[#53453], {es-issue}57711[#57711], {es-issue}57853[#57853])
+* Add view_index_metadata privilege over metricbeat-* for monitoring agent {es-pull}63750[#63750] (issue: {es-issue}63750[#63750])
 
 CRUD::
 * Propagate forceExecution when acquiring permit {es-pull}60634[#60634] (issue: {es-issue}60359[#60359])
@@ -229,6 +234,7 @@ Engine::
 
 Features/ILM+SLM::
 * Fix ILM history index settings {es-pull}61880[#61880] (issues: {es-issue}61457[#61457], {es-issue}61863[#61863])
+* Ensure cancelled SLM jobs do not continue to run {es-pull}63762[#63762] (issue: {es-issue}63754[#63754])
 
 Features/Java Low Level REST Client::
 * Handle non-default port in Cloud-Id {es-pull}61581[#61581]
@@ -274,6 +280,8 @@ Search::
 * Correct how field retrieval handles multifields and copy_to {es-pull}61309[#61309] (issue: {es-issue}61033[#61033])
 * Apply boost only once for distance_feature query {es-pull}63767[#63767]
 * Fixed NullPointerException in `significant_text` aggregation when field does not exist {es-pull}64144[#64144] (issue: {es-issue}64045[#64045])
+* Fix async search to retry updates on version conflict {es-pull}63652[#63652] (issue: {es-issue}63213[#63213])
+* Fix sorted query when date_nanos is used as the numeric_type {es-pull}64183[#64183] (issue: {es-issue}63719[#63719])
 
 Snapshot/Restore::
 * Avoid listener call under SparseFileTracker#mutex {es-pull}61626[#61626] (issue: {es-issue}61520[#61520])
@@ -286,3 +294,17 @@ Snapshot/Restore::
 
 SQL::
 * Allow unescaped wildcard (*) in LIKE pattern {es-pull}63428[#63428] (issue: {es-issue}55108[#55108])
+* Validate integer paramete in string functions {es-pull}63728[#63728] (issue: {es-issue}58923[#58923])
+* Remove filter from field_caps requests {es-pull}63840[#63840] (issue: {es-issue}63832[#63832])
+
+
+
+[[upgrade-7.10.0]]
+[discrete]
+=== Upgrades
+
+Infra/Packaging::
+* Upgrade bundled JDK to 15.0.1 and switch to AdoptOpenJDK {es-pull}64253[#64253]
+
+Store::
+* Upgrade to Lucene-8.7.0 {es-pull}64532[#64532]


### PR DESCRIPTION
Update 7.10 release notes after respin
Add upgrade section to release notes

(cherry picked from commit 9546d0d53298259d9bbdfa3a26fd9b123920e299)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>