### PR TITLE
FieldTypeLookup to not implement Iterable (#64983)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -119,11 +119,8 @@ public final class IndexWarmer {
         public TerminationHandle warmReader(final IndexShard indexShard, final ElasticsearchDirectoryReader reader) {
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
-            for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+            for (MappedFieldType fieldType : mapperService.getEagerGlobalOrdinalsFields()) {
                 final String indexName = fieldType.name();
-                if (fieldType.eagerGlobalOrdinals() == false) {
-                    continue;
-                }
                 warmUpGlobalOrdinals.put(indexName, fieldType);
             }
             final CountDownLatch latch = new CountDownLatch(warmUpGlobalOrdinals.size());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicKeyFieldTypeLookup.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * A container that supports looking up field types for 'dynamic key' fields ({@link DynamicKeyFieldMapper}).
@@ -83,10 +83,8 @@ class DynamicKeyFieldTypeLookup {
         }
     }
 
-    Iterator<MappedFieldType> fieldTypes() {
-        return mappers.values().stream()
-            .<MappedFieldType>map(mapper -> mapper.keyedFieldType(""))
-            .iterator();
+    Stream<MappedFieldType> fieldTypes() {
+        return mappers.values().stream().map(mapper -> mapper.keyedFieldType(""));
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -19,20 +19,20 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.regex.Regex;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * An immutable container for looking up {@link MappedFieldType}s by their name.
  */
-final class FieldTypeLookup implements Iterable<MappedFieldType> {
+final class FieldTypeLookup {
 
     private final Map<String, MappedFieldType> fullNameToFieldType = new HashMap<>();
 
@@ -134,10 +134,14 @@ final class FieldTypeLookup implements Iterable<MappedFieldType> {
             : org.elasticsearch.common.collect.Set.of(resolvedField);
     }
 
-    @Override
-    public Iterator<MappedFieldType> iterator() {
-        Iterator<MappedFieldType> concreteFieldTypes = fullNameToFieldType.values().iterator();
-        Iterator<MappedFieldType> keyedFieldTypes = dynamicKeyLookup.fieldTypes();
-        return Iterators.concat(concreteFieldTypes, keyedFieldTypes);
+    /**
+     * Returns an {@link Iterable} over all the distinct field types matching the provided predicate.
+     * When a field alias is present, {@link #get(String)} returns the same {@link MappedFieldType} no matter if it's  looked up
+     * providing the field name or the alias name. In this case the {@link Iterable} returned by this method will contain only one
+     * instance of the field type. Note that filtering by name is not reliable as it does not take into account field aliases.
+     */
+    Iterable<MappedFieldType> filter(Predicate<MappedFieldType> predicate) {
+        return () -> Stream.concat(fullNameToFieldType.values().stream(), dynamicKeyLookup.fieldTypes())
+            .distinct().filter(predicate).iterator();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -632,8 +632,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     /**
      * Returns all mapped field types.
      */
-    public Iterable<MappedFieldType> fieldTypes() {
-        return this.mapper == null ? Collections.emptySet() : this.mapper.mappers().fieldTypes();
+    public Iterable<MappedFieldType> getEagerGlobalOrdinalsFields() {
+        return this.mapper == null ? Collections.emptySet() :
+            this.mapper.mappers().fieldTypes().filter(MappedFieldType::eagerGlobalOrdinals);
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.collect.List;
 import org.elasticsearch.common.collect.Set;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class FieldTypeLookupTests extends ESTestCase {
 
@@ -38,9 +39,24 @@ public class FieldTypeLookupTests extends ESTestCase {
         Collection<String> names = lookup.simpleMatchToFullName("foo");
         assertNotNull(names);
         assertTrue(names.isEmpty());
-        Iterator<MappedFieldType> itr = lookup.iterator();
-        assertNotNull(itr);
-        assertFalse(itr.hasNext());
+        assertEquals(0, size(lookup.filter(ft -> true)));
+    }
+
+    public void testFilter() {
+        Collection<FieldMapper> fieldMappers = List.of(new MockFieldMapper("field"), new MockFieldMapper("test"));
+        Collection<FieldAliasMapper> fieldAliases = singletonList(new FieldAliasMapper("alias", "alias", "test"));
+        FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(fieldMappers, fieldAliases);
+        Iterable<MappedFieldType> allFieldTypes = fieldTypeLookup.filter(ft -> true);
+        assertEquals(2, size(allFieldTypes));
+        for (MappedFieldType allFieldType : allFieldTypes) {
+            assertThat(allFieldType, instanceOf(MockFieldMapper.FakeFieldType.class));
+        }
+        assertEquals(0, size(fieldTypeLookup.filter(ft -> false)));
+        Iterable<MappedFieldType> fieldIterable = fieldTypeLookup.filter(ft -> ft.name().equals("field"));
+        assertEquals(1, size(fieldIterable));
+        MappedFieldType field = fieldIterable.iterator().next();
+        assertEquals("field", field.name());
+        assertThat(field, instanceOf(MockFieldMapper.FakeFieldType.class));
     }
 
     public void testAddNewField() {
@@ -48,7 +64,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldTypeLookup lookup = new FieldTypeLookup(Collections.singletonList(f), emptyList());
         assertNull(lookup.get("bar"));
         assertEquals(f.fieldType(), lookup.get("foo"));
-        assertEquals(1, size(lookup.iterator()));
+        assertEquals(1, size(lookup.filter(ft -> true)));
     }
 
     public void testAddFieldAlias() {
@@ -107,29 +123,10 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertEquals(Set.of("other_field", "field"), lookup.sourcePaths("field.subfield1"));
     }
 
-    public void testIteratorImmutable() {
-        MockFieldMapper f1 = new MockFieldMapper("foo");
-        FieldTypeLookup lookup = new FieldTypeLookup(Collections.singletonList(f1), emptyList());
-
-        try {
-            Iterator<MappedFieldType> itr = lookup.iterator();
-            assertTrue(itr.hasNext());
-            assertEquals(f1.fieldType(), itr.next());
-            itr.remove();
-            fail("remove should have failed");
-        } catch (UnsupportedOperationException e) {
-            // expected
-        }
-    }
-
-    private int size(Iterator<MappedFieldType> iterator) {
-        if (iterator == null) {
-            throw new NullPointerException("iterator");
-        }
+    private int size(Iterable<MappedFieldType> iterable) {
         int count = 0;
-        while (iterator.hasNext()) {
+        for (MappedFieldType fieldType : iterable) {
             count++;
-            iterator.next();
         }
         return count;
     }

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlattenedFieldLookupTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlattenedFieldLookupTests.java
@@ -127,9 +127,7 @@ public class FlattenedFieldLookupTests extends ESTestCase {
         FieldTypeLookup lookup = new FieldTypeLookup(Arrays.asList(mapper, flattenedMapper), emptyList());
 
         Set<String> fieldNames = new HashSet<>();
-        for (MappedFieldType fieldType : lookup) {
-            fieldNames.add(fieldType.name());
-        }
+        lookup.filter(ft -> true).forEach(ft -> fieldNames.add(ft.name()));
 
         assertThat(fieldNames, containsInAnyOrder(
             mapper.name(), flattenedMapper.name(), flattenedMapper.keyedFieldName()));


### PR DESCRIPTION
FieldTypeLookup implements Iterable which is currently only used in IndexWarmer to iterate through all field types that have eager global ordinals set to true. Implementing Iterable makes it hard to track who iterates through all the field types.

This commit exposes a new method that allows to provide a Predicate and returns an Iterable of all the field types that match the predicate. Also, MapperService no longer exposes a way to iterate through all the field types, but rather only a specific method to iterate through the field types that have eager global ordinals.