### PR TITLE
Move the shared fetch cache to highlighting.

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.lookup.SourceLookup;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,9 +96,7 @@ final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
                                 new SearchHit(slot, "unknown", Collections.emptyMap(), Collections.emptyMap()),
                                 percolatorLeafReaderContext,
                                 slot,
-                                new SourceLookup(),
-                                new HashMap<>()
-                            );
+                                new SourceLookup());
                             subContext.sourceLookup().setSource(document);
                             // force source because MemoryIndex does not store fields
                             SearchHighlightContext highlight = new SearchHighlightContext(fetchContext.highlight().fields(), true);

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorMatchedSlotSubFetchPhaseTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorMatchedSlotSubFetchPhaseTests.java
@@ -43,7 +43,6 @@ import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.stream.IntStream;
 
 import static org.mockito.Mockito.mock;
@@ -69,9 +68,7 @@ public class PercolatorMatchedSlotSubFetchPhaseTests extends ESTestCase {
                         new SearchHit(0),
                         context,
                         0,
-                        new SourceLookup(),
-                        new HashMap<>()
-                    );
+                        new SourceLookup());
                     PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
                     MemoryIndex memoryIndex = new MemoryIndex();
                     memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
@@ -96,9 +93,7 @@ public class PercolatorMatchedSlotSubFetchPhaseTests extends ESTestCase {
                         new SearchHit(0),
                         context,
                         0,
-                        new SourceLookup(),
-                        new HashMap<>()
-                    );
+                        new SourceLookup());
                     PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
                     MemoryIndex memoryIndex = new MemoryIndex();
                     memoryIndex.addField("field", "value1", new WhitespaceAnalyzer());
