### PR TITLE
[7.x] [TEST] Mute SingleNodeTest.testThatLoadingWithNonExistingIndexWorks

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -38,6 +38,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
     // this is the standard setup when starting watcher in a regular cluster
     // the index does not exist, a watch gets added
     // the watch should be executed properly, despite the index being created and the cluster state listener being reloaded
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/54096")
     public void testThatLoadingWithNonExistingIndexWorks() throws Exception {
         stopWatcher();
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();


### PR DESCRIPTION
Backport of #65058
Relates #54096 
