### PR TITLE
[ML] fixing ml snapshot upgrader after backport

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
@@ -24,7 +24,9 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeState;
@@ -123,59 +125,90 @@ public class SnapshotUpgradeTaskExecutor extends AbstractJobPersistentTasksExecu
                 jobTaskState.getReason() == null ? "__unknown__" : jobTaskState.getReason()));
             return;
         }
+        final String jobId = params.getJobId();
+        final String snapshotId = params.getSnapshotId();
 
         ActionListener<Boolean> stateAliasHandler = ActionListener.wrap(
-           r -> autodetectProcessManager.upgradeSnapshot((SnapshotUpgradeTask)task, e -> {
-               if (e == null) {
-                   auditor.info(params.getJobId(), "Finished upgrading snapshot [" + params.getSnapshotId() + "]");
-                   logger.info("[{}] [{}] finished upgrading snapshot", params.getJobId(), params.getSnapshotId());
-                   task.markAsCompleted();
-               } else {
-                   logger.warn(
-                       () -> new ParameterizedMessage(
-                           "[{}] failed upgrading snapshot [{}]",
-                           params.getJobId(),
-                           params.getSnapshotId()),
-                       e);
-                   auditor.warning(params.getJobId(),
-                       "failed upgrading snapshot ["
-                           + params.getSnapshotId()
-                           + "] with exception "
-                           + ExceptionsHelper.unwrapCause(e).getMessage());
-                   task.markAsFailed(e);
-               }
-           }),
-           e -> {
-               logger.warn(
-                   () -> new ParameterizedMessage(
-                       "[{}] failed upgrading snapshot [{}] as ml state alias creation failed",
-                       params.getJobId(),
-                       params.getSnapshotId()),
-                   e);
-               auditor.warning(params.getJobId(),
-                   "failed upgrading snapshot ["
-                       + params.getSnapshotId()
-                       + "] with exception "
-                       + ExceptionsHelper.unwrapCause(e).getMessage());
-               // We need to update cluster state so the API caller can be notified and exit
-               // As we have not set the task state to STARTED, it might still be waiting.
-               task.updatePersistentTaskState(
-                   new SnapshotUpgradeTaskState(SnapshotUpgradeState.FAILED, -1, e.getMessage()),
-                   ActionListener.wrap(
-                       r -> task.markAsFailed(e),
-                       failure -> {
-                           logger.warn(
-                               new ParameterizedMessage(
-                                   "[{}] [{}] failed to set task to failed",
-                                   params.getJobId(),
-                                   params.getSnapshotId()),
-                               failure);
-                           task.markAsFailed(e);
-                       }
-                   ));
-           }
+            r -> autodetectProcessManager.upgradeSnapshot((SnapshotUpgradeTask)task, e -> {
+                if (e == null) {
+                    auditor.info(jobId, "Finished upgrading snapshot [" + snapshotId + "]");
+                    logger.info("[{}] [{}] finished upgrading snapshot", jobId, snapshotId);
+                    task.markAsCompleted();
+                } else {
+                    logger.warn(
+                        () -> new ParameterizedMessage(
+                            "[{}] failed upgrading snapshot [{}]",
+                            jobId,
+                            snapshotId),
+                        e);
+                    auditor.warning(jobId,
+                        "failed upgrading snapshot ["
+                            + snapshotId
+                            + "] with exception "
+                            + ExceptionsHelper.unwrapCause(e).getMessage());
+                    task.markAsFailed(e);
+                }
+            }),
+            e -> {
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "[{}] failed upgrading snapshot [{}] as ml state alias creation failed",
+                        jobId,
+                        snapshotId),
+                    e);
+                auditor.warning(jobId,
+                    "failed upgrading snapshot ["
+                        + snapshotId
+                        + "] with exception "
+                        + ExceptionsHelper.unwrapCause(e).getMessage());
+                // We need to update cluster state so the API caller can be notified and exit
+                // As we have not set the task state to STARTED, it might still be waiting.
+                task.updatePersistentTaskState(
+                    new SnapshotUpgradeTaskState(SnapshotUpgradeState.FAILED, -1, e.getMessage()),
+                    ActionListener.wrap(
+                        r -> task.markAsFailed(e),
+                        failure -> {
+                            logger.warn(
+                                new ParameterizedMessage(
+                                    "[{}] [{}] failed to set task to failed",
+                                    jobId,
+                                    snapshotId),
+                                failure);
+                            task.markAsFailed(e);
+                        }
+                    ));
+            }
         );
