### PR TITLE
[7.10] [DOCS] Remove 7.10.0 coming tag (#64813)

### DIFF
--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.10.0]]
 == {es} version 7.10.0
 
-coming[7.10.0]
-
 Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 
 [[breaking-7.10.0]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Remove 7.10.0 coming tag (#64813)