### PR TITLE
Simplify SourceLookup interface.

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -44,6 +44,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.lookup.FieldLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -156,8 +157,8 @@ public class SearchFieldsIT extends ESIntegTestCase {
 
         @SuppressWarnings("unchecked")
         static Object sourceScript(Map<String, Object> vars, String path) {
-            Map<String, Object> source = (Map) vars.get("_source");
-            return XContentMapValues.extractValue(path, source);
+            SourceLookup source = (SourceLookup) vars.get("_source");
+            return source.extractValue(path, null);
         }
 
         static Object docScript(Map<String, Object> vars, String fieldName) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -36,6 +36,7 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Collection;
@@ -72,8 +73,8 @@ public class SearchStatsIT extends ESIntegTestCase {
         @Override
         protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
             return Collections.singletonMap("_source.field", vars -> {
-                Map<?, ?> src = (Map) vars.get("_source");
-                return src.get("field");
+                SourceLookup src = (SourceLookup) vars.get("_source");
+                return src.extractValue("field", null);
             });
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -41,10 +41,10 @@ import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 
-public class SourceLookup implements Map<String, Object> {
+public class SourceLookup {
 
     private LeafReader reader;
-    CheckedBiConsumer<Integer, FieldsVisitor, IOException> fieldReader;
+    private CheckedBiConsumer<Integer, FieldsVisitor, IOException> fieldReader;
 
     private int docId = -1;
 
@@ -180,66 +180,5 @@ public class SourceLookup implements Map<String, Object> {
 
     public Object filter(FetchSourceContext context) {
         return context.getFilter().apply(loadSourceIfNeeded());
-    }
-
-    @Override
-    public Object get(Object key) {
-        return loadSourceIfNeeded().get(key);
-    }
-
-    @Override
-    public int size() {
-        return loadSourceIfNeeded().size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return loadSourceIfNeeded().isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-        return loadSourceIfNeeded().containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        return loadSourceIfNeeded().containsValue(value);
-    }
-
-    @Override
-    public Set<String> keySet() {
-        return loadSourceIfNeeded().keySet();
-    }
-
-    @Override
-    public Collection<Object> values() {
-        return loadSourceIfNeeded().values();
-    }
-
-    @Override
-    public Set<Map.Entry<String, Object>> entrySet() {
-        return loadSourceIfNeeded().entrySet();
-    }
-
-    @Override
-    public Object put(String key, Object value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Object remove(Object key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    @SuppressWarnings("rawtypes")
-    public void putAll(Map m) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -34,10 +34,8 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
@@ -88,17 +88,17 @@ public abstract class AbstractFieldScript {
     }
 
     /**
-     * Expose the {@code _source} to the script.
-     */
-    protected final Map<String, Object> getSource() {
-        return leafSearchLookup.source();
-    }
-
-    /**
      * Expose field data to the script as {@code doc}.
      */
     public final Map<String, ScriptDocValues<?>> getDoc() {
         return leafSearchLookup.doc();
+    }
+
+    /**
+     * A non-public convenience method that's used in testing.
+     */
+    protected final Map<String, Object> getSource() {
+        return leafSearchLookup.source().loadSourceIfNeeded();
     }
 
     /**


### PR DESCRIPTION
SourceLookup does not need to implement Map, because we no longer expose source
directly to scripts in a top-level `_source` variable.