-        AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary(client, clusterState, expressionResolver, stateAliasHandler);
+
+        // Make sure the state index and alias exist
+        ActionListener<Boolean> resultsMappingUpdateHandler = ActionListener.wrap(
+            ack -> AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary(client, clusterState, expressionResolver, stateAliasHandler),
+            task::markAsFailed
+        );
+
+        // Try adding the results doc mapping - this updates to the latest version if an old mapping is present
+        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
+            ack -> ElasticsearchMappings.addDocMappingIfMissing(
+                AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
+                AnomalyDetectorsIndex::resultsMapping,
+                client,
+                clusterState,
+                resultsMappingUpdateHandler),
+            e -> {
+                // Due to a bug in 7.9.0 it's possible that the annotations index already has incorrect mappings
+                // and it would cause more harm than good to block jobs from opening in subsequent releases
+                logger.warn(new ParameterizedMessage("[{}] ML annotations index could not be updated with latest mappings", jobId), e);
+                ElasticsearchMappings.addDocMappingIfMissing(
+                    AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
+                    AnomalyDetectorsIndex::resultsMapping,
+                    client,
+                    clusterState,
+                    resultsMappingUpdateHandler);
+            }
+        );
+
+        // Create the annotations index if necessary - this also updates the mappings if an old mapping is present
+        AnnotationIndex.createAnnotationsIndexIfNecessary(client, clusterState, annotationsIndexUpdateHandler);
     }
 
     @Override

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.upgrades;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.client.MachineLearningClient;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -98,9 +99,11 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
                 createJobAndSnapshots();
                 break;
             case MIXED:
+                assumeTrue("We should only test if old cluster is before new cluster", UPGRADE_FROM_VERSION.before(Version.CURRENT));
                 testSnapshotUpgradeFailsOnMixedCluster();
                 break;
             case UPGRADED:
+                assumeTrue("We should only test if old cluster is before new cluster", UPGRADE_FROM_VERSION.before(Version.CURRENT));
                 ensureHealth((request -> {
                     request.addParameter("timeout", "70s");
                     request.addParameter("wait_for_nodes", "3");

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -53,6 +53,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -86,7 +87,6 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      */
     public void testSnapshotUpgrader() throws Exception {
         hlrc = new HLRC(client()).machineLearning();
-        //assumeTrue("Snapshot upgrader should only upgrade from the last major", UPGRADE_FROM_VERSION.major < 7);
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
         adjustLoggingLevels.setJsonEntity(
             "{\"transient\": {" +
@@ -98,7 +98,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
                 createJobAndSnapshots();
                 break;
             case MIXED:
-                // Add mixed cluster test after backported
+                testSnapshotUpgradeFailsOnMixedCluster();
                 break;
             case UPGRADED:
                 ensureHealth((request -> {
@@ -112,6 +112,24 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
             default:
                 throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
         }
+    }
+
+    private void testSnapshotUpgradeFailsOnMixedCluster() throws Exception {
+        Job job = getJob(JOB_ID).jobs().get(0);
+        String currentSnapshot = job.getModelSnapshotId();
+        GetModelSnapshotsResponse modelSnapshots = getModelSnapshots(job.getId());
+        assertThat(modelSnapshots.snapshots(), hasSize(2));
+
+        ModelSnapshot snapshot = modelSnapshots.snapshots()
+            .stream()
+            .filter(s -> s.getSnapshotId().equals(currentSnapshot) == false)
+            .findFirst()
+            .orElseThrow(() -> new ElasticsearchException("Not found snapshot other than " + currentSnapshot));
+
+       Exception ex = expectThrows(Exception.class, () -> hlrc.upgradeJobSnapshot(
+            new UpgradeJobModelSnapshotRequest(JOB_ID, snapshot.getSnapshotId(), null, true),
+            RequestOptions.DEFAULT));
+       assertThat(ex.getMessage(), containsString("All nodes must be the same version"));
     }
 
     private void testSnapshotUpgrade() throws Exception {
@@ -135,6 +153,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
 
         List<ModelSnapshot> snapshots = getModelSnapshots(job.getId(), snapshot.getSnapshotId()).snapshots();
         assertThat(snapshots, hasSize(1));
+        snapshot = snapshots.get(0);
         assertThat(snapshot.getLatestRecordTimeStamp(), equalTo(snapshots.get(0).getLatestRecordTimeStamp()));
 
         // Does the snapshot still work?


### PR DESCRIPTION
This addresses two bugs in snapshot upgrader that were found in backport and adds a new mixed cluster test.