### PR TITLE
Cleanup Snapshot ITs Further (#63985)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -36,6 +36,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.greaterThan;
@@ -78,8 +79,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         final String repo = "test-repo";
         createRepository(repo, "fs");
 
-        logger.info("--> creating snapshot 1");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot1).setIndices(indexName).setWaitForCompletion(true).get();
+        createSnapshot(repo, snapshot1, Collections.singletonList(indexName));
 
         logger.info("--> Shutting down initial primary node [{}]", primaryNode);
         stopNode(primaryNode);
@@ -87,7 +87,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         ensureYellow(indexName);
         final String snapshot2 = "snap-2";
         logger.info("--> creating snapshot 2");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot2).setIndices(indexName).setWaitForCompletion(true).get();
+        createSnapshot(repo, snapshot2, Collections.singletonList(indexName));
 
         assertTwoIdenticalShardSnapshots(repo, indexName, snapshot1, snapshot2);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataSnapshotIT.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoryMissingException;
+import org.elasticsearch.test.TestCustomMetadata;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequestBuilderThrows;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class CustomMetadataSnapshotIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(TestCustomMetadataPlugin.class);
+    }
+
+    public void testRestoreCustomMetadata() throws Exception {
+        Path tempDir = randomRepoPath();
+
+        logger.info("--> start node");
+        internalCluster().startNode();
+        createIndex("test-idx");
+        logger.info("--> add custom persistent metadata");
+        updateClusterState(currentState -> {
+            ClusterState.Builder builder = ClusterState.builder(currentState);
+            Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+            metadataBuilder.putCustom(SnapshottableMetadata.TYPE, new SnapshottableMetadata("before_snapshot_s"));
+            metadataBuilder.putCustom(NonSnapshottableMetadata.TYPE, new NonSnapshottableMetadata("before_snapshot_ns"));
+            metadataBuilder.putCustom(SnapshottableGatewayMetadata.TYPE, new SnapshottableGatewayMetadata("before_snapshot_s_gw"));
+            metadataBuilder.putCustom(NonSnapshottableGatewayMetadata.TYPE, new NonSnapshottableGatewayMetadata("before_snapshot_ns_gw"));
+            metadataBuilder.putCustom(SnapshotableGatewayNoApiMetadata.TYPE,
+                    new SnapshotableGatewayNoApiMetadata("before_snapshot_s_gw_noapi"));
+            builder.metadata(metadataBuilder);
+            return builder.build();
+        });
+
+        createRepository("test-repo", "fs", tempDir);
+        createFullSnapshot("test-repo", "test-snap");
+        assertThat(getSnapshot("test-repo", "test-snap").state(), equalTo(SnapshotState.SUCCESS));
+
+        logger.info("--> change custom persistent metadata");
+        updateClusterState(currentState -> {
+            ClusterState.Builder builder = ClusterState.builder(currentState);
+            Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+            if (randomBoolean()) {
+                metadataBuilder.putCustom(SnapshottableMetadata.TYPE, new SnapshottableMetadata("after_snapshot_s"));
+            } else {
+                metadataBuilder.removeCustom(SnapshottableMetadata.TYPE);
+            }
+            metadataBuilder.putCustom(NonSnapshottableMetadata.TYPE, new NonSnapshottableMetadata("after_snapshot_ns"));
+            if (randomBoolean()) {
+                metadataBuilder.putCustom(SnapshottableGatewayMetadata.TYPE, new SnapshottableGatewayMetadata("after_snapshot_s_gw"));
+            } else {
+                metadataBuilder.removeCustom(SnapshottableGatewayMetadata.TYPE);
+            }
+            metadataBuilder.putCustom(NonSnapshottableGatewayMetadata.TYPE, new NonSnapshottableGatewayMetadata("after_snapshot_ns_gw"));
+            metadataBuilder.removeCustom(SnapshotableGatewayNoApiMetadata.TYPE);
+            builder.metadata(metadataBuilder);
+            return builder.build();
+        });
+
+        logger.info("--> delete repository");
+        assertAcked(clusterAdmin().prepareDeleteRepository("test-repo"));
+
+        createRepository("test-repo-2", "fs", tempDir);
+
+        logger.info("--> restore snapshot");
+        clusterAdmin().prepareRestoreSnapshot("test-repo-2", "test-snap").setRestoreGlobalState(true).setIndices("-*")
+                .setWaitForCompletion(true).execute().actionGet();
+
+        logger.info("--> make sure old repository wasn't restored");
+        assertRequestBuilderThrows(clusterAdmin().prepareGetRepositories("test-repo"), RepositoryMissingException.class);
+        assertThat(clusterAdmin().prepareGetRepositories("test-repo-2").get().repositories().size(), equalTo(1));
+
+        logger.info("--> check that custom persistent metadata was restored");
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        logger.info("Cluster state: {}", clusterState);
+        Metadata metadata = clusterState.getMetadata();
+        assertThat(((SnapshottableMetadata) metadata.custom(SnapshottableMetadata.TYPE)).getData(), equalTo("before_snapshot_s"));
+        assertThat(((NonSnapshottableMetadata) metadata.custom(NonSnapshottableMetadata.TYPE)).getData(), equalTo("after_snapshot_ns"));
+        assertThat(((SnapshottableGatewayMetadata) metadata.custom(SnapshottableGatewayMetadata.TYPE)).getData(),
+                equalTo("before_snapshot_s_gw"));
+        assertThat(((NonSnapshottableGatewayMetadata) metadata.custom(NonSnapshottableGatewayMetadata.TYPE)).getData(),
+                equalTo("after_snapshot_ns_gw"));
+
+        logger.info("--> restart all nodes");
+        internalCluster().fullRestart();
+        ensureYellow();
+
+        logger.info("--> check that gateway-persistent custom metadata survived full cluster restart");
+        clusterState = clusterAdmin().prepareState().get().getState();
+        logger.info("Cluster state: {}", clusterState);
+        metadata = clusterState.getMetadata();
+        assertThat(metadata.custom(SnapshottableMetadata.TYPE), nullValue());
+        assertThat(metadata.custom(NonSnapshottableMetadata.TYPE), nullValue());
+        assertThat(((SnapshottableGatewayMetadata) metadata.custom(SnapshottableGatewayMetadata.TYPE)).getData(),
+                equalTo("before_snapshot_s_gw"));
+        assertThat(((NonSnapshottableGatewayMetadata) metadata.custom(NonSnapshottableGatewayMetadata.TYPE)).getData(),
+                equalTo("after_snapshot_ns_gw"));
+        // Shouldn't be returned as part of API response
+        assertThat(metadata.custom(SnapshotableGatewayNoApiMetadata.TYPE), nullValue());
+        // But should still be in state
+        metadata = internalCluster().getInstance(ClusterService.class).state().metadata();
+        assertThat(((SnapshotableGatewayNoApiMetadata) metadata.custom(SnapshotableGatewayNoApiMetadata.TYPE)).getData(),
+                equalTo("before_snapshot_s_gw_noapi"));
+    }
+
+    public static class TestCustomMetadataPlugin extends Plugin {
+
+        private final List<NamedWriteableRegistry.Entry> namedWritables = new ArrayList<>();
+        private final List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
+
+        public TestCustomMetadataPlugin() {
+            registerBuiltinWritables();
+        }
+
+        private <T extends Metadata.Custom> void registerMetadataCustom(String name, Writeable.Reader<T> reader,
+                                                                        Writeable.Reader<NamedDiff> diffReader,
+                                                                        CheckedFunction<XContentParser, T, IOException> parser) {
+            namedWritables.add(new NamedWriteableRegistry.Entry(Metadata.Custom.class, name, reader));
+            namedWritables.add(new NamedWriteableRegistry.Entry(NamedDiff.class, name, diffReader));
+            namedXContents.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(name), parser));
+        }
+
+        private void registerBuiltinWritables() {
+            registerMetadataCustom(SnapshottableMetadata.TYPE, SnapshottableMetadata::readFrom,
+                    SnapshottableMetadata::readDiffFrom, SnapshottableMetadata::fromXContent);
+            registerMetadataCustom(NonSnapshottableMetadata.TYPE, NonSnapshottableMetadata::readFrom,
+                    NonSnapshottableMetadata::readDiffFrom, NonSnapshottableMetadata::fromXContent);
+            registerMetadataCustom(SnapshottableGatewayMetadata.TYPE, SnapshottableGatewayMetadata::readFrom,
+                    SnapshottableGatewayMetadata::readDiffFrom, SnapshottableGatewayMetadata::fromXContent);
+            registerMetadataCustom(NonSnapshottableGatewayMetadata.TYPE, NonSnapshottableGatewayMetadata::readFrom,
+                    NonSnapshottableGatewayMetadata::readDiffFrom, NonSnapshottableGatewayMetadata::fromXContent);
+            registerMetadataCustom(SnapshotableGatewayNoApiMetadata.TYPE, SnapshotableGatewayNoApiMetadata::readFrom,
+                    NonSnapshottableGatewayMetadata::readDiffFrom, SnapshotableGatewayNoApiMetadata::fromXContent);
+        }
+
+        @Override
+        public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+            return namedWritables;
+        }
+
+        @Override
+        public List<NamedXContentRegistry.Entry> getNamedXContent() {
+            return namedXContents;
+        }
+    }
+
+    private static class SnapshottableMetadata extends TestCustomMetadata {
+        public static final String TYPE = "test_snapshottable";
+
+        SnapshottableMetadata(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        public static SnapshottableMetadata readFrom(StreamInput in) throws IOException {
+            return readFrom(SnapshottableMetadata::new, in);
+        }
+
+        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+            return readDiffFrom(TYPE, in);
+        }
+
+        public static SnapshottableMetadata fromXContent(XContentParser parser) throws IOException {
+            return fromXContent(SnapshottableMetadata::new, parser);
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return Metadata.API_AND_SNAPSHOT;
+        }
+    }
+
+    private static class NonSnapshottableMetadata extends TestCustomMetadata {
+        public static final String TYPE = "test_non_snapshottable";
+
+        NonSnapshottableMetadata(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        public static NonSnapshottableMetadata readFrom(StreamInput in) throws IOException {
+            return readFrom(NonSnapshottableMetadata::new, in);
+        }
+
+        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+            return readDiffFrom(TYPE, in);
+        }
+
+        public static NonSnapshottableMetadata fromXContent(XContentParser parser) throws IOException {
+            return fromXContent(NonSnapshottableMetadata::new, parser);
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return Metadata.API_ONLY;
+        }
+    }
+
+    private static class SnapshottableGatewayMetadata extends TestCustomMetadata {
+        public static final String TYPE = "test_snapshottable_gateway";
+
+        SnapshottableGatewayMetadata(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        public static SnapshottableGatewayMetadata readFrom(StreamInput in) throws IOException {
+            return readFrom(SnapshottableGatewayMetadata::new, in);
+        }
+
+        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+            return readDiffFrom(TYPE, in);
+        }
+
+        public static SnapshottableGatewayMetadata fromXContent(XContentParser parser) throws IOException {
+            return fromXContent(SnapshottableGatewayMetadata::new, parser);
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.API, Metadata.XContentContext.SNAPSHOT, Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class NonSnapshottableGatewayMetadata extends TestCustomMetadata {
+        public static final String TYPE = "test_non_snapshottable_gateway";
+
+        NonSnapshottableGatewayMetadata(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        public static NonSnapshottableGatewayMetadata readFrom(StreamInput in) throws IOException {
+            return readFrom(NonSnapshottableGatewayMetadata::new, in);
+        }
+
+        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+            return readDiffFrom(TYPE, in);
+        }
+
+        public static NonSnapshottableGatewayMetadata fromXContent(XContentParser parser) throws IOException {
+            return fromXContent(NonSnapshottableGatewayMetadata::new, parser);
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return Metadata.API_AND_GATEWAY;
+        }
+
+    }
+
+    private static class SnapshotableGatewayNoApiMetadata extends TestCustomMetadata {
+        public static final String TYPE = "test_snapshottable_gateway_no_api";
+
+        SnapshotableGatewayNoApiMetadata(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        public static SnapshotableGatewayNoApiMetadata readFrom(StreamInput in) throws IOException {
+            return readFrom(SnapshotableGatewayNoApiMetadata::new, in);
+        }
+
+        public static SnapshotableGatewayNoApiMetadata fromXContent(XContentParser parser) throws IOException {
+            return fromXContent(SnapshotableGatewayNoApiMetadata::new, parser);
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT);
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataSnapshotIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoryMissingException;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.TestCustomMetadata;
 
 import java.io.IOException;
@@ -47,6 +48,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequ
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class CustomMetadataSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.snapshots;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -35,29 +34,16 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.CheckedFunction;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
 import org.elasticsearch.index.seqno.RetentionLeases;
@@ -66,7 +52,6 @@ import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.rest.AbstractRestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -78,7 +63,6 @@ import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.TestCustomMetadata;
 import org.elasticsearch.test.disruption.BusyMasterServiceDisruption;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -96,20 +80,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequestBuilderThrows;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -120,213 +101,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0, transportClientRatio = 0)
 public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
 
-    public static class TestCustomMetadataPlugin extends Plugin {
-
-        private final List<NamedWriteableRegistry.Entry> namedWritables = new ArrayList<>();
-        private final List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
-
-        public TestCustomMetadataPlugin() {
-            registerBuiltinWritables();
-        }
-
-        private <T extends Metadata.Custom> void registerMetadataCustom(String name, Writeable.Reader<T> reader,
-                                                                        Writeable.Reader<NamedDiff> diffReader,
-                                                                        CheckedFunction<XContentParser, T, IOException> parser) {
-            namedWritables.add(new NamedWriteableRegistry.Entry(Metadata.Custom.class, name, reader));
-            namedWritables.add(new NamedWriteableRegistry.Entry(NamedDiff.class, name, diffReader));
-            namedXContents.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(name), parser));
-        }
-
-        private void registerBuiltinWritables() {
-            registerMetadataCustom(SnapshottableMetadata.TYPE, SnapshottableMetadata::readFrom,
-                SnapshottableMetadata::readDiffFrom, SnapshottableMetadata::fromXContent);
-            registerMetadataCustom(NonSnapshottableMetadata.TYPE, NonSnapshottableMetadata::readFrom,
-                NonSnapshottableMetadata::readDiffFrom, NonSnapshottableMetadata::fromXContent);
-            registerMetadataCustom(SnapshottableGatewayMetadata.TYPE, SnapshottableGatewayMetadata::readFrom,
-                SnapshottableGatewayMetadata::readDiffFrom, SnapshottableGatewayMetadata::fromXContent);
-            registerMetadataCustom(NonSnapshottableGatewayMetadata.TYPE, NonSnapshottableGatewayMetadata::readFrom,
-                NonSnapshottableGatewayMetadata::readDiffFrom, NonSnapshottableGatewayMetadata::fromXContent);
-            registerMetadataCustom(SnapshotableGatewayNoApiMetadata.TYPE, SnapshotableGatewayNoApiMetadata::readFrom,
-                NonSnapshottableGatewayMetadata::readDiffFrom, SnapshotableGatewayNoApiMetadata::fromXContent);
-        }
-
-        @Override
-        public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-            return namedWritables;
-        }
-
-        @Override
-        public List<NamedXContentRegistry.Entry> getNamedXContent() {
-            return namedXContents;
-        }
-    }
-
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockRepository.Plugin.class, TestCustomMetadataPlugin.class, BrokenSettingPlugin.class,
-                MockTransportService.TestPlugin.class);
-    }
-
-    public static class BrokenSettingPlugin extends Plugin {
-        private static boolean breakSetting = false;
-        private static final IllegalArgumentException EXCEPTION =  new IllegalArgumentException("this setting goes boom");
-
-        static void breakSetting(boolean breakSetting) {
-            BrokenSettingPlugin.breakSetting = breakSetting;
-        }
-
-        static final Setting<String> BROKEN_SETTING = new Setting<>("setting.broken", "default", s->s,
-                s-> {
-                    if ((s.equals("default") == false && breakSetting)) {
-                        throw EXCEPTION;
-                    }
-                },
-                Setting.Property.NodeScope, Setting.Property.Dynamic);
-
-        @Override
-        public List<Setting<?>> getSettings() {
-            return Collections.singletonList(BROKEN_SETTING);
-        }
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37485")
-    public void testExceptionWhenRestoringPersistentSettings() {
-        logger.info("--> start 2 nodes");
-        internalCluster().startNodes(2);
-
-        Client client = client();
-        Consumer<String> setSettingValue = value -> {
-            client.admin().cluster().prepareUpdateSettings().setPersistentSettings(
-                    Settings.builder()
-                            .put(BrokenSettingPlugin.BROKEN_SETTING.getKey(), value))
-                    .execute().actionGet();
-        };
-
-        Consumer<String> assertSettingValue = value -> {
-            assertThat(client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).execute().actionGet().getState()
-                            .getMetadata().persistentSettings().get(BrokenSettingPlugin.BROKEN_SETTING.getKey()),
-                    equalTo(value));
-        };
-
-        logger.info("--> set test persistent setting");
-        setSettingValue.accept("new value");
-        assertSettingValue.accept("new value");
-
-        createRepository("test-repo", "fs");
-        createFullSnapshot("test-repo", "test-snap");
-        assertThat(getSnapshot("test-repo", "test-snap").state(), equalTo(SnapshotState.SUCCESS));
-
-        logger.info("--> change the test persistent setting and break it");
-        setSettingValue.accept("new value 2");
-        assertSettingValue.accept("new value 2");
-        BrokenSettingPlugin.breakSetting(true);
-
-        logger.info("--> restore snapshot");
-        try {
-            client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setRestoreGlobalState(true)
-                .setWaitForCompletion(true).execute().actionGet();
-
-        } catch (IllegalArgumentException ex) {
-            assertEquals(BrokenSettingPlugin.EXCEPTION.getMessage(), ex.getMessage());
-        }
-
-        assertSettingValue.accept("new value 2");
-    }
-
-    public void testRestoreCustomMetadata() throws Exception {
-        Path tempDir = randomRepoPath();
-
-        logger.info("--> start node");
-        internalCluster().startNode();
-        createIndex("test-idx");
-        logger.info("--> add custom persistent metadata");
-        updateClusterState(currentState -> {
-            ClusterState.Builder builder = ClusterState.builder(currentState);
-            Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
-            metadataBuilder.putCustom(SnapshottableMetadata.TYPE, new SnapshottableMetadata("before_snapshot_s"));
-            metadataBuilder.putCustom(NonSnapshottableMetadata.TYPE, new NonSnapshottableMetadata("before_snapshot_ns"));
-            metadataBuilder.putCustom(SnapshottableGatewayMetadata.TYPE, new SnapshottableGatewayMetadata("before_snapshot_s_gw"));
-            metadataBuilder.putCustom(NonSnapshottableGatewayMetadata.TYPE, new NonSnapshottableGatewayMetadata("before_snapshot_ns_gw"));
-            metadataBuilder.putCustom(SnapshotableGatewayNoApiMetadata.TYPE,
-                new SnapshotableGatewayNoApiMetadata("before_snapshot_s_gw_noapi"));
-            builder.metadata(metadataBuilder);
-            return builder.build();
-        });
-
-        createRepository("test-repo", "fs", tempDir);
-        createFullSnapshot("test-repo", "test-snap");
-        assertThat(getSnapshot("test-repo", "test-snap").state(), equalTo(SnapshotState.SUCCESS));
-
-        logger.info("--> change custom persistent metadata");
-        updateClusterState(currentState -> {
-            ClusterState.Builder builder = ClusterState.builder(currentState);
-            Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
-            if (randomBoolean()) {
-                metadataBuilder.putCustom(SnapshottableMetadata.TYPE, new SnapshottableMetadata("after_snapshot_s"));
-            } else {
-                metadataBuilder.removeCustom(SnapshottableMetadata.TYPE);
-            }
-            metadataBuilder.putCustom(NonSnapshottableMetadata.TYPE, new NonSnapshottableMetadata("after_snapshot_ns"));
-            if (randomBoolean()) {
-                metadataBuilder.putCustom(SnapshottableGatewayMetadata.TYPE, new SnapshottableGatewayMetadata("after_snapshot_s_gw"));
-            } else {
-                metadataBuilder.removeCustom(SnapshottableGatewayMetadata.TYPE);
-            }
-            metadataBuilder.putCustom(NonSnapshottableGatewayMetadata.TYPE, new NonSnapshottableGatewayMetadata("after_snapshot_ns_gw"));
-            metadataBuilder.removeCustom(SnapshotableGatewayNoApiMetadata.TYPE);
-            builder.metadata(metadataBuilder);
-            return builder.build();
-        });
-
-        logger.info("--> delete repository");
-        assertAcked(clusterAdmin().prepareDeleteRepository("test-repo"));
-
-        createRepository("test-repo-2", "fs", tempDir);
-
-        logger.info("--> restore snapshot");
-        clusterAdmin().prepareRestoreSnapshot("test-repo-2", "test-snap").setRestoreGlobalState(true).setIndices("-*")
-            .setWaitForCompletion(true).execute().actionGet();
-
-        logger.info("--> make sure old repository wasn't restored");
-        assertRequestBuilderThrows(clusterAdmin().prepareGetRepositories("test-repo"), RepositoryMissingException.class);
-        assertThat(clusterAdmin().prepareGetRepositories("test-repo-2").get().repositories().size(), equalTo(1));
-
-        logger.info("--> check that custom persistent metadata was restored");
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
-        logger.info("Cluster state: {}", clusterState);
-        Metadata metadata = clusterState.getMetadata();
-        assertThat(((SnapshottableMetadata) metadata.custom(SnapshottableMetadata.TYPE)).getData(), equalTo("before_snapshot_s"));
-        assertThat(((NonSnapshottableMetadata) metadata.custom(NonSnapshottableMetadata.TYPE)).getData(), equalTo("after_snapshot_ns"));
-        assertThat(((SnapshottableGatewayMetadata) metadata.custom(SnapshottableGatewayMetadata.TYPE)).getData(),
-            equalTo("before_snapshot_s_gw"));
-        assertThat(((NonSnapshottableGatewayMetadata) metadata.custom(NonSnapshottableGatewayMetadata.TYPE)).getData(),
-            equalTo("after_snapshot_ns_gw"));
-
-        logger.info("--> restart all nodes");
-        internalCluster().fullRestart();
-        ensureYellow();
-
-        logger.info("--> check that gateway-persistent custom metadata survived full cluster restart");
-        clusterState = clusterAdmin().prepareState().get().getState();
-        logger.info("Cluster state: {}", clusterState);
-        metadata = clusterState.getMetadata();
-        assertThat(metadata.custom(SnapshottableMetadata.TYPE), nullValue());
-        assertThat(metadata.custom(NonSnapshottableMetadata.TYPE), nullValue());
-        assertThat(((SnapshottableGatewayMetadata) metadata.custom(SnapshottableGatewayMetadata.TYPE)).getData(),
-            equalTo("before_snapshot_s_gw"));
-        assertThat(((NonSnapshottableGatewayMetadata) metadata.custom(NonSnapshottableGatewayMetadata.TYPE)).getData(),
-            equalTo("after_snapshot_ns_gw"));
-        // Shouldn't be returned as part of API response
-        assertThat(metadata.custom(SnapshotableGatewayNoApiMetadata.TYPE), nullValue());
-        // But should still be in state
-        metadata = internalCluster().getInstance(ClusterService.class).state().metadata();
-        assertThat(((SnapshotableGatewayNoApiMetadata) metadata.custom(SnapshotableGatewayNoApiMetadata.TYPE)).getData(),
-            equalTo("before_snapshot_s_gw_noapi"));
+        return Arrays.asList(MockRepository.Plugin.class, MockTransportService.TestPlugin.class);
     }
 
     public void testSnapshotDuringNodeShutdown() throws Exception {
@@ -426,9 +207,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
     public void testRestoreIndexWithMissingShards() throws Exception {
         disableRepoConsistencyCheck("This test leaves behind a purposely broken repository");
         logger.info("--> start 2 nodes");
-        internalCluster().startNode();
-        internalCluster().startNode();
-        cluster().wipeIndices("_all");
+        internalCluster().startNodes(2);
 
         logger.info("--> create an index that will have some unallocated shards");
         assertAcked(prepareCreate("test-idx-some", 2, indexSettingsNoReplicas(6)));
@@ -559,9 +338,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
     public void testRestoreIndexWithShardsMissingInLocalGateway() throws Exception {
         logger.info("--> start 2 nodes");
-
         internalCluster().startNodes(2);
-        cluster().wipeIndices("_all");
 
         createRepository("test-repo", "fs");
 
@@ -1278,177 +1055,5 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             }
         }));
         return files;
