### PR TITLE
[ML] adding new entropy custom feature processor for data frame analytics

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/MlInferenceNamedXContentProvider.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.client.ml.inference;
 
 import org.elasticsearch.client.ml.inference.preprocessing.CustomWordEmbedding;
+import org.elasticsearch.client.ml.inference.preprocessing.Entropy;
 import org.elasticsearch.client.ml.inference.preprocessing.NGram;
 import org.elasticsearch.client.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.client.ml.inference.trainedmodel.InferenceConfig;
@@ -60,6 +61,8 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             CustomWordEmbedding::fromXContent));
         namedXContent.add(new NamedXContentRegistry.Entry(PreProcessor.class, new ParseField(NGram.NAME),
             NGram::fromXContent));
+        namedXContent.add(new NamedXContentRegistry.Entry(PreProcessor.class, new ParseField(Entropy.NAME),
+            Entropy::fromXContent));
 
         // Model
         namedXContent.add(new NamedXContentRegistry.Entry(TrainedModel.class, new ParseField(Tree.NAME), Tree::fromXContent));

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/Entropy.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/preprocessing/Entropy.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.inference.preprocessing;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+
+/**
+ * PreProcessor for Shannon entropy calculation for a string
+ */
+public class Entropy implements PreProcessor {
+
+    public static final String NAME = "entropy_encoding";
+    public static final ParseField FIELD = new ParseField("field");
+    public static final ParseField FEATURE_NAME = new ParseField("feature_name");
+    public static final ParseField CUSTOM = new ParseField("custom");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<Entropy, Void> PARSER = new ConstructingObjectParser<Entropy, Void>(
+            NAME,
+            true,
+            a -> new Entropy((String)a[0],
+                (String)a[1],
+                (Boolean)a[2]));
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), FEATURE_NAME);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), CUSTOM);
+    }
+
+    public static Entropy fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final String field;
+    private final String featureName;
+    private final Boolean custom;
+
+    Entropy(String field, String featureName, Boolean custom) {
+        this.field = field;
+        this.featureName = featureName;
+        this.custom = custom;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (field != null) {
+            builder.field(FIELD.getPreferredName(), field);
+        }
+        if (featureName != null) {
+            builder.field(FEATURE_NAME.getPreferredName(), featureName);
+        }
+        if (custom != null) {
+            builder.field(CUSTOM.getPreferredName(), custom);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getFeatureName() {
+        return featureName;
+    }
+
+    public Boolean getCustom() {
+        return custom;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Entropy nGram = (Entropy) o;
+        return Objects.equals(field, nGram.field) &&
+            Objects.equals(featureName, nGram.featureName) &&
+            Objects.equals(custom, nGram.custom);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, featureName, custom);
+    }
+
+    public static Builder builder(String field) {
+        return new Builder(field);
+    }
+
+    public static class Builder {
+
+        private String field;
+        private String featureName;
+        private Boolean custom;
+
+        public Builder(String field) {
+            this.field = field;
+        }
+
+        public Builder setField(String field) {
+            this.field = field;
+            return this;
+        }
+
+        public Builder setCustom(boolean custom) {
+            this.custom = custom;
+            return this;
+        }
+
+        public Builder setFeatureName(String featureName) {
+            this.featureName = featureName;
+            return this;
+        }
+
+        public Builder setCustom(Boolean custom) {
+            this.custom = custom;
+            return this;
+        }
+
+        public Entropy build() {
+            return new Entropy(field, featureName, custom);
+        }
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -75,6 +75,7 @@ import org.elasticsearch.client.ml.dataframe.stats.classification.Classification
 import org.elasticsearch.client.ml.dataframe.stats.outlierdetection.OutlierDetectionStats;
 import org.elasticsearch.client.ml.dataframe.stats.regression.RegressionStats;
 import org.elasticsearch.client.ml.inference.preprocessing.CustomWordEmbedding;
+import org.elasticsearch.client.ml.inference.preprocessing.Entropy;
 import org.elasticsearch.client.ml.inference.preprocessing.FrequencyEncoding;
 import org.elasticsearch.client.ml.inference.preprocessing.NGram;
 import org.elasticsearch.client.ml.inference.preprocessing.OneHotEncoding;
@@ -707,7 +708,7 @@ public class RestHighLevelClientTests extends ESTestCase {
 
     public void testProvidedNamedXContents() {
         List<NamedXContentRegistry.Entry> namedXContents = RestHighLevelClient.getProvidedNamedXContents();
-        assertEquals(75, namedXContents.size());
+        assertEquals(76, namedXContents.size());
         Map<Class<?>, Integer> categories = new HashMap<>();
         List<String> names = new ArrayList<>();
         for (NamedXContentRegistry.Entry namedXContent : namedXContents) {
@@ -792,9 +793,14 @@ public class RestHighLevelClientTests extends ESTestCase {
                 registeredMetricName(Regression.NAME, MeanSquaredLogarithmicErrorMetric.NAME),
                 registeredMetricName(Regression.NAME, HuberMetric.NAME),
                 registeredMetricName(Regression.NAME, RSquaredMetric.NAME)));
-        assertEquals(Integer.valueOf(5), categories.get(org.elasticsearch.client.ml.inference.preprocessing.PreProcessor.class));
+        assertEquals(Integer.valueOf(6), categories.get(org.elasticsearch.client.ml.inference.preprocessing.PreProcessor.class));
         assertThat(names,
-            hasItems(FrequencyEncoding.NAME, OneHotEncoding.NAME, TargetMeanEncoding.NAME, CustomWordEmbedding.NAME, NGram.NAME));
+            hasItems(FrequencyEncoding.NAME,
+                OneHotEncoding.NAME,
+                TargetMeanEncoding.NAME,
+                CustomWordEmbedding.NAME,
+                NGram.NAME,
+                Entropy.NAME));
         assertEquals(Integer.valueOf(3), categories.get(org.elasticsearch.client.ml.inference.trainedmodel.TrainedModel.class));
         assertThat(names, hasItems(Tree.NAME, Ensemble.NAME, LangIdentNeuralNetwork.NAME));
         assertEquals(Integer.valueOf(4),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/preprocessing/EntropyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/preprocessing/EntropyTests.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.inference.preprocessing;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+
+
+public class EntropyTests extends AbstractXContentTestCase<Entropy> {
+
+    @Override
+    protected Entropy doParseInstance(XContentParser parser) throws IOException {
+        return Entropy.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected Entropy createTestInstance() {
+        return createRandom();
+    }
+
+    public static Entropy createRandom() {
+        return new Entropy(randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomBoolean() ? null : randomBoolean());
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.plugins.spi.NamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.CustomWordEmbedding;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.Entropy;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.FrequencyEncoding;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.LenientlyParsedPreProcessor;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.NGram;
@@ -67,6 +68,8 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             (p, c) -> CustomWordEmbedding.fromXContentLenient(p)));
         namedXContent.add(new NamedXContentRegistry.Entry(LenientlyParsedPreProcessor.class, NGram.NAME,
             (p, c) -> NGram.fromXContentLenient(p, (PreProcessor.PreProcessorParseContext) c)));
+        namedXContent.add(new NamedXContentRegistry.Entry(LenientlyParsedPreProcessor.class, Entropy.NAME,
+            (p, c) -> Entropy.fromXContentLenient(p, (PreProcessor.PreProcessorParseContext) c)));
 
         // PreProcessing Strict
         namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedPreProcessor.class, OneHotEncoding.NAME,
@@ -79,6 +82,8 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             (p, c) -> CustomWordEmbedding.fromXContentStrict(p)));
         namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedPreProcessor.class, NGram.NAME,
             (p, c) -> NGram.fromXContentStrict(p, (PreProcessor.PreProcessorParseContext) c)));
+        namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedPreProcessor.class, Entropy.NAME,
+            (p, c) -> Entropy.fromXContentStrict(p, (PreProcessor.PreProcessorParseContext) c)));
 
         // Model Lenient
         namedXContent.add(new NamedXContentRegistry.Entry(LenientlyParsedTrainedModel.class, Tree.NAME, Tree::fromXContentLenient));
