### PR TITLE
Isolate sql cli tests with dedicated testcase

### DIFF
--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliReplTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliReplTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.cli;
 
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.cli.command.CliCommand;
 import org.elasticsearch.xpack.sql.cli.command.CliSession;
 
@@ -15,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class CliReplTests extends ESTestCase {
+public class CliReplTests extends SqlCliTestCase {
 
     public void testBasicCliFunctionality() throws Exception {
         CliTerminal cliTerminal = new TestTerminal(

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliSessionTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliSessionTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.sql.cli;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.sql.cli.command.CliSession;
 import org.elasticsearch.xpack.sql.client.ClientException;
@@ -25,7 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class CliSessionTests extends ESTestCase {
+public class CliSessionTests extends SqlCliTestCase {
 
     public void testProperConnection() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/ConnectionBuilderTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/ConnectionBuilderTests.java
@@ -6,9 +6,9 @@
 package org.elasticsearch.xpack.sql.cli;
 
 import org.elasticsearch.cli.UserException;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.ConnectionConfiguration;
 import org.elasticsearch.xpack.sql.client.SslConfig;
+
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -21,12 +21,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ConnectionBuilderTests extends ESTestCase {
+public class ConnectionBuilderTests extends SqlCliTestCase {
 
     public void testDefaultConnection() throws Exception {
         CliTerminal testTerminal = mock(CliTerminal.class);
         ConnectionBuilder connectionBuilder = new ConnectionBuilder(testTerminal);
-        boolean binaryCommunication = randomBoolean();
+        boolean binaryCommunication = random().nextBoolean();
         ConnectionConfiguration con = connectionBuilder.buildConnection(null, null, binaryCommunication);
         assertNull(con.authUser());
         assertNull(con.authPass());
@@ -109,7 +109,7 @@ public class ConnectionBuilderTests extends ESTestCase {
 
     public void testUserGaveUpOnPassword() throws Exception {
         CliTerminal testTerminal = mock(CliTerminal.class);
-        UserException ue = new UserException(randomInt(), randomAlphaOfLength(5));
+        UserException ue = new UserException(random().nextInt(), randomAlphaOfLength(5));
         when(testTerminal.readPassword("password: ")).thenThrow(ue);
         ConnectionBuilder connectionBuilder = new ConnectionBuilder(testTerminal);
         UserException actual = expectThrows(UserException.class, () ->
@@ -119,7 +119,7 @@ public class ConnectionBuilderTests extends ESTestCase {
 
     public void testUserGaveUpOnKeystorePassword() throws Exception {
         CliTerminal testTerminal = mock(CliTerminal.class);
-        UserException ue = new UserException(randomInt(), randomAlphaOfLength(5));
+        UserException ue = new UserException(random().nextInt(), randomAlphaOfLength(5));
         when(testTerminal.readPassword("keystore password: ")).thenThrow(ue);
         when(testTerminal.readPassword("password: ")).thenReturn("password");
         ConnectionBuilder connectionBuilder = new ConnectionBuilder(testTerminal) {
@@ -132,7 +132,7 @@ public class ConnectionBuilderTests extends ESTestCase {
             buildConnection(connectionBuilder, "https://user@foobar:9242/", "keystore_location"));
         assertSame(actual, ue);
     }
-    
+
     private ConnectionConfiguration buildConnection(ConnectionBuilder builder, String connectionStringArg,
                                                     String keystoreLocation) throws UserException {
         return builder.buildConnection(connectionStringArg, keystoreLocation, randomBoolean());

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/JLineTerminalTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/JLineTerminalTests.java
@@ -7,19 +7,19 @@ package org.elasticsearch.xpack.sql.cli;
 
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
-import org.elasticsearch.test.ESTestCase;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Terminal;
+
 import java.io.IOException;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-public class JLineTerminalTests extends ESTestCase {
+public class JLineTerminalTests extends SqlCliTestCase {
     private final Terminal wrapped = mock(Terminal.class);
     private final LineReader reader = mock(LineReader.class);
 

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/SqlCliTestCase.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/SqlCliTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.cli;
+
+import com.carrotsearch.randomizedtesting.annotations.Listeners;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TimeUnits;
+import org.elasticsearch.test.junit.listeners.LoggingListener;
+import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
+
+@Listeners({
+    ReproduceInfoPrinter.class,
+    LoggingListener.class
+})
+@ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
+@ThreadLeakLingering(linger = 5000) // 5 sec lingering
+@TimeoutSuite(millis = 20 * TimeUnits.MINUTE)
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")
+// we suppress pretty much all the lucene codecs for now, except asserting
+// assertingcodec is the winner for a codec here: it finds bugs and gives clear exceptions.
+@LuceneTestCase.SuppressCodecs({
+    "SimpleText", "Memory", "CheapBastard", "Direct", "Compressing", "FST50", "FSTOrd50",
+    "TestBloomFilteredLucenePostings", "MockRandom", "BlockTreeOrds", "LuceneFixedGap",
+    "LuceneVarGapFixedInterval", "LuceneVarGapDocFreqInterval", "Lucene50"
+})
+@LuceneTestCase.SuppressReproduceLine
+public abstract class SqlCliTestCase extends LuceneTestCase {
+
+    public boolean randomBoolean() {
+        return random().nextBoolean();
+    }
+
+    public String randomAlphaOfLength(int length) {
+        return randomAsciiLettersOfLength(length);
+    }
+}

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/VersionTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/VersionTests.java
@@ -6,10 +6,9 @@
 package org.elasticsearch.xpack.sql.cli;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
 
-public class VersionTests extends ESTestCase {
+public class VersionTests extends SqlCliTestCase {
     public void testVersionIsCurrent() {
         /* This test will only work properly in gradle because in gradle we run the tests
          * using the jar. */

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/BuiltinCommandTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/BuiltinCommandTests.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.cli.command;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.cli.SqlCliTestCase;
 import org.elasticsearch.xpack.sql.cli.TestTerminal;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
 import org.elasticsearch.xpack.sql.client.HttpClient;
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 
-public class BuiltinCommandTests extends ESTestCase {
+public class BuiltinCommandTests extends SqlCliTestCase {
 
     public void testInvalidCommand() throws Exception {
         TestTerminal testTerminal = new TestTerminal();

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/CliCommandsTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/CliCommandsTests.java
@@ -5,14 +5,14 @@
  */
 package org.elasticsearch.xpack.sql.cli.command;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.cli.SqlCliTestCase;
 import org.elasticsearch.xpack.sql.cli.TestTerminal;
 import org.elasticsearch.xpack.sql.client.HttpClient;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class CliCommandsTests extends ESTestCase {
+public class CliCommandsTests extends SqlCliTestCase {
 
     public void testCliCommands() {
         TestTerminal testTerminal = new TestTerminal();

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/ServerInfoCliCommandTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/ServerInfoCliCommandTests.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.sql.cli.command;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.cli.SqlCliTestCase;
 import org.elasticsearch.xpack.sql.cli.TestTerminal;
 import org.elasticsearch.xpack.sql.client.HttpClient;
 import org.elasticsearch.xpack.sql.proto.MainResponse;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ServerInfoCliCommandTests extends ESTestCase {
+public class ServerInfoCliCommandTests extends SqlCliTestCase {
 
     public void testInvalidCommand() throws Exception {
         TestTerminal testTerminal = new TestTerminal();

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/ServerQueryCliCommandTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/command/ServerQueryCliCommandTests.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.cli.command;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.cli.SqlCliTestCase;
 import org.elasticsearch.xpack.sql.cli.TestTerminal;
 import org.elasticsearch.xpack.sql.client.HttpClient;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ServerQueryCliCommandTests extends ESTestCase {
+public class ServerQueryCliCommandTests extends SqlCliTestCase {
 
     public void testExceptionHandling() throws Exception {
         TestTerminal testTerminal = new TestTerminal();


### PR DESCRIPTION
The sql cli tests build on ESTestCase, but this triggers security
manager initialization for tests. However, this is unrealistic for the
sql cli both because it does not run with security manager, and the
cli only picks up the server jar that contains the policy and security
manager bootstrapping code unintentionally. Removing the depdnence on
the server code would be ideal, but until that can happen, this commit
starts the separation by adding a dedicated testcase for these tests
which does not use BootstrapForTesting.