### PR TITLE
[7.x] ILM: Add support for the searchable_snapshot action in the hot phase (#64883)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -4,12 +4,20 @@
 
 beta::[]
 
-Phases allowed: cold.
+Phases allowed: hot, cold.
 
 Takes a snapshot of the managed index in the configured repository
 and mounts it as a searchable snapshot.
 If the managed index is part of a <<data-streams, data stream>>,
 the mounted index replaces the original index in the data stream.
+
+To use the `searchable_snapshot` action in the `hot` phase, the `rollover`
+action *must* be present. If no rollover action is configured, {ilm-init}
+will reject the policy.
+
+IMPORTANT: If the `searchable_snapshot` action is used in the `hot` phase the
+subsequent phases cannot define any of the `shrink`, `forcemerge`, `freeze` or
+`searchable_snapshot` (also available in the cold phase) actions.
 
 [NOTE]
 This action cannot be performed on a data stream's write index. Attempts to do

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
  * registers an observer and waits to try again when a snapshot is no longer running.
  */
 public abstract class AsyncRetryDuringSnapshotActionStep extends AsyncActionStep {
-    private final Logger logger = LogManager.getLogger(AsyncRetryDuringSnapshotActionStep.class);
+    private static final Logger logger = LogManager.getLogger(AsyncRetryDuringSnapshotActionStep.class);
 
     public AsyncRetryDuringSnapshotActionStep(StepKey key, StepKey nextStepKey, Client client) {
         super(key, nextStepKey, client);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeAction.java
@@ -5,7 +5,10 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,7 +25,10 @@ import java.util.List;
  * A {@link LifecycleAction} which freezes the index.
  */
 public class FreezeAction implements LifecycleAction {
+    private static final Logger logger = LogManager.getLogger(FreezeAction.class);
+
     public static final String NAME = "freeze";
+    public static final String CONDITIONAL_SKIP_FREEZE_STEP = BranchingStep.NAME + "-freeze-check-prerequisites";
 
     private static final ObjectParser<FreezeAction, Void> PARSER = new ObjectParser<>(NAME, FreezeAction::new);
 
@@ -59,13 +65,31 @@ public class FreezeAction implements LifecycleAction {
 
     @Override
     public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {
+        StepKey preFreezeMergeBranchingKey = new StepKey(phase, NAME, CONDITIONAL_SKIP_FREEZE_STEP);
         StepKey checkNotWriteIndex = new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME);
         StepKey freezeStepKey = new StepKey(phase, NAME, FreezeStep.NAME);
 
+        BranchingStep conditionalSkipFreezeStep = new BranchingStep(preFreezeMergeBranchingKey, checkNotWriteIndex, nextStepKey,
+            (index, clusterState) -> {
+                IndexMetadata indexMetadata = clusterState.getMetadata().index(index);
+                assert indexMetadata != null : "index " + index.getName() + " must exist in the cluster state";
+                String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings());
+                if (indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME) != null) {
+                    logger.warn("[{}] action is configured for index [{}] in policy [{}] which is mounted as searchable snapshot. " +
+                        "Skipping this action", FreezeAction.NAME, index.getName(), policyName);
+                    return true;
+                }
+                if (indexMetadata.getSettings().getAsBoolean("index.frozen", false)) {
+                    logger.debug("skipping [{}] action for index [{}] in policy [{}] as the index is already frozen", FreezeAction.NAME,
+                        index.getName(), policyName);
+                    return true;
+                }
+                return false;
+            });
         CheckNotDataStreamWriteIndexStep checkNoWriteIndexStep = new CheckNotDataStreamWriteIndexStep(checkNotWriteIndex,
             freezeStepKey);
         FreezeStep freezeStep = new FreezeStep(freezeStepKey, nextStepKey, client);
-        return Arrays.asList(checkNoWriteIndexStep, freezeStep);
+        return Arrays.asList(conditionalSkipFreezeStep, checkNoWriteIndexStep, freezeStep);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
@@ -27,6 +27,9 @@ public class LifecycleSettings {
     public static final String SLM_RETENTION_DURATION = "slm.retention_duration";
     public static final String SLM_MINIMUM_INTERVAL = "slm.minimum_interval";
 
+    // This is not a setting configuring ILM per se, but certain ILM actions need to validate the managed index is not
+    // already mounted as a searchable snapshot. Those ILM actions will check if the index has this setting name configured.
+    public static final String SNAPSHOT_INDEX_NAME = "index.store.snapshot.index_name";
 
     public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.positiveTimeSetting(LIFECYCLE_POLL_INTERVAL,
         TimeValue.timeValueMinutes(10), Setting.Property.Dynamic, Setting.Property.NodeScope);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeActionTests.java
@@ -38,17 +38,20 @@ public class FreezeActionTests extends AbstractActionTestCase<FreezeAction> {
                 randomAlphaOfLengthBetween(1, 10));
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
         assertNotNull(steps);
-        assertEquals(2, steps.size());
-        StepKey expectedFirstStepKey = new StepKey(phase, FreezeAction.NAME, CheckNotDataStreamWriteIndexStep.NAME);
-        StepKey expectedSecondStepKey = new StepKey(phase, FreezeAction.NAME, FreezeStep.NAME);
+        assertEquals(3, steps.size());
+        StepKey expectedFirstStepKey = new StepKey(phase, FreezeAction.NAME, FreezeAction.CONDITIONAL_SKIP_FREEZE_STEP);
+        StepKey expectedSecondStepKey = new StepKey(phase, FreezeAction.NAME, CheckNotDataStreamWriteIndexStep.NAME);
+        StepKey expectedThirdStepKey = new StepKey(phase, FreezeAction.NAME, FreezeStep.NAME);
 
-        CheckNotDataStreamWriteIndexStep firstStep = (CheckNotDataStreamWriteIndexStep) steps.get(0);
-        FreezeStep secondStep = (FreezeStep) steps.get(1);
+        BranchingStep firstStep = (BranchingStep) steps.get(0);
+        CheckNotDataStreamWriteIndexStep secondStep = (CheckNotDataStreamWriteIndexStep) steps.get(1);
+        FreezeStep thirdStep = (FreezeStep) steps.get(2);
 
         assertThat(firstStep.getKey(), equalTo(expectedFirstStepKey));
-        assertThat(firstStep.getNextStepKey(), equalTo(expectedSecondStepKey));
 
         assertEquals(expectedSecondStepKey, secondStep.getKey());
-        assertEquals(nextStepKey, secondStep.getNextStepKey());
+        assertEquals(expectedThirdStepKey, secondStep.getNextStepKey());
+        assertEquals(expectedThirdStepKey, thirdStep.getKey());
+        assertEquals(nextStepKey, thirdStep.getNextStepKey());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,52 +100,17 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
     public static LifecyclePolicy randomTimeseriesLifecyclePolicyWithAllPhases(@Nullable String lifecycleName) {
         List<String> phaseNames = TimeseriesLifecycleType.VALID_PHASES;
         Map<String, Phase> phases = new HashMap<>(phaseNames.size());
-        Function<String, Set<String>> validActions = (phase) -> {
-            switch (phase) {
-                case "hot":
-                    return TimeseriesLifecycleType.VALID_HOT_ACTIONS;
-                case "warm":
-                    return TimeseriesLifecycleType.VALID_WARM_ACTIONS;
-                case "cold":
-                    return TimeseriesLifecycleType.VALID_COLD_ACTIONS;
-                case "delete":
-                    return TimeseriesLifecycleType.VALID_DELETE_ACTIONS;
-                default:
-                    throw new IllegalArgumentException("invalid phase [" + phase + "]");
-            }};
-        Function<String, LifecycleAction> randomAction = (action) -> {
-            switch (action) {
-                case AllocateAction.NAME:
-                    return AllocateActionTests.randomInstance();
-                case DeleteAction.NAME:
-                    return new DeleteAction();
-                case WaitForSnapshotAction.NAME:
-                    return WaitForSnapshotActionTests.randomInstance();
-                case ForceMergeAction.NAME:
-                    return ForceMergeActionTests.randomInstance();
-                case ReadOnlyAction.NAME:
-                    return new ReadOnlyAction();
-                case RolloverAction.NAME:
-                    return RolloverActionTests.randomInstance();
-                case ShrinkAction.NAME:
-                    return ShrinkActionTests.randomInstance();
-                case FreezeAction.NAME:
-                    return new FreezeAction();
-                case SetPriorityAction.NAME:
-                    return SetPriorityActionTests.randomInstance();
-                case UnfollowAction.NAME:
-                    return new UnfollowAction();
-                case SearchableSnapshotAction.NAME:
-                    return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
-                case MigrateAction.NAME:
-                    return new MigrateAction(false);
-                default:
-                    throw new IllegalArgumentException("invalid action [" + action + "]");
-            }};
+        Function<String, Set<String>> validActions = getPhaseToValidActions();
+        Function<String, LifecycleAction> randomAction = getNameToActionFunction();
         for (String phase : phaseNames) {
             TimeValue after = TimeValue.parseTimeValue(randomTimeValue(0, 1000000000, "s", "m", "h", "d"), "test_after");
             Map<String, LifecycleAction> actions = new HashMap<>();
             Set<String> actionNames = validActions.apply(phase);
+            if (phase.equals(TimeseriesLifecycleType.HOT_PHASE) == false) {
+                // let's make sure the other phases don't configure actions that conflict with the `searchable_snapshot` action
+                // configured in the hot phase
+                actionNames.removeAll(TimeseriesLifecycleType.ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT);
+            }
             for (String action : actionNames) {
                 actions.put(action, randomAction.apply(action));
             }
@@ -157,57 +123,35 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
         List<String> phaseNames = randomSubsetOf(
             between(0, TimeseriesLifecycleType.VALID_PHASES.size() - 1), TimeseriesLifecycleType.VALID_PHASES);
         Map<String, Phase> phases = new HashMap<>(phaseNames.size());
-        Function<String, Set<String>> validActions = (phase) -> {
-            switch (phase) {
-                case "hot":
-                    return TimeseriesLifecycleType.VALID_HOT_ACTIONS;
-                case "warm":
-                    return TimeseriesLifecycleType.VALID_WARM_ACTIONS;
-                case "cold":
-                    return TimeseriesLifecycleType.VALID_COLD_ACTIONS;
-                case "delete":
-                    return TimeseriesLifecycleType.VALID_DELETE_ACTIONS;
-                default:
-                    throw new IllegalArgumentException("invalid phase [" + phase + "]");
-            }};
-        Function<String, LifecycleAction> randomAction = (action) -> {
-            switch (action) {
-                case AllocateAction.NAME:
-                    return AllocateActionTests.randomInstance();
-                case WaitForSnapshotAction.NAME:
-                    return WaitForSnapshotActionTests.randomInstance();
-                case DeleteAction.NAME:
-                    return new DeleteAction();
-                case ForceMergeAction.NAME:
-                    return ForceMergeActionTests.randomInstance();
-                case ReadOnlyAction.NAME:
-                    return new ReadOnlyAction();
-                case RolloverAction.NAME:
-                    return RolloverActionTests.randomInstance();
-                case ShrinkAction.NAME:
-                    return ShrinkActionTests.randomInstance();
-                case FreezeAction.NAME:
-                    return new FreezeAction();
-                case SetPriorityAction.NAME:
-                    return SetPriorityActionTests.randomInstance();
-                case UnfollowAction.NAME:
-                    return new UnfollowAction();
-                case SearchableSnapshotAction.NAME:
-                    return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
-                case MigrateAction.NAME:
-                    return new MigrateAction(false);
-                default:
-                    throw new IllegalArgumentException("invalid action [" + action + "]");
-            }};
+        Function<String, Set<String>> validActions = getPhaseToValidActions();
+        Function<String, LifecycleAction> randomAction = getNameToActionFunction();
+        // as what actions end up in the hot phase influence what actions are allowed in the subsequent phases we'll move the hot phase
+        // at the front of the phases to process (if it exists)
+        if (phaseNames.contains(TimeseriesLifecycleType.HOT_PHASE)) {
+            phaseNames.remove(TimeseriesLifecycleType.HOT_PHASE);
+            phaseNames.add(0, TimeseriesLifecycleType.HOT_PHASE);
+        }
+        boolean hotPhaseContainsSearchableSnap = false;
         for (String phase : phaseNames) {
             TimeValue after = TimeValue.parseTimeValue(randomTimeValue(0, 1000000000, "s", "m", "h", "d"), "test_after");
             Map<String, LifecycleAction> actions = new HashMap<>();
             List<String> actionNames = randomSubsetOf(validActions.apply(phase));
 
-            // If the hot phase has any actions that require a rollover, then ensure there is one so that the policy will validate
-            if (phase.equals(TimeseriesLifecycleType.HOT_PHASE)
-                && actionNames.stream().anyMatch(TimeseriesLifecycleType.HOT_ACTIONS_THAT_REQUIRE_ROLLOVER::contains)) {
-                actionNames.add(RolloverAction.NAME);
+            if (phase.equals(TimeseriesLifecycleType.HOT_PHASE)) {
+                // If the hot phase has any actions that require a rollover, then ensure there is one so that the policy will validate
+                if (actionNames.stream().anyMatch(TimeseriesLifecycleType.HOT_ACTIONS_THAT_REQUIRE_ROLLOVER::contains)) {
+                    actionNames.add(RolloverAction.NAME);
+                }
+
+                if (actionNames.contains(SearchableSnapshotAction.NAME)) {
+                    hotPhaseContainsSearchableSnap = true;
+                }
+            } else {
+                if (hotPhaseContainsSearchableSnap) {
+                    // let's make sure the other phases don't configure actions that conflict with a possible `searchable_snapshot` action
+                    // configured in the hot phase
+                    actionNames.removeAll(TimeseriesLifecycleType.ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT);
+                }
             }
 
             for (String action : actionNames) {
@@ -216,6 +160,54 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
             phases.put(phase, new Phase(phase, after, actions));
         }
         return new LifecyclePolicy(TimeseriesLifecycleType.INSTANCE, lifecycleName, phases);
+    }
+
+    private static Function<String, Set<String>> getPhaseToValidActions() {
+        return (phase) -> {
+            switch (phase) {
+                case "hot":
+                    return new HashSet<>(TimeseriesLifecycleType.VALID_HOT_ACTIONS);
+                case "warm":
+                    return new HashSet<>(TimeseriesLifecycleType.VALID_WARM_ACTIONS);
+                case "cold":
+                    return new HashSet<>(TimeseriesLifecycleType.VALID_COLD_ACTIONS);
+                case "delete":
+                    return new HashSet<>(TimeseriesLifecycleType.VALID_DELETE_ACTIONS);
+                default:
+                    throw new IllegalArgumentException("invalid phase [" + phase + "]");
+            }};
+    }
+
+    private static Function<String, LifecycleAction> getNameToActionFunction() {
+        return (action) -> {
+                switch (action) {
+                    case AllocateAction.NAME:
+                        return AllocateActionTests.randomInstance();
+                    case WaitForSnapshotAction.NAME:
+                        return WaitForSnapshotActionTests.randomInstance();
+                    case DeleteAction.NAME:
+                        return new DeleteAction();
+                    case ForceMergeAction.NAME:
+                        return ForceMergeActionTests.randomInstance();
+                    case ReadOnlyAction.NAME:
+                        return new ReadOnlyAction();
+                    case RolloverAction.NAME:
+                        return RolloverActionTests.randomInstance();
+                    case ShrinkAction.NAME:
+                        return ShrinkActionTests.randomInstance();
+                    case FreezeAction.NAME:
+                        return new FreezeAction();
+                    case SetPriorityAction.NAME:
+                        return SetPriorityActionTests.randomInstance();
+                    case UnfollowAction.NAME:
+                        return new UnfollowAction();
+                    case SearchableSnapshotAction.NAME:
+                        return new SearchableSnapshotAction(randomAlphaOfLengthBetween(1, 10));
+                    case MigrateAction.NAME:
+                        return new MigrateAction(false);
+                    default:
+                        throw new IllegalArgumentException("invalid action [" + action + "]");
+                }};
     }
 
     public static LifecyclePolicy randomTestLifecyclePolicy(@Nullable String lifecycleName) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -24,7 +24,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         StepKey nextStepKey = new StepKey(phase, randomAlphaOfLengthBetween(1, 5), randomAlphaOfLengthBetween(1, 5));
 
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
-        assertThat(steps.size(), is(action.isForceMergeIndex() ? 15 : 13));
+        assertThat(steps.size(), is(action.isForceMergeIndex() ? 16 : 14));
 
         List<StepKey> expectedSteps = action.isForceMergeIndex() ? expectedStepKeysWithForceMerge(phase) :
             expectedStepKeysNoForceMerge(phase);
@@ -44,17 +44,18 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         assertThat(steps.get(12).getKey(), is(expectedSteps.get(12)));
 
         if (action.isForceMergeIndex()) {
-            assertThat(steps.get(13).getKey(), is(expectedSteps.get(13)));
-            AsyncActionBranchingStep branchStep = (AsyncActionBranchingStep) steps.get(6);
-            assertThat(branchStep.getNextKeyOnIncompleteResponse(), is(expectedSteps.get(5)));
+            assertThat(steps.get(14).getKey(), is(expectedSteps.get(14)));
+            AsyncActionBranchingStep branchStep = (AsyncActionBranchingStep) steps.get(7);
+            assertThat(branchStep.getNextKeyOnIncompleteResponse(), is(expectedSteps.get(6)));
         } else {
-            AsyncActionBranchingStep branchStep = (AsyncActionBranchingStep) steps.get(4);
-            assertThat(branchStep.getNextKeyOnIncompleteResponse(), is(expectedSteps.get(3)));
+            AsyncActionBranchingStep branchStep = (AsyncActionBranchingStep) steps.get(5);
+            assertThat(branchStep.getNextKeyOnIncompleteResponse(), is(expectedSteps.get(4)));
         }
     }
 
     private List<StepKey> expectedStepKeysWithForceMerge(String phase) {
         return org.elasticsearch.common.collect.List.of(
+            new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
             new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
             new StepKey(phase, NAME, ForceMergeStep.NAME),
@@ -74,6 +75,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
     private List<StepKey> expectedStepKeysNoForceMerge(String phase) {
         return org.elasticsearch.common.collect.List.of(
+            new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
             new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
             new StepKey(phase, NAME, GenerateSnapshotNameStep.NAME),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.COLD_PHASE;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.HOT_PHASE;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.ORDERED_VALID_COLD_ACTIONS;
@@ -32,6 +33,7 @@ import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.VALID_HOT
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.VALID_PHASES;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.VALID_WARM_ACTIONS;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.WARM_PHASE;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -193,12 +195,28 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         }
     }
 
+    public void testActionsThatCannotFollowSearchableSnapshot() {
+        assertThat(ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT.size(), is(4));
+        assertThat(ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT, containsInAnyOrder(ShrinkAction.NAME, FreezeAction.NAME,
+            ForceMergeAction.NAME, SearchableSnapshotAction.NAME));
+    }
+
+    public void testValidateActionsFollowingSearchableSnapshot() {
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction("repo")));
+        Phase warmPhase = new Phase("warm", TimeValue.ZERO, Map.of(ShrinkAction.NAME, new ShrinkAction(1)));
+        Phase coldPhase = new Phase("cold", TimeValue.ZERO, Map.of(FreezeAction.NAME, new FreezeAction()));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> TimeseriesLifecycleType.validateActionsFollowingSearchableSnapshot(List.of(hotPhase, warmPhase, coldPhase)));
+        assertThat(e.getMessage(), is("phases [warm,cold] define one or more of [searchable_snapshot, forcemerge, freeze, shrink] actions" +
+            " which are not allowed after a managed index is mounted as a searchable snapshot"));
+    }
+
     public void testGetOrderedPhases() {
         Map<String, Phase> phaseMap = new HashMap<>();
         for (String phaseName : randomSubsetOf(randomIntBetween(0, VALID_PHASES.size()), VALID_PHASES)) {
             phaseMap.put(phaseName, new Phase(phaseName, TimeValue.ZERO, Collections.emptyMap()));
         }
-
 
         assertTrue(isSorted(TimeseriesLifecycleType.INSTANCE.getOrderedPhases(phaseMap), Phase::getName, VALID_PHASES));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -202,12 +202,17 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     }
 
     public void testValidateActionsFollowingSearchableSnapshot() {
-        Phase hotPhase = new Phase("hot", TimeValue.ZERO, Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction("repo")));
-        Phase warmPhase = new Phase("warm", TimeValue.ZERO, Map.of(ShrinkAction.NAME, new ShrinkAction(1)));
-        Phase coldPhase = new Phase("cold", TimeValue.ZERO, Map.of(FreezeAction.NAME, new FreezeAction()));
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(
+            SearchableSnapshotAction.NAME, new SearchableSnapshotAction("repo")));
+        Phase warmPhase = new Phase("warm", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(
+            ShrinkAction.NAME, new ShrinkAction(1)));
+        Phase coldPhase = new Phase("cold", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(
+            FreezeAction.NAME, new FreezeAction()));
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> TimeseriesLifecycleType.validateActionsFollowingSearchableSnapshot(List.of(hotPhase, warmPhase, coldPhase)));
+            () -> TimeseriesLifecycleType.validateActionsFollowingSearchableSnapshot(org.elasticsearch.common.collect.List.of(
+                hotPhase, warmPhase, coldPhase))
+        );
         assertThat(e.getMessage(), is("phases [warm,cold] define one or more of [searchable_snapshot, forcemerge, freeze, shrink] actions" +
             " which are not allowed after a managed index is mounted as a searchable snapshot"));
     }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -199,10 +199,12 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
     public void testCreateInvalidPolicy() {
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> createPolicy(client(), policy,
-            new Phase("hot", TimeValue.ZERO, Map.of(RolloverAction.NAME, new RolloverAction(null, null, 1L), SearchableSnapshotAction.NAME,
+            new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(RolloverAction.NAME,
+                new RolloverAction(null, null, 1L), SearchableSnapshotAction.NAME,
                 new SearchableSnapshotAction(randomAlphaOfLengthBetween(4, 10)))),
-            new Phase("warm", TimeValue.ZERO, Map.of(ForceMergeAction.NAME, new ForceMergeAction(1, null))),
-            new Phase("cold", TimeValue.ZERO, Map.of(FreezeAction.NAME, new FreezeAction())),
+            new Phase("warm", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(ForceMergeAction.NAME,
+                new ForceMergeAction(1, null))),
+            new Phase("cold", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(FreezeAction.NAME, new FreezeAction())),
             null
             )
         );
@@ -215,9 +217,10 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         String snapshotRepo = randomAlphaOfLengthBetween(4, 10);
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());
         createPolicy(client(), policy,
-            new Phase("hot", TimeValue.ZERO, Map.of(RolloverAction.NAME, new RolloverAction(null, null, 1L), SearchableSnapshotAction.NAME,
-                new SearchableSnapshotAction(snapshotRepo))),
-            new Phase("warm", TimeValue.timeValueDays(30), Map.of(SetPriorityAction.NAME, new SetPriorityAction(999))),
+            new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(RolloverAction.NAME,
+                new RolloverAction(null, null, 1L), SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo))),
+            new Phase("warm", TimeValue.timeValueDays(30), org.elasticsearch.common.collect.Map.of(SetPriorityAction.NAME,
+                new SetPriorityAction(999))),
             null, null
         );
 
