### PR TITLE
Unused boost parameter should not throw mapping exception (#64999)

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -94,6 +94,11 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         return new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
     }
 
+    @Override
+    protected String typeName() {
+        return "token_count";
+    }
+
     /**
      *  When position increments are counted, we're looking to make sure that we:
         - don't count tokens without an increment

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParametrizedFieldMapper.java
@@ -634,7 +634,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         // made no sense; if we've got here, that means that they're not declared on a current mapper,
         // and so we emit a deprecation warning rather than failing a previously working mapping.
         private static final Set<String> DEPRECATED_PARAMS
-            = new HashSet<>(Arrays.asList("store", "meta", "index", "doc_values", "index_options", "similarity"));
+            = new HashSet<>(Arrays.asList("store", "meta", "boost", "index", "doc_values", "index_options", "similarity"));
 
         private static boolean isDeprecatedParameter(String propName, Version indexCreatedVersion) {
             return DEPRECATED_PARAMS.contains(propName);

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -46,6 +46,11 @@ public class GeoShapeFieldMapperTests extends FieldMapperTestCase2<GeoShapeField
     }
 
     @Override
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    @Override
     protected GeoShapeFieldMapper.Builder newBuilder() {
         return new GeoShapeFieldMapper.Builder("geoshape");
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -70,6 +70,11 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
     }
 
     @Override
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    @Override
     protected void minimalMapping(XContentBuilder b) throws IOException {
         b.field("type", "geo_shape").field("strategy", "recursive");
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -246,20 +246,26 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         );
     }
 
+    protected String typeName() throws IOException {
+        MapperService ms = createMapperService(fieldMapping(this::minimalMapping));
+        return ms.fieldType("field").typeName();
+    }
+
+    protected boolean supportsOrIgnoresBoost() {
+        return true;
+    }
+
     public final void testDeprecatedBoost() throws IOException {
-        try {
-            createMapperService(fieldMapping(b -> {
-                minimalMapping(b);
-                b.field("boost", 2.0);
-            }));
-            assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
-        }
-        catch (MapperParsingException e) {
-            assertThat(e.getMessage(), anyOf(
-                containsString("unknown parameter [boost]"),
-                containsString("[boost : 2.0]")));
-        }
-        assertParseMinimalWarnings();
+        assumeTrue("Does not support [boost] parameter", supportsOrIgnoresBoost());
+        createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("boost", 2.0);
+        }));
+        String type = typeName();
+        String[] warnings = new String[] {
+            "Parameter [boost] on field [field] is deprecated and will be removed in 8.0",
+            "Parameter [boost] has no effect on type [" + type + "] and will be removed in future" };
+        allowedWarnings(warnings);
     }
 
     /**


### PR DESCRIPTION
We were correctly dealing with boosts that had an effect, but mappers
that had a silently accepted but ignored boost parameter were throwing
an error instead of continuing to ignore the boost but emitting a
warning.

Fixes #64982