### PR TITLE
[7.9] [DOCS] Adds recommendation about when to use chunking_config in manual mode. (#65060)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -934,8 +934,9 @@ There are three available modes:
 +
 --
 * `auto`: The chunk size is dynamically calculated. This is the default and
-recommended value.
-* `manual`: Chunking is applied according to the specified `time_span`.
+recommended value when the {dfeed} does not use aggregations.
+* `manual`: Chunking is applied according to the specified `time_span`. Use this 
+mode when the {dfeed} uses aggregations.
 * `off`: No chunking is applied.
 --
 end::mode[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Adds recommendation about when to use chunking_config in manual mode. (#65060)