-    }
-
-    public static class SnapshottableMetadata extends TestCustomMetadata {
-        public static final String TYPE = "test_snapshottable";
-
-        public SnapshottableMetadata(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        public static SnapshottableMetadata readFrom(StreamInput in) throws IOException {
-            return readFrom(SnapshottableMetadata::new, in);
-        }
-
-        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
-            return readDiffFrom(TYPE, in);
-        }
-
-        public static SnapshottableMetadata fromXContent(XContentParser parser) throws IOException {
-            return fromXContent(SnapshottableMetadata::new, parser);
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return Metadata.API_AND_SNAPSHOT;
-        }
-    }
-
-    public static class NonSnapshottableMetadata extends TestCustomMetadata {
-        public static final String TYPE = "test_non_snapshottable";
-
-        public NonSnapshottableMetadata(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        public static NonSnapshottableMetadata readFrom(StreamInput in) throws IOException {
-            return readFrom(NonSnapshottableMetadata::new, in);
-        }
-
-        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
-            return readDiffFrom(TYPE, in);
-        }
-
-        public static NonSnapshottableMetadata fromXContent(XContentParser parser) throws IOException {
-            return fromXContent(NonSnapshottableMetadata::new, parser);
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return Metadata.API_ONLY;
-        }
-    }
-
-    public static class SnapshottableGatewayMetadata extends TestCustomMetadata {
-        public static final String TYPE = "test_snapshottable_gateway";
-
-        public SnapshottableGatewayMetadata(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        public static SnapshottableGatewayMetadata readFrom(StreamInput in) throws IOException {
-            return readFrom(SnapshottableGatewayMetadata::new, in);
-        }
-
-        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
-            return readDiffFrom(TYPE, in);
-        }
-
-        public static SnapshottableGatewayMetadata fromXContent(XContentParser parser) throws IOException {
-            return fromXContent(SnapshottableGatewayMetadata::new, parser);
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.API, Metadata.XContentContext.SNAPSHOT, Metadata.XContentContext.GATEWAY);
-        }
-    }
-
-    public static class NonSnapshottableGatewayMetadata extends TestCustomMetadata {
-        public static final String TYPE = "test_non_snapshottable_gateway";
-
-        public NonSnapshottableGatewayMetadata(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        public static NonSnapshottableGatewayMetadata readFrom(StreamInput in) throws IOException {
-            return readFrom(NonSnapshottableGatewayMetadata::new, in);
-        }
-
-        public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
-            return readDiffFrom(TYPE, in);
-        }
-
-        public static NonSnapshottableGatewayMetadata fromXContent(XContentParser parser) throws IOException {
-            return fromXContent(NonSnapshottableGatewayMetadata::new, parser);
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return Metadata.API_AND_GATEWAY;
-        }
-
-    }
-
-    public static class SnapshotableGatewayNoApiMetadata extends TestCustomMetadata {
-        public static final String TYPE = "test_snapshottable_gateway_no_api";
-
-        public SnapshotableGatewayNoApiMetadata(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        public static SnapshotableGatewayNoApiMetadata readFrom(StreamInput in) throws IOException {
-            return readFrom(SnapshotableGatewayNoApiMetadata::new, in);
-        }
-
-        public static SnapshotableGatewayNoApiMetadata fromXContent(XContentParser parser) throws IOException {
-            return fromXContent(SnapshotableGatewayNoApiMetadata::new, parser);
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT);
-        }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.snapshots;
 
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
@@ -77,12 +76,9 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         createRepository("repository", CountingMockRepositoryPlugin.TYPE);
 
         // Creating a snapshot does not load any metadata
-        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("repository", "snap")
-                                                                                    .setIncludeGlobalState(true)
-                                                                                    .setWaitForCompletion(true)
-                                                                                    .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().failedShards(), equalTo(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().status(), equalTo(RestStatus.OK));
+        SnapshotInfo snapshotInfo = createFullSnapshot("repository", "snap");
+        assertThat(snapshotInfo.failedShards(), equalTo(0));
+        assertThat(snapshotInfo.status(), equalTo(RestStatus.OK));
         assertGlobalMetadataLoads("snap", 0);
         assertIndexMetadataLoads("snap", "docs", 0);
         assertIndexMetadataLoads("snap", "others", 0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.snapshots;
 
 import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
@@ -38,6 +37,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestStatus;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -90,24 +90,8 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         createRepository(repoName, "fs", absolutePath);
 
-        logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName1)
-                .setWaitForCompletion(true)
-                .setIndices(indexName1)
-                .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
-
-        CreateSnapshotResponse createSnapshotResponse2 = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName2)
-                .setWaitForCompletion(true)
-                .setIndices(indexName2)
-                .get();
-        assertThat(createSnapshotResponse2.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse2.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse2.getSnapshotInfo().totalShards()));
-        assertThat(createSnapshotResponse2.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        createSnapshot(repoName, snapshotName1, Collections.singletonList(indexName1));
+        createSnapshot(repoName, snapshotName2, Collections.singletonList(indexName2));
 
         RestoreSnapshotResponse restoreSnapshotResponse1 = client.admin().cluster().prepareRestoreSnapshot(repoName, snapshotName1)
                 .setWaitForCompletion(false)
@@ -147,15 +131,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         createRepository(repoName, "fs", absolutePath);
 
-        logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName)
-                .setWaitForCompletion(true)
-                .setIndices(indexName1, indexName2)
-                .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        createSnapshot(repoName, snapshotName, Arrays.asList(indexName1, indexName2));
 
         ActionFuture<RestoreSnapshotResponse> restoreSnapshotResponse1 = client.admin().cluster()
                 .prepareRestoreSnapshot(repoName, snapshotName)
