### PR TITLE
MappingLookup to not implement Iterable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -39,9 +39,9 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -156,14 +156,14 @@ public class TransportGetFieldMappingsIndexAction
             return Collections.emptyMap();
         }
         Map<String, FieldMappingMetadata> fieldMappings = new HashMap<>();
-        final MappingLookup allFieldMappers = documentMapper.mappers();
+        final MappingLookup mappingLookup = documentMapper.mappers();
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
-                for (Mapper fieldMapper : allFieldMappers) {
+                for (Mapper fieldMapper : mappingLookup.fieldMappers()) {
                     addFieldMapper(fieldPredicate, fieldMapper.name(), fieldMapper, fieldMappings, request.includeDefaults());
                 }
             } else if (Regex.isSimpleMatchPattern(field)) {
-                for (Mapper fieldMapper : allFieldMappers) {
+                for (Mapper fieldMapper : mappingLookup.fieldMappers()) {
                     if (Regex.simpleMatch(field, fieldMapper.name())) {
                         addFieldMapper(fieldPredicate,  fieldMapper.name(),
                                 fieldMapper, fieldMappings, request.includeDefaults());
@@ -171,7 +171,7 @@ public class TransportGetFieldMappingsIndexAction
                 }
             } else {
                 // not a pattern
-                Mapper fieldMapper = allFieldMappers.getMapper(field);
+                Mapper fieldMapper = mappingLookup.getMapper(field);
                 if (fieldMapper != null) {
                     addFieldMapper(fieldPredicate, field, fieldMapper, fieldMappings, request.includeDefaults());
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -27,12 +27,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public final class MappingLookup implements Iterable<Mapper> {
+public final class MappingLookup {
 
     /** Full field name to mapper */
     private final Map<String, Mapper> fieldMappers;
@@ -132,7 +131,7 @@ public final class MappingLookup implements Iterable<Mapper> {
         return fieldMappers.get(field);
     }
 
-    public FieldTypeLookup fieldTypes() {
+    FieldTypeLookup fieldTypes() {
         return fieldTypeLookup;
     }
 
@@ -144,9 +143,11 @@ public final class MappingLookup implements Iterable<Mapper> {
         return this.indexAnalyzer;
     }
 
-    @Override
-    public Iterator<Mapper> iterator() {
-        return fieldMappers.values().iterator();
+    /**
+     * Returns an iterable over all the registered field mappers (including alias mappers)
+     */
+    public Iterable<Mapper> fieldMappers() {
+        return fieldMappers.values();
     }
 
     public void checkLimits(IndexSettings settings) {


### PR DESCRIPTION
Implementing Iterable makes it hard to track who iterates through the mappers, and also it is not super clear what it allows to iterate through given that the object holds both field mappers and field types.

This commit replaces implementing Iterable with a specific method called fieldMappers that returns an Iterable<Mapper>
