### PR TITLE
Fix "resource not found" exception on existing EQL async search

### DIFF
--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
@@ -121,6 +121,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
         if (randomBoolean()) {
             // let's timeout first
             GetAsyncResultRequest getResultsRequest = new GetAsyncResultRequest(response.id())
+                .setKeepAlive(TimeValue.timeValueMinutes(10))
                 .setWaitForCompletionTimeout(TimeValue.timeValueMillis(10));
             EqlSearchResponse responseWithTimeout = client().execute(EqlAsyncGetResultAction.INSTANCE, getResultsRequest).get();
             assertThat(responseWithTimeout.isRunning(), is(true));
@@ -130,6 +131,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
         // Now we wait
         GetAsyncResultRequest getResultsRequest = new GetAsyncResultRequest(response.id())
+            .setKeepAlive(TimeValue.timeValueMinutes(10))
             .setWaitForCompletionTimeout(TimeValue.timeValueSeconds(10));
         ActionFuture<EqlSearchResponse> future = client().execute(EqlAsyncGetResultAction.INSTANCE, getResultsRequest);
         disableBlocks(plugins);
@@ -141,7 +143,6 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
             Exception ex = expectThrows(Exception.class, future::actionGet);
             assertThat(ex.getCause().getMessage(), containsString("by zero"));
         }
-
         AcknowledgedResponse deleteResponse =
             client().execute(DeleteAsyncResultAction.INSTANCE, new DeleteAsyncResultRequest(response.id())).actionGet();
         assertThat(deleteResponse.isAcknowledged(), equalTo(true));

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
@@ -56,7 +56,7 @@ public class TransportEqlAsyncGetResultAction extends HandledTransportAction<Get
         Writeable.Reader<StoredAsyncResponse<EqlSearchResponse>> reader = in -> new StoredAsyncResponse<>(EqlSearchResponse::new, in);
         AsyncTaskIndexService<StoredAsyncResponse<EqlSearchResponse>> store = new AsyncTaskIndexService<>(XPackPlugin.ASYNC_RESULTS_INDEX,
             clusterService, threadPool.getThreadContext(), client, ASYNC_SEARCH_ORIGIN, reader, registry);
-        return new AsyncResultsService<>(store, true, EqlSearchTask.class,
+        return new AsyncResultsService<>(store, false, EqlSearchTask.class,
             (task, listener, timeout) -> AsyncTaskManagementService.addCompletionListener(threadPool, task, listener, timeout),
             transportService.getTaskManager(), clusterService);
     }


### PR DESCRIPTION
This change fixes the initialization of the async results service
for the EQL get async action. The boolean that differentiates EQL
from normal _async_search request is set incorrectly, which results
in errors (404) when extending the keep alive of a running EQL search.

Fixes #65108