### PR TITLE
[ML] The ML plugin doesn't need socket permissions

### DIFF
--- a/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security.policy
@@ -1,7 +1,4 @@
 grant {
-  // needed for multiple server implementations used in tests
-  permission java.net.SocketPermission "*", "accept,connect";
-
   // needed for Windows named pipes in machine learning
   permission java.io.FilePermission "\\\\.\\pipe\\*", "read,write";
 };


### PR DESCRIPTION
I think these got propagated accidentally when X-Pack
was split into multiple plugins.