### PR TITLE
[Test] Output authResult details on test failures (#65043)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
@@ -192,10 +192,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
 
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=ironman", new SecureString(PASSWORD)), future);
-        final AuthenticationResult result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
-        final User user = result.getUser();
-        assertThat(user, is(notNullValue()));
+        final User user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContaining(containsString("Avengers")));
     }
 
@@ -211,8 +208,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
         // Thor does not have a UPN of form CN=Thor@ad.test.elasticsearch.com
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=Thor", new SecureString(PASSWORD)), future);
-        User user = future.actionGet().getUser();
-        assertThat(user, is(notNullValue()));
+        final User user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContaining(containsString("Avengers")));
     }
 
@@ -348,8 +344,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
 
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=ironman", new SecureString(PASSWORD)), future);
-        User user = future.actionGet().getUser();
-        assertThat(user, is(notNullValue()));
+        final User user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContaining(equalTo("group_role")));
     }
 
@@ -366,8 +361,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
 
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=Thor", new SecureString(PASSWORD)), future);
-        User user = future.actionGet().getUser();
-        assertThat(user, is(notNullValue()));
+        final User user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContainingInAnyOrder(equalTo("group_role"), equalTo("user_role")));
     }
 
@@ -412,18 +406,12 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
 
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=Thor", new SecureString(PASSWORD)), future);
-        AuthenticationResult result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
-        User user = result.getUser();
-        assertThat(user, notNullValue());
+        User user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContaining("_role_13"));
 
         future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("CN=ironman", new SecureString(PASSWORD)), future);
-        result = future.actionGet();
-        assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
-        user = result.getUser();
-        assertThat(user, notNullValue());
+        user = getAndVerifyAuthUser(future);
         assertThat(user.roles(), arrayContaining("_role_12"));
     }
 
@@ -559,5 +547,13 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
                     randomBoolean() ? VerificationMode.CERTIFICATE : VerificationMode.NONE);
         }
         return builder.put(extraSettings).build();
+    }
+
+    private User getAndVerifyAuthUser(PlainActionFuture<AuthenticationResult> future) {
+        final AuthenticationResult result = future.actionGet();
+        assertThat(result.toString(), result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
+        final User user = result.getUser();
+        assertThat(user, is(notNullValue()));
+        return user;
     }
 }


### PR DESCRIPTION
Currently when the tests fail to authenticate, they only show that user is null
or status is not success. It would be helpful to have knowledge about the whole 
AuthenticationResult object. This PR refactors the code to always show the 
stringified authenticationResult on failure.
