### PR TITLE
[7.x] [DOCS] Add heading and anchor to reindex with ingest pipeline section (#64835)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -410,6 +410,9 @@ POST _reindex
 --------------------------------------------------
 // TEST[s/^/PUT source\n/]
 
+[[reindex-with-an-ingest-pipeline]]
+===== Reindex with an ingest pipeline
+
 Reindex can also use the <<ingest>> feature by specifying a
 `pipeline` like this:
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add heading and anchor to reindex with ingest pipeline section (#64835)