### PR TITLE
Fix a NPE bug caused by code keep executing after listener returns (#64762)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.action.token;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -29,6 +30,7 @@ import org.elasticsearch.xpack.security.authc.kerberos.KerberosAuthenticationTok
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Transport action responsible for creating a token based on a request. Requests provide user
@@ -78,7 +80,12 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
     private void authenticateAndCreateToken(GrantType grantType, CreateTokenRequest request, ActionListener<CreateTokenResponse> listener) {
         Authentication originatingAuthentication = securityContext.getAuthentication();
         try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
-            final AuthenticationToken authToken = extractAuthenticationToken(grantType, request, listener);
+            final Tuple<AuthenticationToken, Optional<Exception>> tokenAndException = extractAuthenticationToken(grantType, request);
+            if (tokenAndException.v2().isPresent()) {
+                listener.onFailure(tokenAndException.v2().get());
+                return;
+            }
+            final AuthenticationToken authToken = tokenAndException.v1();
             if (authToken == null) {
                 listener.onFailure(new IllegalStateException(
                         "grant_type [" + request.getGrantType() + "] is not supported by the create token action"));
@@ -101,23 +108,23 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
         }
     }
 
-    private AuthenticationToken extractAuthenticationToken(GrantType grantType, CreateTokenRequest request,
-            ActionListener<CreateTokenResponse> listener) {
+    private Tuple<AuthenticationToken, Optional<Exception>> extractAuthenticationToken(GrantType grantType, CreateTokenRequest request) {
         AuthenticationToken authToken = null;
         if (grantType == GrantType.PASSWORD) {
             authToken = new UsernamePasswordToken(request.getUsername(), request.getPassword());
         } else if (grantType == GrantType.KERBEROS) {
             SecureString kerberosTicket = request.getKerberosTicket();
             String base64EncodedToken = kerberosTicket.toString();
-            byte[] decodedKerberosTicket = null;
+            byte[] decodedKerberosTicket;
             try {
                 decodedKerberosTicket = Base64.getDecoder().decode(base64EncodedToken);
             } catch (IllegalArgumentException iae) {
-                listener.onFailure(new UnsupportedOperationException("could not decode base64 kerberos ticket " + base64EncodedToken));
+                return new Tuple<>(null,
+                    Optional.of(new UnsupportedOperationException("could not decode base64 kerberos ticket " + base64EncodedToken, iae)));
             }
             authToken = new KerberosAuthenticationToken(decodedKerberosTicket);
         }
-        return authToken;
+        return new Tuple<>(authToken, Optional.empty());
     }
 
     private void clearCredentialsFromRequest(GrantType grantType, CreateTokenRequest request) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -26,12 +26,14 @@ import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
+import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -60,9 +62,11 @@ import java.time.Clock;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -267,5 +271,39 @@ public class TransportCreateTokenActionTests extends ESTestCase {
             assertNotNull(sourceMap.get("access_token"));
             assertNotNull(sourceMap.get("refresh_token"));
         }
+    }
+
+    public void testKerberosGrantTypeWillFailOnBase64DecodeError() throws Exception {
+        final TokenService tokenService = new TokenService(SETTINGS, Clock.systemUTC(), client, license, securityContext,
+            securityIndex, securityIndex, clusterService);
+        Authentication authentication = new Authentication(new User("joe"), new Authentication.RealmRef("realm", "type", "node"), null);
+        authentication.writeToContext(threadPool.getThreadContext());
+
+        final TransportCreateTokenAction action = new TransportCreateTokenAction(threadPool,
+            mock(TransportService.class), new ActionFilters(Collections.emptySet()), tokenService,
+            authenticationService, securityContext);
+        final CreateTokenRequest createTokenRequest = new CreateTokenRequest();
+        createTokenRequest.setGrantType("_kerberos");
+        final char[] invalidBase64Chars = "!\"#$%&\\'()*,./:;<>?@[]^_`{|}~\t\n\r".toCharArray();
+        final String kerberosTicketValue = Strings.arrayToDelimitedString(
+            randomArray(1, 10, Character[]::new,
+                () -> invalidBase64Chars[randomIntBetween(0, invalidBase64Chars.length - 1)]), "");
+        createTokenRequest.setKerberosTicket(new SecureString(kerberosTicketValue.toCharArray()));
+
+        PlainActionFuture<CreateTokenResponse> tokenResponseFuture = new PlainActionFuture<>();
+        action.doExecute(null, createTokenRequest, assertListenerIsOnlyCalledOnce(tokenResponseFuture));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> tokenResponseFuture.actionGet());
+        assertThat(e.getMessage(), containsString("could not decode base64 kerberos ticket"));
+        // The code flow should stop after above failure and never reach authenticationService
+        Mockito.verifyZeroInteractions(authenticationService);
+    }
+
+    private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {
+        final AtomicInteger callCount = new AtomicInteger(0);
+        return ActionListener.runBefore(delegate, () -> {
+            if (callCount.incrementAndGet() != 1) {
+                fail("Listener was called twice");
+            }
+        });
     }
 }


### PR DESCRIPTION
Another instance of the classic bug of "not returning after listener.onFailure is invoked". 
The bug did not cause any real issue since the execution simply runs into a NPE.