@@ -200,10 +176,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .boxed().collect(Collectors.toMap(shardId -> shardId, indexMetadata::primaryTerm));
 
         createRepository("test-repo", "fs");
-        final CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
-                .setWaitForCompletion(true).setIndices(indexName).get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(numPrimaries));
-        assertThat(createSnapshotResponse.getSnapshotInfo().failedShards(), equalTo(0));
+        createSnapshot("test-repo", "test-snap", Collections.singletonList(indexName));
 
         assertAcked(client().admin().indices().prepareClose(indexName));
 
@@ -232,12 +205,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().indices().preparePutMapping("test-idx").setType("_doc").setSource("baz", "type=text"));
         ensureGreen();
 
-        logger.info("--> snapshot it");
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
-                .setWaitForCompletion(true).setIndices("test-idx").get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+        createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
 
         logger.info("--> delete the index and recreate it with foo field");
         cluster().wipeIndices("test-idx");
@@ -283,10 +251,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         assertFalse(client().admin().indices().prepareGetAliases("alias-123").get().getAliases().isEmpty());
 
-        logger.info("--> snapshot");
-        assertThat(clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
-                        .setIndices().setWaitForCompletion(true).get().getSnapshotInfo().state(),
-                equalTo(SnapshotState.SUCCESS));
+        createSnapshot("test-repo", "test-snap", Collections.emptyList());
 
         logger.info("-->  delete all indices");
         cluster().wipeIndices("test-idx-1", "test-idx-2", "test-idx-3");
