### PR TITLE
[7.10] [ML] fix custom feature processor extraction bugs around boolean fields and custom one_hot feature output order (#64937)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/NGram.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/NGram.java
@@ -134,6 +134,13 @@ public class NGram implements LenientlyParsedPreProcessor, StrictlyParsedPreProc
         if (length > MAX_LENGTH) {
             throw ExceptionsHelper.badRequestException("[{}] must be not be greater than [{}]", LENGTH.getPreferredName(), MAX_LENGTH);
         }
+        if (Arrays.stream(this.nGrams).anyMatch(i -> i > length)) {
+            throw ExceptionsHelper.badRequestException(
+                "[{}] and [{}] are invalid; all ngrams must be shorter than or equal to length [{}]",
+                NGRAMS.getPreferredName(),
+                LENGTH.getPreferredName(),
+                length);
+        }
         this.custom = custom;
     }
 
@@ -292,6 +299,9 @@ public class NGram implements LenientlyParsedPreProcessor, StrictlyParsedPreProc
         int totalNgrams = 0;
         for (int nGram : nGrams) {
             totalNgrams += (length - (nGram - 1));
+        }
+        if (totalNgrams <= 0) {
+            return Collections.emptyList();
         }
         List<String> ngramOutputs = new ArrayList<>(totalNgrams);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -68,13 +69,13 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
 
     public OneHotEncoding(String field, Map<String, String> hotMap, Boolean custom) {
         this.field = ExceptionsHelper.requireNonNull(field, FIELD);
-        this.hotMap = Collections.unmodifiableMap(ExceptionsHelper.requireNonNull(hotMap, HOT_MAP));
-        this.custom = custom == null ? false : custom;
+        this.hotMap = Collections.unmodifiableMap(new TreeMap<>(ExceptionsHelper.requireNonNull(hotMap, HOT_MAP)));
+        this.custom = custom != null && custom;
     }
 
     public OneHotEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
-        this.hotMap = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        this.hotMap = Collections.unmodifiableMap(new TreeMap<>(in.readMap(StreamInput::readString, StreamInput::readString)));
         if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             this.custom = in.readBoolean();
         } else {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/NGramTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/NGramTests.java
@@ -42,11 +42,12 @@ public class NGramTests extends PreProcessingTests<NGram> {
     }
 
     public static NGram createRandom(Boolean isCustom) {
+        int possibleLength = randomIntBetween(1, 10);
         return new NGram(
             randomAlphaOfLength(10),
-            IntStream.generate(() -> randomIntBetween(1, 5)).limit(5).boxed().collect(Collectors.toList()),
+            IntStream.generate(() -> randomIntBetween(1, Math.min(possibleLength, 5))).limit(5).boxed().collect(Collectors.toList()),
             randomBoolean() ? null : randomIntBetween(0, 10),
-            randomBoolean() ? null : randomIntBetween(1, 10),
+            randomBoolean() ? null : possibleLength,
             isCustom,
             randomBoolean() ? null : randomAlphaOfLength(10));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -352,7 +352,7 @@ public class DataFrameDataExtractor {
         return ExtractedFieldsDetector.getCategoricalOutputFields(context.extractedFields, analysis);
     }
 
-    private static boolean isValidValue(Object value) {
+    public static boolean isValidValue(Object value) {
         // We should allow a number, string or a boolean.
         // It is possible for a field to be categorical and have a `keyword` mapping, but be any of these
         // three types, in the same index.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
@@ -16,6 +16,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor.isValidValue;
+
 public class ProcessedField {
     private final PreProcessor preProcessor;
 
@@ -36,8 +38,9 @@ public class ProcessedField {
     }
 
     public Object[] value(SearchHit hit, Function<String, ExtractedField> fieldExtractor) {
-        Map<String, Object> inputs = new HashMap<>(preProcessor.inputFields().size(), 1.0f);
-        for (String field : preProcessor.inputFields()) {
+        List<String> inputFields = getInputFieldNames();
+        Map<String, Object> inputs = new HashMap<>(inputFields.size(), 1.0f);
+        for (String field : inputFields) {
             ExtractedField extractedField = fieldExtractor.apply(field);
             if (extractedField == null) {
                 return new Object[0];
@@ -47,7 +50,7 @@ public class ProcessedField {
                 continue;
             }
             final Object value = values[0];
-            if (values.length == 1 && (value instanceof String || value instanceof Number)) {
+            if (values.length == 1 && (isValidValue(value))) {
                 inputs.put(field, value);
             }
         }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [ML] fix custom feature processor extraction bugs around boolean fields and custom one_hot feature output order (#64937)