### PR TITLE
Preserve ordering when resolving data stream indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -51,6 +51,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -236,7 +237,7 @@ public class IndexNameExpressionResolver {
         }
 
         boolean excludedDataStreams = false;
-        final Set<Index> concreteIndices = new HashSet<>(expressions.size());
+        final Set<Index> concreteIndices = new LinkedHashSet<>(expressions.size());
         for (String expression : expressions) {
             IndexAbstraction indexAbstraction = metadata.getIndicesLookup().get(expression);
             if (indexAbstraction == null ) {


### PR DESCRIPTION
The `IndexNameExpressionResolver::concreteIndices` method is used often to resolve the backing indices for data streams. Backing indices are ordered and the method returns an `Index[]` which implies ordering. The method also correctly resolves the backing indices in order but saves them in a local `HashSet<Index>` which is later converted to an `Index[]` at which point the ordering may be lost since hash set traversal order is non-deterministic. This changes the `HashSet<Index>` to `LinkedHashSet<Index>` which preserves the order of the backing indices.

Relates to https://github.com/elastic/elasticsearch/issues/65012