### PR TITLE
[DOCS] Clarify ingest attachment example

### DIFF
--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -42,8 +42,8 @@ string. On Unix-like systems, you can do this using the `base64` command:
 base64 -in myfile.rtf
 ----
 
-The following base64 string is for an `.rtf` file containing the text `Lorem
-ipsum dolor sit amet`:
+The command returns the base64 string for the file. The following base64 string
+is for an `.rtf` file containing the text `Lorem ipsum dolor sit amet`:
 `e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=`.
 
 Use an attachment processor to decode the string and extract the file's

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -34,9 +34,8 @@ include::install_remove.asciidoc[]
 [[ingest-attachment-json-ex]]
 ==== Example
 
-If attaching files JSON documents, you must first encode the attachment file as a
-base64 string. On Unix-like systems, you can use a `base64` command to encode
-the file:
+If attaching files to JSON documents, you must first encode the file as a base64
+string. On Unix-like systems, you can do this using the `base64` command:
 
 [source,shell]
 ----

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -35,15 +35,15 @@ include::install_remove.asciidoc[]
 ==== Example
 
 If attaching files to JSON documents, you must first encode the file as a base64
-string. On Unix-like systems, you can do this using the `base64` command:
+string. On Unix-like systems, you can do this using a `base64` command:
 
 [source,shell]
 ----
 base64 -in myfile.rtf
 ----
 
-The command returns the base64 string for the file. The following base64 string
-is for an `.rtf` file containing the text `Lorem ipsum dolor sit amet`:
+The command returns the base64-encoded string for the file. The following base64
+string is for an `.rtf` file containing the text `Lorem ipsum dolor sit amet`:
 `e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=`.
 
 Use an attachment processor to decode the string and extract the file's

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -34,9 +34,9 @@ include::install_remove.asciidoc[]
 [[ingest-attachment-json-ex]]
 ==== Example
 
-If attaching files to JSON documents, you must first encode the file as a base64
-string. On Unix-like systems, you can use a command like this get the base64
-string for a file:
+If attaching files JSON documents, you must first encode the attachment file as a
+base64 string. On Unix-like systems, you can use a `base64` command to encode
+the file:
 
 [source,shell]
 ----

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -30,10 +30,27 @@ include::install_remove.asciidoc[]
 | `ignore_missing`       | no        | `false`          | If `true` and `field` does not exist, the processor quietly exits without modifying the document
 |======
 
-For example, this:
+[discrete]
+[[ingest-attachment-json-ex]]
+==== Example
+
+To add a file attachment to a JSON document, you must first encode the file as a
+base64 string. On Unix-like systems, you can use a command like this:
+
+[source,shell]
+----
+base64 -in myfile.rtf
+----
+
+The following base64 string encodes a Rich Text Format (`.rtf`) file containing
+the text `Lorem ipsum dolor sit amet`:
+`e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=`.
+
+Use an attachment processor to decode the string and extract the original file's
+properties, including its content:
 
 [source,console]
---------------------------------------------------
+----
 PUT _ingest/pipeline/attachment
 {
   "description" : "Extract attachment information",
@@ -50,12 +67,12 @@ PUT my-index-000001/_doc/my_id?pipeline=attachment
   "data": "e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0="
 }
 GET my-index-000001/_doc/my_id
---------------------------------------------------
+----
 
-Returns this:
+The document's `attachment` object contains extracted properties for the file:
 
 [source,console-result]
---------------------------------------------------
+----
 {
   "found": true,
   "_index": "my-index-000001",
@@ -73,14 +90,13 @@ Returns this:
     }
   }
 }
---------------------------------------------------
+----
 // TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term" : 1/"_primary_term" : $body._primary_term/]
 
-
-To specify only some fields to be extracted:
+To extract only certain `attachment` fields, specify the `properties` array:
 
 [source,console]
---------------------------------------------------
+----
 PUT _ingest/pipeline/attachment
 {
   "description" : "Extract attachment information",
@@ -93,7 +109,7 @@ PUT _ingest/pipeline/attachment
     }
   ]
 }
---------------------------------------------------
+----
 
 NOTE: Extracting contents from binary data is a resource intensive operation and
       consumes a lot of resources. It is highly recommended to run pipelines

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -34,8 +34,9 @@ include::install_remove.asciidoc[]
 [[ingest-attachment-json-ex]]
 ==== Example
 
-If ingesting JSON documents, you must first encode the attachment file as a
-base64 string. On Unix-like systems, you can use a command like this:
+If attaching files to JSON documents, you must first encode the file as a base64
+string. On Unix-like systems, you can use a command like this get the base64
+string for a file:
 
 [source,shell]
 ----

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -34,7 +34,7 @@ include::install_remove.asciidoc[]
 [[ingest-attachment-json-ex]]
 ==== Example
 
-To add a file attachment to a JSON document, you must first encode the file as a
+If ingesting JSON documents, you must first encode the attachment file as a
 base64 string. On Unix-like systems, you can use a command like this:
 
 [source,shell]
@@ -42,12 +42,12 @@ base64 string. On Unix-like systems, you can use a command like this:
 base64 -in myfile.rtf
 ----
 
-The following base64 string encodes a Rich Text Format (`.rtf`) file containing
-the text `Lorem ipsum dolor sit amet`:
+The following base64 string is for an `.rtf` file containing the text `Lorem
+ipsum dolor sit amet`:
 `e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=`.
 
-Use an attachment processor to decode the string and extract the original file's
-properties, including its content:
+Use an attachment processor to decode the string and extract the file's
+properties:
 
 [source,console]
 ----


### PR DESCRIPTION
Provides some additional context for the example, including a `base64` command.

Closes #27156

### Preview
https://elasticsearch_65143.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/master/using-ingest-attachment.html#ingest-attachment-json-ex