### PR TITLE
Fix Needless WARN Logging during Snapshot ABORT

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.snapshots;
 
+import org.elasticsearch.snapshots.AbortedSnapshotException;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -95,7 +97,10 @@ public class IndexShardSnapshotStatus {
             this.totalFileCount = totalFileCount;
             this.incrementalSize = incrementalSize;
             this.totalSize = totalSize;
+        } else if (isAborted()) {
+            throw new AbortedSnapshotException();
         } else {
+            assert false : "Should not try to move stage [" + stage.get() + "] to [STARTED]";
             throw new IllegalStateException("Unable to move the shard snapshot status to [STARTED]: " +
                 "expecting [INIT] but got [" + stage.get() + "]");
         }
@@ -118,6 +123,7 @@ public class IndexShardSnapshotStatus {
             this.totalTime = Math.max(0L, endTime - startTime);
             this.generation.set(newGeneration);
         } else {
+            assert false : "Should not try to move stage [" + stage.get() + "] to [DONE]";
             throw new IllegalStateException("Unable to move the shard snapshot status to [DONE]: " +
                 "expecting [FINALIZE] but got [" + stage.get() + "]");
         }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -110,7 +110,10 @@ public class IndexShardSnapshotStatus {
     public synchronized Copy moveToFinalize(final long indexVersion) {
         if (stage.compareAndSet(Stage.STARTED, Stage.FINALIZE)) {
             this.indexVersion = indexVersion;
+        } else if (isAborted()) {
+            throw new AbortedSnapshotException();
         } else {
+            assert false : "Should not try to move stage [" + stage.get() + "] to [FINALIZE]";
             throw new IllegalStateException("Unable to move the shard snapshot status to [FINALIZE]: " +
                 "expecting [STARTED] but got [" + stage.get() + "]");
         }


### PR DESCRIPTION
This is spamming test and cloud logs needlessly with `WARN` logging:

The fact that we run into `ABORTED` when moving from `INIT` to `STARTED` is not a bug
since during a snapshot abort we might have concurrently moved the status to `ABORTED`
due to a cluster state update. In this case we should throw `AbortedSnapshotException`
so that upstream logic will avoid logging a warning for this expected exception.