@@ -161,6 +166,8 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             CustomWordEmbedding::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(PreProcessor.class, NGram.NAME.getPreferredName(),
             NGram::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(PreProcessor.class, Entropy.NAME.getPreferredName(),
+            Entropy::new));
 
         // Model
         namedWriteables.add(new NamedWriteableRegistry.Entry(TrainedModel.class, Tree.NAME.getPreferredName(), Tree::new));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Entropy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Entropy.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.inference.preprocessing;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PrimitiveIterator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.lucene.util.RamUsageEstimator.sizeOf;
+
+/**
+ * PreProcessor for n-gram encoding a string
+ */
+public class Entropy implements LenientlyParsedPreProcessor, StrictlyParsedPreProcessor {
+
+    // Maximum optimization array size
+    // Maybe could be dynamically determined based on underlying architecture
+    private static final int OPTIMIZATION_SIZE = 127;
+
+    public static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Entropy.class);
+    public static final ParseField NAME = new ParseField("entropy_encoding");
+    public static final ParseField FIELD = new ParseField("field");
+    public static final ParseField FEATURE_NAME = new ParseField("feature_name");
+    public static final ParseField CUSTOM = new ParseField("custom");
+
+    private static final ConstructingObjectParser<Entropy, PreProcessorParseContext> STRICT_PARSER = createParser(false);
+    private static final ConstructingObjectParser<Entropy, PreProcessorParseContext> LENIENT_PARSER = createParser(true);
+
+    @SuppressWarnings("unchecked")
+    private static ConstructingObjectParser<Entropy, PreProcessorParseContext> createParser(boolean lenient) {
+        ConstructingObjectParser<Entropy, PreProcessorParseContext> parser = new ConstructingObjectParser<>(
+            NAME.getPreferredName(),
+            lenient,
+            (a, c) -> new Entropy((String)a[0],
+                (String)a[1],
+                a[2] == null ? c.isCustomByDefault() : (Boolean)a[2]));
+        parser.declareString(ConstructingObjectParser.constructorArg(), FIELD);
+        parser.declareString(ConstructingObjectParser.constructorArg(), FEATURE_NAME);
+        parser.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), CUSTOM);
+        return parser;
+    }
+
+    public static Entropy fromXContentStrict(XContentParser parser, PreProcessorParseContext context) {
+        return STRICT_PARSER.apply(parser, context == null ?  PreProcessorParseContext.DEFAULT : context);
+    }
+
+    public static Entropy fromXContentLenient(XContentParser parser, PreProcessorParseContext context) {
+        return LENIENT_PARSER.apply(parser, context == null ?  PreProcessorParseContext.DEFAULT : context);
+    }
+
+    private final String field;
+    private final String featureName;
+    private final boolean custom;
+
+    public Entropy(String field, String featureName, boolean custom) {
+        this.field = ExceptionsHelper.requireNonNull(field, FIELD);
+        this.featureName = ExceptionsHelper.requireNonNull(featureName, FEATURE_NAME);
+        this.custom = custom;
+    }
+
+    public Entropy(StreamInput in) throws IOException {
+        this.field = in.readString();
+        this.featureName = in.readString();
+        this.custom = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeString(featureName);
+        out.writeBoolean(custom);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
+    public List<String> inputFields() {
+        return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<String> outputFields() {
+        return Collections.singletonList(featureName);
+    }
+
+    @Override
+    public void process(Map<String, Object> fields) {
+        Object value = fields.get(field);
+        if (value == null) {
+            return;
+        }
+        // TODO should we support an array input for entropy of entries?
+        // TODO should entropy also optionally include length as a feature?
+        final String stringValue = value.toString();
+        double entropy = entropyCalc(stringValue);
+        fields.put(featureName, entropy);
+    }
+
+    double entropyCalc(String stringValue) {
+        final double len = stringValue.length();
+        // This provides a nice optimization for throughput.
+        // The entire basic latin code block fits is within 0x0000..0x007F.
+        // So, this provides a good optimization for those types of characters
+        // We still have a sparse hashmap for the rest.
+        int[] vals = new int[OPTIMIZATION_SIZE];
+        Map<Integer, Integer> biggerCounts = new HashMap<>();
+        for (PrimitiveIterator.OfInt it = stringValue.codePoints().iterator(); it.hasNext(); ) {
+            int cp = it.next();
+            if (cp < OPTIMIZATION_SIZE) {
+                vals[cp]++;
+            } else {
+                biggerCounts.compute(cp, (_k, v) -> v == null ? 1 : v + 1);
+            }
+        }
+
+        double entropy = 0.0;
+        for (int count : vals) {
+            if (count > 0) {
+                double probability = count / len;
+                entropy -= probability * (Math.log(probability) / Math.log(2));
+            }
+        }
+        for (Integer count : biggerCounts.values()) {
+            double probability = count / len;
+            entropy -= probability * (Math.log(probability) / Math.log(2));
+        }
+        return entropy;
+    }
+
+    @Override
+    public Map<String, String> reverseLookup() {
+        return outputFields().stream().collect(Collectors.toMap(Function.identity(), ignored -> field));
+    }
+
+    @Override
+    public String getOutputFieldType(String outputField) {
+        return NumberFieldMapper.NumberType.DOUBLE.typeName();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = SHALLOW_SIZE;
+        size += sizeOf(field);
+        size += sizeOf(featureName);
+        return size;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public String getName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(FIELD.getPreferredName(), field);
+        builder.field(FEATURE_NAME.getPreferredName(), featureName);
+        builder.field(CUSTOM.getPreferredName(), custom);
+        builder.endObject();
+        return builder;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getFeatureName() {
+        return featureName;
+    }
+
+    @Override
+    public boolean isCustom() {
+        return custom;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Entropy entropy = (Entropy) o;
+        return custom == entropy.custom &&
+            Objects.equals(field, entropy.field) &&
+            Objects.equals(featureName, entropy.featureName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, featureName, custom);
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/NamedXContentObjectsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/NamedXContentObjectsTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.EntropyTests;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.NGramTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.LenientlyParsedTrainedModel;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.StrictlyParsedTrainedModel;
@@ -35,7 +37,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-//TODO these tests are temporary until the named objects are actually used by an encompassing class (i.e. ModelInferer)
 public class NamedXContentObjectsTests extends AbstractXContentTestCase<NamedXContentObjectsTests.NamedObjectContainer> {
 
     static class NamedObjectContainer implements ToXContentObject {
@@ -151,9 +152,13 @@ public class NamedXContentObjectsTests extends AbstractXContentTestCase<NamedXCo
         int max = randomIntBetween(1, 10);
         List<PreProcessor> preProcessors = new ArrayList<>(max);
         for (int i = 0; i < max; i++) {
-            preProcessors.add(randomFrom(FrequencyEncodingTests.createRandom(),
+            preProcessors.add(randomFrom(
+                FrequencyEncodingTests.createRandom(),
                 OneHotEncodingTests.createRandom(),
-                TargetMeanEncodingTests.createRandom()));
+                TargetMeanEncodingTests.createRandom(),
+                NGramTests.createRandom(),
+                EntropyTests.createRandom()
+                ));
         }
         NamedObjectContainer container = new NamedObjectContainer();
         container.setPreProcessors(preProcessors);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/EntropyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/EntropyTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.inference.preprocessing;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+
+public class EntropyTests extends PreProcessingTests<Entropy> {
+
+    @Override
+    protected Entropy doParseInstance(XContentParser parser) throws IOException {
+        return lenient ?
+            Entropy.fromXContentLenient(parser, PreProcessor.PreProcessorParseContext.DEFAULT) :
+            Entropy.fromXContentStrict(parser, PreProcessor.PreProcessorParseContext.DEFAULT);
+    }
+
+    @Override
+    protected Entropy createTestInstance() {
+        return createRandom();
+    }
+
+    public static Entropy createRandom() {
+        return createRandom(randomBoolean());
+    }
+
+    public static Entropy createRandom(boolean isCustom) {
+        return new Entropy(randomAlphaOfLength(10), randomAlphaOfLength(10), isCustom);
+    }
+
+    @Override
+    protected Writeable.Reader<Entropy> instanceReader() {
+        return Entropy::new;
+    }
+
+    public void testEntropyCalculation() {
+
+        String input = "foo";
+        String output = "bar";
+        Entropy encoding = new Entropy(input, output, randomBoolean());
+
+        assertThat(encoding.entropyCalc(""),closeTo(0.0, 0.00001));
+        assertThat(encoding.entropyCalc("aaaaa"),closeTo(0.0, 0.00001));
+        assertThat(encoding.entropyCalc("babababababa"),closeTo(1.0, 0.00001));
+        assertThat(encoding.entropyCalc("thisisarandomstring"),closeTo(3.32636040, 0.00001));
+    }
+
+    public void testInputOutputFields() {
+        String field = randomAlphaOfLength(10);
+        String output = randomAlphaOfLength(10);
+        Entropy encoding = new Entropy(field, output, randomBoolean());
+        assertThat(encoding.inputFields(), containsInAnyOrder(field));
+        assertThat(encoding.outputFields(), containsInAnyOrder(output));
+    }
+
+}

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -46,8 +46,12 @@ import org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification.Preci
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification.Recall;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.Entropy;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.FrequencyEncoding;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.NGram;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.TargetMeanEncoding;
 import org.junit.After;
 import org.junit.Before;
 
@@ -309,15 +313,21 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                     new OneHotEncoding(ALIAS_TO_KEYWORD_FIELD, MapBuilder.<String, String>newMapBuilder()
                         .put(KEYWORD_FIELD_VALUES.get(0), "cat_column_custom")
                         .put(KEYWORD_FIELD_VALUES.get(1), "dog_column_custom").map(), true),
-                    new OneHotEncoding(ALIAS_TO_NESTED_FIELD, MapBuilder.<String, String>newMapBuilder()
-                        .put(KEYWORD_FIELD_VALUES.get(0), "cat_column_custom_1")
-                        .put(KEYWORD_FIELD_VALUES.get(1), "dog_column_custom_1").map(), true),
-                    new OneHotEncoding(NESTED_FIELD, MapBuilder.<String, String>newMapBuilder()
-                        .put(KEYWORD_FIELD_VALUES.get(0), "cat_column_custom_2")
-                        .put(KEYWORD_FIELD_VALUES.get(1), "dog_column_custom_2").map(), true),
-                    new OneHotEncoding(TEXT_FIELD, MapBuilder.<String, String>newMapBuilder()
-                        .put(KEYWORD_FIELD_VALUES.get(0), "cat_column_custom_3")
-                        .put(KEYWORD_FIELD_VALUES.get(1), "dog_column_custom_3").map(), true)
+                    new FrequencyEncoding(ALIAS_TO_NESTED_FIELD,
+                        "freq_enc",
+                        MapBuilder.<String, Double>newMapBuilder()
+                        .put(KEYWORD_FIELD_VALUES.get(0), 0.5)
+                        .put(KEYWORD_FIELD_VALUES.get(1), 0.5).map(),
+                        true),
+                    new TargetMeanEncoding(NESTED_FIELD,
+                        "targetMean",
+                        MapBuilder.<String, Double>newMapBuilder()
+                        .put(KEYWORD_FIELD_VALUES.get(0), 0.3)
+                        .put(KEYWORD_FIELD_VALUES.get(1), 0.1).map(),
+                        0.0,
+                        true),
+                    new NGram(TEXT_FIELD, "f", new int[]{1}, 0, 2, true),
+                    new Entropy(TEXT_FIELD, "entropy", true)
                 )));
         putAnalytics(config);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -371,11 +371,11 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         TrainedModelConfig modelConfig = response.getResources().results().get(0);
         modelConfig.ensureParsedDefinition(xContentRegistry());
         assertThat(modelConfig.getModelDefinition().getPreProcessors().size(), greaterThan(0));
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 5; i++) {
             PreProcessor preProcessor = modelConfig.getModelDefinition().getPreProcessors().get(i);
             assertThat(preProcessor.isCustom(), is(true));
         }
-        for (int i = 4; i < modelConfig.getModelDefinition().getPreProcessors().size(); i++) {
+        for (int i = 5; i < modelConfig.getModelDefinition().getPreProcessors().size(); i++) {
             PreProcessor preProcessor = modelConfig.getModelDefinition().getPreProcessors().get(i);
             assertThat(preProcessor.isCustom(), is(false));
         }


### PR DESCRIPTION
This adds a new Shannon entropy encoder for data frame analytics and inference.

Shannon entropy is a simple encoding for gathering the information provided inside a single string. 

Example:

"aaaaa" Provides no information
"babababababa" Provides 1 bit of information
"thisisarandomstring" is 3.3 bits of information