### PR TITLE
[DOCS] Adds UI related limitation to configuring aggs docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -47,7 +47,7 @@ functions, set the interval to the same value as the bucket span.
 
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
 plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
-Viewer** nor the ***Anomaly Explorer** in {kib} can plot and display an anomaly 
+Viewer** nor the **Anomaly Explorer** in {kib} can plot and display an anomaly 
 chart for the job. Single Metric Viewer don't support configurations where 
 the aggregation interval and the bucket span in Single Metric Viewer don't 
 match. To avoid this case, make sure that the aggregation interval in the 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,6 +45,10 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
+If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
+plot is not enabled for the {anomaly-job}, then the **Single Metric Viewer** in 
+{kib} cannot plot and display an anomaly chart for the job.
+
 
 [discrete]
 [[aggs-include-jobs]]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -48,7 +48,7 @@ functions, set the interval to the same value as the bucket span.
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
 plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
 Viewer** nor the **Anomaly Explorer** in {kib} can plot and display an anomaly 
-chart for the job. Single Metric Viewer don't support configurations where 
+chart for the job. Single Metric Viewer doesn't support configurations where 
 the aggregation interval and the bucket span in Single Metric Viewer don't 
 match. To avoid this case, make sure that the aggregation interval in the 
 {dfeed} configuration and the bucket span in the {anomaly-job} configuration 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,14 +45,14 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
-If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
-plot is not enabled for the {anomaly-job}, then neither can the **Single Metric 
-Viewer** nor the **Anomaly Explorer** in {kib} plot and display an anomaly 
+If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and model 
+plot is not enabled for the {anomaly-job}, neither the **Single Metric 
+Viewer** nor the **Anomaly Explorer** can plot and display an anomaly 
 chart for the job.
 
 When the aggregation interval of the {dfeed} and the bucket span of the job 
-don't match, the values of the chart plotted in both the Single Metric Viewer 
-and the Anomaly Explorer differs from the actual values of the job. To avoid 
+don't match, the values of the chart plotted in both the **Single Metric Viewer** 
+and the **Anomaly Explorer** differ from the actual values of the job. To avoid 
 this behavior, make sure that the aggregation interval in the {dfeed} 
 configuration and the bucket span in the {anomaly-job} configuration have the 
 same values.

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,15 +45,15 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
-If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and model 
-plot is not enabled for the {anomaly-job}, neither the **Single Metric 
+If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and 
+model plot is not enabled for the {anomaly-job}, neither the **Single Metric 
 Viewer** nor the **Anomaly Explorer** can plot and display an anomaly 
-chart for the job.
+chart for the job. In this cases, the charts are blank.
 
 When the aggregation interval of the {dfeed} and the bucket span of the job 
-don't match, the values of the chart plotted in both the **Single Metric Viewer** 
-and the **Anomaly Explorer** differ from the actual values of the job. To avoid 
-this behavior, make sure that the aggregation interval in the {dfeed} 
+don't match, the values of the chart plotted in both the **Single Metric 
+Viewer** and the **Anomaly Explorer** differ from the actual values of the job. 
+To avoid this behavior, make sure that the aggregation interval in the {dfeed} 
 configuration and the bucket span in the {anomaly-job} configuration have the 
 same values.
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -48,7 +48,8 @@ functions, set the interval to the same value as the bucket span.
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and 
 model plot is not enabled for the {anomaly-job}, neither the **Single Metric 
 Viewer** nor the **Anomaly Explorer** can plot and display an anomaly 
-chart for the job. In this cases, the charts are blank.
+chart for the job. In this cases, the charts are not visible and an explanatory 
+message is shown.
 
 When the aggregation interval of the {dfeed} and the bucket span of the job 
 don't match, the values of the chart plotted in both the **Single Metric 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -46,8 +46,9 @@ your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
-plot is not enabled for the {anomaly-job}, then the **Single Metric Viewer** in 
-{kib} cannot plot and display an anomaly chart for the job.
+plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
+Viewer** nor the ***Anomaly Explorer** in {kib} can plot and display an anomaly 
+chart for the job.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -46,13 +46,16 @@ your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
-plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
-Viewer** nor the **Anomaly Explorer** in {kib} can plot and display an anomaly 
-chart for the job. Single Metric Viewer doesn't support configurations where 
-the aggregation interval and the bucket span in Single Metric Viewer don't 
-match. To avoid this case, make sure that the aggregation interval in the 
-{dfeed} configuration and the bucket span in the {anomaly-job} configuration 
-have the same values.
+plot is not enabled for the {anomaly-job}, then neither can the **Single Metric 
+Viewer** nor the **Anomaly Explorer** in {kib} plot and display an anomaly 
+chart for the job.
+
+When the aggregation interval of the {dfeed} and the bucket span of the job 
+don't match, the values of the chart plotted in both the Single Metric Viewer 
+and the Anomaly Explorer differs from the actual values of the job. To avoid 
+this behavior, make sure that the aggregation interval in the {dfeed} 
+configuration and the bucket span in the {anomaly-job} configuration have the 
+same values.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -48,7 +48,11 @@ functions, set the interval to the same value as the bucket span.
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
 plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
 Viewer** nor the ***Anomaly Explorer** in {kib} can plot and display an anomaly 
-chart for the job.
+chart for the job. Single Metric Viewer don't support configurations where 
+the aggregation interval and the bucket span in Single Metric Viewer don't 
+match. To avoid this case, make sure that the aggregation interval in the 
+{dfeed} configuration and the bucket span in the {anomaly-job} configuration 
+have the same values.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -48,7 +48,7 @@ functions, set the interval to the same value as the bucket span.
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and 
 model plot is not enabled for the {anomaly-job}, neither the **Single Metric 
 Viewer** nor the **Anomaly Explorer** can plot and display an anomaly 
-chart for the job. In this cases, the charts are blank.
+chart for the job. In these cases, the charts are blank.
 
 When the aggregation interval of the {dfeed} and the bucket span of the job 
 don't match, the values of the chart plotted in both the **Single Metric 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -48,12 +48,8 @@ functions, set the interval to the same value as the bucket span.
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and 
 model plot is not enabled for the {anomaly-job}, neither the **Single Metric 
 Viewer** nor the **Anomaly Explorer** can plot and display an anomaly 
-<<<<<<< HEAD
 chart for the job. In this cases, the charts are not visible and an explanatory 
 message is shown.
-=======
-chart for the job. In these cases, the charts are blank.
->>>>>>> c7ee66b56a48246a14543ad24dc6b691a1c9a226
 
 When the aggregation interval of the {dfeed} and the bucket span of the job 
 don't match, the values of the chart plotted in both the **Single Metric 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -47,7 +47,7 @@ functions, set the interval to the same value as the bucket span.
 
 If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms`>> and model 
 plot is not enabled for the {anomaly-job}, then neither the **Single Metric 
-Viewer** nor the ***Anomaly Explorer** in {kib} can plot and display an anomaly 
+Viewer** nor the **Anomaly Explorer** in {kib} can plot and display an anomaly 
 chart for the job.
 
 


### PR DESCRIPTION
## Overview

This PR adds a UI related limitation to the `Requirements and limitations` section of the Aggregating data for faster performance doc. The limitation is about aggregation types in datafeeds that are not supported by the Single Metric Viewer in Kibana.

**Applies to 7.11 and above.** 
(https://github.com/elastic/elasticsearch/pull/65190 handles 7.10 and below.)

### Preview

[Requirements and limitations](https://elasticsearch_65184.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-configuring-aggregation.html#aggs-limits-dfeeds)