### PR TITLE
[7.10] [DOCS] EQL: Update docs for null tiebreakers (#65078)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -246,8 +246,8 @@ this value.
 `tiebreaker_field`::
 (Optional, string)
 Field used to sort hits with the same
-<<eql-search-api-timestamp-field,timestamp>> in ascending, lexicographic order.
-See <<eql-search-specify-a-sort-tiebreaker>>.
+<<eql-search-api-timestamp-field,timestamp>> in ascending order. See
+<<eql-search-specify-a-sort-tiebreaker>>.
 
 [[eql-search-api-timestamp-field]]
 `timestamp_field`::
@@ -491,7 +491,7 @@ in ascending order.
 
 If two or more events share the same timestamp, the
 <<eql-search-api-tiebreaker-field,`tiebreaker_field`>> field is used to sort
-the events in ascending, lexicographic order.
+the events in ascending order.
 
 [source,console-result]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -390,20 +390,15 @@ or event category field.
 
 By default, the EQL search API returns matching hits by timestamp. If two or
 more events share the same timestamp, {es} uses a tiebreaker field value to sort
-the events in ascending, lexicographic order.
+the events in ascending order. {es} orders events with no
+tiebreaker value after events with a value.
 
 If you don't specify a tiebreaker field or the events also share the same
 tiebreaker value, {es} considers the events concurrent. Concurrent events cannot
 be part of the same sequence and may not be returned in a consistent sort order.
 
-To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you
-specify a tiebreaker field for a sequence query, all events in the searched data
-streams or indices must contain a tiebreaker field value. For basic queries,
-{es} orders matching events with no tiebreaker value after events with a
-tiebreaker value.
-
-If you use the {ecs-ref}[ECS], we recommend using `event.sequence` as the
-tiebreaker field.
+To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
+the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.
 
 [source,console]
 ----


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] EQL: Update docs for null tiebreakers (#65078)