### PR TITLE
Autoscaling reactive storage decider

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -53,6 +53,8 @@ import org.elasticsearch.xpack.autoscaling.rest.RestDeleteAutoscalingPolicyHandl
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingCapacityHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingPolicyHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestPutAutoscalingPolicyHandler;
+import org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageDeciderConfiguration;
+import org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageDeciderService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.util.ArrayList;
@@ -187,6 +189,11 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
                 AutoscalingDeciderResult.Reason.class,
                 FixedAutoscalingDeciderConfiguration.NAME,
                 FixedAutoscalingDeciderService.FixedReason::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                AutoscalingDeciderConfiguration.class,
+                ReactiveStorageDeciderService.NAME,
+                ReactiveStorageDeciderConfiguration::new
             )
         );
     }
@@ -199,6 +206,11 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
                 AutoscalingDeciderConfiguration.class,
                 new ParseField(FixedAutoscalingDeciderConfiguration.NAME),
                 FixedAutoscalingDeciderConfiguration::parse
+            ),
+            new NamedXContentRegistry.Entry(
+                AutoscalingDeciderConfiguration.class,
+                new ParseField(ReactiveStorageDeciderService.NAME),
+                ReactiveStorageDeciderConfiguration::parse
             )
         );
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
@@ -13,6 +13,8 @@ import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
@@ -35,7 +37,9 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
         final ActionFilters actionFilters,
         final IndexNameExpressionResolver indexNameExpressionResolver,
         final AutoscalingCalculateCapacityService.Holder capacityServiceHolder,