@@ -351,11 +316,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                         .endObject())
                 .get().isAcknowledged(), equalTo(true));
 
-        logger.info("--> snapshot");
-        final SnapshotInfo snapshotInfo = assertSuccessful(clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
-                .setIndices().setWaitForCompletion(true).execute());
-        assertThat(snapshotInfo.totalShards(), equalTo(0));
-        assertThat(snapshotInfo.successfulShards(), equalTo(0));
+        createSnapshot("test-repo", "test-snap", Collections.emptyList());
         assertThat(getSnapshot("test-repo", "test-snap").state(), equalTo(SnapshotState.SUCCESS));
 
         logger.info("-->  delete test template");
@@ -374,7 +335,6 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertIndexTemplateExists(getIndexTemplatesResponse, "test-template");
     }
 
-
     public void testRenameOnRestore() throws Exception {
         Client client = client();
 
@@ -392,12 +352,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         indexRandomDocs("test-idx-1", 100);
         indexRandomDocs("test-idx-2", 100);
 
-        logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
-                .setWaitForCompletion(true).setIndices("test-idx-1", "test-idx-2").get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+        createSnapshot("test-repo", "test-snap", Arrays.asList("test-idx-1", "test-idx-2"));
 
         logger.info("--> restore indices with different names");
         RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
@@ -498,10 +453,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .put("chunk_size", 100, ByteSizeUnit.BYTES));
 
         createIndexWithRandomDocs("test-idx", 100);
