### PR TITLE
FieldTypeLookup to not implement Iterable

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -119,11 +119,8 @@ public final class IndexWarmer {
         public TerminationHandle warmReader(final IndexShard indexShard, final ElasticsearchDirectoryReader reader) {
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
-            for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+            for (MappedFieldType fieldType : mapperService.fieldTypes(MappedFieldType::eagerGlobalOrdinals)) {
                 final String indexName = fieldType.name();
-                if (fieldType.eagerGlobalOrdinals() == false) {
-                    continue;
-                }
                 warmUpGlobalOrdinals.put(indexName, fieldType);
             }
             final CountDownLatch latch = new CountDownLatch(warmUpGlobalOrdinals.size());

--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -119,7 +119,7 @@ public final class IndexWarmer {
         public TerminationHandle warmReader(final IndexShard indexShard, final ElasticsearchDirectoryReader reader) {
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
-            for (MappedFieldType fieldType : mapperService.fieldTypes(MappedFieldType::eagerGlobalOrdinals)) {
+            for (MappedFieldType fieldType : mapperService.getEagerGlobalOrdinalsFields()) {
                 final String indexName = fieldType.name();
                 warmUpGlobalOrdinals.put(indexName, fieldType);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldTypeLookup.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * A container that supports looking up field types for 'dynamic key' fields ({@link DynamicKeyFieldMapper}).
@@ -83,10 +83,8 @@ class DynamicKeyFieldTypeLookup {
         }
     }
 
-    Iterator<MappedFieldType> fieldTypes() {
-        return mappers.values().stream()
-            .<MappedFieldType>map(mapper -> mapper.keyedFieldType(""))
-            .iterator();
+    Stream<MappedFieldType> fieldTypes() {
+        return mappers.values().stream().map(mapper -> mapper.keyedFieldType(""));
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -134,7 +134,14 @@ final class FieldTypeLookup {
             : Set.of(resolvedField);
     }
 
-    Iterable<MappedFieldType> fieldTypes(Predicate<MappedFieldType> predicate) {
-        return () -> Stream.concat(fullNameToFieldType.values().stream(), dynamicKeyLookup.fieldTypes()).filter(predicate).iterator();
+    /**
+     * Returns an {@link Iterable} over all the distinct field types matching the provided predicate.
+     * When a field alias is present, {@link #get(String)} returns the same {@link MappedFieldType} no matter if it's  looked up
+     * providing the field name or the alias name. In this case the {@link Iterable} returned by this method will contain only one
+     * instance of the field type. Note that filtering by name is not reliable as it does not take into account field aliases.
+     */
+    Iterable<MappedFieldType> filter(Predicate<MappedFieldType> predicate) {
+        return () -> Stream.concat(fullNameToFieldType.values().stream(), dynamicKeyLookup.fieldTypes())
+            .distinct().filter(predicate).iterator();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -19,20 +19,20 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.regex.Regex;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * An immutable container for looking up {@link MappedFieldType}s by their name.
  */
-final class FieldTypeLookup implements Iterable<MappedFieldType> {
+final class FieldTypeLookup {
 
     private final Map<String, MappedFieldType> fullNameToFieldType = new HashMap<>();
 
@@ -134,10 +134,7 @@ final class FieldTypeLookup implements Iterable<MappedFieldType> {
             : Set.of(resolvedField);
     }
 
-    @Override
-    public Iterator<MappedFieldType> iterator() {
-        Iterator<MappedFieldType> concreteFieldTypes = fullNameToFieldType.values().iterator();
-        Iterator<MappedFieldType> keyedFieldTypes = dynamicKeyLookup.fieldTypes();
-        return Iterators.concat(concreteFieldTypes, keyedFieldTypes);
+    Iterable<MappedFieldType> fieldTypes(Predicate<MappedFieldType> predicate) {
+        return () -> Stream.concat(fullNameToFieldType.values().stream(), dynamicKeyLookup.fieldTypes()).filter(predicate).iterator();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -434,7 +434,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      * Returns all mapped field types.
      */
     public Iterable<MappedFieldType> fieldTypes(Predicate<MappedFieldType> predicate) {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().fieldTypes(predicate);
+        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().filter(predicate);
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class MapperService extends AbstractIndexComponent implements Closeable {
@@ -432,8 +433,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     /**
      * Returns all mapped field types.
      */
-    public Iterable<MappedFieldType> fieldTypes() {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes();
+    public Iterable<MappedFieldType> fieldTypes(Predicate<MappedFieldType> predicate) {
+        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().fieldTypes(predicate);
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -63,7 +63,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class MapperService extends AbstractIndexComponent implements Closeable {
@@ -433,8 +432,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     /**
      * Returns all mapped field types.
      */
-    public Iterable<MappedFieldType> fieldTypes(Predicate<MappedFieldType> predicate) {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes().filter(predicate);
+    public Iterable<MappedFieldType> getEagerGlobalOrdinalsFields() {
+        return this.mapper == null ? Collections.emptySet() :
+            this.mapper.mappers().fieldTypes().filter(MappedFieldType::eagerGlobalOrdinals);
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlattenedFieldLookupTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlattenedFieldLookupTests.java
@@ -127,9 +127,7 @@ public class FlattenedFieldLookupTests extends ESTestCase {
         FieldTypeLookup lookup = new FieldTypeLookup(Arrays.asList(mapper, flattenedMapper), emptyList());
 
         Set<String> fieldNames = new HashSet<>();
-        for (MappedFieldType fieldType : lookup) {
-            fieldNames.add(fieldType.name());
-        }
+        lookup.filter(ft -> true).forEach(ft -> fieldNames.add(ft.name()));
 
         assertThat(fieldNames, containsInAnyOrder(
             mapper.name(), flattenedMapper.name(), flattenedMapper.keyedFieldName()));


### PR DESCRIPTION
FieldTypeLookup implements Iterable which is currently only used in IndexWarmer to iterate through all field types that have eager global ordinals set to true. Implementing Iterable makes it hard to track who iterates through all the field types.

This commit exposes a new method that allows to provide a Predicate and returns an Iterable of all the field types that match the predicate.
