### PR TITLE
Add note about NFS UID and GUID requirements

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -108,10 +108,11 @@ same location on all master and data nodes. Then add the file system's
 path or parent directory to the `path.repo` setting in `elasticsearch.yml` for
 each master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.
-[NOTE]
-====
-When using NFS mounts make sure that all of the cluster nodes use the same UID and GUID numbers for the elasticsearch user, otherwise the repository verification will fail because of file permission mismatch when writing to the shared filesystem.
-====
+
+IMPORTANT: If using a network file system (NFS) mount, use the same `elasticsearch`
+user ID (UID) and group ID (GUID) across all nodes. Otherwise, mismatched file
+permissions may cause write failures.
+
 Supported `path.repo` values vary by platform:
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -109,9 +109,10 @@ path or parent directory to the `path.repo` setting in `elasticsearch.yml` for
 each master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.
 
-IMPORTANT: If using a network file system (NFS) mount, use the same `elasticsearch`
-user ID (UID) and group ID (GUID) across all nodes. Otherwise, mismatched file
-permissions may cause write failures.
+IMPORTANT: By default, a network file system (NFS) uses user IDs (UIDs) and
+group IDs (GIDs) to match accounts across nodes. If your shared file system is
+an NFS and your nodes don't use the same UIDs and GIDs, update your NFS
+configuration to account for this.
 
 Supported `path.repo` values vary by platform:
 

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -108,7 +108,10 @@ same location on all master and data nodes. Then add the file system's
 path or parent directory to the `path.repo` setting in `elasticsearch.yml` for
 each master and data node. For running clusters, this requires a
 <<restart-cluster-rolling,rolling restart>> of each node.
-
+[NOTE]
+====
+When using NFS mounts make sure that all of the cluster nodes use the same UID and GUID numbers for the elasticsearch user, otherwise the repository verification will fail because of file permission mismatch when writing to the shared filesystem.
+====
 Supported `path.repo` values vary by platform:
 
 include::{es-repo-dir}/tab-widgets/code.asciidoc[]


### PR DESCRIPTION
This seems to be a common problem with NFS snapshot repositories, a google search immediately brings up 3 discuss forums posts about snapshot repository problems and they all have to do with mismatched UID and GUID for elasticsearch user.


