### PR TITLE
[7.9][DOCS] Fixes parameter name in Evaluate DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -92,7 +92,7 @@ document is an outlier.
   `auc_roc`:::
     (Optional, object) The AUC ROC (area under the curve of the receiver 
     operating characteristic) score and optionally the curve. Default value is 
-    {"includes_curve": false}.
+    {"include_curve": false}.
     
   `confusion_matrix`:::
     (Optional, object) Set the different thresholds of the {olscore} at where


### PR DESCRIPTION
## Overview

This PR fixes the name of the `include_curve` parameter.

### Preview

[Evaluate DFA docs - binary soft classification](https://elasticsearch_64878.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.9/evaluate-dfanalytics.html#binary-sc-resources)