### PR TITLE
Unused boost parameter should not throw mapping exception

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -99,6 +99,11 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         return new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
     }
 
+    @Override
+    protected String typeName() {
+        return "token_count";
+    }
+
     /**
      *  When position increments are counted, we're looking to make sure that we:
         - don't count tokens without an increment

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1014,7 +1014,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         // made no sense; if we've got here, that means that they're not declared on a current mapper,
         // and so we emit a deprecation warning rather than failing a previously working mapping.
         private static final Set<String> DEPRECATED_PARAMS
-            = new HashSet<>(Arrays.asList("store", "meta", "index", "doc_values", "index_options", "similarity"));
+            = new HashSet<>(Arrays.asList("store", "meta", "index", "doc_values", "index_options", "similarity", "boost"));
 
         private static boolean isDeprecatedParameter(String propName, Version indexCreatedVersion) {
             return DEPRECATED_PARAMS.contains(propName);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -272,20 +272,15 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public final void testDeprecatedBoost() throws IOException {
-        try {
-            createMapperService(fieldMapping(b -> {
-                minimalMapping(b);
-                b.field("boost", 2.0);
-            }));
-            String[] warnings = Strings.concatStringArrays(getParseMinimalWarnings(),
-                new String[]{"Parameter [boost] on field [field] is deprecated and will be removed in 8.0"});
-            assertWarnings(warnings);
-        } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), anyOf(
-                containsString("unknown parameter [boost]"),
-                containsString("[boost : 2.0]")));
-        }
-        assertParseMinimalWarnings();
+        MapperService ms = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("boost", 2.0);
+        }));
+        String type = ms.fieldType("field").typeName();
+        String[] warnings = Strings.concatStringArrays(getParseMinimalWarnings(),
+            new String[]{"Parameter [boost] on field [field] is deprecated and will be removed in 8.0",
+                         "Parameter [boost] has no effect on type [" + type + "] and will be removed in future"});
+        allowedWarnings(warnings);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -271,12 +271,17 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         );
     }
 
+    protected String typeName() throws IOException {
+        MapperService ms = createMapperService(fieldMapping(this::minimalMapping));
+        return ms.fieldType("field").typeName();
+    }
+
     public final void testDeprecatedBoost() throws IOException {
         MapperService ms = createMapperService(fieldMapping(b -> {
             minimalMapping(b);
             b.field("boost", 2.0);
         }));
-        String type = ms.fieldType("field").typeName();
+        String type = typeName();
         String[] warnings = Strings.concatStringArrays(getParseMinimalWarnings(),
             new String[]{"Parameter [boost] on field [field] is deprecated and will be removed in 8.0",
                          "Parameter [boost] has no effect on type [" + type + "] and will be removed in future"});


### PR DESCRIPTION
We were correctly dealing with boosts that had an effect, but mappers
that had a silently accepted but ignored boost parameter were throwing
an error instead of continuing to ignore the boost but emitting a 
warning.

Fixes #64982 