### PR TITLE
[DOCS] Fixes example aggregation syntax in datafeed aggregations

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -298,12 +298,13 @@ determine the cardinality of your data, you can run searches such as:
 
 [source,js]
 --------------------------------------------------
-GET .../_search {
+GET .../_search 
+{
   "aggs": {
     "service_cardinality": {
       "cardinality": {
         "field": "service"
-        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes an example API call in the `Aggregating data for faster performance` piece.