@@ -249,11 +252,13 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         }, 30, TimeUnit.SECONDS);
 
         createPolicy(client(), policy,
-            new Phase("hot", TimeValue.ZERO, Map.of(SetPriorityAction.NAME, new SetPriorityAction(10))),
+            new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(SetPriorityAction.NAME, new SetPriorityAction(10))),
             new Phase("warm", TimeValue.ZERO,
-                Map.of(ShrinkAction.NAME, new ShrinkAction(1), ForceMergeAction.NAME, new ForceMergeAction(1, null))
+                org.elasticsearch.common.collect.Map.of(ShrinkAction.NAME, new ShrinkAction(1), ForceMergeAction.NAME,
+                    new ForceMergeAction(1, null))
             ),
-            new Phase("cold", TimeValue.ZERO, Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo))),
+            new Phase("cold", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(SearchableSnapshotAction.NAME,
+                new SearchableSnapshotAction(snapshotRepo))),
             null
         );
 
@@ -271,9 +276,10 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         String snapshotRepo = randomAlphaOfLengthBetween(4, 10);
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());
         createPolicy(client(), policy,
-            new Phase("hot", TimeValue.ZERO, Map.of(RolloverAction.NAME, new RolloverAction(null, null, 1L),
-                SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo))),
-            new Phase("warm", TimeValue.timeValueDays(30), Map.of(SetPriorityAction.NAME, new SetPriorityAction(999))),
+            new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(RolloverAction.NAME,
+                new RolloverAction(null, null, 1L), SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo))),
+            new Phase("warm", TimeValue.timeValueDays(30), org.elasticsearch.common.collect.Map.of(SetPriorityAction.NAME,
+                new SetPriorityAction(999))),
             null, null
         );
 
