### PR TITLE
EQL: [Tests] Add option to preserve data dir

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -107,7 +107,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private static final TimeUnit ADDITIONAL_CONFIG_TIMEOUT_UNIT = TimeUnit.SECONDS;
     private static final List<String> OVERRIDABLE_SETTINGS = Arrays.asList(
         "path.repo",
-        "discovery.seed_providers"
+        "discovery.seed_providers",
+        "path.data"
 
     );
 

--- a/x-pack/plugin/eql/qa/correctness/README.md
+++ b/x-pack/plugin/eql/qa/correctness/README.md
@@ -74,7 +74,14 @@ If one wants to run an ES node manually (most probably to be able to debug the s
 ./gradlew :x-pack:plugin:eql:qa:correctness:runEqlCorrectnessNode --debug-jvm
 ```
 
-**Set the `eql_test_credentials_file` environmental variable correctly in the shell before running the command above,**
+**Set the `eql_test_credentials_file` environmental variable correctly in the shell before running the command above.**
+
+#### Preserve data across node restarts
+If you'd like to preserve the restored index and avoid the network download and delay of restoring them on every run of the node,
+you can set the `eql_test_es_data_dir` environmental variable to point to a desired directory, e.g.:
+```shell script
+export eql_test_es_data_dir=/tmp/esData
+```
 
 Once the ES node is up and running, the data can be restored from the snapshot by running the `main` of the 
 `EqlDataLoader` class.
@@ -84,4 +91,4 @@ Once the data is loaded, a specific query can be run against the running ES node
 ./gradlew ':x-pack:plugin:eql:qa:correctness:javaRestTest' --tests "org.elasticsearch.xpack.eql.EsEQLCorrectnessIT.test {<queryNo>}" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=runTask-0
 ```
 
-**Set the `eql_test_credentials_file` environmental variable correctly in the shell before running the command above,**
+**Set the `eql_test_credentials_file` environmental variable correctly in the shell before running the command above.**

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 }
 
 File serviceAccountFile = (System.getenv("eql_test_credentials_file") ?: System.getProperty("eql.test.credentials.file")) as File
+String esDataDir = System.getenv("eql_test_es_data_dir") ?: System.getProperty("eql.test.data.dir")
 
 testClusters {
   all {
@@ -30,6 +31,9 @@ testClusters {
     }
     testDistribution = 'DEFAULT'
     setting 'xpack.license.self_generated.type', 'basic'
+    if (esDataDir) {
+      setting 'path.data', esDataDir
+    }
     jvmArgs '-Xms4g', '-Xmx4g'
   }
   runTask {


### PR DESCRIPTION
When debugging eql correctness tests, on every new build/run of the test
node the 2.2GB data is restored from the gcs bucket and slows down
productivity. Now a system env var can be set to point to a data dir,
so that the user can only load the data once and use the data dir
across multiple test runs.
