### PR TITLE
[DOCS] Clarify diff between shards per node settings

### DIFF
--- a/docs/reference/index-modules/allocation/total_shards.asciidoc
+++ b/docs/reference/index-modules/allocation/total_shards.asciidoc
@@ -25,8 +25,9 @@ You can also limit the amount of shards a node can have regardless of the index:
 Maximum number of primary and replica shards allocated to each node. Defaults to
 `-1` (unlimited).
 
-For example, a cluster has a `cluster.routing.allocation.total_shards_per_node`
-setting of `100` and three nodes with the following shard allocations:
+{es} checks this setting during shard allocation. For example, a cluster has a
+`cluster.routing.allocation.total_shards_per_node` setting of `100` and three
+nodes with the following shard allocations:
 
 - Node A: 100 shards
 - Node B: 98 shards

--- a/docs/reference/index-modules/allocation/total_shards.asciidoc
+++ b/docs/reference/index-modules/allocation/total_shards.asciidoc
@@ -22,8 +22,8 @@ You can also limit the amount of shards a node can have regardless of the index:
 +
 --
 (<<dynamic-cluster-setting,Dynamic>>)
-Maximum number of primary and replica shards allocated to each node. This limit
-includes primary and replica shards. Defaults to `-1` (unlimited).
+Maximum number of primary and replica shards allocated to each node. Defaults to
+`-1` (unlimited).
 
 For example, a cluster has a `cluster.routing.allocation.total_shards_per_node`
 setting of `100` and three nodes with the following shard allocations:

--- a/docs/reference/index-modules/allocation/total_shards.asciidoc
+++ b/docs/reference/index-modules/allocation/total_shards.asciidoc
@@ -22,19 +22,18 @@ You can also limit the amount of shards a node can have regardless of the index:
 +
 --
 (<<dynamic-cluster-setting,Dynamic>>)
-Maximum number of shards allocated to each node. This limit includes primary and
-replica shards. Defaults to `-1` (unlimited).
+Maximum number of primary and replica shards allocated to each node. This limit
+includes primary and replica shards. Defaults to `-1` (unlimited).
 
-{es} checks this limit during shard allocation. For example, a cluster has a
-`cluster.routing.allocation.total_shards_per_node` setting of `100` and three
-nodes with the following shard allocations:
+For example, a cluster has a `cluster.routing.allocation.total_shards_per_node`
+setting of `100` and three nodes with the following shard allocations:
 
 - Node A: 100 shards
 - Node B: 98 shards
 - Node C: 1 shard
 
 If node C fails, {es} reallocates its shard to node B. Reallocating the shard to
-node A would exceed node A's 100 shards limit.
+node A would exceed node A's shard limit.
 --
 
 [WARNING]

--- a/docs/reference/index-modules/allocation/total_shards.asciidoc
+++ b/docs/reference/index-modules/allocation/total_shards.asciidoc
@@ -17,10 +17,25 @@ number of shards from a single index allowed per node:
 
 You can also limit the amount of shards a node can have regardless of the index:
 
+[[cluster-total-shards-per-node]]
 `cluster.routing.allocation.total_shards_per_node`::
++
+--
+(<<dynamic-cluster-setting,Dynamic>>)
+Maximum number of shards allocated to each node. This limit includes primary and
+replica shards. Defaults to `-1` (unlimited).
 
-    The maximum number of shards (replicas and primaries) that will be
-    allocated to a single node globally.  Defaults to unbounded (-1).
+{es} checks this limit during shard allocation. For example, a cluster has a
+`cluster.routing.allocation.total_shards_per_node` setting of `100` and three
+nodes with the following shard allocations:
+
+- Node A: 100 shards
+- Node B: 98 shards
+- Node C: 1 shard
+
+If node C fails, {es} reallocates its shard to node B. Reallocating the shard to
+node A would exceed node A's 100 shards limit.
+--
 
 [WARNING]
 =======================================

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -63,8 +63,8 @@ calculates the limit as follows:
 
 `cluster.max_shards_per_node * number of data nodes`
 
-Shards for closed indices do not count toward this limit. Defaults to `-1`
-(unlimited). A cluster with no data nodes is also unlimited.
+Shards for closed indices do not count toward this limit. Defaults to `1000`.
+A cluster with no data nodes is unlimited.
 
 {es} rejects any request that creates more shards than this limit allows. For
 example, a cluster with a `cluster.max_shards_per_node` setting of `100` and

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -63,7 +63,8 @@ calculates this limit as follows:
 
 `cluster.max_shards_per_node * number of data nodes`
 
