### PR TITLE
Prevent deletion of ILM history template in rest tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1315,6 +1315,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "synthetics-mappings":
             case ".snapshot-blob-cache":
             case ".deprecation-indexing-template":
+            case "ilm-history":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
This change marks ILM history template as automatically created one so it should not be deleted between tests runs. That should prevent various races between template creation and indexing documents into ILM history.

Closes #64992