-
-        logger.info("--> snapshot");
-        client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
-                .setWaitForCompletion(true).setIndices("test-idx").get();
+        createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
 
         logger.info("--> delete index");
         cluster().wipeIndices("test-idx");
@@ -562,12 +514,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")).get(), 0);
         assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")).get(), numdocs);
 
-        logger.info("--> snapshot it");
-        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
-                .setWaitForCompletion(true).setIndices("test-idx").get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+        createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
 
         logger.info("--> delete the index and recreate it while changing refresh interval and analyzer");
         cluster().wipeIndices("test-idx");
@@ -667,12 +614,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 client().admin().indices().prepareUpdateSettings("test-idx").setSettings(initialSettingsBuilder).get();
             }
 
-            logger.info("--> snapshot index");
-            CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
-                    .setWaitForCompletion(true).setIndices("test-idx").get();
-            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-                    equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+            createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
 
             logger.info("--> remove blocks and delete index");
             disableIndexBlock("test-idx", IndexMetadata.SETTING_BLOCKS_METADATA);
@@ -736,8 +678,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             indexRandomDocs("test-index", between(0, 100));
             flush("test-index");
         }
-        clusterAdmin().prepareCreateSnapshot("test-repo", "snapshot-0")
-                .setIndices("test-index").setWaitForCompletion(true).get();
+        createSnapshot("test-repo", "snapshot-0", Collections.singletonList("test-index"));
         final SnapshotRestoreException restoreError = expectThrows(SnapshotRestoreException.class,
                 () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                         .setIndexSettings(Settings.builder().put(INDEX_SOFT_DELETES_SETTING.getKey(), false))

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37485")
+public class SnapshotBrokenSettingsIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(BrokenSettingPlugin.class);
+    }
+
+    public void testExceptionWhenRestoringPersistentSettings() {
+        logger.info("--> start 2 nodes");
+        internalCluster().startNodes(2);
+
+        Client client = client();
+        Consumer<String> setSettingValue = value -> client.admin().cluster().prepareUpdateSettings().setPersistentSettings(
+                Settings.builder().put(BrokenSettingPlugin.BROKEN_SETTING.getKey(), value)).execute().actionGet();
+
+        Consumer<String> assertSettingValue = value -> assertThat(client.admin().cluster().prepareState().setRoutingTable(false)
+                .setNodes(false).execute().actionGet().getState().getMetadata().persistentSettings()
+                .get(BrokenSettingPlugin.BROKEN_SETTING.getKey()), equalTo(value));
+
+        logger.info("--> set test persistent setting");
+        setSettingValue.accept("new value");
+        assertSettingValue.accept("new value");
+
+        createRepository("test-repo", "fs");
+        createFullSnapshot("test-repo", "test-snap");
+        assertThat(getSnapshot("test-repo", "test-snap").state(), equalTo(SnapshotState.SUCCESS));
+
+        logger.info("--> change the test persistent setting and break it");
+        setSettingValue.accept("new value 2");
+        assertSettingValue.accept("new value 2");
+        BrokenSettingPlugin.breakSetting();
+
+        logger.info("--> restore snapshot");
+        final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+                client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setRestoreGlobalState(true)
+                        .setWaitForCompletion(true).execute()::actionGet);
+        assertEquals(BrokenSettingPlugin.EXCEPTION.getMessage(), ex.getMessage());
+
+        assertSettingValue.accept("new value 2");
+    }
+
+    public static class BrokenSettingPlugin extends Plugin {
+        private static boolean breakSetting = false;
+        private static final IllegalArgumentException EXCEPTION =  new IllegalArgumentException("this setting goes boom");
+
+        static void breakSetting() {
+            BrokenSettingPlugin.breakSetting = true;
+        }
+
+        static final Setting<String> BROKEN_SETTING = new Setting<>("setting.broken", "default", s->s,
+                s-> {
+                    if ((s.equals("default") == false && breakSetting)) {
+                        throw EXCEPTION;
+                    }
+                },
+                Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return Collections.singletonList(BROKEN_SETTING);
+        }
+    }
+}


### PR DESCRIPTION
Drying up a few more spots and extracting tests that use their own custom plugins to separate
classes to make the giant `DedicatedClusterSnapshotRestoreIT` suite a little more digestible.

backport of #63985 