### PR TITLE
lowers minimum compatibility of rollup v2 metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RollupMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RollupMetadata.java
@@ -99,7 +99,7 @@ public class RollupMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0;
+        return Version.V_7_11_0;
     }
 
     @Override


### PR DESCRIPTION
This commit lowers the minimum compatibility of RollupMetadata
since #64892 was merged into 7.11.

relates to #64680.