### PR TITLE
Adding doc for the new API introduced by #64517 - /_security/saml/metadata/{realm}

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -56,6 +56,7 @@ testClusters.integTest {
   setting 'xpack.security.authc.realms.pki.pki1.certificate_authorities', '[ "testClient.crt" ]'
   setting 'xpack.security.authc.realms.pki.pki1.delegation.enabled', 'true'
   setting 'xpack.security.authc.realms.saml.saml1.order', '4'
+  setting 'xpack.security.authc.realms.saml.saml1.sp.logout', 'https://kibana.example.com/logout'
   setting 'xpack.security.authc.realms.saml.saml1.idp.entity_id', 'https://my-idp.org'
   setting 'xpack.security.authc.realms.saml.saml1.idp.metadata.path', 'idp-docs-metadata.xml'
   setting 'xpack.security.authc.realms.saml.saml1.sp.entity_id', 'https://kibana.org'

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -56,7 +56,7 @@ testClusters.integTest {
   setting 'xpack.security.authc.realms.pki.pki1.certificate_authorities', '[ "testClient.crt" ]'
   setting 'xpack.security.authc.realms.pki.pki1.delegation.enabled', 'true'
   setting 'xpack.security.authc.realms.saml.saml1.order', '4'
-  setting 'xpack.security.authc.realms.saml.saml1.sp.logout', 'https://kibana.example.com/logout'
+  setting 'xpack.security.authc.realms.saml.saml1.sp.logout', 'https://kibana.org/logout'
   setting 'xpack.security.authc.realms.saml.saml1.idp.entity_id', 'https://my-idp.org'
   setting 'xpack.security.authc.realms.saml.saml1.idp.metadata.path', 'idp-docs-metadata.xml'
   setting 'xpack.security.authc.realms.saml.saml1.sp.entity_id', 'https://kibana.org'

--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -103,6 +103,7 @@ realm when using a custom web application other than Kibana
 * <<security-api-saml-authenticate, Submit an authentication response>>
 * <<security-api-saml-logout, Logout an authenticated user>>
 * <<security-api-saml-invalidate, Submit a logout request from the IdP>>
+* <<security-api-saml-sp-metadata,Generate SAML metadata>>
 
 
 include::security/authenticate.asciidoc[]
@@ -141,4 +142,5 @@ include::security/saml-prepare-authentication-api.asciidoc[]
 include::security/saml-authenticate-api.asciidoc[]
 include::security/saml-logout-api.asciidoc[]
 include::security/saml-invalidate-api.asciidoc[]
+include::security/saml-sp-metadata.asciidoc[]
 include::security/ssl.asciidoc[]

--- a/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
@@ -7,15 +7,21 @@ Generate SAML metadata for a SAML 2.0 Service Provider.
 [[security-api-saml-sp-metadata-request]]
 ==== {api-request-title}
 
-`GET /_security/saml/metadata/<realmname>`
+`GET /_security/saml/metadata/<realm_name>`
 
 [[security-api-saml-sp-metadata-desc]]
 ==== {api-description-title}
 
-The SAML 2.0 specification provides a mechanism for Service Providers to describe their
-capabilities and configuration using a metadata file.
-This API generates Service Provider metadata, based on the configuration of a SAML realm
+The SAML 2.0 specification provides a mechanism for Service Providers to
+describe their capabilities and configuration using a metadata file. This API
+generates Service Provider metadata, based on the configuration of a SAML realm
 in Elasticsearch.
+
+[[security-api-saml-sp-metadata-path-params]]
+==== {api-path-parms-title}
+
+`<realm_name>`::
+  (Required, string) The name of the SAML realm in {es}.
 
 [[security-api-saml-sp-metadata-response-body]]
 ==== {api-response-body-title}

--- a/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
@@ -15,7 +15,7 @@ Generate SAML metadata for a SAML 2.0 Service Provider.
 The SAML 2.0 specification provides a mechanism for Service Providers to
 describe their capabilities and configuration using a metadata file. This API
 generates Service Provider metadata, based on the configuration of a SAML realm
-in Elasticsearch.
+in {es}.
 
 [[security-api-saml-sp-metadata-path-params]]
 ==== {api-path-parms-title}
@@ -39,11 +39,11 @@ SAML realm `saml1`:
 --------------------------------------------------
 GET /_security/saml/metadata/saml1
 --------------------------------------------------
-The API returns the following response:
+The API returns the following response containing the SAML metadata as an XML string:
 
 [source,console-result]
 --------------------------------------------------
 {
-    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
+    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.org/logout\"/><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -38,6 +38,7 @@ The API returns the following response:
 [source,js]
 --------------------------------------------------
 {
-    "xml_metadata":"<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.example.com/\">\n  <md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n    <md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/>\n    <md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.example.com/api/security/v1/saml\" index=\"1\" isDefault=\"true\"/>\n  </md:SPSSODescriptor>\n</md:EntityDescriptor>\n"
+    "metadata" : "<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://kibana.example.com/"><md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://kibana.example.com/logout"/><md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://kibana.example.com/api/security/v1/saml" index="1" isDefault="true"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------
+// NOTCONSOLE

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -1,0 +1,43 @@
+[role="xpack"]
+[[security-api-saml-sp-metadata]]
+=== SAML sp metadata API
+
+Generate a SAML 2.0 Service Provider Metadata.
+
+[[security-api-saml-sp-metadata-request]]
+==== {api-request-title}
+
+`POST /_security/saml/metadata/<realmname>`
+
+[[security-api-saml-sp-metadata-desc]]
+==== {api-description-title}
+
+The SAML 2.0 specification provides a mechanism for Service Providers to describe their
+capabilities and configuration using a metadata file.
+This API generates Service Provider metadata, based on the configuration of a SAML realm
+in Elasticsearch.
+
+[[security-api-saml-sp-metadata-response-body]]
+==== {api-response-body-title}
+
+`metadata`::
+(string) An XML string that contains a SAML Service Providers metadata for the realm.
+
+[[security-api-saml-sp-metadata-example]]
+==== {api-examples-title}
+
+The following example generate Service Provider metadata for
+SAML realm `saml1`:
+
+[source,console]
+--------------------------------------------------
+GET /_security/saml/metadata/saml1
+--------------------------------------------------
+The API returns the following response:
+
+[source,js]
+--------------------------------------------------
+{
+    "xml_metadata":"<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.example.com/\">\n  <md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n    <md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/>\n    <md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.example.com/api/security/v1/saml\" index=\"1\" isDefault=\"true\"/>\n  </md:SPSSODescriptor>\n</md:EntityDescriptor>\n"
+}
+--------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -38,6 +38,6 @@ The API returns the following response:
 [source,console-result]
 --------------------------------------------------
 {
-    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
+    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -38,6 +38,6 @@ The API returns the following response:
 [source,console-result]
 --------------------------------------------------
 {
-    "metadata" : "<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://kibana.example.com/"><md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://kibana.example.com/logout"/><md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://kibana.example.com/api/security/v1/saml" index="1" isDefault="true"/></md:SPSSODescriptor></md:EntityDescriptor>"
+    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.example.com/\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.example.com/api/security/v1/saml\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -38,6 +38,6 @@ The API returns the following response:
 [source,console-result]
 --------------------------------------------------
 {
-    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.example.com/\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.example.com/logout\"/><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.example.com/api/security/v1/saml\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
+    "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml_sp_metadata.asciidoc
@@ -1,13 +1,13 @@
 [role="xpack"]
 [[security-api-saml-sp-metadata]]
-=== SAML sp metadata API
+=== SAML service provider metadata API
 
-Generate a SAML 2.0 Service Provider Metadata.
+Generate SAML metadata for a SAML 2.0 Service Provider.
 
 [[security-api-saml-sp-metadata-request]]
 ==== {api-request-title}
 
-`POST /_security/saml/metadata/<realmname>`
+`GET /_security/saml/metadata/<realmname>`
 
 [[security-api-saml-sp-metadata-desc]]
 ==== {api-description-title}
@@ -21,12 +21,12 @@ in Elasticsearch.
 ==== {api-response-body-title}
 
 `metadata`::
-(string) An XML string that contains a SAML Service Providers metadata for the realm.
+(string) An XML string that contains a SAML Service Provider's metadata for the realm.
 
 [[security-api-saml-sp-metadata-example]]
 ==== {api-examples-title}
 
-The following example generate Service Provider metadata for
+The following example generates Service Provider metadata for
 SAML realm `saml1`:
 
 [source,console]
@@ -35,10 +35,9 @@ GET /_security/saml/metadata/saml1
 --------------------------------------------------
 The API returns the following response:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "metadata" : "<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://kibana.example.com/"><md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://kibana.example.com/logout"/><md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://kibana.example.com/api/security/v1/saml" index="1" isDefault="true"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------
-// NOTCONSOLE


### PR DESCRIPTION
Adding doc for the new API introduced by #64517 - /_security/saml/metadata/{realm}

Related to #49018

### Preview

* https://elasticsearch_65065.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api-saml-sp-metadata.html
* https://elasticsearch_65065.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api.html#security-saml-apis