-        final ClusterInfoService clusterInfoService
+        final ClusterInfoService clusterInfoService,
+        final AllocationDeciders allocationDeciders,
+        final ShardsAllocator shardsAllocator
     ) {
         super(
             GetAutoscalingCapacityAction.NAME,
@@ -48,7 +52,7 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
             GetAutoscalingCapacityAction.Response::new,
             ThreadPool.Names.SAME
         );
-        this.capacityService = capacityServiceHolder.get();
+        this.capacityService = capacityServiceHolder.get(allocationDeciders, shardsAllocator);
         this.clusterInfoService = clusterInfoService;
         assert this.capacityService != null;
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
@@ -6,8 +6,13 @@
 
 package org.elasticsearch.xpack.autoscaling.capacity;
 
+import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.Set;
 
@@ -24,4 +29,17 @@ public interface AutoscalingDeciderContext {
      * Return the nodes governed by the policy.
      */
     Set<DiscoveryNode> nodes();
+
+    /**
+     * Return the roles of the policy
+     */
+    Set<DiscoveryNodeRole> roles();
+
+    ClusterInfo info();
+
+    SnapshotShardSizeInfo snapshotShardSizeInfo();
+
+    ShardsAllocator shardsAllocator();
+
+    AllocationDeciders allocationDeciders();
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderConfiguration.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderConfiguration;
+
+import java.io.IOException;
+
+public class ReactiveStorageDeciderConfiguration implements AutoscalingDeciderConfiguration {
+    private static final ObjectParser<ReactiveStorageDeciderConfiguration, Void> PARSER;
+
+    static {
+        PARSER = new ObjectParser<>(ReactiveStorageDeciderService.NAME, ReactiveStorageDeciderConfiguration::new);
+    }
+
+    public static ReactiveStorageDeciderConfiguration parse(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public ReactiveStorageDeciderConfiguration() {}
+
+    public ReactiveStorageDeciderConfiguration(StreamInput in) throws IOException {
+        this();
+    }
+
+    @Override
+    public String name() {
+        return ReactiveStorageDeciderService.NAME;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ReactiveStorageDeciderService.NAME;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {}
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_EXCLUDE_SETTING;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_INCLUDE_SETTING;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_REQUIRE_SETTING;
+
+public class ReactiveStorageDeciderService implements AutoscalingDeciderService<ReactiveStorageDeciderConfiguration> {
+    public static final String NAME = "reactive_storage";
+
+    private static final Logger logger = LogManager.getLogger(ReactiveStorageDeciderService.class);
+
+    private static final Predicate<DiscoveryNodeRole> DATA_ROLE_PREDICATE = DiscoveryNode.getPossibleRoles()
+        .stream()
+        .filter(DiscoveryNodeRole::canContainData)
+        .collect(Collectors.toSet())::contains;
+
+    public ReactiveStorageDeciderService() {}
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public AutoscalingDeciderResult scale(ReactiveStorageDeciderConfiguration decider, AutoscalingDeciderContext context) {
+        AutoscalingCapacity autoscalingCapacity = context.currentCapacity();
+        if (autoscalingCapacity == null || autoscalingCapacity.tier().storage() == null) {
+            return new AutoscalingDeciderResult(null, new ReactiveReason("current capacity not available"));
+        }
+
+        ClusterState state = simulateStartAndAllocate(context.state(), context);
+        Predicate<IndexMetadata> indexTierPredicate = indexTierPredicate(context);
+        Predicate<DiscoveryNode> nodeTierPredicate = context.nodes()::contains;
+
+        AutoscalingCapacity plusOne = AutoscalingCapacity.builder()
+            .total(autoscalingCapacity.tier().storage().getBytes() + 1, null)
+            .build();
+        if (storagePreventsAllocation(state, context, indexTierPredicate, nodeTierPredicate)) {
+            return new AutoscalingDeciderResult(plusOne, new ReactiveReason("not enough storage available for unassigned shards"));
+        } else if (storagePreventsRemainOrMove(state, context, indexTierPredicate, nodeTierPredicate)) {
+            return new AutoscalingDeciderResult(plusOne, new ReactiveReason("not enough storage available for assigned shards"));
+        } else {
+            // the message here is tricky, since storage might not be OK, but in that case, increasing storage alone would not help since
+            // other deciders prevents allocation/moving shards.
+            AutoscalingCapacity ok = AutoscalingCapacity.builder().total(autoscalingCapacity.tier().storage(), null).build();
+            return new AutoscalingDeciderResult(ok, new ReactiveReason("storage ok"));
+        }
+    }
+
+    static boolean storagePreventsAllocation(
+        ClusterState state,
+        AutoscalingDeciderContext context,
+        Predicate<IndexMetadata> indexTierPredicate,
+        Predicate<DiscoveryNode> nodeTierPredicate
+    ) {
+        RoutingNodes routingNodes = new RoutingNodes(state, false);
+        RoutingAllocation allocation = new RoutingAllocation(
+            context.allocationDeciders(),
+            routingNodes,
+            state,
+            context.info(),
+            context.snapshotShardSizeInfo(),
+            System.nanoTime()
+        );
+        Metadata metadata = state.metadata();
+        return StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .filter(u -> indexTierPredicate.test(metadata.getIndexSafe(u.index())))
+            .anyMatch(shard -> cannotAllocateDueToStorage(shard, allocation, context, nodeTierPredicate));
+    }
+
+    static boolean storagePreventsRemainOrMove(
+        ClusterState state,
+        AutoscalingDeciderContext context,
+        Predicate<IndexMetadata> tierPredicate,
+        Predicate<DiscoveryNode> nodeTierPredicate
+    ) {
+        RoutingNodes routingNodes = new RoutingNodes(state, false);
+        RoutingAllocation allocation = new RoutingAllocation(
+            context.allocationDeciders(),
+            routingNodes,
+            state,
+            context.info(),
+            context.snapshotShardSizeInfo(),
+            System.nanoTime()
+        );
+        Metadata metadata = state.metadata();
+        return state.getRoutingNodes()
+            .shardsWithState(ShardRoutingState.STARTED)
+            .stream()
+            .filter(shard -> tierPredicate.test(metadata.getIndexSafe(shard.index())))
+            .filter(
+                shard -> context.allocationDeciders().canRemain(shard, routingNodes.node(shard.currentNodeId()), allocation) == Decision.NO
+            )
+            .filter(shard -> canAllocate(shard, allocation, context, nodeTierPredicate) == false)
+            .anyMatch(
+                shard -> cannotAllocateDueToStorage(shard, allocation, context, nodeTierPredicate)
+                    || cannotRemainDueToStorage(shard, allocation, context)
+            );
+    }
+
+    private static boolean canAllocate(
+        ShardRouting shard,
+        RoutingAllocation allocation,
+        AutoscalingDeciderContext context,
+        Predicate<DiscoveryNode> nodeTierPredicate
+    ) {
+        return nodesInTier(allocation.routingNodes(), nodeTierPredicate).anyMatch(
+            node -> context.allocationDeciders().canAllocate(shard, node, allocation) != Decision.NO
+        );
+    }
+
+    /**
+     * Check that disk decider is only decider for a node preventing allocation of the shard.
+     * @return true if and only if a node exists in the tier where only disk decider prevents allocation
+     */
+    private static boolean cannotAllocateDueToStorage(
+        ShardRouting shard,
+        RoutingAllocation allocation,
+        AutoscalingDeciderContext context,
+        Predicate<DiscoveryNode> nodeTierPredicate
+    ) {
+        assert allocation.debugDecision() == false;
+        allocation.debugDecision(true);
+        try {
+            return nodesInTier(allocation.routingNodes(), nodeTierPredicate).map(
+                node -> context.allocationDeciders().canAllocate(shard, node, allocation)
+            ).anyMatch(ReactiveStorageDeciderService::isDiskOnlyNoDecision);
+        } finally {
+            allocation.debugDecision(false);
+        }
+    }
+
+    /**
+     * Check that the disk decider is only decider that says NO to let shard remain on current node.
+     * @return true if and only if disk decider is only decider that says NO to canRemain.
+     */
+    private static boolean cannotRemainDueToStorage(ShardRouting shard, RoutingAllocation allocation, AutoscalingDeciderContext context) {
+        assert allocation.debugDecision() == false;
+        allocation.debugDecision(true);
+        try {
+            return isDiskOnlyNoDecision(
+                context.allocationDeciders().canRemain(shard, allocation.routingNodes().node(shard.currentNodeId()), allocation)
+            );
+        } finally {
+            allocation.debugDecision(false);
+        }
+    }
+
+    static boolean isDiskOnlyNoDecision(Decision decision) {
+        // we consider throttling==yes, throttling should be temporary.
+        List<Decision> nos = decision.getDecisions()
+            .stream()
+            .filter(single -> single.type() == Decision.Type.NO)
+            .collect(Collectors.toList());
+        return nos.size() == 1 && DiskThresholdDecider.NAME.equals(nos.get(0).label());
+
+    }
+
+    static Stream<RoutingNode> nodesInTier(RoutingNodes routingNodes, Predicate<DiscoveryNode> nodeTierPredicate) {
+        Predicate<RoutingNode> routingNodePredicate = rn -> nodeTierPredicate.test(rn.node());
+        return StreamSupport.stream(routingNodes.spliterator(), false).filter(routingNodePredicate);
+    }
+
+    static ClusterState simulateStartAndAllocate(ClusterState state, AutoscalingDeciderContext context) {
+        while (true) {
+            RoutingNodes routingNodes = new RoutingNodes(state, false);
+            RoutingAllocation allocation = new RoutingAllocation(
+                context.allocationDeciders(),
+                routingNodes,
+                state,
+                context.info(),
+                context.snapshotShardSizeInfo(),
+                System.nanoTime()
+            );
+
+            List<ShardRouting> shards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
+            // replicas before primaries, since replicas can be reinit'ed, resulting in a new ShardRouting instance.
+            shards.stream()
+                .filter(Predicate.not(ShardRouting::primary))
+                .forEach(s -> { allocation.routingNodes().startShard(logger, s, allocation.changes()); });
+            shards.stream()
+                .filter(ShardRouting::primary)
+                .forEach(s -> { allocation.routingNodes().startShard(logger, s, allocation.changes()); });
+            context.shardsAllocator().allocate(allocation);
+            ClusterState nextState = updateClusterState(state, allocation);
+
+            if (nextState == state) {
+                return state;
+            } else {
+                state = nextState;
+            }
+        }
+    }
+
+    static ClusterState updateClusterState(ClusterState oldState, RoutingAllocation allocation) {
+        assert allocation.metadata() == oldState.metadata();
+        if (allocation.routingNodesChanged() == false) {
+            return oldState;
+        }
+        final RoutingTable oldRoutingTable = oldState.routingTable();
+        final RoutingNodes newRoutingNodes = allocation.routingNodes();
+        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
+        final Metadata newMetadata = allocation.updateMetadataWithRoutingChanges(newRoutingTable);
+        assert newRoutingTable.validate(newMetadata); // validates the routing table is coherent with the cluster state metadata
+
+        return ClusterState.builder(oldState).routingTable(newRoutingTable).metadata(newMetadata).build();
+    }
+
+    static Predicate<IndexMetadata> indexTierPredicate(AutoscalingDeciderContext context) {
+        return imd -> belongsToTier(
+            imd,
+            context.roles().stream().filter(DATA_ROLE_PREDICATE).map(DiscoveryNodeRole::roleName).collect(Collectors.toSet())::contains
+        );
+    }
+
+    private enum OpType {
+        AND,
+        OR
+    }
+
+    private static boolean belongsToTier(IndexMetadata imd, Predicate<String> dataRoles) {
+        // some logic replication to DataTierAllcationDecider here, since we do not necessarily have a node.
+        Settings indexSettings = imd.getSettings();
+        String indexRequire = INDEX_ROUTING_REQUIRE_SETTING.get(indexSettings);
+        String indexInclude = INDEX_ROUTING_INCLUDE_SETTING.get(indexSettings);
+        String indexExclude = INDEX_ROUTING_EXCLUDE_SETTING.get(indexSettings);
+
+        if (Strings.hasText(indexRequire)) {
+            if (allocationAllowed(OpType.AND, indexRequire, dataRoles) == false) {
+                return false;
+            }
+        }
+        if (Strings.hasText(indexInclude)) {
+            if (allocationAllowed(OpType.OR, indexInclude, dataRoles) == false) {
+                return false;
+            }
+        }
+        if (Strings.hasText(indexExclude)) {
+            if (allocationAllowed(OpType.OR, indexExclude, dataRoles)) {
+                return false;
+            }
+        }
+
+        String tierPreference = INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
+        // we only take first preference to ensure we spin up new tiers as required.
+        if (Strings.hasText(tierPreference)) {
+            String tier = Strings.tokenizeToStringArray(tierPreference, ",")[0];
+            if (allocationAllowed(OpType.AND, tier, dataRoles) == false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean allocationAllowed(OpType opType, String tierSetting, Predicate<String> dataRoles) {
+        // minor logic replication to DataTierAllcationDecider here, since we do not necessarily have a node.
+        String[] values = Strings.tokenizeToStringArray(tierSetting, ",");
+        for (String value : values) {
+            // generic "data" roles are considered to have all tiers
+            if (dataRoles.test(DiscoveryNodeRole.DATA_ROLE.roleName()) || dataRoles.test(value)) {
+                if (opType == OpType.OR) {
+                    return true;
+                }
+            } else {
+                if (opType == OpType.AND) {
+                    return false;
+                }
+            }
+        }
+        if (opType == OpType.OR) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static class ReactiveReason implements AutoscalingDeciderResult.Reason {
+        private String reason;
+
+        public ReactiveReason(String reason) {
+            this.reason = reason;
+        }
+
+        public ReactiveReason(StreamInput in) throws IOException {
+            this.reason = in.readString();
+        }
+
+        @Override
+        public String summary() {
+            return reason;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return ReactiveStorageDeciderService.NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(reason);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("reason", reason);
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderConfigurationSerializationTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderConfigurationSerializationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.autoscaling.Autoscaling;
+
+import java.io.IOException;
+
+public class ReactiveStorageDeciderConfigurationSerializationTests extends AbstractSerializingTestCase<
+    ReactiveStorageDeciderConfiguration> {
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(new Autoscaling(Settings.EMPTY).getNamedWriteables());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(new Autoscaling(Settings.EMPTY).getNamedXContent());
+    }
+
+    @Override
+    protected ReactiveStorageDeciderConfiguration doParseInstance(XContentParser parser) throws IOException {
+        return ReactiveStorageDeciderConfiguration.parse(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<ReactiveStorageDeciderConfiguration> instanceReader() {
+        return ReactiveStorageDeciderConfiguration::new;
+    }
+
+    @Override
+    protected ReactiveStorageDeciderConfiguration createTestInstance() {
+        return new ReactiveStorageDeciderConfiguration();
+    }
+
+    @Override
+    protected ReactiveStorageDeciderConfiguration mutateInstance(ReactiveStorageDeciderConfiguration instance) throws IOException {
+        return null;
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
+import org.elasticsearch.xpack.core.DataTier;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Test the higher level parts of {@link ReactiveStorageDeciderService} that all require a similar setup.
+ */
+public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
+    private static final Logger logger = LogManager.getLogger(ReactiveStorageDeciderDecisionTests.class);
+
+    private static final AllocationDecider CAN_ALLOCATE_NO_DECIDER = new AllocationDecider() {
+        @Override
+        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            return Decision.NO;
+        }
+    };
+    private static final AllocationDecider CAN_REMAIN_NO_DECIDER = new AllocationDecider() {
+        @Override
+        public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            return Decision.NO;
+        }
+    };
+    private static final BalancedShardsAllocator SHARDS_ALLOCATOR = new BalancedShardsAllocator(Settings.EMPTY);
+
+    private ClusterState state;
+    private final int hotNodes = randomIntBetween(1, 8);
+    private final int warmNodes = randomIntBetween(1, 3);
+    // these are the shards that the decider tests work on
+    private Set<ShardId> subjectShards;
+    // say NO with disk label for subject shards
+    private AllocationDecider mockCanAllocateDiskDecider = new AllocationDecider() {
+        @Override
+        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) return allocation.decision(
+                Decision.NO,
+                DiskThresholdDecider.NAME,
+                "test"
+            );
+            return super.canAllocate(shardRouting, node, allocation);
+        }
+    };
+    // say NO with disk label for subject shards
+    private AllocationDecider mockCanRemainDiskDecider = new AllocationDecider() {
+        @Override
+        public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) return allocation.decision(
+                Decision.NO,
+                DiskThresholdDecider.NAME,
+                "test"
+            );
+            return super.canAllocate(shardRouting, node, allocation);
+        }
+    };
+
+    @Before
+    public void setup() {
+        DiscoveryNode.setAdditionalRoles(
+            Set.of(DataTier.DATA_CONTENT_NODE_ROLE, DataTier.DATA_HOT_NODE_ROLE, DataTier.DATA_WARM_NODE_ROLE, DataTier.DATA_COLD_NODE_ROLE)
+        );
+        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
+        state = addRandomIndices(hotNodes, hotNodes, state);
+        state = addDataNodes("data_hot", "hot", state, hotNodes);
+        state = addDataNodes("data_warm", "warm", state, warmNodes);
+        this.state = state;
+
+        Set<ShardId> shardIds = shardIds(state.getRoutingNodes().unassigned());
+        this.subjectShards = new HashSet<>(randomSubsetOf(randomIntBetween(1, shardIds.size()), shardIds));
+    }
+
+    public void testStoragePreventsAllocation() {
+        ClusterState lastState = null;
+        int maxRounds = state.getRoutingNodes().unassigned().size() + 3; // (allocated + start + detect-same)
+        int round = 0;
+        while (lastState != state && round < maxRounds) {
+            boolean prevents = hasAllocatableSubjectShards();
+            assert round != 0 || prevents;
+            verify(ReactiveStorageDeciderService::storagePreventsAllocation, prevents, mockCanAllocateDiskDecider);
+            verify(ReactiveStorageDeciderService::storagePreventsAllocation, false, mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+            verify(ReactiveStorageDeciderService::storagePreventsAllocation, false);
+            if (hasUnassignedSubjectShards()) {
+                verifyScale(1, "not enough storage available for unassigned shards", mockCanAllocateDiskDecider);
+            } else {
+                assert prevents == false;
+                verifyScale(0, "storage ok", mockCanAllocateDiskDecider);
+            }
+            verifyScale(0, "storage ok", mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+            verifyScale(0, "storage ok");
+            verifyScale(addDataNodes("data_hot", "additional", state, hotNodes), 0, "storage ok", mockCanAllocateDiskDecider);
+            lastState = state;
+            startRandomShards();
+            ++round;
+        }
+        assert round > 0;
+        assertThat(state, sameInstance(lastState));
+        assertThat(
+            ReactiveStorageDeciderService.simulateStartAndAllocate(state, createContext(mockCanAllocateDiskDecider)),
+            sameInstance(state)
+        );
+    }
+
+    public void testStoragePreventsMove() {
+        // allocate shards (will allocate all primaries)
+        allocate();
+
+        // pick set of shards to force on to warm nodes.
+        Set<ShardId> warmShards = Sets.union(new HashSet<>(randomSubsetOf(shardIds(state.getRoutingNodes().unassigned()))), subjectShards);
+
+        // start warm shards. Only use primary shards for simplicity.
+        withRoutingAllocation(
+            allocation -> allocation.routingNodes()
+                .shardsWithState(ShardRoutingState.INITIALIZING)
+                .stream()
+                .filter(ShardRouting::primary)
+                .filter(s -> warmShards.contains(s.shardId()))
+                .forEach(shard -> allocation.routingNodes().startShard(logger, shard, allocation.changes()))
+        );
+
+        do {
+            startRandomShards();
+            // all of the relevant replicas are assigned too.
+        } while (StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .map(ShardRouting::shardId)
+            .anyMatch(warmShards::contains));
+
+        // relocate warm shards to warm nodes and start them
+        withRoutingAllocation(
+            allocation -> allocation.routingNodes()
+                .shardsWithState(ShardRoutingState.STARTED)
+                .stream()
+                .filter(ShardRouting::primary)
+                .filter(s -> warmShards.contains(s.shardId()))
+                .forEach(
+                    shard -> allocation.routingNodes()
+                        .startShard(
+                            logger,
+                            allocation.routingNodes()
+                                .relocateShard(shard, randomNodeId(allocation.routingNodes(), "warm"), 0L, allocation.changes())
+                                .v2(),
+                            allocation.changes()
+                        )
+                )
+        );
+
+        verify(ReactiveStorageDeciderService::storagePreventsRemainOrMove, true, mockCanAllocateDiskDecider);
+        verify(ReactiveStorageDeciderService::storagePreventsRemainOrMove, false, mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verify(ReactiveStorageDeciderService::storagePreventsRemainOrMove, false);
+
+        verifyScale(1, "not enough storage available for assigned shards", mockCanAllocateDiskDecider);
+        verifyScale(0, "storage ok", mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok");
+        verifyScale(addDataNodes("data_hot", "additional", state, hotNodes), 0, "storage ok", mockCanAllocateDiskDecider);
+    }
+
+    public void testStoragePreventsRemain() {
+        allocate();
+        // we can only decide on a move for started shards (due to for instance ThrottlingAllocationDecider assertion).
+        for (int i = 0; i < randomIntBetween(1, 4) || hasStartedSubjectShard() == false; ++i) {
+            startRandomShards();
+        }
+
+        verify(ReactiveStorageDeciderService::storagePreventsRemainOrMove, true, mockCanRemainDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verify(
+            ReactiveStorageDeciderService::storagePreventsRemainOrMove,
+            false,
+            mockCanRemainDiskDecider,
+            CAN_REMAIN_NO_DECIDER,
+            CAN_ALLOCATE_NO_DECIDER
+        );
+        verify(ReactiveStorageDeciderService::storagePreventsRemainOrMove, false);
+
+        // maybe relocate, which means no longer started. This is OK for scale, since it simulates start.
+        startRandomShards();
+
+        verifyScale(1, "not enough storage available for assigned shards", mockCanRemainDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok", mockCanRemainDiskDecider, CAN_REMAIN_NO_DECIDER, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok");
+    }
+
+    public void testSimulateStartAndAllocate() {
+        AllocationDecider mockDecider = new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                String nodeName = node.node().getName();
+                String nodeDigit = nodeName.substring(nodeName.length() - 1);
+                return (Integer.parseInt(nodeDigit) & 1) == (shardRouting.shardId().id() & 1) ? Decision.YES : Decision.NO;
+            }
+
+            @Override
+            public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return canAllocate(shardRouting, node, allocation);
+            }
+        };
+
+        ClusterState lastState = null;
+        int maxRounds = state.getRoutingNodes().unassigned().size() + 3; // (allocate + start + detect-same)
+        int round = 0;
+        while (lastState != state && round < maxRounds) {
+            ClusterState simulatedState = ReactiveStorageDeciderService.simulateStartAndAllocate(state, createContext(mockDecider));
+            assertThat(simulatedState.nodes(), sameInstance(state.nodes()));
+            assertThat(simulatedState.metadata().indices().keys().toArray(), equalTo(state.metadata().indices().keys().toArray()));
+            assertThat(simulatedState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING), empty());
+            assertThat(simulatedState.getRoutingNodes().shardsWithState(ShardRoutingState.RELOCATING), empty());
+            RoutingAllocation allocation = createRoutingAllocation(simulatedState, createAllocationDeciders(mockDecider));
+            StreamSupport.stream(simulatedState.getRoutingNodes().spliterator(), false)
+                .flatMap(n -> n.shardsWithState(ShardRoutingState.STARTED).stream().map(s -> Tuple.tuple(n, s)))
+                .forEach(t -> verifyAllocation(t.v1(), t.v2(), allocation));
+            StreamSupport.stream(simulatedState.getRoutingNodes().unassigned().spliterator(), false)
+                .forEach(s -> verifyUnassigned(s, allocation));
+
+            lastState = state;
+            startRandomShards(createAllocationDeciders(mockDecider));
+            ++round;
+        }
+        assert round > 0;
+        assertThat(state, sameInstance(lastState));
+        assertThat(ReactiveStorageDeciderService.simulateStartAndAllocate(state, createContext(mockDecider)), sameInstance(state));
+    }
+
+    public interface BooleanVerificationSubject {
+        boolean invoke(
+            ClusterState state,
+            AutoscalingDeciderContext context,
+            Predicate<IndexMetadata> indexMetadataPredicate,
+            Predicate<DiscoveryNode> nodePredicate
+        );
+    }
+
+    public void verify(BooleanVerificationSubject subject, boolean expected, AllocationDecider... allocationDeciders) {
+        Predicate<DiscoveryNode> hotNodePredicate = n -> n.getName().startsWith("hot");
+        assertThat(subject.invoke(state, createContext(allocationDeciders), i -> true, hotNodePredicate), equalTo(expected));
+    }
+
+    public void verifyScale(int direction, String reason, AllocationDecider... allocationDeciders) {
+        verifyScale(state, direction, reason, allocationDeciders);
+    }
+
+    public static void verifyScale(ClusterState state, int direction, String reason, AllocationDecider... allocationDeciders) {
+        ReactiveStorageDeciderService decider = new ReactiveStorageDeciderService();
+        TestAutoscalingDeciderContext context = createContext(
+            state,
+            Set.of(DataTier.DATA_HOT_NODE_ROLE, DataTier.DATA_WARM_NODE_ROLE),
+            allocationDeciders
+        );
+        AutoscalingDeciderResult result = decider.scale(new ReactiveStorageDeciderConfiguration(), context);
+        // todo: change this to be deterministic tests.
+        if (context.currentCapacity != null && context.currentCapacity.tier() != null && context.currentCapacity.tier().storage() != null) {
+            assertThat(
+                Long.signum(result.requiredCapacity().tier().storage().getBytes() - context.currentCapacity.tier().storage().getBytes()),
+                equalTo(direction)
+            );
+            assertThat(result.reason().summary(), equalTo(reason));
+        } else {
+            assertThat(result.requiredCapacity(), is(nullValue()));
+            assertThat(result.reason().summary(), equalTo("current capacity not available"));
+        }
+    }
+
+    private void verifyUnassigned(ShardRouting unassigned, RoutingAllocation allocation) {
+        for (RoutingNode routingNode : allocation.routingNodes()) {
+            assertThat(allocation.deciders().canAllocate(unassigned, routingNode, allocation).type(), not(equalTo(Decision.Type.YES)));
+        }
+    }
+
+    private void verifyAllocation(RoutingNode node, ShardRouting shard, RoutingAllocation allocation) {
+        assertThat(allocation.deciders().canRemain(shard, node, allocation).type(), equalTo(Decision.Type.YES));
+    }
+
+    private boolean hasAllocatableSubjectShards() {
+        AllocationDeciders deciders = createAllocationDeciders();
+        RoutingAllocation allocation = createRoutingAllocation(state, createAllocationDeciders());
+        return StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .filter(shard -> subjectShards.contains(shard.shardId()))
+            .anyMatch(
+                shard -> StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                    .anyMatch(node -> deciders.canAllocate(shard, node, allocation) != Decision.NO)
+            );
+    }
+
+    private boolean hasUnassignedSubjectShards() {
+        return StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .anyMatch(shard -> subjectShards.contains(shard.shardId()));
+    }
+
+    private boolean hasStartedSubjectShard() {
+        return state.getRoutingNodes()
+            .shardsWithState(ShardRoutingState.STARTED)
+            .stream()
+            .filter(ShardRouting::primary)
+            .map(ShardRouting::shardId)
+            .anyMatch(subjectShards::contains);
+    }
+
+    private static AllocationDeciders createAllocationDeciders(AllocationDecider... extraDeciders) {
+        Set<Setting<?>> allSettings = Stream.concat(
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+            Stream.of(
+                DataTierAllocationDecider.CLUSTER_ROUTING_REQUIRE_SETTING,
+                DataTierAllocationDecider.CLUSTER_ROUTING_INCLUDE_SETTING,
+                DataTierAllocationDecider.CLUSTER_ROUTING_EXCLUDE_SETTING
+            )
+        ).collect(Collectors.toSet());
+
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, allSettings);
+        Collection<AllocationDecider> systemAllocationDeciders = ClusterModule.createAllocationDeciders(
+            Settings.builder()
+                .put(
+                    ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(),
+                    Integer.MAX_VALUE
+                )
+                .build(),
+            clusterSettings,
+            Collections.emptyList()
+        );
+        return new AllocationDeciders(
+            Stream.of(
+                Stream.of(extraDeciders),
+                Stream.of(new DataTierAllocationDecider(clusterSettings)),
+                systemAllocationDeciders.stream()
+            ).flatMap(s -> s).collect(Collectors.toList())
+        );
+    }
+
+    private static RoutingAllocation createRoutingAllocation(ClusterState state, AllocationDeciders allocationDeciders) {
+        RoutingNodes routingNodes = new RoutingNodes(state, false);
+        return new RoutingAllocation(allocationDeciders, routingNodes, state, createClusterInfo(state), null, System.nanoTime());
+    }
+
+    private void withRoutingAllocation(Consumer<RoutingAllocation> block) {
+        RoutingAllocation allocation = createRoutingAllocation(state, createAllocationDeciders());
+        block.accept(allocation);
+        state = ReactiveStorageDeciderService.updateClusterState(state, allocation);
+    }
+
+    private void allocate() {
+        withRoutingAllocation(SHARDS_ALLOCATOR::allocate);
+    }
+
+    private void startRandomShards() {
+        startRandomShards(createAllocationDeciders());
+    }
+
+    private void startRandomShards(AllocationDeciders allocationDeciders) {
+        RoutingAllocation allocation = createRoutingAllocation(state, allocationDeciders);
+
+        List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
+        initializingShards.sort(Comparator.comparing(ShardRouting::shardId).thenComparing(ShardRouting::primary, Boolean::compare));
+        List<ShardRouting> shards = randomSubsetOf(Math.min(randomIntBetween(1, 100), initializingShards.size()), initializingShards);
+
+        // replicas before primaries, since replicas can be reinit'ed, resulting in a new ShardRouting instance.
+        shards.stream()
+            .filter(Predicate.not(ShardRouting::primary))
+            .forEach(s -> { allocation.routingNodes().startShard(logger, s, allocation.changes()); });
+        shards.stream()
+            .filter(ShardRouting::primary)
+            .forEach(s -> { allocation.routingNodes().startShard(logger, s, allocation.changes()); });
+        SHARDS_ALLOCATOR.allocate(allocation);
+
+        // ensure progress by only relocating a shard if we started more than one shard.
+        if (shards.size() > 1 && randomBoolean()) {
+            List<ShardRouting> started = allocation.routingNodes().shardsWithState(ShardRoutingState.STARTED);
+            if (started.isEmpty() == false) {
+                ShardRouting toMove = randomFrom(started);
+                Set<RoutingNode> candidates = StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                    .filter(n -> allocation.deciders().canAllocate(toMove, n, allocation) == Decision.YES)
+                    .collect(Collectors.toSet());
+                if (candidates.isEmpty() == false) {
+                    allocation.routingNodes().relocateShard(toMove, randomFrom(candidates).nodeId(), 0L, allocation.changes());
+                }
+            }
+        }
+
+        state = ReactiveStorageDeciderService.updateClusterState(state, allocation);
+
+    }
+
+    private TestAutoscalingDeciderContext createContext(AllocationDecider... allocationDeciders) {
+        return createContext(state, Set.of(DataTier.DATA_HOT_NODE_ROLE, DataTier.DATA_WARM_NODE_ROLE), allocationDeciders);
+    }
+
+    private TestAutoscalingDeciderContext createContext(DiscoveryNodeRole role, AllocationDecider... allocationDeciders) {
+        return createContext(state, Set.of(role), allocationDeciders);
+    }
+
+    private static TestAutoscalingDeciderContext createContext(
+        ClusterState state,
+        Set<DiscoveryNodeRole> roles,
+        AllocationDecider... allocationDeciders
+    ) {
+        final BalancedShardsAllocator shardsAllocator = new BalancedShardsAllocator(Settings.EMPTY);
+        return new TestAutoscalingDeciderContext(
+            state,
+            roles,
+            shardsAllocator,
+            createAllocationDeciders(allocationDeciders),
+            randomAutoscalingCapacity()
+        );
+    }
+
+    private static class TestAutoscalingDeciderContext implements AutoscalingDeciderContext {
+        private final ClusterState state;
+        private final ShardsAllocator shardsAllocator;
+        private final AllocationDeciders allocationDeciders;
+        private final AutoscalingCapacity currentCapacity;
+        private final Set<DiscoveryNode> nodes;
+        private final Set<DiscoveryNodeRole> roles;
+        private ClusterInfo info;
+
+        private TestAutoscalingDeciderContext(
+            ClusterState state,
+            Set<DiscoveryNodeRole> roles,
+            ShardsAllocator shardsAllocator,
+            AllocationDeciders allocationDeciders,
+            AutoscalingCapacity currentCapacity
+        ) {
+            this.state = state;
+            this.shardsAllocator = shardsAllocator;
+            this.allocationDeciders = allocationDeciders;
+            this.currentCapacity = currentCapacity;
+            this.roles = roles;
+            this.nodes = StreamSupport.stream(state.nodes().spliterator(), false)
+                .filter(n -> roles.stream().anyMatch(n.getRoles()::contains))
+                .collect(Collectors.toSet());
+        }
+
+        @Override
+        public ClusterState state() {
+            return state;
+        }
+
+        @Override
+        public AutoscalingCapacity currentCapacity() {
+            return currentCapacity;
+        }
+
+        @Override
+        public Set<DiscoveryNode> nodes() {
+            return nodes;
+        }
+
+        @Override
+        public Set<DiscoveryNodeRole> roles() {
+            return roles;
+        }
+
+        @Override
+        public ClusterInfo info() {
+            if (info == null) {
+                info = createClusterInfo(state);
+            }
+            return info;
+        }
+
+        @Override
+        public SnapshotShardSizeInfo snapshotShardSizeInfo() {
+            return null;
+        }
+
+        @Override
+        public ShardsAllocator shardsAllocator() {
+            return shardsAllocator;
+        }
+
+        @Override
+        public AllocationDeciders allocationDeciders() {
+            return allocationDeciders;
+        }
+    }
+
+    private static ClusterInfo createClusterInfo(ClusterState state) {
+        // testing does not depend on info so just pretend infinite space to let regular disk decider pass
+        Map<String, DiskUsage> diskUsages = StreamSupport.stream(state.nodes().spliterator(), false)
+            .collect(Collectors.toMap(DiscoveryNode::getId, node -> new DiskUsage(node.getId(), null, "the_path", 1, 1)));
+        ImmutableOpenMap<String, DiskUsage> immutableDiskUsages = ImmutableOpenMap.<String, DiskUsage>builder().putAll(diskUsages).build();
+
+        return new ClusterInfo() {
+            @Override
+            public ImmutableOpenMap<String, DiskUsage> getNodeLeastAvailableDiskUsages() {
+                return immutableDiskUsages;
+            }
+
+            @Override
+            public ImmutableOpenMap<String, DiskUsage> getNodeMostAvailableDiskUsages() {
+                return immutableDiskUsages;
+            }
+
+            @Override
+            public String getDataPath(ShardRouting shardRouting) {
+                return "the_path";
+            }
+        };
+    }
+
+    private static ClusterState addRandomIndices(int minShards, int maxShardCopies, ClusterState state) {
+        String[] tierSettingNames = new String[] {
+            DataTierAllocationDecider.INDEX_ROUTING_REQUIRE,
+            DataTierAllocationDecider.INDEX_ROUTING_INCLUDE,
+            DataTierAllocationDecider.INDEX_ROUTING_PREFER };
+        int shards = randomIntBetween(minShards, 20);
+        Metadata.Builder builder = Metadata.builder();
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        while (shards > 0) {
+            IndexMetadata indexMetadata = IndexMetadata.builder("test" + "-" + shards)
+                .settings(settings(Version.CURRENT).put(randomFrom(tierSettingNames), "data_hot"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, maxShardCopies - 1))
+                .build();
+
+            builder.put(indexMetadata, false);
+            routingTableBuilder.addAsNew(indexMetadata);
+            shards -= indexMetadata.getNumberOfShards() * (indexMetadata.getNumberOfReplicas() + 1);
+        }
+
+        return ClusterState.builder(state).metadata(builder).routingTable(routingTableBuilder.build()).build();
+    }
+
+    private static ClusterState addDataNodes(String tier, String prefix, ClusterState state, int nodes) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder(state.nodes());
+        IntStream.range(0, nodes).mapToObj(i -> newDataNode(tier, prefix + "_" + i)).forEach(builder::add);
+        return ClusterState.builder(state).nodes(builder).build();
+    }
+
+    private static DiscoveryNode newDataNode(String tier, String nodeName) {
+        return new DiscoveryNode(
+            nodeName,
+            UUIDs.randomBase64UUID(),
+            buildNewFakeTransportAddress(),
+            Map.of(),
+            Set.of(DiscoveryNode.getRoleFromRoleName(tier)),
+            Version.CURRENT
+        );
+    }
+
+    private static String randomNodeId(RoutingNodes routingNodes, String tier) {
+        return randomFrom(
+            ReactiveStorageDeciderService.nodesInTier(routingNodes, n -> n.getName().startsWith(tier)).collect(Collectors.toSet())
+        ).nodeId();
+    }
+
+    private static Set<ShardId> shardIds(Iterable<ShardRouting> candidateShards) {
+        return StreamSupport.stream(candidateShards.spliterator(), false).map(ShardRouting::shardId).collect(Collectors.toSet());
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Tests the primitive methods in {@link ReactiveStorageDeciderService}. Tests of higher level methods are in
+ * {@link ReactiveStorageDeciderDecisionTests}
+ */
+public class ReactiveStorageDeciderServiceTests extends ESTestCase {
+    private static final List<String> SOME_ALLOCATION_DECIDERS = Arrays.asList(
+        SameShardAllocationDecider.NAME,
+        AwarenessAllocationDecider.NAME,
+        EnableAllocationDecider.NAME
+    );
+
+    public void testIsDiskOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE));
+        }
+        decision.add(new Decision.Single(Decision.Type.NO, DiskThresholdDecider.NAME, "test"));
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(
+                label -> new Decision.Single(
+                    randomValueOtherThan(Decision.Type.NO, () -> randomFrom(Decision.Type.values())),
+                    label,
+                    "test " + label
+                )
+            )
+            .forEach(decision::add);
+
+        assertThat(ReactiveStorageDeciderService.isDiskOnlyNoDecision(decision), is(true));
+    }
+
+    public void testIsNotDiskOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE, Decision.NO));
+        }
+        if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.NO, DiskThresholdDecider.NAME, "test"));
+            if (randomBoolean()) {
+                decision.add(Decision.NO);
+            } else {
+                decision.add(new Decision.Single(Decision.Type.NO, randomFrom(SOME_ALLOCATION_DECIDERS), "test"));
+            }
+        } else if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.YES, DiskThresholdDecider.NAME, "test"));
+        }
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(label -> new Decision.Single(randomFrom(Decision.Type.values()), label, "test " + label))
+            .forEach(decision::add);
+
+        assertThat(ReactiveStorageDeciderService.isDiskOnlyNoDecision(decision), is(false));
+    }
+
+    public void testNodesInTier() {
+        int hotNodes = randomIntBetween(0, 8);
+        int warmNodes = randomIntBetween(0, 8);
+        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
+        state = addDataNodes("hot", "hot", state, hotNodes);
+        Set<DiscoveryNode> expectedHotNodes = StreamSupport.stream(state.nodes().spliterator(), false).collect(Collectors.toSet());
+        state = addDataNodes("warm", "warm", state, warmNodes);
+
+        Set<DiscoveryNode> hotTier = ReactiveStorageDeciderService.nodesInTier(state.getRoutingNodes(), n -> n.getName().startsWith("hot"))
+            .map(RoutingNode::node)
+            .collect(Collectors.toSet());
+        assertThat(hotTier, equalTo(expectedHotNodes));
+    }
+
+    public void testUpdateClusterState() {
+        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
+        state = addDataNodes("hot", "hot", state, randomIntBetween(1, 20));
+        IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+        ClusterState.Builder builder = ClusterState.builder(state).metadata(Metadata.builder().put(indexMetadata, false));
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        routingTableBuilder.addAsNew(indexMetadata);
+        builder.routingTable(routingTableBuilder.build());
+        state = builder.build();
+
+        RoutingAllocation allocation = new RoutingAllocation(
+            new AllocationDeciders(Collections.emptyList()),
+            new RoutingNodes(state, false),
+            state,
+            null,
+            null,
+            System.nanoTime()
+        );
+        assertThat(ReactiveStorageDeciderService.updateClusterState(state, allocation), sameInstance(state));
+
+        RoutingNodes routingNodes = allocation.routingNodes();
+        for (RoutingNodes.UnassignedShards.UnassignedIterator iterator = routingNodes.unassigned().iterator(); iterator.hasNext();) {
+            ShardRouting candidate = iterator.next();
+            if (candidate.primary()) {
+                iterator.initialize(
+                    randomFrom(
+                        StreamSupport.stream(state.nodes().spliterator(), false).map(DiscoveryNode::getId).collect(Collectors.toList())
+                    ),
+                    null,
+                    0L,
+                    allocation.changes()
+                );
+            }
+        }
+        ClusterState updatedState = ReactiveStorageDeciderService.updateClusterState(state, allocation);
+        assertThat(updatedState, not(sameInstance(state)));
+        assertThat(
+            updatedState.getRoutingNodes().shardsWithState(ShardRoutingState.UNASSIGNED),
+            hasSize(indexMetadata.getNumberOfShards() * indexMetadata.getNumberOfReplicas())
+        );
+        assertThat(
+            updatedState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING),
+            hasSize(indexMetadata.getNumberOfShards())
+        );
+    }
+
+    private static ClusterState addDataNodes(String tier, String prefix, ClusterState state, int nodes) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder(state.nodes());
+        IntStream.range(0, nodes).mapToObj(i -> newDataNode(tier, prefix + "_" + i)).forEach(builder::add);
+        return ClusterState.builder(state).nodes(builder).build();
+    }
+
+    private static DiscoveryNode newDataNode(String tier, String nodeName) {
+        return new DiscoveryNode(
+            nodeName,
+            UUIDs.randomBase64UUID(),
+            buildNewFakeTransportAddress(),
+            Map.of("tier", tier),
+            Set.of(DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT
+        );
+    }
+}


### PR DESCRIPTION
This commits adds the initial version of the reactive storage decider.
The reactive storage decider will signal to scale up if storage alone
prevents allocation of unassigned shards or prevents shards from either
remaining where they are or moving to another node.

The reactive storage decider does not try to look into the future, thus
at the time the reactive decider asks to scale up, the cluster is
already in a need for more storage.

This initial version also only adds 1 byte to current size when a scale
up is detected, will follow-up adding the ability to calculate a better
estimate for the additional storage needed.