### PR TITLE
[7.x] Mark component and composable index template APIs as stable (#65013)

### DIFF
--- a/docs/reference/indices/simulate-template.asciidoc
+++ b/docs/reference/indices/simulate-template.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Simulate template</titleabbrev>
 ++++
 
-experimental[]
-
 Returns the index configuration that would be applied by a particular 
 <<indices-templates, index template>>.
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Deletes a component template"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns information about whether a particular component template exist"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns one or more component templates"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Creates or updates a component template"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Deletes an index template."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns information about whether a particular index template exists."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns an index template."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Creates or updates an index template."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate resolving the given template name or body"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mark component and composable index template APIs as stable (#65013)