### PR TITLE
EQL: Allow null tiebreakers inside ordinals/sequences

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
@@ -25,7 +25,7 @@ public class Criterion<Q extends QueryRequest> {
 
     private final boolean reverse;
 
-    Criterion(int stage,
+    public Criterion(int stage,
               Q queryRequest,
               List<HitExtractor> keys,
               HitExtractor timestamp,
@@ -79,7 +79,7 @@ public class Criterion<Q extends QueryRequest> {
 
         if (tiebreaker != null) {
             Object tb = tiebreaker.extract(hit);
-            if (tb instanceof Comparable == false) {
+            if (tb != null && tb instanceof Comparable == false) {
                 throw new EqlIllegalArgumentException("Expected tiebreaker to be Comparable but got {}", tb);
             }
             tbreaker = (Comparable<Object>) tb;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
@@ -58,17 +58,15 @@ public class Ordinal implements Comparable<Ordinal> {
         }
         if (timestamp == o.timestamp) {
             if (tiebreaker != null) {
-                if (o.tiebreaker != null) {
-                    return tiebreaker.compareTo(o.tiebreaker);
-                }
-                // nulls are first - lower than any other value
-                // other tiebreaker is null this one isn't, fall through 1
+                // if the other tiebreaker is null, it is higher (nulls are last)
+                return o.tiebreaker != null ? tiebreaker.compareTo(o.tiebreaker) : -1;
             }
-            // null tiebreaker
+            // this tiebreaker is null
             else {
-                if (o.tiebreaker != null) {
-                    return -1;
-                } else {
+                // nulls are last so unless both are null (equal)
+                // this ordinal is greater (after) then the other tiebreaker
+                // so fall through to 1
+                if (o.tiebreaker == null) {
                     return 0;
                 }
             }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.eql.execution.search;
+
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
+import org.elasticsearch.xpack.eql.execution.assembler.BoxedQueryRequest;
+import org.elasticsearch.xpack.eql.execution.assembler.Criterion;
+import org.elasticsearch.xpack.eql.execution.search.extractor.FieldHitExtractor;
+import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+
+public class CriterionOrdinalExtractionTests extends ESTestCase {
+    private String tsField = "timestamp";
+    private String tieField = "tiebreaker";
+
+    private HitExtractor tsExtractor = new FieldHitExtractor(tsField, tsField, DataTypes.LONG, null, true, null, false);
+    private HitExtractor tieExtractor = new FieldHitExtractor(tieField, tieField, DataTypes.LONG, null, true, null, false);
+
+    public void testTimeOnly() throws Exception {
+        long time = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, null), false);
+        assertEquals(time, ordinal.timestamp());
+        assertNull(ordinal.tiebreaker());
+    }
+
+    public void testTimeAndTie() throws Exception {
+        long time = randomLong();
+        long ts = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, ts), true);
+        assertEquals(time, ordinal.timestamp());
+        assertEquals(ts, ordinal.tiebreaker());
+    }
+
+    public void testTimeAndTieNull() throws Exception {
+        long time = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, null), true);
+        assertEquals(time, ordinal.timestamp());
+        assertNull(ordinal.tiebreaker());
+    }
+
+    public void testTimeNotComparable() throws Exception {
+        HitExtractor tsWrongExtractor = new FieldHitExtractor(tsField, tsField, DataTypes.BINARY, null, true, null, false);
+        SearchHit hit = searchHit(randomAlphaOfLength(10), null);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsWrongExtractor, null, false);
+        EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
+        assertTrue(exception.getMessage().startsWith("Expected timestamp"));
+    }
+
+    public void testTieNotComparable() throws Exception {
+        final Object o = randomDateTimeZone();
+        HitExtractor tieWrongExtractor = new HitExtractor() {
+            @Override
+            public Object extract(SearchHit hit) {
+                return o;
+            }
+
+            @Override
+            public String hitName() {
+                return null;
+            }
+
+            @Override
+            public String getWriteableName() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+            }
+        };
+        SearchHit hit = searchHit(randomLong(), o);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, tieWrongExtractor, false);
+        EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
+        assertTrue(exception.getMessage().startsWith("Expected tiebreaker"));
+    }
+
+    private SearchHit searchHit(Object timeValue, Object tieValue) {
+        Map<String, DocumentField> fields = new HashMap<>();
+        fields.put(tsField, new DocumentField(tsField, singletonList(timeValue)));
+        fields.put(tieField, new DocumentField(tsField, singletonList(tieValue)));
+
+        return new SearchHit(randomInt(), randomAlphaOfLength(10), fields, emptyMap());
+    }
+
+    private Ordinal ordinal(SearchHit hit, boolean withTie) {
+        return new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, withTie ? tieExtractor : null, false).ordinal(hit);
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
@@ -55,16 +55,16 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
     }
 
     public void testTimeNotComparable() throws Exception {
-        HitExtractor tsWrongExtractor = new FieldHitExtractor(tsField, tsField, DataTypes.BINARY, null, true, null, false);
+        HitExtractor badExtractor = new FieldHitExtractor(tsField, tsField, DataTypes.BINARY, null, true, null, false);
         SearchHit hit = searchHit(randomAlphaOfLength(10), null);
-        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsWrongExtractor, null, false);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), badExtractor, null, false);
         EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
         assertTrue(exception.getMessage().startsWith("Expected timestamp"));
     }
 
     public void testTieNotComparable() throws Exception {
         final Object o = randomDateTimeZone();
-        HitExtractor tieWrongExtractor = new HitExtractor() {
+        HitExtractor badExtractor = new HitExtractor() {
             @Override
             public Object extract(SearchHit hit) {
                 return o;
@@ -85,7 +85,7 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
             }
         };
         SearchHit hit = searchHit(randomLong(), o);
-        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, tieWrongExtractor, false);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, badExtractor, false);
         EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
         assertTrue(exception.getMessage().startsWith("Expected tiebreaker"));
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
@@ -27,10 +27,10 @@ import static java.util.Collections.singletonList;
 
 public class CriterionOrdinalExtractionTests extends ESTestCase {
     private String tsField = "timestamp";
-    private String tieField = "tiebreaker";
+    private String tbField = "tiebreaker";
 
     private HitExtractor tsExtractor = new FieldHitExtractor(tsField, tsField, DataTypes.LONG, null, true, null, false);
-    private HitExtractor tieExtractor = new FieldHitExtractor(tieField, tieField, DataTypes.LONG, null, true, null, false);
+    private HitExtractor tbExtractor = new FieldHitExtractor(tbField, tbField, DataTypes.LONG, null, true, null, false);
 
     public void testTimeOnly() throws Exception {
         long time = randomLong();
@@ -39,15 +39,15 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
         assertNull(ordinal.tiebreaker());
     }
 
-    public void testTimeAndTie() throws Exception {
+    public void testTimeAndTiebreaker() throws Exception {
         long time = randomLong();
-        long ts = randomLong();
-        Ordinal ordinal = ordinal(searchHit(time, ts), true);
+        long tb = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, tb), true);
         assertEquals(time, ordinal.timestamp());
-        assertEquals(ts, ordinal.tiebreaker());
+        assertEquals(tb, ordinal.tiebreaker());
     }
 
