### PR TITLE
Remove unused typeParsers method from ParserContext (#65046)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -114,6 +114,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return typeParsers.apply(type);
             }
 
+            public RuntimeFieldType.Parser runtimeFieldTypeParser(String type) {
+                return runtimeTypeParsers.apply(type);
+            }
+
             public Version indexVersionCreated() {
                 return indexVersionCreated;
             }
@@ -132,10 +136,6 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             }
 
             public boolean isWithinMultiField() { return false; }
-
-            protected Function<String, TypeParser> typeParsers() { return typeParsers; }
-
-            protected Function<String, RuntimeFieldType.Parser> runtimeTypeParsers() { return runtimeTypeParsers; }
 
             protected Function<String, SimilarityProvider> similarityLookupService() { return similarityLookupService; }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
@@ -78,7 +78,7 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
                 } else {
                     type = typeNode.toString();
                 }
-                Parser typeParser = parserContext.runtimeTypeParsers().apply(type);
+                Parser typeParser = parserContext.runtimeFieldTypeParser(type);
                 if (typeParser == null) {
                     throw new MapperParsingException("No handler for type [" + type +
                         "] declared on runtime field [" + fieldName + "]");


### PR DESCRIPTION
ParserContext already exposes a typeParser(String) method hence it does not need to expose all the parsers. Same for the runtime field parsers.

