### PR TITLE
[Transform] make state handling more robust when stop is called while indexer shuts down

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -222,8 +222,8 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                             nextSearch();
                         } else {
                             onFinish(ActionListener.wrap(
-                                onFinishResponse -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();}),
-                                onFinishFailure -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();})));
+                                onFinishResponse -> doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure),
+                                onFinishFailure -> doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure)));
                         }
                     },
                     this::finishWithFailure));
@@ -402,13 +402,13 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     private void finishWithSearchFailure(Exception exc) {
         stats.incrementSearchFailures();
         onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();});
+        doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure);
     }
 
     private void finishWithIndexingFailure(Exception exc) {
         stats.incrementIndexingFailures();
         onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();});
+        doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure);
     }
 
     private void finishWithFailure(Exception exc) {
@@ -485,8 +485,8 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 stats.markEndProcessing();
                 // execute finishing tasks
                 onFinish(ActionListener.wrap(
-                        r -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();}),
-                        e -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();})));
+                        r -> doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure),
+                        e -> doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure)));
                 return;
             }
 
@@ -617,7 +617,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
         case STOPPING:
             logger.info("Indexer job encountered [" + IndexerState.STOPPING + "] state, halting indexer.");
-            doSaveState(finishAndSetState(), getPosition(), () -> {afterFinishOrFailure();});
+            doSaveState(finishAndSetState(), getPosition(), this::afterFinishOrFailure);
             return false;
 
         case STOPPED:

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -222,8 +222,8 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                             nextSearch();
                         } else {
                             onFinish(ActionListener.wrap(
-                                onFinishResponse -> doSaveState(finishAndSetState(), position.get(), () -> {}),
-                                onFinishFailure -> doSaveState(finishAndSetState(), position.get(), () -> {})));
+                                onFinishResponse -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();}),
+                                onFinishFailure -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();})));
                         }
                     },
                     this::finishWithFailure));
@@ -380,6 +380,12 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     protected abstract void onFinish(ActionListener<Void> listener);
 
     /**
+     * Called after onFinish or after onFailure and all the following steps - in particular state persistence - are completed.
+     */
+    protected void afterFinishOrFailure() {
+    }
+
+    /**
      * Called when the indexer is stopped. This is only called when the indexer is stopped
      * via {@link #stop()} as opposed to {@link #onFinish(ActionListener)} which is called
      * when the indexer's work is done.
@@ -396,18 +402,19 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     private void finishWithSearchFailure(Exception exc) {
         stats.incrementSearchFailures();
         onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), () -> {});
+        doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();});
     }
 
     private void finishWithIndexingFailure(Exception exc) {
         stats.incrementIndexingFailures();
         onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), () -> {});
+        doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();});
     }
 
     private void finishWithFailure(Exception exc) {
         onFailure(exc);
         finishAndSetState();
+        afterFinishOrFailure();
     }
 
     private IndexerState finishAndSetState() {
@@ -478,8 +485,8 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 stats.markEndProcessing();
                 // execute finishing tasks
                 onFinish(ActionListener.wrap(
-                        r -> doSaveState(finishAndSetState(), position.get(), () -> {}),
-                        e -> doSaveState(finishAndSetState(), position.get(), () -> {})));
+                        r -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();}),
+                        e -> doSaveState(finishAndSetState(), position.get(), () -> {afterFinishOrFailure();})));
                 return;
             }
 
@@ -610,7 +617,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
         case STOPPING:
             logger.info("Indexer job encountered [" + IndexerState.STOPPING + "] state, halting indexer.");
-            doSaveState(finishAndSetState(), getPosition(), () -> {});
+            doSaveState(finishAndSetState(), getPosition(), () -> {afterFinishOrFailure();});
             return false;
 
         case STOPPED:

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java
@@ -263,7 +263,6 @@ public class TransformStats implements Writeable, ToXContentObject {
             } else if (taskState == TransformTaskState.FAILED) {
                 return FAILED;
             } else {
-
                 // If we get here then the task state must be started, and that means we should have an indexer state
                 assert (taskState == TransformTaskState.STARTED);
                 assert (indexerState != null);
@@ -276,7 +275,7 @@ public class TransformStats implements Writeable, ToXContentObject {
                     case STOPPING:
                         return STOPPING;
                     case STOPPED:
-                        return STOPPED;
+                        return STOPPING;
                     case ABORTING:
                         return ABORTING;
                     default:
@@ -304,12 +303,12 @@ public class TransformStats implements Writeable, ToXContentObject {
                 case ABORTING:
                     return new Tuple<>(TransformTaskState.STARTED, IndexerState.ABORTING);
                 case STOPPING:
-                    return new Tuple<>(TransformTaskState.STARTED, IndexerState.STOPPING);
-                case STOPPED:
-                    // This one is not deterministic, because an overall state of STOPPED could arise
-                    // from either (STOPPED, null) or (STARTED, STOPPED). However, (STARTED, STOPPED)
+                    // This one is not deterministic, because an overall state of STOPPING could arise
+                    // from either (STARTED, STOPPED) or (STARTED, STOPPING). However, (STARTED, STOPPED)
                     // is a very short-lived state so it's reasonable to assume the other, especially
                     // as this method is only for mixed version cluster compatibility.
+                    return new Tuple<>(TransformTaskState.STARTED, IndexerState.STOPPING);
+                case STOPPED:
                     return new Tuple<>(TransformTaskState.STOPPED, null);
                 case FAILED:
                     return new Tuple<>(TransformTaskState.FAILED, null);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -76,6 +76,9 @@ public class TransformIT extends TransformIntegTestCase {
         waitUntilCheckpoint(config.getId(), 1L);
 
         stopTransform(config.getId());
+        assertBusy(() -> {
+            assertEquals(TransformStats.State.STOPPED, getTransformStats(config.getId()).getTransformsStats().get(0).getState());
+        });
 
         TransformConfig storedConfig = getTransform(config.getId()).getTransformConfigurations().get(0);
         assertThat(storedConfig.getVersion(), equalTo(Version.CURRENT));


### PR DESCRIPTION
fix a version conflict exception if stop is called while indexer is
shutting down. Report the overall transform stats STOPPED if and only 
if there is no task (and therefore no indexer)

relates #62204

**Testing**

The issue is hard to test. The result of the problem is a wrong indexer state in the 
state document of the internal transform index and errors in the log. Both are not accessible
from the test. Using the `_stats` API the state reports `STOPPED` independent of the 
state document in the index, because there is no task. This works by design.

(Because of the above I came to the conclusion that the severity of this issue is only
log spam. I think there is no functional problem. If the wrong state causes the indexer to
immediately start when `_start` is called, however we call `start()` on the indexer anyway)

Manual test:

```
./gradlew ':x-pack:plugin:transform:qa:multi-node-tests:javaRestTest' --tests "org.elasticsearch.xpack.transform.integration.TransformIT.testTransformCrud" -Dtests.iters=50
```

followed by grep on the logs for `VersionConflictEngineException`