### PR TITLE
Port rest integ tests to use task avoidance api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,9 +287,10 @@ gradle.projectsEvaluated {
       // :test:framework:test cannot run before and after :server:test
       return
     }
-    if (tasks.findByPath('test') != null && tasks.findByPath('integTest') != null) {
-      integTest.mustRunAfter test
+    tasks.matching {it.name.equals('integTest')}.configureEach {integTestTask ->
+      integTestTask.mustRunAfter tasks.matching { it.name.equals("test") }
     }
+
     configurations.matching { it.canBeResolved }.all { Configuration configuration ->
       dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
         Project upstreamProject = dep.dependencyProject

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -39,8 +39,8 @@ class DocsTestPlugin implements Plugin<Project> {
 
         String distribution = System.getProperty('tests.distribution', 'default')
         // The distribution can be configured with -Dtests.distribution on the command line
-        project.testClusters.integTest.testDistribution = distribution.toUpperCase()
-        project.testClusters.integTest.nameCustomization = { it.replace("integTest", "node") }
+        project.testClusters.matching { it.name.equals("integTest") }.configureEach { testDistribution = distribution.toUpperCase() }
+        project.testClusters.matching { it.name.equals("integTest") }.configureEach { nameCustomization = { it.replace("integTest", "node") } }
         // Docs are published separately so no need to assemble
         project.tasks.named("assemble").configure {enabled = false }
         Map<String, String> commonDefaultSubstitutions = [

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.TaskProvider
 
 /**
  * Adds support for starting an Elasticsearch cluster before running integration
@@ -47,10 +48,11 @@ class RestTestPlugin implements Plugin<Project> {
         }
         project.getPlugins().apply(RestTestBasePlugin.class);
         project.pluginManager.apply(TestClustersPlugin)
-        RestIntegTestTask integTest = project.tasks.create('integTest', RestIntegTestTask.class)
-        integTest.description = 'Runs rest tests against an elasticsearch cluster.'
-        integTest.group = JavaBasePlugin.VERIFICATION_GROUP
-        integTest.mustRunAfter(project.tasks.named('precommit'))
+        TaskProvider<RestIntegTestTask> integTest = project.tasks.register('integTest', RestIntegTestTask.class) {
+            it.description = 'Runs rest tests against an elasticsearch cluster.'
+            it.group = JavaBasePlugin.VERIFICATION_GROUP
+            it.mustRunAfter(project.tasks.named('precommit'))
+        }
         project.tasks.named('check').configure { it.dependsOn(integTest) }
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -64,11 +64,15 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         setupDependencies(project, yamlTestSourceSet);
 
         // setup the copy for the rest resources
-        project.getTasks().withType(CopyRestApiTask.class, copyRestApiTask -> {
-            copyRestApiTask.sourceSetName = SOURCE_SET_NAME;
-            project.getTasks().named(yamlTestSourceSet.getProcessResourcesTaskName()).configure(t -> t.dependsOn(copyRestApiTask));
-        });
-        project.getTasks().withType(CopyRestTestsTask.class, copyRestTestTask -> { copyRestTestTask.sourceSetName = SOURCE_SET_NAME; });
+        project.getTasks()
+            .withType(CopyRestApiTask.class)
+            .configureEach(copyRestApiTask -> { copyRestApiTask.sourceSetName = SOURCE_SET_NAME; });
+        project.getTasks()
+            .named(yamlTestSourceSet.getProcessResourcesTaskName())
+            .configure(t -> t.dependsOn(project.getTasks().withType(CopyRestApiTask.class)));
+        project.getTasks()
+            .withType(CopyRestTestsTask.class)
+            .configureEach(copyRestTestTask -> copyRestTestTask.sourceSetName = SOURCE_SET_NAME);
 
         // setup IDE
         GradleUtils.setupIdeForTestSourceSet(project, yamlTestSourceSet);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.gradle.testclusters;
 
+import groovy.lang.Closure;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.Nested;
@@ -44,5 +45,19 @@ public interface TestClustersAware extends Task {
     }
 
     default void beforeStart() {}
+
+    default void cluster(Closure<ElasticsearchCluster> configClosure) {
+        assert getClusters().size() == 1;
+        ElasticsearchCluster cluster = getClusters().iterator().next();
+        configClosure.setDelegate(cluster);
+        configClosure.call(cluster);
+    }
+
+    default void clusters(Closure<ElasticsearchCluster> configClosure) {
+        getClusters().stream().forEach(c -> {
+            configClosure.setDelegate(c);
+            configClosure.call(c);
+        });
+    }
 
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -39,7 +39,9 @@ public interface TestClustersAware extends Task {
         cluster.getNodes()
             .stream()
             .flatMap(node -> node.getDistributions().stream())
-            .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze())));
+            .forEach(distro ->
+                dependsOn(getProject().provider(() -> distro.maybeFreeze()))
+            );
         cluster.getNodes().forEach(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
         getClusters().add(cluster);
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -39,9 +39,7 @@ public interface TestClustersAware extends Task {
         cluster.getNodes()
             .stream()
             .flatMap(node -> node.getDistributions().stream())
-            .forEach(distro ->
-                dependsOn(getProject().provider(() -> distro.maybeFreeze()))
-            );
+            .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze())));
         cluster.getNodes().forEach(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
         getClusters().add(cluster);
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.gradle.testclusters;
 
-import groovy.lang.Closure;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.Nested;
@@ -45,19 +44,4 @@ public interface TestClustersAware extends Task {
     }
 
     default void beforeStart() {}
-
-    default void cluster(Closure<ElasticsearchCluster> configClosure) {
-        assert getClusters().size() == 1;
-        ElasticsearchCluster cluster = getClusters().iterator().next();
-        configClosure.setDelegate(cluster);
-        configClosure.call(cluster);
-    }
-
-    default void clusters(Closure<ElasticsearchCluster> configClosure) {
-        getClusters().stream().forEach(c -> {
-            configClosure.setDelegate(c);
-            configClosure.call(c);
-        });
-    }
-
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -200,12 +200,14 @@ public abstract class GradleUtils {
      * Extends one configuration from another and refreshes the classpath of a provided Test.
      * The Test parameter is only needed for eagerly defined test tasks.
      */
-    public static void extendSourceSet(Project project, String parentSourceSetName, String childSourceSetName, Test test) {
+    public static void extendSourceSet(Project project, String parentSourceSetName, String childSourceSetName, TaskProvider<Test> test) {
         extendSourceSet(project, parentSourceSetName, childSourceSetName);
         if (test != null) {
-            SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-            SourceSet child = sourceSets.getByName(childSourceSetName);
-            test.setClasspath(child.getRuntimeClasspath());
+            test.configure(t -> {
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+                SourceSet child = sourceSets.getByName(childSourceSetName);
+                t.setClasspath(child.getRuntimeClasspath());
+            });
         }
     }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -48,53 +48,57 @@ restResources {
   }
 }
 
-testClusters.integTest {
-  if (singleNode().testDistribution == DEFAULT) {
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'indices.lifecycle.history_index_enabled', 'false'
-    if (BuildParams.isSnapshotBuild() == false) {
-      systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+tasks.named("integTest").configure {
+  testClusters.integTest {
+    if (singleNode().testDistribution == DEFAULT) {
+      setting 'xpack.license.self_generated.type', 'trial'
+      setting 'indices.lifecycle.history_index_enabled', 'false'
+      if (BuildParams.isSnapshotBuild() == false) {
+        systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+      }
+      setting 'xpack.autoscaling.enabled', 'true'
+      keystorePassword 's3cr3t'
     }
-    setting 'xpack.autoscaling.enabled', 'true'
-    keystorePassword 's3cr3t'
+
+    // enable regexes in painless so our tests don't complain about example snippets that use them
+    setting 'script.painless.regex.enabled', 'true'
+    setting 'path.repo', "${buildDir}/cluster/shared/repo"
+    Closure configFile = {
+      extraConfigFile it, file("src/test/cluster/config/$it")
+    }
+    configFile 'analysis/example_word_list.txt'
+    configFile 'analysis/hyphenation_patterns.xml'
+    configFile 'analysis/synonym.txt'
+    configFile 'analysis/stemmer_override.txt'
+    configFile 'userdict_ja.txt'
+    configFile 'userdict_ko.txt'
+    configFile 'KeywordTokenizer.rbbi'
+    extraConfigFile 'hunspell/en_US/en_US.aff', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.aff')
+    extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
+    // Whitelist reindexing from the local node so we can test it.
+    setting 'reindex.remote.whitelist', '127.0.0.1:*'
+
+    // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+    systemProperty 'es.transport.cname_in_publish_address', 'true'
   }
 
-  // enable regexes in painless so our tests don't complain about example snippets that use them
-  setting 'script.painless.regex.enabled', 'true'
-  setting 'path.repo', "${buildDir}/cluster/shared/repo"
-  Closure configFile = {
-    extraConfigFile it, file("src/test/cluster/config/$it")
+  // build the cluster with all plugins
+  project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
+    /* Skip repositories. We just aren't going to be able to test them so it
+     * doesn't make sense to waste time installing them.
+     */
+    if (subproj.path.startsWith(':plugins:repository-')) {
+      return
+    }
+    // Do not install ingest-attachment in a FIPS 140 JVM as this is not supported
+    if (subproj.path.startsWith(':plugins:ingest-attachment') && BuildParams.inFipsJvm) {
+      return
+    }
+    testClusters.integTest.plugin subproj.path
   }
-  configFile 'analysis/example_word_list.txt'
-  configFile 'analysis/hyphenation_patterns.xml'
-  configFile 'analysis/synonym.txt'
-  configFile 'analysis/stemmer_override.txt'
-  configFile 'userdict_ja.txt'
-  configFile 'userdict_ko.txt'
-  configFile 'KeywordTokenizer.rbbi'
-  extraConfigFile 'hunspell/en_US/en_US.aff', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.aff')
-  extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
-  // Whitelist reindexing from the local node so we can test it.
-  setting 'reindex.remote.whitelist', '127.0.0.1:*'
-
-  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
-  systemProperty 'es.transport.cname_in_publish_address', 'true'
 }
 
-// build the cluster with all plugins
-project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
-  /* Skip repositories. We just aren't going to be able to test them so it
-   * doesn't make sense to waste time installing them.
-   */
-  if (subproj.path.startsWith(':plugins:repository-')) {
-    return
-  }
-  // Do not install ingest-attachment in a FIPS 140 JVM as this is not supported
-  if (subproj.path.startsWith(':plugins:ingest-attachment') && BuildParams.inFipsJvm) {
-    return
-  }
-  testClusters.integTest.plugin subproj.path
-}
+
 
 buildRestTests.docs = fileTree(projectDir) {
   // No snippets in here!

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -48,39 +48,37 @@ restResources {
   }
 }
 
-tasks.named("integTest").configure {
-  testClusters.integTest {
-    if (singleNode().testDistribution == DEFAULT) {
-      setting 'xpack.license.self_generated.type', 'trial'
-      setting 'indices.lifecycle.history_index_enabled', 'false'
-      if (BuildParams.isSnapshotBuild() == false) {
-        systemProperty 'es.autoscaling_feature_flag_registered', 'true'
-      }
-      setting 'xpack.autoscaling.enabled', 'true'
-      keystorePassword 's3cr3t'
+testClusters.matching { it.name == "integTest"}.configureEach {
+  if (singleNode().testDistribution == DEFAULT) {
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'indices.lifecycle.history_index_enabled', 'false'
+    if (BuildParams.isSnapshotBuild() == false) {
+      systemProperty 'es.autoscaling_feature_flag_registered', 'true'
     }
-
-    // enable regexes in painless so our tests don't complain about example snippets that use them
-    setting 'script.painless.regex.enabled', 'true'
-    setting 'path.repo', "${buildDir}/cluster/shared/repo"
-    Closure configFile = {
-      extraConfigFile it, file("src/test/cluster/config/$it")
-    }
-    configFile 'analysis/example_word_list.txt'
-    configFile 'analysis/hyphenation_patterns.xml'
-    configFile 'analysis/synonym.txt'
-    configFile 'analysis/stemmer_override.txt'
-    configFile 'userdict_ja.txt'
-    configFile 'userdict_ko.txt'
-    configFile 'KeywordTokenizer.rbbi'
-    extraConfigFile 'hunspell/en_US/en_US.aff', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.aff')
-    extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
-    // Whitelist reindexing from the local node so we can test it.
-    setting 'reindex.remote.whitelist', '127.0.0.1:*'
-
-    // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
-    systemProperty 'es.transport.cname_in_publish_address', 'true'
+    setting 'xpack.autoscaling.enabled', 'true'
+    keystorePassword 's3cr3t'
   }
+
+  // enable regexes in painless so our tests don't complain about example snippets that use them
+  setting 'script.painless.regex.enabled', 'true'
+  setting 'path.repo', "${buildDir}/cluster/shared/repo"
+  Closure configFile = {
+    extraConfigFile it, file("src/test/cluster/config/$it")
+  }
+  configFile 'analysis/example_word_list.txt'
+  configFile 'analysis/hyphenation_patterns.xml'
+  configFile 'analysis/synonym.txt'
+  configFile 'analysis/stemmer_override.txt'
+  configFile 'userdict_ja.txt'
+  configFile 'userdict_ko.txt'
+  configFile 'KeywordTokenizer.rbbi'
+  extraConfigFile 'hunspell/en_US/en_US.aff', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.aff')
+  extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
+  // Whitelist reindexing from the local node so we can test it.
+  setting 'reindex.remote.whitelist', '127.0.0.1:*'
+
+  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+  systemProperty 'es.transport.cname_in_publish_address', 'true'
 
   // build the cluster with all plugins
   project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
@@ -94,11 +92,9 @@ tasks.named("integTest").configure {
     if (subproj.path.startsWith(':plugins:ingest-attachment') && BuildParams.inFipsJvm) {
       return
     }
-    testClusters.integTest.plugin subproj.path
+    plugin subproj.path
   }
 }
-
-
 
 buildRestTests.docs = fileTree(projectDir) {
   // No snippets in here!

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -99,7 +99,7 @@ tasks.named("integTest").configure {
   dependsOn(project.tasks.named("bundlePlugin"))
 }
 
-testClusters.integTest {
+project.testClusters.matching { it.name.equals("integTest") }.configureEach {
   plugin(project.tasks.bundlePlugin.archiveFile)
 }
 

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -99,7 +99,7 @@ tasks.named("integTest").configure {
   dependsOn(project.tasks.named("bundlePlugin"))
 }
 
-project.testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   plugin(project.tasks.bundlePlugin.archiveFile)
 }
 

--- a/qa/die-with-dignity/build.gradle
+++ b/qa/die-with-dignity/build.gradle
@@ -10,9 +10,9 @@ esplugin {
 }
 
 // let the javaRestTest see the classpath of main
-GradleUtils.extendSourceSet(project, "main", "javaRestTest", javaRestTest)
+GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
-javaRestTest {
+tasks.named("javaRestTest").configure {
   systemProperty 'tests.security.manager', 'false'
   systemProperty 'tests.system_call_filter', 'false'
   nonInputProperties.systemProperty 'log', "${-> testClusters.javaRestTest.singleNode().getServerLog()}"

--- a/qa/logging-config/build.gradle
+++ b/qa/logging-config/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.standalone-test'
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   /**
    * Provide a custom log4j configuration where layout is an old style pattern and confirm that Elasticsearch
    * can successfully startup.
@@ -33,7 +33,7 @@ testClusters.integTest {
 integTest {
   nonInputProperties.systemProperty 'tests.logfile',
     "${-> testClusters.integTest.singleNode().getServerLog().absolutePath.replaceAll("_server.json", ".log")}"
-  
+
   nonInputProperties.systemProperty 'tests.jsonLogfile',
     "${-> testClusters.integTest.singleNode().getServerLog()}"
 }

--- a/qa/logging-config/build.gradle
+++ b/qa/logging-config/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.standalone-test'
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   /**
    * Provide a custom log4j configuration where layout is an old style pattern and confirm that Elasticsearch
    * can successfully startup.

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -26,6 +26,6 @@ dependencies {
   testImplementation project(':modules:ingest-common')
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'node.roles', '[data,master,remote_cluster_client]'
 }

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -26,6 +26,6 @@ dependencies {
   testImplementation project(':modules:ingest-common')
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   setting 'node.roles', '[data,master,remote_cluster_client]'
 }

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -29,12 +29,12 @@ restResources {
 }
 
 File repo = file("$buildDir/testclusters/repo")
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   numberOfNodes = 2
   setting 'path.repo', repo.absolutePath
 }
 
-integTest {
+tasks.named("integTest").configure {
   doFirst {
     project.delete(repo)
     repo.mkdirs()

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -29,7 +29,7 @@ restResources {
 }
 
 File repo = file("$buildDir/testclusters/repo")
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   numberOfNodes = 2
   setting 'path.repo', repo.absolutePath
 }

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'elasticsearch.rest-resources'
 
 int pluginsCount = 0
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   project(':plugins').getChildProjects().each { pluginName, pluginProject ->
     if (BuildParams.inFipsJvm && pluginName == "ingest-attachment") {
       // Do not attempt to install ingest-attachment in FIPS 140 as it is not supported (it depends on non-FIPS BouncyCastle)

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'elasticsearch.rest-resources'
 
 int pluginsCount = 0
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   project(':plugins').getChildProjects().each { pluginName, pluginProject ->
     if (BuildParams.inFipsJvm && pluginName == "ingest-attachment") {
       // Do not attempt to install ingest-attachment in FIPS 140 as it is not supported (it depends on non-FIPS BouncyCastle)

--- a/qa/unconfigured-node-name/build.gradle
+++ b/qa/unconfigured-node-name/build.gradle
@@ -23,11 +23,11 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   nameCustomization = { null }
 }
 
-integTest {
+tasks.named("integTest").configure {
   nonInputProperties.systemProperty 'tests.logfile',
     "${-> testClusters.integTest.singleNode().getServerLog()}"
 }

--- a/qa/unconfigured-node-name/build.gradle
+++ b/qa/unconfigured-node-name/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   nameCustomization = { null }
 }
 

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -19,5 +19,5 @@ testClusters.all {
   module ':modules:mapper-extras'
 }
 
-test.enabled = false
-jarHell.enabled = false
+tasks.named("test").configure {enabled = false }
+tasks.named("jarHell").configure {enabled = false }

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -27,7 +27,7 @@ restResources {
   }
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   extraConfigFile 'op-jwks.json', xpackProject('test:idp-fixture').file("oidc/op-jwks.json")
   extraConfigFile 'idp-docs-metadata.xml', xpackProject('test:idp-fixture').file("idp/shibboleth-idp/metadata/idp-docs-metadata.xml")
   extraConfigFile 'testClient.crt', xpackProject('plugin:security').file("src/test/resources/org/elasticsearch/xpack/security/action/pki_delegation/testClient.crt")

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -27,7 +27,7 @@ restResources {
   }
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   extraConfigFile 'op-jwks.json', xpackProject('test:idp-fixture').file("oidc/op-jwks.json")
   extraConfigFile 'idp-docs-metadata.xml', xpackProject('test:idp-fixture').file("idp/shibboleth-idp/metadata/idp-docs-metadata.xml")
   extraConfigFile 'testClient.crt', xpackProject('plugin:security').file("src/test/resources/org/elasticsearch/xpack/security/action/pki_delegation/testClient.crt")

--- a/x-pack/plugin/deprecation/qa/rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/rest/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 // let the javaRestTest see the classpath of main
-GradleUtils.extendSourceSet(project, "main", "javaRestTest", javaRestTest)
+GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
 restResources {
   restApi {

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -41,7 +41,7 @@ tasks.register('follow-cluster', RestIntegTestTask) {
   systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.matching{ it.equals('follow-cluster') }.configureEach {
+testClusters.matching{ it.name.equals('follow-cluster') }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -11,14 +11,14 @@ dependencies {
 
 File repoDir = file("$buildDir/testclusters/repo")
 
-task 'leader-cluster'(type: RestIntegTestTask) {
+tasks.register('leader-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
     systemProperty 'tests.target_cluster', 'leader'
     /* To support taking index snapshots, we have to set path.repo setting */
     systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.'leader-cluster' {
+testClusters.matching { it.name.equals('leader-cluster') }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'
@@ -29,7 +29,7 @@ testClusters.'leader-cluster' {
   setting 'indices.lifecycle.poll_interval', '1000ms'
 }
 
-task 'follow-cluster'(type: RestIntegTestTask) {
+tasks.register('follow-cluster', RestIntegTestTask) {
   dependsOn 'leader-cluster'
     useCluster testClusters.'leader-cluster'
     systemProperty 'tests.target_cluster', 'follow'
@@ -41,7 +41,7 @@ task 'follow-cluster'(type: RestIntegTestTask) {
     systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.'follow-cluster' {
+testClusters.matching{ it.equals('follow-cluster') }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'
@@ -54,5 +54,6 @@ testClusters.'follow-cluster' {
     { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
 }
 
-check.dependsOn 'follow-cluster'
-test.enabled = false // no unit tests for this module, only the rest integration test
+tasks.named("check").configure { dependsOn 'follow-cluster' }
+// no unit tests for this module, only the rest integration test
+tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -18,7 +18,7 @@ tasks.register('leader-cluster', RestIntegTestTask) {
     systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.matching { it.name.equals('leader-cluster') }.configureEach {
+testClusters.matching { it.name == 'leader-cluster' }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'
@@ -41,7 +41,7 @@ tasks.register('follow-cluster', RestIntegTestTask) {
   systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.matching{ it.name.equals('follow-cluster') }.configureEach {
+testClusters.matching{ it.name == 'follow-cluster' }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -30,15 +30,15 @@ testClusters.matching { it.name.equals('leader-cluster') }.configureEach {
 }
 
 tasks.register('follow-cluster', RestIntegTestTask) {
-  dependsOn 'leader-cluster'
-    useCluster testClusters.'leader-cluster'
-    systemProperty 'tests.target_cluster', 'follow'
-    nonInputProperties.systemProperty 'tests.leader_host',
-      "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
-    nonInputProperties.systemProperty 'tests.leader_remote_cluster_seed',
-      "${-> testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}"
-    /* To support taking index snapshots, we have to set path.repo setting */
-    systemProperty 'tests.path.repo', repoDir.absolutePath
+  dependsOn tasks.findByName('leader-cluster')
+  useCluster testClusters.'leader-cluster'
+  systemProperty 'tests.target_cluster', 'follow'
+  nonInputProperties.systemProperty 'tests.leader_host',
+    "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
+  nonInputProperties.systemProperty 'tests.leader_remote_cluster_seed',
+    "${-> testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}"
+  /* To support taking index snapshots, we have to set path.repo setting */
+  systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
 testClusters.matching{ it.equals('follow-cluster') }.configureEach {

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 }
 
 // let the javaRestTest see the classpath of main
-GradleUtils.extendSourceSet(project, "main", "javaRestTest", javaRestTest)
+GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
 
 File repoDir = file("$buildDir/testclusters/repo")

--- a/x-pack/plugin/repositories-metering-api/qa/azure/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/azure/build.gradle
@@ -66,7 +66,7 @@ integTest {
   nonInputProperties.systemProperty 'test.azure.base_path', azureBasePath + "_repositories_metering_tests_" + BuildParams.testSeed
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/repositories-metering-api/qa/azure/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/azure/build.gradle
@@ -66,7 +66,7 @@ integTest {
   nonInputProperties.systemProperty 'test.azure.base_path', azureBasePath + "_repositories_metering_tests_" + BuildParams.testSeed
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
@@ -110,7 +110,7 @@ integTest {
   nonInputProperties.systemProperty 'test.gcs.base_path', gcsBasePath + "_repositories_metering" + BuildParams.testSeed
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
@@ -110,7 +110,7 @@ integTest {
   nonInputProperties.systemProperty 'test.gcs.base_path', gcsBasePath + "_repositories_metering" + BuildParams.testSeed
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
@@ -48,7 +48,7 @@ integTest {
   nonInputProperties.systemProperty 'test.s3.base_path', s3BasePath ? s3BasePath + "_repositories_metering" + BuildParams.testSeed : 'base_path'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
@@ -48,7 +48,7 @@ integTest {
   nonInputProperties.systemProperty 'test.s3.base_path', s3BasePath ? s3BasePath + "_repositories_metering" + BuildParams.testSeed : 'base_path'
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.bundlePlugin.archiveFile
 

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -10,21 +10,18 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
-  testImplementation project(path: xpackModule('rollup'))
+    testImplementation project(path: xpackModule('rollup'))
 }
 
 restResources {
-  restApi {
-    includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
-    includeXpack 'rollup'
-  }
+    restApi {
+        includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
+        includeXpack 'rollup'
+    }
 }
 
-tasks.named("integTest").configure {
-  cluster {
+testClusters.matching { it.name == "integTest" }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.license.self_generated.type', 'basic'
     systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
-  }
 }
-

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -20,9 +20,11 @@ restResources {
   }
 }
 
-testClusters.integTest {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'basic'
-  systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+tasks.named("integTest").configure {
+  cluster {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'basic'
+    systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+  }
 }
 

--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -47,7 +47,7 @@ integTest {
   nonInputProperties.systemProperty 'test.azure.base_path', azureBasePath + "_searchable_snapshots_tests_" + BuildParams.testSeed
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -47,7 +47,7 @@ integTest {
   nonInputProperties.systemProperty 'test.azure.base_path', azureBasePath + "_searchable_snapshots_tests_" + BuildParams.testSeed
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -91,7 +91,7 @@ integTest {
   nonInputProperties.systemProperty 'test.gcs.base_path', gcsBasePath + "_searchable_snapshots_tests" + BuildParams.testSeed
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -91,7 +91,7 @@ integTest {
   nonInputProperties.systemProperty 'test.gcs.base_path', gcsBasePath + "_searchable_snapshots_tests" + BuildParams.testSeed
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -32,7 +32,7 @@ integTest {
   systemProperty 'test.minio.base_path', 'searchable_snapshots_tests'
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -32,7 +32,7 @@ integTest {
   systemProperty 'test.minio.base_path', 'searchable_snapshots_tests'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -13,7 +13,7 @@ integTest {
   systemProperty 'tests.path.repo', repoDir
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -13,7 +13,7 @@ integTest {
   systemProperty 'tests.path.repo', repoDir
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -47,7 +47,7 @@ integTest {
   nonInputProperties.systemProperty 'test.s3.base_path', s3BasePath ? s3BasePath + "_searchable_snapshots_tests" + BuildParams.testSeed : 'base_path'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -47,7 +47,7 @@ integTest {
   nonInputProperties.systemProperty 'test.s3.base_path', s3BasePath ? s3BasePath + "_searchable_snapshots_tests" + BuildParams.testSeed : 'base_path'
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -106,7 +106,7 @@ subprojects {
     apply plugin: 'elasticsearch.testclusters'
     apply plugin: 'elasticsearch.rest-test'
 
-    testClusters.matching { it.name.equals("integTest") }.configureEach {
+    testClusters.matching { it.name == "integTest" }.configureEach {
       testDistribution = 'DEFAULT'
       setting 'xpack.ml.enabled', 'false'
       setting 'xpack.watcher.enabled', 'false'

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -106,7 +106,7 @@ subprojects {
     apply plugin: 'elasticsearch.testclusters'
     apply plugin: 'elasticsearch.rest-test'
 
-    testClusters.integTest {
+    testClusters.matching { it.name.equals("integTest") }.configureEach {
       testDistribution = 'DEFAULT'
       setting 'xpack.ml.enabled', 'false'
       setting 'xpack.watcher.enabled', 'false'

--- a/x-pack/plugin/sql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/sql/qa/server/multi-node/build.gradle
@@ -6,7 +6,7 @@ description = 'Run a subset of SQL tests against multiple nodes'
  * feel should need to be tested against more than one node.
  */
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   numberOfNodes = 2
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/sql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/sql/qa/server/multi-node/build.gradle
@@ -6,7 +6,7 @@ description = 'Run a subset of SQL tests against multiple nodes'
  * feel should need to be tested against more than one node.
  */
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   numberOfNodes = 2
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     testArtifacts project(path: mainProject.path, configuration: 'testArtifacts')
   }
 
-  testClusters.matching { it.name.equals("integTest") }.configureEach {
+  testClusters.matching { it.name == "integTest" }.configureEach {
     testDistribution = 'DEFAULT'
     // Setup auditing so we can use it in some tests
     setting 'xpack.security.audit.enabled', 'true'

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     testArtifacts project(path: mainProject.path, configuration: 'testArtifacts')
   }
 
-  testClusters.integTest {
+  testClusters.matching { it.name.equals("integTest") }.configureEach {
     testDistribution = 'DEFAULT'
     // Setup auditing so we can use it in some tests
     setting 'xpack.security.audit.enabled', 'true'

--- a/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
@@ -11,7 +11,7 @@ integTest {
   }
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   // The setup that we actually want
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.http.ssl.enabled', 'true'

--- a/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
@@ -11,7 +11,7 @@ integTest {
   }
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   // The setup that we actually want
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.http.ssl.enabled', 'true'

--- a/x-pack/plugin/sql/qa/server/security/without-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/without-ssl/build.gradle
@@ -2,6 +2,6 @@ integTest {
   systemProperty 'tests.ssl.enabled', 'false'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/plugin/sql/qa/server/security/without-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/without-ssl/build.gradle
@@ -2,6 +2,6 @@ integTest {
   systemProperty 'tests.ssl.enabled', 'false'
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/plugin/sql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/sql/qa/server/single-node/build.gradle
@@ -1,4 +1,4 @@
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/plugin/sql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/sql/qa/server/single-node/build.gradle
@@ -1,4 +1,4 @@
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -24,7 +24,7 @@ integTest {
     systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -24,7 +24,7 @@ integTest {
     systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   // force localhost IPv4 otherwise it is a chicken and egg problem where we need the keytab for the hostname when starting the cluster
   // but do not know the exact address that is first in the http ports file

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   // force localhost IPv4 otherwise it is a chicken and egg problem where we need the keytab for the hostname when starting the cluster
   // but do not know the exact address that is first in the http ports file

--- a/x-pack/qa/multi-node/build.gradle
+++ b/x-pack/qa/multi-node/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/multi-node/build.gradle
+++ b/x-pack/qa/multi-node/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
   keystorePassword 's3cr3t'

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
   keystorePassword 's3cr3t'

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -21,7 +21,7 @@ forbiddenPatterns {
 
 File caFile = project.file('src/test/resources/ssl/ca.p12')
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   // Whitelist reindexing from the local node so we can test it.
   extraConfigFile 'http.key', file('src/test/resources/ssl/http.key')

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -21,7 +21,7 @@ forbiddenPatterns {
 
 File caFile = project.file('src/test/resources/ssl/ca.p12')
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   // Whitelist reindexing from the local node so we can test it.
   extraConfigFile 'http.key', file('src/test/resources/ssl/http.key')

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -21,7 +21,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 3
     }
   }
-  testClusters.matching { it.name.startsWith("${baseName}-") }.all {
+  testClusters.matching { it.name.startsWith("${baseName}-") }.configureEach {
     testDistribution = "DEFAULT"
     versions = [bwcVersion.toString(), project.version]
 
@@ -32,7 +32,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     setting 'xpack.license.self_generated.type', 'trial'
   }
 
-  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
+  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.all {
     useCluster testClusters."${baseName}-leader"
     useCluster testClusters."${baseName}-follower"
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -32,7 +32,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     setting 'xpack.license.self_generated.type', 'trial'
   }
 
-  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.all {
+  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster testClusters."${baseName}-leader"
     useCluster testClusters."${baseName}-follower"
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -41,7 +41,7 @@ tasks.register("setupPorts") {
 
 integTest.dependsOn "setupPorts"
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -41,7 +41,7 @@ tasks.register("setupPorts") {
 
 integTest.dependsOn "setupPorts"
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -8,12 +8,12 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-integTest {
+tasks.named("integTest").configure {
   nonInputProperties.systemProperty 'tests.config.dir', "${-> testClusters.integTest.singleNode().getConfigDir()}"
   systemProperty 'tests.security.manager', 'false'
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -13,7 +13,7 @@ tasks.named("integTest").configure {
   systemProperty 'tests.security.manager', 'false'
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -44,7 +44,7 @@ processTestResources.dependsOn(copyKeyCerts)
 integTest.dependsOn(copyKeyCerts)
 
 def pluginsCount = 0
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.interval', '1s'
 

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -44,7 +44,7 @@ processTestResources.dependsOn(copyKeyCerts)
 integTest.dependsOn(copyKeyCerts)
 
 def pluginsCount = 0
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.interval', '1s'
 

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 int pluginsCount = 0
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 int pluginsCount = 0
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/smoke-test-security-with-mustache/build.gradle
+++ b/x-pack/qa/smoke-test-security-with-mustache/build.gradle
@@ -13,7 +13,7 @@ restResources {
   }
 }
 
-testClusters.matching { it.name.equals("integTest") }.configureEach {
+testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/smoke-test-security-with-mustache/build.gradle
+++ b/x-pack/qa/smoke-test-security-with-mustache/build.gradle
@@ -13,7 +13,7 @@ restResources {
   }
 }
 
-testClusters.integTest {
+testClusters.matching { it.name.equals("integTest") }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.security.enabled', 'true'

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -41,7 +41,7 @@ if (!jiraUrl && !jiraUser && !jiraPassword && !jiraProject) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.integTest {
+  testClusters.matching { it.name.equals("integTest") }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -41,7 +41,7 @@ if (!jiraUrl && !jiraUser && !jiraPassword && !jiraProject) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.matching { it.name.equals("integTest") }.configureEach {
+  testClusters.matching { it.name == "integTest" }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -20,7 +20,7 @@ if (!pagerDutyServiceKey) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.integTest {
+  testClusters.matching { it.name.equals("integTest") }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -20,7 +20,7 @@ if (!pagerDutyServiceKey) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.matching { it.name.equals("integTest") }.configureEach {
+  testClusters.matching { it.name == "integTest" }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -20,7 +20,7 @@ if (!slackUrl) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.matching { it.name.equals("integTest") }.configureEach {
+  testClusters.matching { it.name == "integTest" }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -20,7 +20,7 @@ if (!slackUrl) {
   integTest.enabled = false
   testingConventions.enabled = false
 } else {
-  testClusters.integTest {
+  testClusters.matching { it.name.equals("integTest") }.configureEach {
     testDistribution = 'DEFAULT'
     setting 'xpack.security.enabled', 'false'
     setting 'xpack.ml.enabled', 'false'


### PR DESCRIPTION
This ports the majority of the rest integ tests tasks to use the task avoidance api. 

- There are some edge cases left that we need to investigate, but we can do that separately.