-    public void testTimeAndTieNull() throws Exception {
+    public void testTimeAndTiebreakerNull() throws Exception {
         long time = randomLong();
         Ordinal ordinal = ordinal(searchHit(time, null), true);
         assertEquals(time, ordinal.timestamp());
@@ -62,7 +62,7 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
         assertTrue(exception.getMessage().startsWith("Expected timestamp"));
     }
 
-    public void testTieNotComparable() throws Exception {
+    public void testTiebreakerNotComparable() throws Exception {
         final Object o = randomDateTimeZone();
         HitExtractor badExtractor = new HitExtractor() {
             @Override
@@ -90,15 +90,15 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
         assertTrue(exception.getMessage().startsWith("Expected tiebreaker"));
     }
 
-    private SearchHit searchHit(Object timeValue, Object tieValue) {
+    private SearchHit searchHit(Object timeValue, Object tiebreakerValue) {
         Map<String, DocumentField> fields = new HashMap<>();
         fields.put(tsField, new DocumentField(tsField, singletonList(timeValue)));
-        fields.put(tieField, new DocumentField(tsField, singletonList(tieValue)));
+        fields.put(tbField, new DocumentField(tsField, singletonList(tiebreakerValue)));
 
         return new SearchHit(randomInt(), randomAlphaOfLength(10), fields, emptyMap());
     }
 
-    private Ordinal ordinal(SearchHit hit, boolean withTie) {
-        return new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, withTie ? tieExtractor : null, false).ordinal(hit);
+    private Ordinal ordinal(SearchHit hit, boolean withTiebreaker) {
+        return new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, withTiebreaker ? tbExtractor : null, false).ordinal(hit);
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/OrdinalTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/OrdinalTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.eql.execution.search;
+
+import org.elasticsearch.test.ESTestCase;
+
+@SuppressWarnings("unchecked")
+public class OrdinalTests extends ESTestCase {
+
+    public void testCompareToDifferentTs() {
+        Ordinal one = new Ordinal(randomLong(), (Comparable) randomLong());
+        Ordinal two = new Ordinal(randomLong(), (Comparable) randomLong());
+
+        assertEquals(Long.valueOf(one.timestamp()).compareTo(two.timestamp()), one.compareTo(two));
+    }
+
+    public void testCompareToSameTsDifferentTie() {
+        Long ts = randomLong();
+        Ordinal one = new Ordinal(ts, (Comparable) randomLong());
+        Ordinal two = new Ordinal(ts, (Comparable) randomLong());
+
+        assertEquals(one.tiebreaker().compareTo(two.tiebreaker()), one.compareTo(two));
+    }
+
+    public void testCompareToSameTsOneTieNull() {
+        Long ts = randomLong();
+        Ordinal one = new Ordinal(ts, (Comparable) randomLong());
+        Ordinal two = new Ordinal(ts, null);
+
+        assertEquals(-1, one.compareTo(two));
+    }
+
+    @SuppressWarnings("rawtypes")
+    public void testCompareToSameTsSameTie() {
+        Long ts = randomLong();
+        Comparable c = randomLong();
+        Ordinal one = new Ordinal(ts, c);
+        Ordinal two = new Ordinal(ts, c);
+
+        assertEquals(0, one.compareTo(two));
+        assertEquals(0, one.compareTo(one));
+        assertEquals(0, two.compareTo(two));
+    }
+
+    public void testCompareToSameTsSameTieNull() {
+        Long ts = randomLong();
+        Ordinal one = new Ordinal(ts, null);
+        Ordinal two = new Ordinal(ts, null);
+
+        assertEquals(0, one.compareTo(two));
+        assertEquals(0, one.compareTo(one));
+        assertEquals(0, two.compareTo(two));
+    }
+
+    public void testTestBetween() {
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
+        Ordinal between = new Ordinal(randomLongBetween(3000, 4000), (Comparable) randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+
+        assertTrue(before.between(before, after));
+        assertTrue(after.between(before, after));
+        assertTrue(between.between(before, after));
+
+        assertFalse(new Ordinal(randomLongBetween(0, 999), null).between(before, after));
+        assertFalse(new Ordinal(randomLongBetween(7000, 8000), null).between(before, after));
+    }
+
+    public void testTestBefore() {
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+
+        assertTrue(before.before(after));
+        assertFalse(before.before(before));
+        assertFalse(after.before(before));
+    }
+
+    public void testBeforeOrAt() {
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+
+        assertTrue(before.beforeOrAt(after));
+        assertTrue(before.beforeOrAt(before));
+        assertFalse(after.beforeOrAt(before));
+    }
+
+    public void testTestAfter() {
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+
+        assertTrue(after.after(before));
+        assertFalse(after.after(after));
+        assertFalse(before.after(after));
+    }
+
+    public void testAfterOrAt() {
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+
+        assertTrue(after.afterOrAt(before));
+        assertTrue(after.afterOrAt(after));
+        assertFalse(before.afterOrAt(after));
+    }
+}


### PR DESCRIPTION
Align Ordinal comparator to consider nulls last (higher) in tiebreakers.
Add unit tests to Ordinal comparisons and criterion extraction.

Fix #64706

