### PR TITLE
[7.x] [ML] Truncate long audit messages (#64849)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
@@ -6,13 +6,20 @@
 package org.elasticsearch.xpack.core.common.notifications;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
+import java.io.IOException;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class AbstractAuditMessageTests extends AbstractXContentTestCase<AbstractAuditMessageTests.TestAuditMessage> {
 
@@ -77,6 +84,70 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
         assertThat(message.getLevel(), equalTo(Level.ERROR));
         assertThat(message.getTimestamp(), equalTo(TIMESTAMP));
         assertThat(message.getNodeName(), equalTo(NODE_NAME));
+    }
+
+    public void testLongMessageIsTruncated() throws IOException {
+        AbstractAuditMessage longMessage = new AbstractAuditMessage(
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            "thisis17charslong".repeat(490),
+            randomFrom(Level.values()),
+            new Date(),
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20)
+        ) {
+            @Override
+            public String getJobType() {
+                return "unused";
+            }
+
+            @Override
+            protected String getResourceField() {
+                return "unused";
+            }
+        };
+
+        assertThat(longMessage.getMessage().length(), greaterThan(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
+
+        // serialise the message and check the new message is truncated
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalXContent = XContentHelper.toXContent(longMessage, xContentType, randomBoolean());
+        XContentParser parser = createParser(XContentFactory.xContent(xContentType), originalXContent);
+        AbstractAuditMessage parsed = doParseInstance(parser);
+        assertThat(parsed.getMessage().length(), equalTo(AbstractAuditMessage.MAX_AUDIT_MESSAGE_CHARS));
+    }
+
+    public void testTruncateString() {
+        String message = "a short message short message short message short message short message";
+        String truncated = AbstractAuditMessage.truncateMessage(message, 20);
+        assertEquals("a ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(20));
+
+        truncated = AbstractAuditMessage.truncateMessage(message, 23);
+        assertEquals("a short ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(23));
+
+        truncated = AbstractAuditMessage.truncateMessage(message, 31);
+        assertEquals("a short message ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(31));
+
+        truncated = AbstractAuditMessage.truncateMessage(message, 32);
+        assertEquals("a short message ... (truncated)", truncated);
+        assertThat(truncated.length(), lessThanOrEqualTo(32));
+    }
+
+    public void testTruncateString_noSpaceChar() {
+        String message = "ashortmessageshortmessageshortmessageshortmessageshortmessage";
+        String truncated = AbstractAuditMessage.truncateMessage(message, 20);
+        assertEquals("ashor... (truncated)", truncated);
+        assertEquals(20, truncated.length());
+        truncated = AbstractAuditMessage.truncateMessage(message, 25);
+        assertEquals("ashortmess... (truncated)", truncated);
+        assertEquals(25, truncated.length());
+    }
+
+    public void testTruncateString_tabsInsteadOfSpaces() {
+        String truncated = AbstractAuditMessage.truncateMessage("a\tshort\tmessage\tshort\tmessage", 25);
+        assertEquals("a\tshort\tme... (truncated)", truncated);
+        assertEquals(25, truncated.length());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
@@ -87,9 +87,13 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
     }
 
     public void testLongMessageIsTruncated() throws IOException {
+        StringBuilder messageText = new StringBuilder();
+        for (int i=0; i<490; i++) {
+            messageText.append("thisis17charslong");
+        }
         AbstractAuditMessage longMessage = new AbstractAuditMessage(
             randomBoolean() ? null : randomAlphaOfLength(10),
-            "thisis17charslong".repeat(490),
+            messageText.toString(),
             randomFrom(Level.values()),
             new Date(),
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Truncate long audit messages (#64849)