### PR TITLE
Use ingest wrapped listener for on rejected errors

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -713,7 +713,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                             assert Thread.currentThread().getName().contains(executorName);
                             doInternalExecute(task, bulkRequest, executorName, actionListener);
                         } else {
-                            threadPool.executor(executorName).execute(new ActionRunnable<>(listener) {
+                            threadPool.executor(executorName).execute(new ActionRunnable<>(actionListener) {
                                 @Override
                                 protected void doRun() {
                                     doInternalExecute(task, bulkRequest, executorName, actionListener);


### PR DESCRIPTION
After an ingest pipeline has been performed, we wrap the bulk listener
with a new listener which adjusts the response appropriately. Currently,
we are using the original listener when an uncaught exception occurs.
Currently, this produces the same functionality as the wrapped listener.
But this commit cleans up the code by using the wrapped listener anyway.