### PR TITLE
Remove support for index analysis version setting.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -85,11 +85,6 @@ public class Analysis {
         if (sVersion != null) {
             return Lucene.parseVersion(sVersion, Version.LATEST, logger);
         }
-        // check for explicit version on the index itself as default for all analysis components
-        sVersion = indexSettings.get("index.analysis.version");
-        if (sVersion != null) {
-            return Lucene.parseVersion(sVersion, Version.LATEST, logger);
-        }
         // resolve the analysis version based on the version the index was created with
         return org.elasticsearch.Version.indexCreated(indexSettings).luceneVersion;
     }


### PR DESCRIPTION
By default, analyzers are initialized with the Lucene version on which the index
was created. The 'index.analysis.version' setting allows for specifying a
different Lucene version for analyzers.

This PR proposes to remove the setting since it adds complexity and there's not
a good use case for it.