@@ -122,9 +117,7 @@ public class PercolatorMatchedSlotSubFetchPhaseTests extends ESTestCase {
                         new SearchHit(0),
                         context,
                         0,
-                        new SourceLookup(),
-                        new HashMap<>()
-                    );
+                        new SourceLookup());
                     PercolateQuery.QueryStore queryStore = ctx -> docId -> null;
                     MemoryIndex memoryIndex = new MemoryIndex();
                     memoryIndex.addField("field", "value", new WhitespaceAnalyzer());

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * Sub phase within the fetch phase used to fetch things *about* the documents like highlighting or matched queries.
@@ -38,21 +37,18 @@ public interface FetchSubPhase {
         private final LeafReaderContext readerContext;
         private final int docId;
         private final SourceLookup sourceLookup;
-        private final Map<String, Object> cache;
 
         public HitContext(
             SearchHit hit,
             LeafReaderContext context,
             int docId,
-            SourceLookup sourceLookup,
-            Map<String, Object> cache
+            SourceLookup sourceLookup
         ) {
             this.hit = hit;
             this.readerContext = context;
             this.docId = docId;
             this.sourceLookup = sourceLookup;
             sourceLookup.setSegmentAndDocument(context, docId);
-            this.cache = cache;
         }
 
         public SearchHit hit() {
@@ -87,11 +83,6 @@ public interface FetchSubPhase {
 
         public IndexReader topLevelReader() {
             return ReaderUtil.getTopLevelContext(readerContext).reader();
-        }
-
-        // TODO move this into Highlighter
-        public Map<String, Object> cache() {
-            return cache;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -82,10 +82,10 @@ public class FastVectorHighlighter implements Highlighter {
         Encoder encoder = field.fieldOptions().encoder().equals("html") ?
             HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
-        if (!hitContext.cache().containsKey(CACHE_KEY)) {
-            hitContext.cache().put(CACHE_KEY, new HighlighterEntry());
+        if (!fieldContext.cache.containsKey(CACHE_KEY)) {
+            fieldContext.cache.put(CACHE_KEY, new HighlighterEntry());
         }
-        HighlighterEntry cache = (HighlighterEntry) hitContext.cache().get(CACHE_KEY);
+        HighlighterEntry cache = (HighlighterEntry) fieldContext.cache.get(CACHE_KEY);
         FieldHighlightEntry entry = cache.fields.get(fieldType);
         if (entry == null) {
             FragListBuilder fragListBuilder;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FieldHighlightContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FieldHighlightContext.java
@@ -23,6 +23,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 
+import java.util.Map;
+
 public class FieldHighlightContext {
 
     public final String fieldName;
@@ -32,6 +34,7 @@ public class FieldHighlightContext {
     public final FetchSubPhase.HitContext hitContext;
     public final Query query;
     public final boolean forceSource;
+    public final Map<String, Object> cache;
 
     public FieldHighlightContext(String fieldName,
                                  SearchHighlightContext.Field field,
@@ -39,7 +42,8 @@ public class FieldHighlightContext {
                                  FetchContext context,
                                  FetchSubPhase.HitContext hitContext,
                                  Query query,
-                                 boolean forceSource) {
+                                 boolean forceSource,
+                                 Map<String, Object> cache) {
         this.fieldName = fieldName;
         this.field = field;
         this.fieldType = fieldType;
@@ -47,5 +51,6 @@ public class FieldHighlightContext {
         this.hitContext = hitContext;
         this.query = query;
         this.forceSource = forceSource;
+        this.cache = cache;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -55,7 +55,10 @@ public class HighlightPhase implements FetchSubPhase {
     }
 
     public FetchSubPhaseProcessor getProcessor(FetchContext context, SearchHighlightContext highlightContext, Query query) {
-        Map<String, Function<HitContext, FieldHighlightContext>> contextBuilders = contextBuilders(context, highlightContext, query);
+        Map<String, Object> sharedCache = new HashMap<>();
+        Map<String, Function<HitContext, FieldHighlightContext>> contextBuilders = contextBuilders(
+            context, highlightContext, query, sharedCache);
+
         return new FetchSubPhaseProcessor() {
             @Override
             public void setNextReader(LeafReaderContext readerContext) {
@@ -97,7 +100,8 @@ public class HighlightPhase implements FetchSubPhase {
 
     private Map<String, Function<HitContext, FieldHighlightContext>> contextBuilders(FetchContext context,
                                                                                      SearchHighlightContext highlightContext,
-                                                                                     Query query) {
+                                                                                     Query query,
+                                                                                     Map<String, Object> sharedCache) {
         Map<String, Function<HitContext, FieldHighlightContext>> builders = new LinkedHashMap<>();
         for (SearchHighlightContext.Field field : highlightContext.fields()) {
             Highlighter highlighter = getHighlighter(field);
@@ -145,7 +149,7 @@ public class HighlightPhase implements FetchSubPhase {
                 boolean forceSource = highlightContext.forceSource(field);
                 builders.put(fieldName,
                     hc -> new FieldHighlightContext(fieldType.name(), field, fieldType, context, hc,
-                        highlightQuery == null ? query : highlightQuery, forceSource));
+                        highlightQuery == null ? query : highlightQuery, forceSource, sharedCache));
             }
         }
         return builders;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -61,12 +61,12 @@ public class PlainHighlighter implements Highlighter {
 
         Encoder encoder = field.fieldOptions().encoder().equals("html") ? HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
-        if (!hitContext.cache().containsKey(CACHE_KEY)) {
-            hitContext.cache().put(CACHE_KEY, new HashMap<>());
+        if (!fieldContext.cache.containsKey(CACHE_KEY)) {
+            fieldContext.cache.put(CACHE_KEY, new HashMap<>());
         }
         @SuppressWarnings("unchecked")
         Map<MappedFieldType, org.apache.lucene.search.highlight.Highlighter> cache =
-            (Map<MappedFieldType, org.apache.lucene.search.highlight.Highlighter>) hitContext.cache().get(CACHE_KEY);
+            (Map<MappedFieldType, org.apache.lucene.search.highlight.Highlighter>) fieldContext.cache.get(CACHE_KEY);
 
         org.apache.lucene.search.highlight.Highlighter entry = cache.get(fieldType);
         if (entry == null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -61,7 +61,7 @@ public class UnifiedHighlighter implements Highlighter {
     @Override
     public HighlightField highlight(FieldHighlightContext fieldContext) throws IOException {
         @SuppressWarnings("unchecked")
-        Map<String, CustomUnifiedHighlighter> cache = (Map<String, CustomUnifiedHighlighter>) fieldContext.hitContext.cache()
+        Map<String, CustomUnifiedHighlighter> cache = (Map<String, CustomUnifiedHighlighter>) fieldContext.cache
             .computeIfAbsent(UnifiedHighlighter.class.getName(), k -> new HashMap<>());
         if (cache.containsKey(fieldContext.fieldName) == false) {
             cache.put(fieldContext.fieldName, buildHighlighter(fieldContext));

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -163,9 +162,7 @@ public class FetchSourcePhaseTests extends ESTestCase {
             searchHit,
             leafReaderContext,
             1,
-            new SourceLookup(),
-            new HashMap<>()
-        );
+            new SourceLookup());
         hitContext.sourceLookup().setSource(source == null ? null : BytesReference.bytes(source));
 
         FetchSourcePhase phase = new FetchSourcePhase();

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
@@ -34,11 +34,11 @@ public class CustomHighlighter implements Highlighter {
     @Override
     public HighlightField highlight(FieldHighlightContext fieldContext) {
         SearchHighlightContext.Field field = fieldContext.field;
-        CacheEntry cacheEntry = (CacheEntry) fieldContext.hitContext.cache().get("test-custom");
+        CacheEntry cacheEntry = (CacheEntry) fieldContext.cache.get("test-custom");
         final int docId = fieldContext.hitContext.readerContext().docBase + fieldContext.hitContext.docId();
         if (cacheEntry == null) {
             cacheEntry = new CacheEntry();
-            fieldContext.hitContext.cache().put("test-custom", cacheEntry);
+            fieldContext.cache.put("test-custom", cacheEntry);
             cacheEntry.docId = docId;
             cacheEntry.position = 1;
         } else {


### PR DESCRIPTION
The cache is only used by highlighters, so it can be scoped to only the
highlighting context.