-Defaults to `-1` (unlimited). A cluster with no data nodes is also unlimited.
+Shards for closed indices do not count toward this limit. Defaults to `-1`
+(unlimited). A cluster with no data nodes is also unlimited.
 
 {es} rejects any request that creates more shards than this limit allows. For
 example, a cluster with a `cluster.max_shards_per_node` setting of `100` and

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -54,15 +54,27 @@ Closed indices do not contribute to the shard count.
 You can dynamically adjust the cluster shard limit with the following setting:
 
 `cluster.max_shards_per_node`::
-     (<<dynamic-cluster-setting,Dynamic>>)
-     Controls the number of shards allowed in the cluster per data node.
++
+--
+(<<dynamic-cluster-setting,Dynamic>>)
+Limits the total number of primary and replica shards for the cluster. {es}
+calculates this limit as follows:
 
-With the default setting, a 3-node cluster allows 3,000 shards total, across all open indexes. 
-If you reduce the limit to 500, the cluster would allow 1,500 shards total.
+`cluster.max_shards_per_node * number of data nodes`
 
-NOTE: If there are no data nodes in the cluster, the limit will not be enforced.
-This allows the creation of indices during cluster creation if dedicated master
-nodes are set up before data nodes.
+Defaults to `-1` (unlimited). A cluster with no data nodes is also unlimited.
+
+To prevent <<size-your-shards,oversharding>>, {es} rejects any request that
+creates shards in excess of this limit. For example, a cluster with a
+`cluster.max_shards_per_node` setting of `100` and three data nodes has a shard
+limit of 300. If the cluster already contains 296 shards, {es} rejects any
+request that adds 5 or more shards to the cluster.
+
+NOTE: This setting does not limit shards for individual nodes. To limit the
+number of shards allocated to each node, use the
+<<cluster-total-shards-per-node,`cluster.routing.allocation.total_shards_per_node`>>
+setting.
+--
 
 [[user-defined-data]]
 ===== User-defined cluster metadata

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -59,7 +59,7 @@ You can dynamically adjust the cluster shard limit with the following setting:
 --
 (<<dynamic-cluster-setting,Dynamic>>)
 Limits the total number of primary and replica shards for the cluster. {es}
-calculates this limit as follows:
+calculates the limit as follows:
 
 `cluster.max_shards_per_node * number of data nodes`
 

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -65,14 +65,13 @@ calculates this limit as follows:
 
 Defaults to `-1` (unlimited). A cluster with no data nodes is also unlimited.
 
-To prevent <<size-your-shards,oversharding>>, {es} rejects any request that
-creates shards in excess of this limit. For example, a cluster with a
-`cluster.max_shards_per_node` setting of `100` and three data nodes has a shard
-limit of 300. If the cluster already contains 296 shards, {es} rejects any
-request that adds 5 or more shards to the cluster.
+{es} rejects any request that creates more shards than this limit allows. For
+example, a cluster with a `cluster.max_shards_per_node` setting of `100` and
+three data nodes has a shard limit of 300. If the cluster already contains 296
+shards, {es} rejects any request that adds five or more shards to the cluster.
 
 NOTE: This setting does not limit shards for individual nodes. To limit the
-number of shards allocated to each node, use the
+number of shards for each node, use the
 <<cluster-total-shards-per-node,`cluster.routing.allocation.total_shards_per_node`>>
 setting.
 --

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -53,6 +53,7 @@ Closed indices do not contribute to the shard count.
 
 You can dynamically adjust the cluster shard limit with the following setting:
 
+[[cluster-max-shards-per-node]]
 `cluster.max_shards_per_node`::
 +
 --


### PR DESCRIPTION
Clarifies differences between the `cluster.routing.allocation.total_shards_per_node` and `cluster.max_shards_per_node` cluster settings.

Closes #51839

### Preview
- `cluster.routing.allocation.total_shards_per_node`: https://elasticsearch_64875.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/allocation-total-shards.html#cluster-total-shards-per-node
- `cluster.max_shards_per_node`: https://elasticsearch_64875.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-cluster.html#cluster-max-shards-per-node