### PR TITLE
[DOCS] Adds scroll_size maximum value to datafeeds API docs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1283,9 +1283,9 @@ and <<script-fields,Script fields>>.
 end::script-fields[]
 
 tag::scroll-size[]
-The `size` parameter that is used in {es} searches. The default value is `1000`. 
-The maximum value is the value of `index.max_result_window` which is 10,000 by 
-default.
+The `size` parameter that is used in {es} searches when the {dfeed} do not use 
+aggregations. The default value is `1000`. The maximum value is the value of 
+`index.max_result_window` which is 10,000 by default.
 end::scroll-size[]
 
 tag::search-bucket-avg[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1283,7 +1283,7 @@ and <<script-fields,Script fields>>.
 end::script-fields[]
 
 tag::scroll-size[]
-The `size` parameter that is used in {es} searches when the {dfeed} do not use 
+The `size` parameter that is used in {es} searches when the {dfeed} does not use 
 aggregations. The default value is `1000`. The maximum value is the value of 
 `index.max_result_window` which is 10,000 by default.
 end::scroll-size[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1283,7 +1283,9 @@ and <<script-fields,Script fields>>.
 end::script-fields[]
 
 tag::scroll-size[]
-The `size` parameter that is used in {es} searches. The default value is `1000`.
+The `size` parameter that is used in {es} searches. The default value is `1000`. 
+The maximum value is the value of `index.max_result_window` which is 10,000 by 
+default.
 end::scroll-size[]
 
 tag::search-bucket-avg[]


### PR DESCRIPTION
## Overview

This PR adds info about the maximum value of `scroll_size` to the description of the parameter in datafeed API docs.