### PR TITLE
[DOCS] Add checksum links for plugin downloads

### DIFF
--- a/docs/plugins/install_remove.asciidoc
+++ b/docs/plugins/install_remove.asciidoc
@@ -22,7 +22,7 @@ be restarted after installation.
 
 You can download this plugin for <<plugin-management-custom-url,offline
 install>> from {plugin_url}/{plugin_name}/{plugin_name}-{version}.zip. To verify
-the downloaded archive, use the related
+the `.zip` file, use the
 {plugin_url}/{plugin_name}/{plugin_name}-{version}.zip.sha512[SHA hash] or
 {plugin_url}/{plugin_name}/{plugin_name}-{version}.zip.asc[ASC key].
 endif::[]

--- a/docs/plugins/install_remove.asciidoc
+++ b/docs/plugins/install_remove.asciidoc
@@ -20,9 +20,11 @@ sudo bin/elasticsearch-plugin install {plugin_name}
 The plugin must be installed on every node in the cluster, and each node must
 be restarted after installation.
 
-This plugin can be downloaded for <<plugin-management-custom-url,offline install>> from
-{plugin_url}/{plugin_name}/{plugin_name}-{version}.zip.
-
+You can download this plugin for <<plugin-management-custom-url,offline
+install>> from {plugin_url}/{plugin_name}/{plugin_name}-{version}.zip. To verify
+the downloaded archive, use the related
+{plugin_url}/{plugin_name}/{plugin_name}-{version}.zip.sha512[SHA hash] or
+{plugin_url}/{plugin_name}/{plugin_name}-{version}.zip.asc[ASC key].
 endif::[]
 
 [discrete]


### PR DESCRIPTION
Links to the SHA hash and ASC key for each plugin.

Relates to #64846

### Preview
ICU Analysis plugin example: https://elasticsearch_64949.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/current/analysis-icu.html#analysis-icu-install