### PR TITLE
Update file extensions.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -52,22 +52,28 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
      * Ideally this should be in sync to what the current version of Lucene is using, but it's harmless to leave extensions out,
      * they'll just miss a proper description in the stats
      */
-    private static final ImmutableOpenMap<String, String> FILE_DESCRIPTIONS = ImmutableOpenMap.<String, String>builder()
+    static final ImmutableOpenMap<String, String> FILE_DESCRIPTIONS = ImmutableOpenMap.<String, String>builder()
             .fPut("si", "Segment Info")
             .fPut("fnm", "Fields")
+            .fPut("fdm", "Field Metadata")
             .fPut("fdx", "Field Index")
             .fPut("fdt", "Field Data")
+            .fPut("tmd", "Term Dictionary Metadata")
             .fPut("tim", "Term Dictionary")
             .fPut("tip", "Term Index")
             .fPut("doc", "Frequencies")
             .fPut("pos", "Positions")
             .fPut("pay", "Payloads")
             .fPut("nvd", "Norms")
-            .fPut("nvm", "Norms")
-            .fPut("dii", "Points")
-            .fPut("dim", "Points")
+            .fPut("nvm", "Norms metadata")
+            .fPut("kdm", "Points Metadata")
+            .fPut("kdi", "Points Index")
+            .fPut("kdm", "Points Metadata")
+            .fPut("kdi", "Points Index")   // old extension
+            .fPut("kdd", "Points")         // old extension
             .fPut("dvd", "DocValues")
-            .fPut("dvm", "DocValues")
+            .fPut("dvm", "DocValues Metadata")
+            .fPut("tvm", "Term Vector Metadata")
             .fPut("tvx", "Term Vector Index")
             .fPut("tvd", "Term Vector Documents")
             .fPut("tvf", "Term Vector Fields")

--- a/server/src/test/java/org/elasticsearch/index/engine/SegmentsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SegmentsStatsTests.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.test.ESTestCase;
+
+public class SegmentsStatsTests extends ESTestCase {
+
+    public void testFileExtensionDescriptions() throws Exception {
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(dir, new IndexWriterConfig()
+                    .setUseCompoundFile(false)
+                    .setMergePolicy(NoMergePolicy.INSTANCE))) {
+                // Create a Lucene index that uses all features
+                Document doc = new Document();
+                StringField id = new StringField("id", "1", Store.YES);
+                doc.add(id);
+                // Points
+                doc.add(new LongPoint("lp", 42L));
+                // Doc values
+                doc.add(new NumericDocValuesField("ndv", 42L));
+                // Inverted index, term vectors and stored fields
+                FieldType ft = new FieldType(TextField.TYPE_STORED);
+                ft.setStoreTermVectors(true);
+                doc.add(new Field("if", "elasticsearch", ft));
+                w.addDocument(doc);
+                id.setStringValue("2");
+                w.addDocument(doc);
+                // Create a live docs file
+                w.deleteDocuments(new Term("id", "2"));
+            }
+
+            for (String file : dir.listAll()) {
+                final String extension = IndexFileNames.getExtension(file);
+                if (extension != null) {
+                    assertTrue(SegmentsStats.FILE_DESCRIPTIONS.get(extension) != null);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This is used to break down disk usage by Lucene data structure.

Backport of #62019
