### PR TITLE
Rename test module

### DIFF
--- a/x-pack/plugin/async-search/qa/rest/build.gradle
+++ b/x-pack/plugin/async-search/qa/rest/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 esplugin {
-  name 'test-deprecated-query'
+  name 'x-pack-test-deprecated-query'
   description 'Deprecated query plugin'
   classname 'org.elasticsearch.query.DeprecatedQueryPlugin'
 }


### PR DESCRIPTION
This commit renames the test module used by async-search so that it does
not trip the check on test modules published with snpashot builds. A
more robust approach will be added in the future so this is not a module
at all, but for now this fixes CI from breaking on release tests.

closes #64910