### PR TITLE
Dry up some ClusterStateUpdateTask Usage

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -29,8 +29,8 @@ import org.elasticsearch.action.support.ActiveShardsObserver;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -113,7 +113,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                         .filter(condition -> conditionResults.get(condition.toString())).collect(Collectors.toList());
                     if (conditionResults.size() == 0 || metConditions.size() > 0) {
                         clusterService.submitStateUpdateTask("rollover_index source [" + sourceIndexName + "] to target ["
-                            + rolloverIndexName + "]", new ClusterStateUpdateTask() {
+                            + rolloverIndexName + "]", new ActionClusterStateUpdateTask<>(listener) {
                             @Override
                             public ClusterState execute(ClusterState currentState) throws Exception {
                                 MetadataRolloverService.RolloverResult rolloverResult = rolloverService.rolloverClusterState(currentState,
@@ -124,11 +124,6 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                                         rolloverRequest.getRolloverTarget());
                                 }
                                 return rolloverResult.clusterState;
-                            }
-
-                            @Override
-                            public void onFailure(String source, Exception e) {
-                                listener.onFailure(e);
                             }
 
                             @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -66,17 +66,9 @@ public class TransportDeleteIndexTemplateAction extends AcknowledgedTransportMas
             new MetadataIndexTemplateService
                 .RemoveRequest(request.name())
                 .masterTimeout(request.masterNodeTimeout()),
-            new MetadataIndexTemplateService.RemoveListener() {
-                @Override
-                public void onResponse(AcknowledgedResponse response) {
-                    listener.onResponse(response);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.debug(() -> new ParameterizedMessage("failed to delete templates [{}]", request.name()), e);
-                    listener.onFailure(e);
-                }
-            });
+            ActionListener.delegateResponse(listener, (l, e) -> {
+                logger.debug(() -> new ParameterizedMessage("failed to delete templates [{}]", request.name()), e);
+                l.onFailure(e);
+            }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -84,18 +84,9 @@ public class TransportPutIndexTemplateAction extends AcknowledgedTransportMaster
                 .create(request.create())
                 .masterTimeout(request.masterNodeTimeout())
                 .version(request.version()),
-
-                new MetadataIndexTemplateService.PutListener() {
-                    @Override
-                    public void onResponse(MetadataIndexTemplateService.PutResponse response) {
-                        listener.onResponse(AcknowledgedResponse.of(response.acknowledged()));
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        logger.debug(() -> new ParameterizedMessage("failed to put template [{}]", request.name()), e);
-                        listener.onFailure(e);
-                    }
-                });
+                ActionListener.delegateResponse(listener, (l, e) -> {
+                    logger.debug(() -> new ParameterizedMessage("failed to put template [{}]", request.name()), e);
+                    l.onFailure(e);
+                }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -30,10 +30,10 @@ import org.elasticsearch.common.unit.TimeValue;
  * An extension interface to {@link ClusterStateUpdateTask} that allows to be notified when
  * all the nodes have acknowledged a cluster state update request
  */
-public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask implements AckedClusterStateTaskListener {
+public abstract class AckedClusterStateUpdateTask extends ActionClusterStateUpdateTask<AcknowledgedResponse>
+        implements AckedClusterStateTaskListener {
 
-    private final ActionListener<AcknowledgedResponse> listener;
-    private final AckedRequest request;
+    private final TimeValue ackTimeout;
 
     protected AckedClusterStateUpdateTask(AckedRequest request, ActionListener<? extends AcknowledgedResponse> listener) {
         this(Priority.NORMAL, request, listener);
@@ -42,9 +42,8 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
     @SuppressWarnings("unchecked")
     protected AckedClusterStateUpdateTask(Priority priority, AckedRequest request,
                                           ActionListener<? extends AcknowledgedResponse> listener) {
-        super(priority, request.masterNodeTimeout());
-        this.listener = (ActionListener<AcknowledgedResponse>) listener;
-        this.request = request;
+        super(priority, request.masterNodeTimeout(), (ActionListener<AcknowledgedResponse>) listener);
+        this.ackTimeout = request.ackTimeout();
     }
 
     /**
@@ -79,15 +78,10 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
         listener.onResponse(newResponse(false));
     }
 
-    @Override
-    public void onFailure(String source, Exception e) {
-        listener.onFailure(e);
-    }
-
     /**
      * Acknowledgement timeout, maximum time interval to wait for acknowledgements
      */
     public final TimeValue ackTimeout() {
-        return request.ackTimeout();
+        return ackTimeout;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/ActionClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ActionClusterStateUpdateTask.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.unit.TimeValue;
+
+public abstract class ActionClusterStateUpdateTask<T> extends ClusterStateUpdateTask {
+
+    protected final ActionListener<T> listener;
+
+    protected ActionClusterStateUpdateTask(ActionListener<T> listener) {
+        this.listener = listener;
+    }
+
+    protected ActionClusterStateUpdateTask(Priority priority, ActionListener<T> listener) {
+        super(priority);
+        this.listener = listener;
+    }
+
+    protected ActionClusterStateUpdateTask(TimeValue timeout, ActionListener<T> listener) {
+        super(timeout);
+        this.listener = listener;
+    }
+
+    protected ActionClusterStateUpdateTask(Priority priority, TimeValue timeout, ActionListener<T> listener) {
+        super(priority, timeout);
+        this.listener = listener;
+    }
+
+    @Override
+    public void onFailure(String source, Exception e) {
+        listener.onFailure(e);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -1434,9 +1434,9 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
                 new IndexScopedSettings(Settings.EMPTY, IndexScopedSettings.BUILT_IN_INDEX_SETTINGS), xContentRegistry);
 
         final List<Throwable> throwables = new ArrayList<>();
-        service.putTemplate(request, new MetadataIndexTemplateService.PutListener() {
+        service.putTemplate(request, new ActionListener<>() {
             @Override
-            public void onResponse(MetadataIndexTemplateService.PutResponse response) {
+            public void onResponse(AcknowledgedResponse response) {
 
             }
 
@@ -1453,9 +1453,9 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
         final List<Throwable> throwables = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
-        service.putTemplate(request, new MetadataIndexTemplateService.PutListener() {
+        service.putTemplate(request, new ActionListener<>() {
             @Override
-            public void onResponse(MetadataIndexTemplateService.PutResponse response) {
+            public void onResponse(AcknowledgedResponse response) {
                 latch.countDown();
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
@@ -27,8 +27,8 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -145,8 +145,8 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
         protected void masterOperation(
             Task task, final UpdateInternalOrPrivateAction.Request request,
             final ClusterState state,
-            final ActionListener<UpdateInternalOrPrivateAction.Response> listener) throws Exception {
-            clusterService.submitStateUpdateTask("update-index-internal-or-private", new ClusterStateUpdateTask() {
+            final ActionListener<UpdateInternalOrPrivateAction.Response> listener) {
+            clusterService.submitStateUpdateTask("update-index-internal-or-private", new ActionClusterStateUpdateTask<>(listener) {
                 @Override
                 public ClusterState execute(final ClusterState currentState) throws Exception {
                     final Metadata.Builder builder = Metadata.builder(currentState.metadata());
@@ -165,12 +165,6 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
                 public void clusterStateProcessed(final String source, final ClusterState oldState, final ClusterState newState) {
                     listener.onResponse(new UpdateInternalOrPrivateAction.Response());
                 }
-
-                @Override
-                public void onFailure(final String source, final Exception e) {
-                    listener.onFailure(e);
-                }
-
             });
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -27,9 +27,9 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -513,15 +513,10 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     protected void updateClusterState(final Function<ClusterState, ClusterState> updater) throws Exception {
         final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
         final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-        clusterService.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("test", new ActionClusterStateUpdateTask<>(future) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return updater.apply(currentState);
-            }
-
-            @Override
-            public void onFailure(String source, Exception e) {
-                future.onFailure(e);
             }
 
             @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -18,8 +18,8 @@ import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -78,17 +78,12 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
         Task task, final UnfollowAction.Request request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("unfollow_action", new ClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("unfollow_action", new ActionClusterStateUpdateTask<>(listener) {
 
             @Override
             public ClusterState execute(final ClusterState current) {
                 String followerIndex = request.getFollowerIndex();
                 return unfollow(followerIndex, current);
-            }
-
-            @Override
-            public void onFailure(final String source, final Exception e) {
-                listener.onFailure(e);
             }
 
             @Override

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
@@ -13,8 +13,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -77,13 +77,7 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
     ) throws Exception {
         clusterService.submitStateUpdateTask(
             "remove-data-stream [" + Strings.arrayToCommaDelimitedString(request.getNames()) + "]",
-            new ClusterStateUpdateTask(Priority.HIGH, request.masterNodeTimeout()) {
-
-                @Override
-                public void onFailure(String source, Exception e) {
-                    listener.onFailure(e);
-                }
-
+            new ActionClusterStateUpdateTask<>(Priority.HIGH, request.masterNodeTimeout(), listener) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return removeDataStream(deleteIndexService, indexNameExpressionResolver, currentState, request);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRemoveIndexLifecyclePolicyAction.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.ilm.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -47,18 +47,13 @@ public class TransportRemoveIndexLifecyclePolicyAction extends TransportMasterNo
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         final Index[] indices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), true, request.indices());
         clusterService.submitStateUpdateTask("remove-lifecycle-for-index",
-                new ClusterStateUpdateTask(request.masterNodeTimeout()) {
+                new ActionClusterStateUpdateTask<>(request.masterNodeTimeout(), listener) {
 
                     private final List<String> failedIndexes = new ArrayList<>();
 
                     @Override
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         return IndexLifecycleTransition.removePolicyForIndexes(indices, currentState, failedIndexes);
-                    }
-
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        listener.onFailure(e);
                     }
 
                     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -20,8 +20,8 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ActionClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -238,7 +238,7 @@ public class MlConfigMigrator {
 
         AtomicReference<RemovalResult> removedConfigs = new AtomicReference<>();
 
-        clusterService.submitStateUpdateTask("remove-migrated-ml-configs", new ClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("remove-migrated-ml-configs", new ActionClusterStateUpdateTask<>(listener) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 RemovalResult removed = removeJobsAndDatafeeds(jobsToRemove, datafeedsToRemove,
@@ -258,11 +258,6 @@ public class MlConfigMigrator {
                 }
                 newState.metadata(metadataBuilder.build());
                 return newState.build();
-            }
-
-            @Override
-            public void onFailure(String source, Exception e) {
-                listener.onFailure(e);
             }
 
             @Override


### PR DESCRIPTION
Just forwarding the failure to a listener is a common pattern.
Drying it up here in a similar fashion to how its done in `ActionRunnable`.