@@ -318,11 +324,12 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         assertOK(client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream)));
 
         createPolicy(client(), policy,
-            new Phase("hot", TimeValue.ZERO, Map.of()),
+            new Phase("hot", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of()),
             new Phase("warm", TimeValue.ZERO,
-                Map.of(ShrinkAction.NAME, new ShrinkAction(1), ForceMergeAction.NAME, new ForceMergeAction(1, null))
+                org.elasticsearch.common.collect.Map.of(ShrinkAction.NAME, new ShrinkAction(1), ForceMergeAction.NAME,
+                    new ForceMergeAction(1, null))
             ),
-            new Phase("cold", TimeValue.ZERO, Map.of(FreezeAction.NAME, new FreezeAction())),
+            new Phase("cold", TimeValue.ZERO, org.elasticsearch.common.collect.Map.of(FreezeAction.NAME, new FreezeAction())),
             null
         );
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
@@ -161,10 +161,12 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
 
         assertThat(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, phaseDef, "phase"),
             contains(
+                new Step.StepKey("phase", "freeze", FreezeAction.CONDITIONAL_SKIP_FREEZE_STEP),
                 new Step.StepKey("phase", "freeze", CheckNotDataStreamWriteIndexStep.NAME),
                 new Step.StepKey("phase", "freeze", FreezeAction.NAME),
                 new Step.StepKey("phase", "allocate", AllocateAction.NAME),
                 new Step.StepKey("phase", "allocate", AllocationRoutedStep.NAME),
+                new Step.StepKey("phase", "forcemerge", ForceMergeAction.CONDITIONAL_SKIP_FORCE_MERGE_STEP),
                 new Step.StepKey("phase", "forcemerge", CheckNotDataStreamWriteIndexStep.NAME),
                 new Step.StepKey("phase", "forcemerge", ReadOnlyAction.NAME),
                 new Step.StepKey("phase", "forcemerge", ForceMergeAction.NAME),


### PR DESCRIPTION
This adds support for the searchable_snapshot ILM action in the hot phase.

We define a series of actions that cannot be executed after the index has been
mounted as a searchable snapshot. Namely: freeze, forcemerge, shrink,
and searchable_snapshot (also available in the cold phase).

If by virtue of snapshot/restoring a managed index or updating an ILM policy while it
is executing for an index, these actions could get to be executed on an index that was
mounted as searchable snapshot in the hot phase. If this happens the actions will
skip entirely. ILM will not move into the ERROR step.

(cherry picked from commit 7d45355)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #64883 