### PR TITLE
Remove Redundant Translog Fsync

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
@@ -172,9 +172,8 @@ final class Checkpoint {
         // now go and write to the channel, in one go.
         try (FileChannel channel = factory.open(checkpointFile, options)) {
             Channels.writeToChannel(bytes, channel);
-            // no need to force metadata, file size stays the same and we did the full fsync
-            // when we first created the file, so the directory entry doesn't change as well
-            channel.force(false);
+            // fsync with metadata as we use this method when creating the file
+            channel.force(true);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1889,7 +1889,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         final Checkpoint checkpoint = Checkpoint.emptyTranslogCheckpoint(0, generation, initialGlobalCheckpoint, minTranslogGeneration);
 
         Checkpoint.write(channelFactory, checkpointFile, checkpoint, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
-        IOUtils.fsync(checkpointFile, false);
         final TranslogWriter writer = TranslogWriter.create(shardId, uuid, generation, translogFile, channelFactory,
             EMPTY_TRANSLOG_BUFFER_SIZE, minTranslogGeneration, initialGlobalCheckpoint,
             () -> {

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
@@ -90,8 +90,6 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
                         checkpoint.generation, checkpoint.minSeqNo, checkpoint.maxSeqNo,
                         checkpoint.globalCheckpoint, checkpoint.minTranslogGeneration, aboveSeqNo);
                     Checkpoint.write(channelFactory, checkpointFile, newCheckpoint, StandardOpenOption.WRITE);
-
-                    IOUtils.fsync(checkpointFile, false);
                     IOUtils.fsync(checkpointFile.getParent(), true);
 
                     newReader = new TranslogReader(newCheckpoint, channel, path, header);

--- a/server/src/main/java/org/elasticsearch/index/translog/TruncateTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TruncateTranslogAction.java
@@ -194,8 +194,6 @@ public class TruncateTranslogAction {
             globalCheckpoint, translogGeneration);
         Checkpoint.write(FileChannel::open, filename, emptyCheckpoint,
             StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE_NEW);
-        // fsync with metadata here to make sure.
-        IOUtils.fsync(filename, false);
     }
 
     /**


### PR DESCRIPTION
All spots using this method would do a fsync with metadata afterwards
so we might as well do a full fsync right away and save a redundant
fsync + re-opening the file.
