### PR TITLE
[docs] Note that the S3 plugin uses the OS/container truststore

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -126,6 +126,11 @@ settings belong in the `elasticsearch.yml` file.
 
     The protocol to use to connect to S3. Valid values are either `http` or
     `https`. Defaults to `https`.
+    
+    NOTE: This plugin wraps the `AmazonS3Client` which will use the default JVM
+    truststore, rather than the truststore configured in Elasticsearch.
+    If you experience certificate validation errors, add your root CA 
+    certificates to the default `cacerts` store.
 
 `proxy.host`::
 


### PR DESCRIPTION
We were having problems with the configuration of this plugin, since it kept throwing certificate validations errors.
In our case, we were connecting to an S3-compatible endpoint in our own infrastructure, of which the certificate was provided by our own internal CA.
What was confusing is that our internal CA is trusted by Elasticsearch, it's included in the truststore.

However, since this plugin wraps the `AmazonS3Client`, seems that it's using the default truststore/CA certificates, rather than the one configured in elasticsearch.

That sort of makes sense once you figure it out, but seems like that kind of caveat that should at least be documented. So I'm adding it here.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? **I have, this is not my first PR**
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? **I have, this is not my first PR**
- If submitting code, have you built your formula locally prior to submission with `gradle check`? **Not relevant, docs changes only**
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed. **Not relevant, docs changes only**
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? **Not relevant, docs changes only**
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. **Not relevant, docs changes only**