### PR TITLE
Improve watcher reporting generation error message

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
@@ -255,8 +255,8 @@ public class ReportingAttachmentParser implements EmailAttachmentParser<Reportin
         HttpResponse response = httpClient.execute(request);
         if (response.status() != 200) {
             throw new ElasticsearchException("Watch[{}] reporting[{}] Error response when trying to trigger reporting generation " +
-                    "host[{}], port[{}] method[{}], path[{}], status[{}]", watchId, attachmentId, request.host(),
-                    request.port(), request.method(), request.path(), response.status());
+                    "host[{}], port[{}] method[{}], path[{}], response[{}]", watchId, attachmentId, request.host(),
+                    request.port(), request.method(), request.path(), response);
         }
 
         return response;


### PR DESCRIPTION
Include the entire response in error message in case of reporting generation error.
The toString of HttpResponse includes not just the status, but also all the other details.