### PR TITLE
Add validation in policy files for missing codebases (#64841)

### DIFF
--- a/modules/systemd/src/test/resources/plugin-security.codebases
+++ b/modules/systemd/src/test/resources/plugin-security.codebases
@@ -1,0 +1,1 @@
+systemd: org.elasticsearch.systemd.SystemdPlugin

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -117,6 +118,13 @@ public class PolicyUtilTests extends ESTestCase {
         assertThat(info.jars, containsInAnyOrder(
             plugin.resolve("foo.jar").toUri().toURL(),
             plugin.resolve("bar.jar").toUri().toURL()));
+    }
+
+    public void testPolicyMissingCodebaseProperty() throws Exception {
+        Path plugin = makeDummyPlugin("missing-codebase.policy", "foo.jar");
+        URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PolicyUtil.readPolicy(policyFile, Map.of()));
+        assertThat(e.getMessage(), containsString("Unknown codebases [codebase.doesnotexist] in policy file"));
     }
 
     public void testPolicyPermissions() throws Exception {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -33,6 +33,7 @@ import java.security.Permission;
 import java.security.Policy;
 import java.security.URIParameter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -123,7 +124,8 @@ public class PolicyUtilTests extends ESTestCase {
     public void testPolicyMissingCodebaseProperty() throws Exception {
         Path plugin = makeDummyPlugin("missing-codebase.policy", "foo.jar");
         URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PolicyUtil.readPolicy(policyFile, Map.of()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> PolicyUtil.readPolicy(policyFile, Collections.emptyMap()));
         assertThat(e.getMessage(), containsString("Unknown codebases [codebase.doesnotexist] in policy file"));
     }
 

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/bootstrap/missing-codebase.policy
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/bootstrap/missing-codebase.policy
@@ -1,0 +1,3 @@
+grant codeBase "${codebase.doesnotexist}" {
+  permission java.lang.RuntimePermission "getClassLoader";
+};

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -38,13 +38,13 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.URIParameter;
 import java.security.cert.Certificate;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 public class PolicyUtil {
@@ -79,8 +79,27 @@ public class PolicyUtil {
     @SuppressForbidden(reason = "accesses fully qualified URLs to configure security")
     public static Policy readPolicy(URL policyFile, Map<String, URL> codebases) {
         try {
-            List<String> propertiesSet = new ArrayList<>();
+            Properties originalProps = System.getProperties();
+            // allow missing while still setting values
+            Set<String> unknownCodebases = new HashSet<>();
+            Map<String, String> codebaseProperties = new HashMap<>();
+            Properties tempProps = new Properties(originalProps) {
+                @Override
+                public String getProperty(String key) {
+                    if (key.startsWith("codebase.")) {
+                        String value = codebaseProperties.get(key);
+                        if (value == null) {
+                            unknownCodebases.add(key);
+                        }
+                        return value;
+                    } else {
+                        return super.getProperty(key);
+                    }
+                }
+            };
+
             try {
+                System.setProperties(tempProps);
                 // set codebase properties
                 for (Map.Entry<String,URL> codebase : codebases.entrySet()) {
                     String name = codebase.getKey();
@@ -92,26 +111,27 @@ public class PolicyUtil {
                     String property = "codebase." + name;
                     String aliasProperty = "codebase." + name.replaceFirst("-\\d+\\.\\d+.*\\.jar", "");
                     if (aliasProperty.equals(property) == false) {
-                        propertiesSet.add(aliasProperty);
-                        String previous = System.setProperty(aliasProperty, url.toString());
+
+                        Object previous = codebaseProperties.put(aliasProperty, url.toString());
                         if (previous != null) {
                             throw new IllegalStateException("codebase property already set: " + aliasProperty + " -> " + previous +
-                                                            ", cannot set to " + url.toString());
+                                ", cannot set to " + url.toString());
                         }
                     }
-                    propertiesSet.add(property);
-                    String previous = System.setProperty(property, url.toString());
+                    Object previous = codebaseProperties.put(property, url.toString());
                     if (previous != null) {
                         throw new IllegalStateException("codebase property already set: " + property + " -> " + previous +
                                                         ", cannot set to " + url.toString());
                     }
                 }
-                return Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
-            } finally {
-                // clear codebase properties
-                for (String property : propertiesSet) {
-                    System.clearProperty(property);
+                Policy policy = Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
+                if (unknownCodebases.isEmpty() == false) {
+                    throw new IllegalArgumentException("Unknown codebases " + unknownCodebases + " in policy file [" + policyFile + "]" +
+                        "\nAvailable codebases: " + codebaseProperties.keySet());
                 }
+                return policy;
+            } finally {
+                System.setProperties(originalProps);
             }
         } catch (NoSuchAlgorithmException | URISyntaxException e) {
             throw new IllegalArgumentException("unable to parse policy file `" + policyFile + "`", e);

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -256,7 +256,7 @@ public class BootstrapForTesting {
                     // load codebase to class map used for tests
                     policyCodebases = new HashMap<>(codebasesMap);
                     Map<String, String> codebasesProps = parsePropertiesFile(codebasesPath);
-                    for (var entry : codebasesProps.entrySet()) {
+                    for (Map.Entry<String, String> entry : codebasesProps.entrySet()) {
                         addClassCodebase(policyCodebases, entry.getKey(), entry.getValue());
                     }
                 }


### PR DESCRIPTION
Elasticsearch plugins can add a java security policy file to grant
additional permissions. These policy files can contain permission grants
for specific jar files, which are specified through system properties.
Unfortunately the java policy parser is lenient when a system property
is missing, meaning we can't know if there is a typo or grant for a no
longer relevant jar file.

This commit adds validation to the policy parsing by overriding the
system properties and tracking when a missing system property is used.