### PR TITLE
[7.x] Prevent deletion of ILM history template in rest tests (#64994)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1355,6 +1355,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "synthetics-mappings":
             case ".snapshot-blob-cache":
             case ".deprecation-indexing-template":
+            case "ilm-history":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Prevent deletion of ILM history template in rest tests (#64994)