### PR TITLE
Autoscaling: add nodes to capacity response

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
@@ -11,7 +11,8 @@
       autoscaling.put_autoscaling_policy:
         name: my_autoscaling_policy
         body:
-          roles : []
+          # voting_only requires master to start so we are sure no nodes match
+          roles: ["voting_only"]
           deciders:
             fixed:
               storage: 1337b
@@ -32,6 +33,8 @@
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.storage: 1337b }
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.memory: 7331b }
   - match: { policies.my_autoscaling_policy.deciders.fixed.reason_summary: "fixed storage [1.3kb] memory [7.1kb] nodes [10]" }
+  - length: { policies.my_autoscaling_policy.current_nodes: 0 }
+
 
   # test cleanup
   - do:

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -52,7 +54,7 @@ public abstract class AutoscalingTestCase extends ESTestCase {
             .mapToObj(i -> Tuple.tuple(Integer.toString(i), randomAutoscalingDeciderResult()))
             .collect(Collectors.toMap(Tuple::v1, Tuple::v2, (a, b) -> { throw new IllegalStateException(); }, TreeMap::new));
         AutoscalingCapacity capacity = new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources());
-        return new AutoscalingDeciderResults(capacity, results);
+        return new AutoscalingDeciderResults(capacity, randomNodes(), results);
     }
 
     public static AutoscalingCapacity randomAutoscalingCapacity() {
@@ -83,6 +85,21 @@ public abstract class AutoscalingTestCase extends ESTestCase {
             addStorage ? randomByteSizeValue() : null,
             addMemory ? randomByteSizeValue() : null
         );
+    }
+
+    public static SortedSet<DiscoveryNode> randomNodes() {
+        String prefix = randomAlphaOfLength(5);
+        return IntStream.range(0, randomIntBetween(1, 10))
+            .mapToObj(
+                i -> new DiscoveryNode(
+                    prefix + i,
+                    buildNewFakeTransportAddress(),
+                    Map.of(),
+                    randomRoles().stream().map(DiscoveryNode::getRoleFromRoleName).collect(Collectors.toSet()),
+                    Version.CURRENT
+                )
+            )
+            .collect(Collectors.toCollection(() -> new TreeSet<>(AutoscalingDeciderResults.DISCOVERY_NODE_COMPARATOR)));
     }
 
     public static ByteSizeValue randomByteSizeValue() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +76,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
 
             // there is no nodes in any tier.
             assertThat(results.currentCapacity(), equalTo(AutoscalingCapacity.ZERO));
+            assertThat(results.currentNodes(), equalTo(Collections.emptySortedSet()));
         }
     }
 


### PR DESCRIPTION
When an autoscaling capacity is calculated, we base this on information
about the current nodes in the cluster. In some cases, we may return
too small or too large a capacity if nodes are missing in the cluster.
The current_nodes returned in the capacity response allows the client
of the autoscaling capacity API to detect this by comparing to the
expected set of nodes. This in turn allows the client to disregard the
capacity for a policy as long as there is a discrepancy.
