### PR TITLE
Added information about `rename_pattern` and `rename_replacement`

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -93,7 +93,7 @@ If `true`, the snapshot's persistent settings, index templates, ingest
 pipelines, and {ilm-init} policies are restored into the current cluster. This
 overwrites any existing cluster settings, templates, pipelines and {ilm-init}
 policies whose names match those in the snapshot.
-<2> Regular expression that matches data streams and indices in the snapshot. Supports https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html-[regular-expression constructs].
+<2> Regular expression that matches data streams and indices in the snapshot. Supports https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html[regular expression constructs].
 <3> Renames data streams and indices that match the `rename_pattern`. `$1` is a reference to the first capturing group. In this example, `index_1` and `index_2` will be renamed as `restored_index_1` and `restored_index_2`.
 
 The restore operation must be performed on a functioning cluster. However, an

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -93,8 +93,8 @@ If `true`, the snapshot's persistent settings, index templates, ingest
 pipelines, and {ilm-init} policies are restored into the current cluster. This
 overwrites any existing cluster settings, templates, pipelines and {ilm-init}
 policies whose names match those in the snapshot.
-<2> Regular expression that will match the name of data streams and indices in the snapshot. This supports https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg-[`capturing groups`].
-<3> String used to rename data streams and indices in the snapshot that match the `rename_pattern`. `$1` is a reference to the first capturing group, which returns the first value found in the tested input. In this example, this corresponds to the number postfixing the index name. Indices `index_1` and `index_2` will be renamed as `restored_index_1` and `restored_index_2`.
+<2> Regular expression that matches data streams and indices in the snapshot. Supports https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html-[regular-expression constructs].
+<3> Renames data streams and indices that match the `rename_pattern`. `$1` is a reference to the first capturing group. In this example, `index_1` and `index_2` will be renamed as `restored_index_1` and `restored_index_2`.
 
 The restore operation must be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-close,closed>> and

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -79,8 +79,8 @@ POST /_snapshot/my_backup/snapshot_1/_restore
   "indices": "data_stream_1,index_1,index_2",
   "ignore_unavailable": true,
   "include_global_state": false,              <1>
-  "rename_pattern": "index_(.+)",
-  "rename_replacement": "restored_index_$1",
+  "rename_pattern": "index_(.+)",             <2>
+  "rename_replacement": "restored_index_$1",  <3>
   "include_aliases": false
 }
 -----------------------------------
@@ -93,6 +93,8 @@ If `true`, the snapshot's persistent settings, index templates, ingest
 pipelines, and {ilm-init} policies are restored into the current cluster. This
 overwrites any existing cluster settings, templates, pipelines and {ilm-init}
 policies whose names match those in the snapshot.
+<2> Regular expression that will match the name of data streams and indices in the snapshot. This supports https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg-[`capturing groups`].
+<3> String used to rename data streams and indices in the snapshot that match the `rename_pattern`. `$1` is a reference to the first capturing group, which returns the first value found in the tested input. In this example, this corresponds to the number postfixing the index name. Indices `index_1` and `index_2` will be renamed as `restored_index_1` and `restored_index_2`.
 
 The restore operation must be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-close,closed>> and


### PR DESCRIPTION
Added information about `rename_pattern` and `rename_replacement`. This is to follow-up some of the unaddressed comments given by @jrodewig in https://github.com/elastic/elasticsearch/pull/59937/files.