### PR TITLE
[DOCS] Adds recommendation about when to use chunking_config in manual mode

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -974,8 +974,9 @@ There are three available modes:
 +
 --
 * `auto`: The chunk size is dynamically calculated. This is the default and
-recommended value.
-* `manual`: Chunking is applied according to the specified `time_span`.
+recommended value when the {dfeed} does not use aggregations.
+* `manual`: Chunking is applied according to the specified `time_span`. Use this 
+mode when the {dfeed} uses aggregations.
 * `off`: No chunking is applied.
 --
 end::mode[]


### PR DESCRIPTION
## Overview

This PR adds a recommendation on when to use `chunking_config` in manual mode (and in auto mode) to the PUT datafeed API docs.

### Preview

[PUT datafeed](https://elasticsearch_65060.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html)