### PR TITLE
[7.x][ML] Increase timeout for RegressionIT.testAliasFields job to ru…

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -482,7 +482,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             "Finished analysis");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63268")
     public void testAliasFields() throws Exception {
         // The goal of this test is to assert alias fields are included in the analytics job.
         // We have a simple dataset with two integer fields: field_1 and field_2.
@@ -548,7 +547,10 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertProgressIsZero(jobId);
 
         startAnalytics(jobId);
-        waitUntilAnalyticsIsStopped(jobId);
+
+        // This seems to some times take a bit longer than 30 seconds on CI
+        // so we give it a minute.
+        waitUntilAnalyticsIsStopped(jobId, TimeValue.timeValueMinutes(1));
 
         double predictionErrorSum = 0.0;
 


### PR DESCRIPTION
…n (#64866)

I looked into the failures for this test as reported in #63268.
Nothing seems odd. The tests failed because the job did not complete
within the 30 seconds we provide. This seems to be happening on
CI workers occasionally. As the test is useful, I think it is ok
to increase the timeout a bit and see how it goes.

Fixes #63268

Backport of #64866
