### PR TITLE
[7.9] [DOCS] Adds scroll_size maximum value to datafeeds API docs (#64986)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1238,7 +1238,9 @@ and <<script-fields,Script fields>>.
 end::script-fields[]
 
 tag::scroll-size[]
-The `size` parameter that is used in {es} searches. The default value is `1000`.
+The `size` parameter that is used in {es} searches when the {dfeed} does not use 
+aggregations. The default value is `1000`. The maximum value is the value of 
+`index.max_result_window` which is 10,000 by default.
 end::scroll-size[]
 
 tag::search-bucket-avg[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Adds scroll_size maximum value to datafeeds API docs (#64986)