### PR TITLE
Optimize shard sorting logic for allocation.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -777,7 +777,9 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                 // that's why it's added last even though it could be easier to read
                 // if we'd apply it earlier. this comparator will only differentiate across
                 // indices all shards of the same index is treated equally.
-                return secondaryComparator.compare(o1, o2);
+                final int secondary = secondaryComparator.compare(o1, o2);
+                assert secondary != 0 : "Index names are equal, should be returned early.";
+                return secondary;
             };
             /*
              * we use 2 arrays and move replicas to the second array once we allocated an identical

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -770,16 +770,14 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                 if (o1.primary() ^ o2.primary()) {
                     return o1.primary() ? -1 : 1;
                 }
-                final int indexCmp;
-                if ((indexCmp = o1.getIndexName().compareTo(o2.getIndexName())) == 0) {
+                if (o1.getIndexName().compareTo(o2.getIndexName()) == 0) {
                     return o1.getId() - o2.getId();
                 }
                 // this comparator is more expensive than all the others up there
                 // that's why it's added last even though it could be easier to read
                 // if we'd apply it earlier. this comparator will only differentiate across
                 // indices all shards of the same index is treated equally.
-                final int secondary = secondaryComparator.compare(o1, o2);
-                return secondary == 0 ? indexCmp : secondary;
+                return secondaryComparator.compare(o1, o2);
             };
             /*
              * we use 2 arrays and move replicas to the second array once we allocated an identical


### PR DESCRIPTION
Secondary comparator orders:
1. Index priority.
2. Index creation date.
3. Index name.

So if secondary comparator returns 0, then index name must be equal, that means `indexCmp` must be 0 and first comparator would be returned in L775.
So we could remove the redundant condition checks.
