### PR TITLE
Fix logic of data path to shard count computation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -66,6 +66,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,6 +80,7 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * IndexModule represents the central extension point for index level custom implementations like:
@@ -413,6 +415,7 @@ public final class IndexModule {
                                         IndicesFieldDataCache indicesFieldDataCache,
                                         NamedWriteableRegistry namedWriteableRegistry,
                                         BooleanSupplier idFieldDataEnabled,
+                                        Supplier<Map<Path, Integer>> dataPathToShardsCountSupplier,
                                         ValuesSourceRegistry valuesSourceRegistry) throws IOException {
         final IndexEventListener eventListener = freeze();
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> readerWrapperFactory =
@@ -442,7 +445,7 @@ public final class IndexModule {
                 engineFactory, circuitBreakerService, bigArrays, threadPool, scriptService, clusterService, client, queryCache,
                 directoryFactory, eventListener, readerWrapperFactory, mapperRegistry, indicesFieldDataCache, searchOperationListeners,
                 indexOperationListeners, namedWriteableRegistry, idFieldDataEnabled, allowExpensiveQueries, expressionResolver,
-                valuesSourceRegistry, recoveryStateFactory);
+                valuesSourceRegistry, recoveryStateFactory, dataPathToShardsCountSupplier);
             success = true;
             return indexService;
         } finally {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -141,6 +141,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -674,6 +675,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 indicesFieldDataCache,
                 namedWriteableRegistry,
                 this::isIdFieldDataEnabled,
+                this::dataPathToShardCount,
                 valuesSourceRegistry
         );
     }
@@ -1615,6 +1617,17 @@ public class IndicesService extends AbstractLifecycleComponent
     @Nullable
     public DateFieldMapper.DateFieldType getTimestampFieldType(Index index) {
         return timestampFieldMapperService.getTimestampFieldType(index);
+    }
+
+    public Map<Path, Integer> dataPathToShardCount() {
+        Map<Path, Integer> dataPathToShardCount = new HashMap<>(nodeEnv.nodeDataPaths().length);
+        for(IndexService indexService : this) {
+            for(IndexShard shard : indexService) {
+                dataPathToShardCount.put(shard.shardPath().getRootStatePath(),
+                    dataPathToShardCount.getOrDefault(shard.shardPath().getRootStatePath(), 0) + 1);
+            }
+        }
+        return dataPathToShardCount;
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -169,7 +169,7 @@ public class IndexModuleTests extends ESTestCase {
     private IndexService newIndexService(IndexModule module) throws IOException {
         return module.newIndexService(CREATE_INDEX, nodeEnvironment, xContentRegistry(), deleter, circuitBreakerService, bigArrays,
                 threadPool, scriptService, clusterService, null, indicesQueryCache, mapperRegistry,
-                new IndicesFieldDataCache(settings, listener), writableRegistry(), () -> false, null);
+                new IndicesFieldDataCache(settings, listener), writableRegistry(), () -> false, () -> Collections.EMPTY_MAP, null);
     }
 
     public void testWrapperIsBound() throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/DiskShardsBalanceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/DiskShardsBalanceTests.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+public class DiskShardsBalanceTests extends ESSingleNodeTestCase {
+
+    public IndicesService getIndicesService() {
+        return getInstanceFromNode(IndicesService.class);
+    }
+
+    public NodeEnvironment getNodeEnvironment() {
+        return getInstanceFromNode(NodeEnvironment.class);
+    }
+
+    @Override
+    protected boolean resetNodeAfterTest() {
+        return true;
+    }
+
+    // config 3 datapaths
+    private int DataPathCount = 3;
+
+    @Override
+    protected Settings nodeSettings() {
+        final String[] absPaths = new String[DataPathCount];
+        for (int i = 0; i < 3; i++) {
+            absPaths[i] = createTempDir().toAbsolutePath().toString();
+        }
+        Settings settings = Settings.builder()
+            .putList(Environment.PATH_DATA_SETTING.getKey(), absPaths).build();
+        return settings;
+    }
+
+    public void testDiskShardsBalance() {
+        final Settings threeShardsSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+
+        final Settings oneShardSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+
+        IndicesService indicesService = getIndicesService();
+        Path[] paths = getNodeEnvironment().nodeDataPaths();
+
+        Map<Path, Integer> actualDataPathToShardCount = null;
+        Map<Path, Integer> expectedDataPathToShardCount = null;
+
+        // create index1 with 3 shards and expect all data path' shard count is 1
+        createIndex("index1", threeShardsSettings);
+        actualDataPathToShardCount = indicesService.dataPathToShardCount();
+        assertTrue(actualDataPathToShardCount.size() == 3);
+        expectedDataPathToShardCount = Map.of(paths[0], 1, paths[1], 1, paths[2], 1);
+        for (Map.Entry<Path, Integer> entry : expectedDataPathToShardCount.entrySet()) {
+            assertTrue(entry.getValue() == actualDataPathToShardCount.get(entry.getKey()));
+        }
+
+        // create index2 with 3 shards and expect all data path' shards is 2
+        createIndex("index2", threeShardsSettings);
+        actualDataPathToShardCount = indicesService.dataPathToShardCount();
+        assertTrue(actualDataPathToShardCount.size() == 3);
+        expectedDataPathToShardCount = Map.of(paths[0], 2, paths[1], 2, paths[2], 2);
+        for (Map.Entry<Path, Integer> entry : expectedDataPathToShardCount.entrySet()) {
+            assertTrue(entry.getValue() == actualDataPathToShardCount.get(entry.getKey()));
+        }
+
+        // create index3_1 with 1 shards and expect datapath[0] is 3
+        createIndex("index3_1", oneShardSettings);
+        actualDataPathToShardCount = indicesService.dataPathToShardCount();
+        assertTrue(actualDataPathToShardCount.size() == 3);
+        expectedDataPathToShardCount = Map.of(paths[0], 3, paths[1], 2, paths[2], 2);
+        for (Map.Entry<Path, Integer> entry : expectedDataPathToShardCount.entrySet()) {
+            assertTrue(entry.getValue() == actualDataPathToShardCount.get(entry.getKey()));
+        }
+
+        // create index3_2 with 1 shards and expect datapath[1] is 3
+        createIndex("index3_2", oneShardSettings);
+        actualDataPathToShardCount = indicesService.dataPathToShardCount();
+        assertTrue(actualDataPathToShardCount.size() == 3);
+        expectedDataPathToShardCount = Map.of(paths[0], 3, paths[1], 3, paths[2], 2);
+        for (Map.Entry<Path, Integer> entry : expectedDataPathToShardCount.entrySet()) {
+            assertTrue(entry.getValue() == actualDataPathToShardCount.get(entry.getKey()));
+        }
+
+        // create index3_3 with 1 shards and expect datapath[2] is 3
+        createIndex("index3_3", oneShardSettings);
+        actualDataPathToShardCount = indicesService.dataPathToShardCount();
+        assertTrue(actualDataPathToShardCount.size() == 3);
+        expectedDataPathToShardCount = Map.of(paths[0], 3, paths[1], 3, paths[2], 3);
+        for (Map.Entry<Path, Integer> entry : expectedDataPathToShardCount.entrySet()) {
+            assertTrue(entry.getValue() == actualDataPathToShardCount.get(entry.getKey()));
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
The pr #27039  introduce tie-break shard path decision based on total number of shards on data paths.  According the codes from https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/index/IndexService.java#L429, `dataPathToShardCount` only represents the  number of shards for current index, rather than the total number of shards on data paths.