### PR TITLE
EQL: Add wildcard functionality to `:` operator

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -342,19 +342,19 @@ query = '''
 registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] : "EN"
 '''
 
-# [[queries]]
-# name = "keyPathWildcard"
-# query = '''
-# registry where key_path : "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F"
-# '''
-# expected_event_ids  = [79]
-#
-# [[queries]]
-# name = "processPathWildcardAndIN"
-# query = '''
-# process where process_path : "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)
-# '''
-# expected_event_ids  = [84, 85]
+[[queries]]
+name = "keyPathWildcard"
+query = '''
+registry where key_path : "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F"
+'''
+expected_event_ids  = [79]
+
+[[queries]]
+name = "processPathWildcardAndIN"
+query = '''
+process where process_path : "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)
+'''
+expected_event_ids  = [84, 85]
 
 [[queries]]
 name = "descendant1"
@@ -385,13 +385,13 @@ process where opcode==1 and process_name : "smss.exe"
 '''
 expected_event_ids  = [78]
 
-# [[queries]]
-# name = "wildcardAndMultipleConditions1"
-# query = '''
-# file where file_path:"*\\red_ttp\\winin*.*"
-#   and opcode in (0,1,2) and user_name:"vagrant"
-# '''
-# expected_event_ids  = [83, 86]
+[[queries]]
+name = "wildcardAndMultipleConditions1"
+query = '''
+file where file_path:"*\\red_ttp\\winin*.*"
+  and opcode in (0,1,2) and user_name:"vagrant"
+'''
+expected_event_ids  = [83, 86]
 
 [[queries]]
 name = "wildcardAndMultipleConditions2"
@@ -401,13 +401,13 @@ file where file_path:"*\\red_ttp\\winin*.*"
 '''
 expected_event_ids  = []
 
-# [[queries]]
-# name = "wildcardAndMultipleConditions3"
-# query = '''
-# file where file_path:"*\\red_ttp\\winin*.*"
-#   and opcode not in (3, 4, 5, 6 ,7) and user_name:"vagrant"
-# '''
-# expected_event_ids  = [83, 86]
+[[queries]]
+name = "wildcardAndMultipleConditions3"
+query = '''
+file where file_path:"*\\red_ttp\\winin*.*"
+  and opcode not in (3, 4, 5, 6 ,7) and user_name:"vagrant"
+'''
+expected_event_ids  = [83, 86]
 
 
 [[queries]]
@@ -878,16 +878,16 @@ sequence
 '''
 expected_event_ids  = [87, 92]
 
-# [[queries]]
-# name = "doubleSameSequenceWithByUntilAndHead1"
-# query = '''
-# sequence
-#   [file where opcode==0 and file_name:"*.exe"] by unique_pid
-#   [file where opcode==0 and file_name:"*.exe"] by unique_pid
-# until [process where opcode==5000] by unique_ppid
-# | head 1
-# '''
-# expected_event_ids  = [55, 61]
+[[queries]]
+name = "doubleSameSequenceWithByUntilAndHead1"
+query = '''
+sequence
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid
+  [file where opcode==0 and file_name:"*.exe"] by unique_pid
+until [process where opcode==5000] by unique_ppid
+| head 1
+'''
+expected_event_ids  = [55, 61]
 
 [[queries]]
 name = "doubleSameSequenceWithByUntilAndHead2"
@@ -1040,16 +1040,16 @@ query = '''
 registry where length(bad_field) > 0
 '''
 
-# [[queries]]
-# name = "multipleConditions2"
-# query = '''
-# process where opcode == 1
-#   and process_name in ("net.exe", "net1.exe")
-#   and not (parent_process_name : "net.exe"
-#   and process_name : "net1.exe")
-#   and command_line : "*group *admin*" and command_line != "* /add*"
-#   '''
-# expected_event_ids  = [97]
+[[queries]]
+name = "multipleConditions2"
+query = '''
+process where opcode == 1
+  and process_name in ("net.exe", "net1.exe")
+  and not (parent_process_name : "net.exe"
+  and process_name : "net1.exe")
+  and command_line : "*group *admin*" and command_line != "* /add*"
+  '''
+expected_event_ids  = [97]
 
 [[queries]]
 name = "anyWithUnique"
@@ -1246,26 +1246,26 @@ sequence
 '''
 expected_event_ids  = [54, 55, 56, 54, 61, 62, 54, 67, 68, 54, 72, 73]
 
-# [[queries]]
-# name = "wildcard1"
-# query = '''
-# process where command_line : "*%*"
-# '''
-# expected_event_ids  = [4, 6, 28]
-#
-# [[queries]]
-# name = "wildcard2"
-# query = '''
-# process where command_line : "*%*%*"
-# '''
-# expected_event_ids  = [4, 6, 28]
-#
-# [[queries]]
-# name = "wildcard3"
-# query = '''
-# process where command_line : "%*%*"
-# '''
-# expected_event_ids  = [4, 6, 28]
+[[queries]]
+name = "wildcard1"
+query = '''
+process where command_line : "*%*"
+'''
+expected_event_ids  = [4, 6, 28]
+
+[[queries]]
+name = "wildcard2"
+query = '''
+process where command_line : "*%*%*"
+'''
+expected_event_ids  = [4, 6, 28]
+
+[[queries]]
+name = "wildcard3"
+query = '''
+process where command_line : "%*%*"
+'''
+expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 name = "uniqueCount1"

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
@@ -487,26 +487,26 @@ sequence by hostname with maxspan=5m
 time = 7.179757833480835
 type = "sequence"
 
-#[[queries]]
-#queryNo = 28
-#case_insensitive = true
-#count = 1
-#expected_event_ids = [3299718, 3364047]
-#filter_counts = [24, 3, 37]
-#filters = [
-#  'process where process_name == "powershell.exe" and opcode == 1',
-#  'powershell where message == "*Get-NetShare*"',
-#  'process where process_name == "powershell.exe" and opcode == 2'
-#]
-#query = """
-#sequence by hostname, pid
-#   [process where process_name == "powershell.exe" and opcode == 1]
-#   [powershell where message == "*Get-NetShare*"]
-#until
-#   [process where process_name == "powershell.exe" and opcode == 2]
-#"""
-#time = 2.123962879180908
-#type = "sequence"
+[[queries]]
+queryNo = 28
+case_insensitive = true
+count = 1
+expected_event_ids = [3299718, 3364047]
+filter_counts = [24, 3, 37]
+filters = [
+  'process where process_name : "powershell.exe" and opcode == 1',
+  'powershell where message : "*Get-NetShare*"',
+  'process where process_name : "powershell.exe" and opcode == 2'
+]
+query = """
+sequence by hostname, pid
+   [process where process_name : "powershell.exe" and opcode == 1]
+   [powershell where message : "*Get-NetShare*"]
+until
+   [process where process_name : "powershell.exe" and opcode == 2]
+"""
+time = 2.123962879180908
+type = "sequence"
 
 [[queries]]
 queryNo = 29

--- a/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
+++ b/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
@@ -100,6 +100,7 @@ operatorExpression
 //   https://github.com/antlr/antlr4/issues/781
 predicate
     : NOT? kind=IN LP expression (COMMA expression)* RP
+    | seqPredicate
     ;
 
 primaryExpression
@@ -124,8 +125,12 @@ constant
     | string                                                                            #stringLiteral
     ;
 
+seqPredicate
+    : SEQ constant                                                                      #seqValue
+    ;
+
 comparisonOperator
-    : SEQ | EQ | NEQ | LT | LTE | GT | GTE
+    : EQ | NEQ | LT | LTE | GT | GTE
     ;
 
 booleanValue

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseBaseListener.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseBaseListener.java
@@ -436,6 +436,18 @@ class EqlBaseBaseListener implements EqlBaseListener {
    *
    * <p>The default implementation does nothing.</p>
    */
+  @Override public void enterSeqValue(EqlBaseParser.SeqValueContext ctx) { }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation does nothing.</p>
+   */
+  @Override public void exitSeqValue(EqlBaseParser.SeqValueContext ctx) { }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation does nothing.</p>
+   */
   @Override public void enterComparisonOperator(EqlBaseParser.ComparisonOperatorContext ctx) { }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseBaseVisitor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseBaseVisitor.java
@@ -262,6 +262,13 @@ class EqlBaseBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements EqlBa
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
+  @Override public T visitSeqValue(EqlBaseParser.SeqValueContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
   @Override public T visitComparisonOperator(EqlBaseParser.ComparisonOperatorContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseListener.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseListener.java
@@ -392,6 +392,18 @@ interface EqlBaseListener extends ParseTreeListener {
    */
   void exitStringLiteral(EqlBaseParser.StringLiteralContext ctx);
   /**
+   * Enter a parse tree produced by the {@code seqValue}
+   * labeled alternative in {@link EqlBaseParser#seqPredicate}.
+   * @param ctx the parse tree
+   */
+  void enterSeqValue(EqlBaseParser.SeqValueContext ctx);
+  /**
+   * Exit a parse tree produced by the {@code seqValue}
+   * labeled alternative in {@link EqlBaseParser#seqPredicate}.
+   * @param ctx the parse tree
+   */
+  void exitSeqValue(EqlBaseParser.SeqValueContext ctx);
+  /**
    * Enter a parse tree produced by {@link EqlBaseParser#comparisonOperator}.
    * @param ctx the parse tree
    */

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
@@ -30,16 +30,16 @@ class EqlBaseParser extends Parser {
     RULE_subquery = 11, RULE_eventQuery = 12, RULE_eventFilter = 13, RULE_expression = 14, 
     RULE_booleanExpression = 15, RULE_valueExpression = 16, RULE_operatorExpression = 17, 
     RULE_predicate = 18, RULE_primaryExpression = 19, RULE_functionExpression = 20, 
-    RULE_functionName = 21, RULE_constant = 22, RULE_comparisonOperator = 23, 
-    RULE_booleanValue = 24, RULE_qualifiedName = 25, RULE_identifier = 26, 
-    RULE_timeUnit = 27, RULE_number = 28, RULE_string = 29, RULE_eventValue = 30;
+    RULE_functionName = 21, RULE_constant = 22, RULE_seqPredicate = 23, RULE_comparisonOperator = 24, 
+    RULE_booleanValue = 25, RULE_qualifiedName = 26, RULE_identifier = 27, 
+    RULE_timeUnit = 28, RULE_number = 29, RULE_string = 30, RULE_eventValue = 31;
   public static final String[] ruleNames = {
     "singleStatement", "singleExpression", "statement", "query", "sequenceParams", 
     "sequence", "join", "pipe", "joinKeys", "joinTerm", "sequenceTerm", "subquery", 
     "eventQuery", "eventFilter", "expression", "booleanExpression", "valueExpression", 
     "operatorExpression", "predicate", "primaryExpression", "functionExpression", 
-    "functionName", "constant", "comparisonOperator", "booleanValue", "qualifiedName", 
-    "identifier", "timeUnit", "number", "string", "eventValue"
+    "functionName", "constant", "seqPredicate", "comparisonOperator", "booleanValue", 
+    "qualifiedName", "identifier", "timeUnit", "number", "string", "eventValue"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -136,9 +136,9 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(62);
+      setState(64);
       statement();
-      setState(63);
+      setState(65);
       match(EOF);
       }
     }
@@ -183,9 +183,9 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(65);
+      setState(67);
       expression();
-      setState(66);
+      setState(68);
       match(EOF);
       }
     }
@@ -236,19 +236,19 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(68);
+      setState(70);
       query();
-      setState(72);
+      setState(74);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==PIPE) {
         {
         {
-        setState(69);
+        setState(71);
         pipe();
         }
         }
-        setState(74);
+        setState(76);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -298,19 +298,19 @@ class EqlBaseParser extends Parser {
     QueryContext _localctx = new QueryContext(_ctx, getState());
     enterRule(_localctx, 6, RULE_query);
     try {
-      setState(78);
+      setState(80);
       switch (_input.LA(1)) {
       case SEQUENCE:
         enterOuterAlt(_localctx, 1);
         {
-        setState(75);
+        setState(77);
         sequence();
         }
         break;
       case JOIN:
         enterOuterAlt(_localctx, 2);
         {
-        setState(76);
+        setState(78);
         join();
         }
         break;
@@ -319,7 +319,7 @@ class EqlBaseParser extends Parser {
       case IDENTIFIER:
         enterOuterAlt(_localctx, 3);
         {
-        setState(77);
+        setState(79);
         eventQuery();
         }
         break;
@@ -370,14 +370,14 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(80);
+      setState(82);
       match(WITH);
       {
-      setState(81);
-      match(MAXSPAN);
-      setState(82);
-      match(ASGN);
       setState(83);
+      match(MAXSPAN);
+      setState(84);
+      match(ASGN);
+      setState(85);
       timeUnit();
       }
       }
@@ -437,19 +437,19 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(85);
+      setState(87);
       match(SEQUENCE);
-      setState(94);
+      setState(96);
       switch (_input.LA(1)) {
       case BY:
         {
-        setState(86);
-        ((SequenceContext)_localctx).by = joinKeys();
         setState(88);
+        ((SequenceContext)_localctx).by = joinKeys();
+        setState(90);
         _la = _input.LA(1);
         if (_la==WITH) {
           {
-          setState(87);
+          setState(89);
           sequenceParams();
           }
         }
@@ -458,13 +458,13 @@ class EqlBaseParser extends Parser {
         break;
       case WITH:
         {
-        setState(90);
-        sequenceParams();
         setState(92);
+        sequenceParams();
+        setState(94);
         _la = _input.LA(1);
         if (_la==BY) {
           {
-          setState(91);
+          setState(93);
           ((SequenceContext)_localctx).disallowed = joinKeys();
           }
         }
@@ -476,29 +476,29 @@ class EqlBaseParser extends Parser {
       default:
         throw new NoViableAltException(this);
       }
-      setState(96);
+      setState(98);
       sequenceTerm();
-      setState(98); 
+      setState(100); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
         {
         {
-        setState(97);
+        setState(99);
         sequenceTerm();
         }
         }
-        setState(100); 
+        setState(102); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
-      setState(104);
+      setState(106);
       _la = _input.LA(1);
       if (_la==UNTIL) {
         {
-        setState(102);
+        setState(104);
         match(UNTIL);
-        setState(103);
+        setState(105);
         ((SequenceContext)_localctx).until = sequenceTerm();
         }
       }
@@ -556,40 +556,40 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(106);
-      match(JOIN);
       setState(108);
+      match(JOIN);
+      setState(110);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(107);
+        setState(109);
         ((JoinContext)_localctx).by = joinKeys();
         }
       }
 
-      setState(110);
+      setState(112);
       joinTerm();
-      setState(112); 
+      setState(114); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
         {
         {
-        setState(111);
+        setState(113);
         joinTerm();
         }
         }
-        setState(114); 
+        setState(116); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
-      setState(118);
+      setState(120);
       _la = _input.LA(1);
       if (_la==UNTIL) {
         {
-        setState(116);
+        setState(118);
         match(UNTIL);
-        setState(117);
+        setState(119);
         ((JoinContext)_localctx).until = joinTerm();
         }
       }
@@ -647,29 +647,29 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(120);
+      setState(122);
       match(PIPE);
-      setState(121);
+      setState(123);
       ((PipeContext)_localctx).kind = match(IDENTIFIER);
-      setState(130);
+      setState(132);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER) | (1L << QUOTED_IDENTIFIER))) != 0)) {
         {
-        setState(122);
+        setState(124);
         booleanExpression(0);
-        setState(127);
+        setState(129);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(123);
+          setState(125);
           match(COMMA);
-          setState(124);
+          setState(126);
           booleanExpression(0);
           }
           }
-          setState(129);
+          setState(131);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
@@ -727,23 +727,23 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(132);
+      setState(134);
       match(BY);
-      setState(133);
+      setState(135);
       expression();
-      setState(138);
+      setState(140);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==COMMA) {
         {
         {
-        setState(134);
+        setState(136);
         match(COMMA);
-        setState(135);
+        setState(137);
         expression();
         }
         }
-        setState(140);
+        setState(142);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -794,13 +794,13 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(141);
-      subquery();
       setState(143);
+      subquery();
+      setState(145);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(142);
+        setState(144);
         ((JoinTermContext)_localctx).by = joinKeys();
         }
       }
@@ -852,13 +852,13 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(145);
-      subquery();
       setState(147);
+      subquery();
+      setState(149);
       _la = _input.LA(1);
       if (_la==BY) {
         {
-        setState(146);
+        setState(148);
         ((SequenceTermContext)_localctx).by = joinKeys();
         }
       }
@@ -907,11 +907,11 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(149);
-      match(LB);
-      setState(150);
-      eventFilter();
       setState(151);
+      match(LB);
+      setState(152);
+      eventFilter();
+      setState(153);
       match(RB);
       }
     }
@@ -955,7 +955,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(153);
+      setState(155);
       eventFilter();
       }
     }
@@ -1005,27 +1005,27 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(157);
+      setState(159);
       switch (_input.LA(1)) {
       case ANY:
         {
-        setState(155);
+        setState(157);
         match(ANY);
         }
         break;
       case STRING:
       case IDENTIFIER:
         {
-        setState(156);
+        setState(158);
         ((EventFilterContext)_localctx).event = eventValue();
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(159);
+      setState(161);
       match(WHERE);
-      setState(160);
+      setState(162);
       expression();
       }
     }
@@ -1069,7 +1069,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(162);
+      setState(164);
       booleanExpression(0);
       }
     }
@@ -1199,7 +1199,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(171);
+      setState(173);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
       case 1:
@@ -1208,9 +1208,9 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(165);
+        setState(167);
         match(NOT);
-        setState(166);
+        setState(168);
         booleanExpression(5);
         }
         break;
@@ -1219,11 +1219,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ProcessCheckContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(167);
-        ((ProcessCheckContext)_localctx).relationship = match(IDENTIFIER);
-        setState(168);
-        match(OF);
         setState(169);
+        ((ProcessCheckContext)_localctx).relationship = match(IDENTIFIER);
+        setState(170);
+        match(OF);
+        setState(171);
         subquery();
         }
         break;
@@ -1232,13 +1232,13 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanDefaultContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(170);
+        setState(172);
         valueExpression();
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(181);
+      setState(183);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1246,7 +1246,7 @@ class EqlBaseParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(179);
+          setState(181);
           _errHandler.sync(this);
           switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
           case 1:
@@ -1254,11 +1254,11 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(173);
-            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(174);
-            ((LogicalBinaryContext)_localctx).operator = match(AND);
             setState(175);
+            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
+            setState(176);
+            ((LogicalBinaryContext)_localctx).operator = match(AND);
+            setState(177);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(3);
             }
             break;
@@ -1267,18 +1267,18 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(176);
-            if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(177);
-            ((LogicalBinaryContext)_localctx).operator = match(OR);
             setState(178);
+            if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
+            setState(179);
+            ((LogicalBinaryContext)_localctx).operator = match(OR);
+            setState(180);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(2);
             }
             break;
           }
           } 
         }
-        setState(183);
+        setState(185);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
       }
@@ -1357,14 +1357,14 @@ class EqlBaseParser extends Parser {
     ValueExpressionContext _localctx = new ValueExpressionContext(_ctx, getState());
     enterRule(_localctx, 32, RULE_valueExpression);
     try {
-      setState(189);
+      setState(191);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
       case 1:
         _localctx = new ValueExpressionDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(184);
+        setState(186);
         operatorExpression(0);
         }
         break;
@@ -1372,11 +1372,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ComparisonContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(185);
-        ((ComparisonContext)_localctx).left = operatorExpression(0);
-        setState(186);
-        comparisonOperator();
         setState(187);
+        ((ComparisonContext)_localctx).left = operatorExpression(0);
+        setState(188);
+        comparisonOperator();
+        setState(189);
         ((ComparisonContext)_localctx).right = operatorExpression(0);
         }
         break;
@@ -1495,7 +1495,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(198);
+      setState(200);
       switch (_input.LA(1)) {
       case FALSE:
       case NULL:
@@ -1511,14 +1511,14 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(192);
-        primaryExpression();
         setState(194);
+        primaryExpression();
+        setState(196);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
         case 1:
           {
-          setState(193);
+          setState(195);
           predicate();
           }
           break;
@@ -1531,7 +1531,7 @@ class EqlBaseParser extends Parser {
         _localctx = new ArithmeticUnaryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(196);
+        setState(198);
         ((ArithmeticUnaryContext)_localctx).operator = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1539,7 +1539,7 @@ class EqlBaseParser extends Parser {
         } else {
           consume();
         }
-        setState(197);
+        setState(199);
         operatorExpression(3);
         }
         break;
@@ -1547,7 +1547,7 @@ class EqlBaseParser extends Parser {
         throw new NoViableAltException(this);
       }
       _ctx.stop = _input.LT(-1);
-      setState(208);
+      setState(210);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1555,7 +1555,7 @@ class EqlBaseParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(206);
+          setState(208);
           _errHandler.sync(this);
           switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
           case 1:
@@ -1563,9 +1563,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(200);
+            setState(202);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(201);
+            setState(203);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ASTERISK) | (1L << SLASH) | (1L << PERCENT))) != 0)) ) {
@@ -1573,7 +1573,7 @@ class EqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(202);
+            setState(204);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(3);
             }
             break;
@@ -1582,9 +1582,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new OperatorExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_operatorExpression);
-            setState(203);
+            setState(205);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(204);
+            setState(206);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1592,14 +1592,14 @@ class EqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(205);
+            setState(207);
             ((ArithmeticBinaryContext)_localctx).right = operatorExpression(2);
             }
             break;
           }
           } 
         }
-        setState(210);
+        setState(212);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
       }
@@ -1632,6 +1632,9 @@ class EqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EqlBaseParser.COMMA, i);
     }
+    public SeqPredicateContext seqPredicate() {
+      return getRuleContext(SeqPredicateContext.class,0);
+    }
     public PredicateContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
     }
@@ -1656,41 +1659,56 @@ class EqlBaseParser extends Parser {
     enterRule(_localctx, 36, RULE_predicate);
     int _la;
     try {
-      enterOuterAlt(_localctx, 1);
-      {
-      setState(212);
-      _la = _input.LA(1);
-      if (_la==NOT) {
+      setState(229);
+      switch (_input.LA(1)) {
+      case IN:
+      case NOT:
+        enterOuterAlt(_localctx, 1);
         {
-        setState(211);
-        match(NOT);
+        setState(214);
+        _la = _input.LA(1);
+        if (_la==NOT) {
+          {
+          setState(213);
+          match(NOT);
+          }
         }
-      }
 
-      setState(214);
-      ((PredicateContext)_localctx).kind = match(IN);
-      setState(215);
-      match(LP);
-      setState(216);
-      expression();
-      setState(221);
-      _errHandler.sync(this);
-      _la = _input.LA(1);
-      while (_la==COMMA) {
-        {
-        {
+        setState(216);
+        ((PredicateContext)_localctx).kind = match(IN);
         setState(217);
-        match(COMMA);
+        match(LP);
         setState(218);
         expression();
-        }
-        }
         setState(223);
         _errHandler.sync(this);
         _la = _input.LA(1);
-      }
-      setState(224);
-      match(RP);
+        while (_la==COMMA) {
+          {
+          {
+          setState(219);
+          match(COMMA);
+          setState(220);
+          expression();
+          }
+          }
+          setState(225);
+          _errHandler.sync(this);
+          _la = _input.LA(1);
+        }
+        setState(226);
+        match(RP);
+        }
+        break;
+      case SEQ:
+        enterOuterAlt(_localctx, 2);
+        {
+        setState(228);
+        seqPredicate();
+        }
+        break;
+      default:
+        throw new NoViableAltException(this);
       }
     }
     catch (RecognitionException re) {
@@ -1798,14 +1816,14 @@ class EqlBaseParser extends Parser {
     PrimaryExpressionContext _localctx = new PrimaryExpressionContext(_ctx, getState());
     enterRule(_localctx, 38, RULE_primaryExpression);
     try {
-      setState(233);
+      setState(238);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,26,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
       case 1:
         _localctx = new ConstantDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(226);
+        setState(231);
         constant();
         }
         break;
@@ -1813,7 +1831,7 @@ class EqlBaseParser extends Parser {
         _localctx = new FunctionContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(227);
+        setState(232);
         functionExpression();
         }
         break;
@@ -1821,7 +1839,7 @@ class EqlBaseParser extends Parser {
         _localctx = new DereferenceContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(228);
+        setState(233);
         qualifiedName();
         }
         break;
@@ -1829,11 +1847,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ParenthesizedExpressionContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(229);
+        setState(234);
         match(LP);
-        setState(230);
+        setState(235);
         expression();
-        setState(231);
+        setState(236);
         match(RP);
         }
         break;
@@ -1893,36 +1911,36 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(235);
+      setState(240);
       ((FunctionExpressionContext)_localctx).name = functionName();
-      setState(236);
+      setState(241);
       match(LP);
-      setState(245);
+      setState(250);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER) | (1L << QUOTED_IDENTIFIER))) != 0)) {
         {
-        setState(237);
-        expression();
         setState(242);
+        expression();
+        setState(247);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(238);
+          setState(243);
           match(COMMA);
-          setState(239);
+          setState(244);
           expression();
           }
           }
-          setState(244);
+          setState(249);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(247);
+      setState(252);
       match(RP);
       }
     }
@@ -1964,7 +1982,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(249);
+      setState(254);
       match(IDENTIFIER);
       }
     }
@@ -2069,13 +2087,13 @@ class EqlBaseParser extends Parser {
     ConstantContext _localctx = new ConstantContext(_ctx, getState());
     enterRule(_localctx, 44, RULE_constant);
     try {
-      setState(255);
+      setState(260);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(251);
+        setState(256);
         match(NULL);
         }
         break;
@@ -2084,7 +2102,7 @@ class EqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(252);
+        setState(257);
         number();
         }
         break;
@@ -2093,7 +2111,7 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(253);
+        setState(258);
         booleanValue();
         }
         break;
@@ -2101,7 +2119,7 @@ class EqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(254);
+        setState(259);
         string();
         }
         break;
@@ -2120,8 +2138,63 @@ class EqlBaseParser extends Parser {
     return _localctx;
   }
 
-  public static class ComparisonOperatorContext extends ParserRuleContext {
+  public static class SeqPredicateContext extends ParserRuleContext {
+    public SeqPredicateContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_seqPredicate; }
+   
+    public SeqPredicateContext() { }
+    public void copyFrom(SeqPredicateContext ctx) {
+      super.copyFrom(ctx);
+    }
+  }
+  public static class SeqValueContext extends SeqPredicateContext {
     public TerminalNode SEQ() { return getToken(EqlBaseParser.SEQ, 0); }
+    public ConstantContext constant() {
+      return getRuleContext(ConstantContext.class,0);
+    }
+    public SeqValueContext(SeqPredicateContext ctx) { copyFrom(ctx); }
+    @Override
+    public void enterRule(ParseTreeListener listener) {
+      if ( listener instanceof EqlBaseListener ) ((EqlBaseListener)listener).enterSeqValue(this);
+    }
+    @Override
+    public void exitRule(ParseTreeListener listener) {
+      if ( listener instanceof EqlBaseListener ) ((EqlBaseListener)listener).exitSeqValue(this);
+    }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof EqlBaseVisitor ) return ((EqlBaseVisitor<? extends T>)visitor).visitSeqValue(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final SeqPredicateContext seqPredicate() throws RecognitionException {
+    SeqPredicateContext _localctx = new SeqPredicateContext(_ctx, getState());
+    enterRule(_localctx, 46, RULE_seqPredicate);
+    try {
+      _localctx = new SeqValueContext(_localctx);
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(262);
+      match(SEQ);
+      setState(263);
+      constant();
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class ComparisonOperatorContext extends ParserRuleContext {
     public TerminalNode EQ() { return getToken(EqlBaseParser.EQ, 0); }
     public TerminalNode NEQ() { return getToken(EqlBaseParser.NEQ, 0); }
     public TerminalNode LT() { return getToken(EqlBaseParser.LT, 0); }
@@ -2149,14 +2222,14 @@ class EqlBaseParser extends Parser {
 
   public final ComparisonOperatorContext comparisonOperator() throws RecognitionException {
     ComparisonOperatorContext _localctx = new ComparisonOperatorContext(_ctx, getState());
-    enterRule(_localctx, 46, RULE_comparisonOperator);
+    enterRule(_localctx, 48, RULE_comparisonOperator);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(257);
+      setState(265);
       _la = _input.LA(1);
-      if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << SEQ) | (1L << EQ) | (1L << NEQ) | (1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
+      if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << NEQ) | (1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
       _errHandler.recoverInline(this);
       } else {
         consume();
@@ -2198,12 +2271,12 @@ class EqlBaseParser extends Parser {
 
   public final BooleanValueContext booleanValue() throws RecognitionException {
     BooleanValueContext _localctx = new BooleanValueContext(_ctx, getState());
-    enterRule(_localctx, 48, RULE_booleanValue);
+    enterRule(_localctx, 50, RULE_booleanValue);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(259);
+      setState(267);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -2267,49 +2340,49 @@ class EqlBaseParser extends Parser {
 
   public final QualifiedNameContext qualifiedName() throws RecognitionException {
     QualifiedNameContext _localctx = new QualifiedNameContext(_ctx, getState());
-    enterRule(_localctx, 50, RULE_qualifiedName);
+    enterRule(_localctx, 52, RULE_qualifiedName);
     int _la;
     try {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(261);
+      setState(269);
       identifier();
-      setState(273);
+      setState(281);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
-          setState(271);
+          setState(279);
           switch (_input.LA(1)) {
           case DOT:
             {
-            setState(262);
+            setState(270);
             match(DOT);
-            setState(263);
+            setState(271);
             identifier();
             }
             break;
           case LB:
             {
-            setState(264);
+            setState(272);
             match(LB);
-            setState(266); 
+            setState(274); 
             _errHandler.sync(this);
             _la = _input.LA(1);
             do {
               {
               {
-              setState(265);
+              setState(273);
               match(INTEGER_VALUE);
               }
               }
-              setState(268); 
+              setState(276); 
               _errHandler.sync(this);
               _la = _input.LA(1);
             } while ( _la==INTEGER_VALUE );
-            setState(270);
+            setState(278);
             match(RB);
             }
             break;
@@ -2318,9 +2391,9 @@ class EqlBaseParser extends Parser {
           }
           } 
         }
-        setState(275);
+        setState(283);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
       }
       }
     }
@@ -2359,12 +2432,12 @@ class EqlBaseParser extends Parser {
 
   public final IdentifierContext identifier() throws RecognitionException {
     IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
-    enterRule(_localctx, 52, RULE_identifier);
+    enterRule(_localctx, 54, RULE_identifier);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(276);
+      setState(284);
       _la = _input.LA(1);
       if ( !(_la==IDENTIFIER || _la==QUOTED_IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2411,18 +2484,18 @@ class EqlBaseParser extends Parser {
 
   public final TimeUnitContext timeUnit() throws RecognitionException {
     TimeUnitContext _localctx = new TimeUnitContext(_ctx, getState());
-    enterRule(_localctx, 54, RULE_timeUnit);
+    enterRule(_localctx, 56, RULE_timeUnit);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(278);
+      setState(286);
       number();
-      setState(280);
+      setState(288);
       _la = _input.LA(1);
       if (_la==IDENTIFIER) {
         {
-        setState(279);
+        setState(287);
         ((TimeUnitContext)_localctx).unit = match(IDENTIFIER);
         }
       }
@@ -2488,15 +2561,15 @@ class EqlBaseParser extends Parser {
 
   public final NumberContext number() throws RecognitionException {
     NumberContext _localctx = new NumberContext(_ctx, getState());
-    enterRule(_localctx, 56, RULE_number);
+    enterRule(_localctx, 58, RULE_number);
     try {
-      setState(284);
+      setState(292);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(282);
+        setState(290);
         match(DECIMAL_VALUE);
         }
         break;
@@ -2504,7 +2577,7 @@ class EqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(283);
+        setState(291);
         match(INTEGER_VALUE);
         }
         break;
@@ -2546,11 +2619,11 @@ class EqlBaseParser extends Parser {
 
   public final StringContext string() throws RecognitionException {
     StringContext _localctx = new StringContext(_ctx, getState());
-    enterRule(_localctx, 58, RULE_string);
+    enterRule(_localctx, 60, RULE_string);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(286);
+      setState(294);
       match(STRING);
       }
     }
@@ -2589,12 +2662,12 @@ class EqlBaseParser extends Parser {
 
   public final EventValueContext eventValue() throws RecognitionException {
     EventValueContext _localctx = new EventValueContext(_ctx, getState());
-    enterRule(_localctx, 60, RULE_eventValue);
+    enterRule(_localctx, 62, RULE_eventValue);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(288);
+      setState(296);
       _la = _input.LA(1);
       if ( !(_la==STRING || _la==IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2643,106 +2716,108 @@ class EqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3.\u0125\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3.\u012d\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
-    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \3\2"+
-    "\3\2\3\2\3\3\3\3\3\3\3\4\3\4\7\4I\n\4\f\4\16\4L\13\4\3\5\3\5\3\5\5\5Q"+
-    "\n\5\3\6\3\6\3\6\3\6\3\6\3\7\3\7\3\7\5\7[\n\7\3\7\3\7\5\7_\n\7\5\7a\n"+
-    "\7\3\7\3\7\6\7e\n\7\r\7\16\7f\3\7\3\7\5\7k\n\7\3\b\3\b\5\bo\n\b\3\b\3"+
-    "\b\6\bs\n\b\r\b\16\bt\3\b\3\b\5\by\n\b\3\t\3\t\3\t\3\t\3\t\7\t\u0080\n"+
-    "\t\f\t\16\t\u0083\13\t\5\t\u0085\n\t\3\n\3\n\3\n\3\n\7\n\u008b\n\n\f\n"+
-    "\16\n\u008e\13\n\3\13\3\13\5\13\u0092\n\13\3\f\3\f\5\f\u0096\n\f\3\r\3"+
-    "\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17\u00a0\n\17\3\17\3\17\3\17\3\20\3\20"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u00ae\n\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\7\21\u00b6\n\21\f\21\16\21\u00b9\13\21\3\22\3\22\3\22\3\22"+
-    "\3\22\5\22\u00c0\n\22\3\23\3\23\3\23\5\23\u00c5\n\23\3\23\3\23\5\23\u00c9"+
-    "\n\23\3\23\3\23\3\23\3\23\3\23\3\23\7\23\u00d1\n\23\f\23\16\23\u00d4\13"+
-    "\23\3\24\5\24\u00d7\n\24\3\24\3\24\3\24\3\24\3\24\7\24\u00de\n\24\f\24"+
-    "\16\24\u00e1\13\24\3\24\3\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\5\25\u00ec"+
-    "\n\25\3\26\3\26\3\26\3\26\3\26\7\26\u00f3\n\26\f\26\16\26\u00f6\13\26"+
-    "\5\26\u00f8\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\5\30\u0102\n"+
-    "\30\3\31\3\31\3\32\3\32\3\33\3\33\3\33\3\33\3\33\6\33\u010d\n\33\r\33"+
-    "\16\33\u010e\3\33\7\33\u0112\n\33\f\33\16\33\u0115\13\33\3\34\3\34\3\35"+
-    "\3\35\5\35\u011b\n\35\3\36\3\36\5\36\u011f\n\36\3\37\3\37\3 \3 \3 \2\4"+
-    " $!\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>\2"+
-    "\b\3\2\33\34\3\2\35\37\4\2\23\23\25\32\4\2\6\6\17\17\3\2*+\4\2\'\'**\u012f"+
-    "\2@\3\2\2\2\4C\3\2\2\2\6F\3\2\2\2\bP\3\2\2\2\nR\3\2\2\2\fW\3\2\2\2\16"+
-    "l\3\2\2\2\20z\3\2\2\2\22\u0086\3\2\2\2\24\u008f\3\2\2\2\26\u0093\3\2\2"+
-    "\2\30\u0097\3\2\2\2\32\u009b\3\2\2\2\34\u009f\3\2\2\2\36\u00a4\3\2\2\2"+
-    " \u00ad\3\2\2\2\"\u00bf\3\2\2\2$\u00c8\3\2\2\2&\u00d6\3\2\2\2(\u00eb\3"+
-    "\2\2\2*\u00ed\3\2\2\2,\u00fb\3\2\2\2.\u0101\3\2\2\2\60\u0103\3\2\2\2\62"+
-    "\u0105\3\2\2\2\64\u0107\3\2\2\2\66\u0116\3\2\2\28\u0118\3\2\2\2:\u011e"+
-    "\3\2\2\2<\u0120\3\2\2\2>\u0122\3\2\2\2@A\5\6\4\2AB\7\2\2\3B\3\3\2\2\2"+
-    "CD\5\36\20\2DE\7\2\2\3E\5\3\2\2\2FJ\5\b\5\2GI\5\20\t\2HG\3\2\2\2IL\3\2"+
-    "\2\2JH\3\2\2\2JK\3\2\2\2K\7\3\2\2\2LJ\3\2\2\2MQ\5\f\7\2NQ\5\16\b\2OQ\5"+
-    "\32\16\2PM\3\2\2\2PN\3\2\2\2PO\3\2\2\2Q\t\3\2\2\2RS\7\22\2\2ST\7\t\2\2"+
-    "TU\7\24\2\2UV\58\35\2V\13\3\2\2\2W`\7\16\2\2XZ\5\22\n\2Y[\5\n\6\2ZY\3"+
-    "\2\2\2Z[\3\2\2\2[a\3\2\2\2\\^\5\n\6\2]_\5\22\n\2^]\3\2\2\2^_\3\2\2\2_"+
-    "a\3\2\2\2`X\3\2\2\2`\\\3\2\2\2`a\3\2\2\2ab\3\2\2\2bd\5\26\f\2ce\5\26\f"+
-    "\2dc\3\2\2\2ef\3\2\2\2fd\3\2\2\2fg\3\2\2\2gj\3\2\2\2hi\7\20\2\2ik\5\26"+
-    "\f\2jh\3\2\2\2jk\3\2\2\2k\r\3\2\2\2ln\7\b\2\2mo\5\22\n\2nm\3\2\2\2no\3"+
-    "\2\2\2op\3\2\2\2pr\5\24\13\2qs\5\24\13\2rq\3\2\2\2st\3\2\2\2tr\3\2\2\2"+
-    "tu\3\2\2\2ux\3\2\2\2vw\7\20\2\2wy\5\24\13\2xv\3\2\2\2xy\3\2\2\2y\17\3"+
-    "\2\2\2z{\7&\2\2{\u0084\7*\2\2|\u0081\5 \21\2}~\7!\2\2~\u0080\5 \21\2\177"+
-    "}\3\2\2\2\u0080\u0083\3\2\2\2\u0081\177\3\2\2\2\u0081\u0082\3\2\2\2\u0082"+
-    "\u0085\3\2\2\2\u0083\u0081\3\2\2\2\u0084|\3\2\2\2\u0084\u0085\3\2\2\2"+
-    "\u0085\21\3\2\2\2\u0086\u0087\7\5\2\2\u0087\u008c\5\36\20\2\u0088\u0089"+
-    "\7!\2\2\u0089\u008b\5\36\20\2\u008a\u0088\3\2\2\2\u008b\u008e\3\2\2\2"+
-    "\u008c\u008a\3\2\2\2\u008c\u008d\3\2\2\2\u008d\23\3\2\2\2\u008e\u008c"+
-    "\3\2\2\2\u008f\u0091\5\30\r\2\u0090\u0092\5\22\n\2\u0091\u0090\3\2\2\2"+
-    "\u0091\u0092\3\2\2\2\u0092\25\3\2\2\2\u0093\u0095\5\30\r\2\u0094\u0096"+
-    "\5\22\n\2\u0095\u0094\3\2\2\2\u0095\u0096\3\2\2\2\u0096\27\3\2\2\2\u0097"+
-    "\u0098\7\"\2\2\u0098\u0099\5\34\17\2\u0099\u009a\7#\2\2\u009a\31\3\2\2"+
-    "\2\u009b\u009c\5\34\17\2\u009c\33\3\2\2\2\u009d\u00a0\7\4\2\2\u009e\u00a0"+
-    "\5> \2\u009f\u009d\3\2\2\2\u009f\u009e\3\2\2\2\u00a0\u00a1\3\2\2\2\u00a1"+
-    "\u00a2\7\21\2\2\u00a2\u00a3\5\36\20\2\u00a3\35\3\2\2\2\u00a4\u00a5\5 "+
-    "\21\2\u00a5\37\3\2\2\2\u00a6\u00a7\b\21\1\2\u00a7\u00a8\7\n\2\2\u00a8"+
-    "\u00ae\5 \21\7\u00a9\u00aa\7*\2\2\u00aa\u00ab\7\f\2\2\u00ab\u00ae\5\30"+
-    "\r\2\u00ac\u00ae\5\"\22\2\u00ad\u00a6\3\2\2\2\u00ad\u00a9\3\2\2\2\u00ad"+
-    "\u00ac\3\2\2\2\u00ae\u00b7\3\2\2\2\u00af\u00b0\f\4\2\2\u00b0\u00b1\7\3"+
-    "\2\2\u00b1\u00b6\5 \21\5\u00b2\u00b3\f\3\2\2\u00b3\u00b4\7\r\2\2\u00b4"+
-    "\u00b6\5 \21\4\u00b5\u00af\3\2\2\2\u00b5\u00b2\3\2\2\2\u00b6\u00b9\3\2"+
-    "\2\2\u00b7\u00b5\3\2\2\2\u00b7\u00b8\3\2\2\2\u00b8!\3\2\2\2\u00b9\u00b7"+
-    "\3\2\2\2\u00ba\u00c0\5$\23\2\u00bb\u00bc\5$\23\2\u00bc\u00bd\5\60\31\2"+
-    "\u00bd\u00be\5$\23\2\u00be\u00c0\3\2\2\2\u00bf\u00ba\3\2\2\2\u00bf\u00bb"+
-    "\3\2\2\2\u00c0#\3\2\2\2\u00c1\u00c2\b\23\1\2\u00c2\u00c4\5(\25\2\u00c3"+
-    "\u00c5\5&\24\2\u00c4\u00c3\3\2\2\2\u00c4\u00c5\3\2\2\2\u00c5\u00c9\3\2"+
-    "\2\2\u00c6\u00c7\t\2\2\2\u00c7\u00c9\5$\23\5\u00c8\u00c1\3\2\2\2\u00c8"+
-    "\u00c6\3\2\2\2\u00c9\u00d2\3\2\2\2\u00ca\u00cb\f\4\2\2\u00cb\u00cc\t\3"+
-    "\2\2\u00cc\u00d1\5$\23\5\u00cd\u00ce\f\3\2\2\u00ce\u00cf\t\2\2\2\u00cf"+
-    "\u00d1\5$\23\4\u00d0\u00ca\3\2\2\2\u00d0\u00cd\3\2\2\2\u00d1\u00d4\3\2"+
-    "\2\2\u00d2\u00d0\3\2\2\2\u00d2\u00d3\3\2\2\2\u00d3%\3\2\2\2\u00d4\u00d2"+
-    "\3\2\2\2\u00d5\u00d7\7\n\2\2\u00d6\u00d5\3\2\2\2\u00d6\u00d7\3\2\2\2\u00d7"+
-    "\u00d8\3\2\2\2\u00d8\u00d9\7\7\2\2\u00d9\u00da\7$\2\2\u00da\u00df\5\36"+
-    "\20\2\u00db\u00dc\7!\2\2\u00dc\u00de\5\36\20\2\u00dd\u00db\3\2\2\2\u00de"+
-    "\u00e1\3\2\2\2\u00df\u00dd\3\2\2\2\u00df\u00e0\3\2\2\2\u00e0\u00e2\3\2"+
-    "\2\2\u00e1\u00df\3\2\2\2\u00e2\u00e3\7%\2\2\u00e3\'\3\2\2\2\u00e4\u00ec"+
-    "\5.\30\2\u00e5\u00ec\5*\26\2\u00e6\u00ec\5\64\33\2\u00e7\u00e8\7$\2\2"+
-    "\u00e8\u00e9\5\36\20\2\u00e9\u00ea\7%\2\2\u00ea\u00ec\3\2\2\2\u00eb\u00e4"+
-    "\3\2\2\2\u00eb\u00e5\3\2\2\2\u00eb\u00e6\3\2\2\2\u00eb\u00e7\3\2\2\2\u00ec"+
-    ")\3\2\2\2\u00ed\u00ee\5,\27\2\u00ee\u00f7\7$\2\2\u00ef\u00f4\5\36\20\2"+
-    "\u00f0\u00f1\7!\2\2\u00f1\u00f3\5\36\20\2\u00f2\u00f0\3\2\2\2\u00f3\u00f6"+
-    "\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5\u00f8\3\2\2\2\u00f6"+
-    "\u00f4\3\2\2\2\u00f7\u00ef\3\2\2\2\u00f7\u00f8\3\2\2\2\u00f8\u00f9\3\2"+
-    "\2\2\u00f9\u00fa\7%\2\2\u00fa+\3\2\2\2\u00fb\u00fc\7*\2\2\u00fc-\3\2\2"+
-    "\2\u00fd\u0102\7\13\2\2\u00fe\u0102\5:\36\2\u00ff\u0102\5\62\32\2\u0100"+
-    "\u0102\5<\37\2\u0101\u00fd\3\2\2\2\u0101\u00fe\3\2\2\2\u0101\u00ff\3\2"+
-    "\2\2\u0101\u0100\3\2\2\2\u0102/\3\2\2\2\u0103\u0104\t\4\2\2\u0104\61\3"+
-    "\2\2\2\u0105\u0106\t\5\2\2\u0106\63\3\2\2\2\u0107\u0113\5\66\34\2\u0108"+
-    "\u0109\7 \2\2\u0109\u0112\5\66\34\2\u010a\u010c\7\"\2\2\u010b\u010d\7"+
-    "(\2\2\u010c\u010b\3\2\2\2\u010d\u010e\3\2\2\2\u010e\u010c\3\2\2\2\u010e"+
-    "\u010f\3\2\2\2\u010f\u0110\3\2\2\2\u0110\u0112\7#\2\2\u0111\u0108\3\2"+
-    "\2\2\u0111\u010a\3\2\2\2\u0112\u0115\3\2\2\2\u0113\u0111\3\2\2\2\u0113"+
-    "\u0114\3\2\2\2\u0114\65\3\2\2\2\u0115\u0113\3\2\2\2\u0116\u0117\t\6\2"+
-    "\2\u0117\67\3\2\2\2\u0118\u011a\5:\36\2\u0119\u011b\7*\2\2\u011a\u0119"+
-    "\3\2\2\2\u011a\u011b\3\2\2\2\u011b9\3\2\2\2\u011c\u011f\7)\2\2\u011d\u011f"+
-    "\7(\2\2\u011e\u011c\3\2\2\2\u011e\u011d\3\2\2\2\u011f;\3\2\2\2\u0120\u0121"+
-    "\7\'\2\2\u0121=\3\2\2\2\u0122\u0123\t\7\2\2\u0123?\3\2\2\2%JPZ^`fjntx"+
-    "\u0081\u0084\u008c\u0091\u0095\u009f\u00ad\u00b5\u00b7\u00bf\u00c4\u00c8"+
-    "\u00d0\u00d2\u00d6\u00df\u00eb\u00f4\u00f7\u0101\u010e\u0111\u0113\u011a"+
-    "\u011e";
+    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
+    "\t!\3\2\3\2\3\2\3\3\3\3\3\3\3\4\3\4\7\4K\n\4\f\4\16\4N\13\4\3\5\3\5\3"+
+    "\5\5\5S\n\5\3\6\3\6\3\6\3\6\3\6\3\7\3\7\3\7\5\7]\n\7\3\7\3\7\5\7a\n\7"+
+    "\5\7c\n\7\3\7\3\7\6\7g\n\7\r\7\16\7h\3\7\3\7\5\7m\n\7\3\b\3\b\5\bq\n\b"+
+    "\3\b\3\b\6\bu\n\b\r\b\16\bv\3\b\3\b\5\b{\n\b\3\t\3\t\3\t\3\t\3\t\7\t\u0082"+
+    "\n\t\f\t\16\t\u0085\13\t\5\t\u0087\n\t\3\n\3\n\3\n\3\n\7\n\u008d\n\n\f"+
+    "\n\16\n\u0090\13\n\3\13\3\13\5\13\u0094\n\13\3\f\3\f\5\f\u0098\n\f\3\r"+
+    "\3\r\3\r\3\r\3\16\3\16\3\17\3\17\5\17\u00a2\n\17\3\17\3\17\3\17\3\20\3"+
+    "\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u00b0\n\21\3\21\3\21\3\21"+
+    "\3\21\3\21\3\21\7\21\u00b8\n\21\f\21\16\21\u00bb\13\21\3\22\3\22\3\22"+
+    "\3\22\3\22\5\22\u00c2\n\22\3\23\3\23\3\23\5\23\u00c7\n\23\3\23\3\23\5"+
+    "\23\u00cb\n\23\3\23\3\23\3\23\3\23\3\23\3\23\7\23\u00d3\n\23\f\23\16\23"+
+    "\u00d6\13\23\3\24\5\24\u00d9\n\24\3\24\3\24\3\24\3\24\3\24\7\24\u00e0"+
+    "\n\24\f\24\16\24\u00e3\13\24\3\24\3\24\3\24\5\24\u00e8\n\24\3\25\3\25"+
+    "\3\25\3\25\3\25\3\25\3\25\5\25\u00f1\n\25\3\26\3\26\3\26\3\26\3\26\7\26"+
+    "\u00f8\n\26\f\26\16\26\u00fb\13\26\5\26\u00fd\n\26\3\26\3\26\3\27\3\27"+
+    "\3\30\3\30\3\30\3\30\5\30\u0107\n\30\3\31\3\31\3\31\3\32\3\32\3\33\3\33"+
+    "\3\34\3\34\3\34\3\34\3\34\6\34\u0115\n\34\r\34\16\34\u0116\3\34\7\34\u011a"+
+    "\n\34\f\34\16\34\u011d\13\34\3\35\3\35\3\36\3\36\5\36\u0123\n\36\3\37"+
+    "\3\37\5\37\u0127\n\37\3 \3 \3!\3!\3!\2\4 $\"\2\4\6\b\n\f\16\20\22\24\26"+
+    "\30\32\34\36 \"$&(*,.\60\62\64\668:<>@\2\b\3\2\33\34\3\2\35\37\3\2\25"+
+    "\32\4\2\6\6\17\17\3\2*+\4\2\'\'**\u0137\2B\3\2\2\2\4E\3\2\2\2\6H\3\2\2"+
+    "\2\bR\3\2\2\2\nT\3\2\2\2\fY\3\2\2\2\16n\3\2\2\2\20|\3\2\2\2\22\u0088\3"+
+    "\2\2\2\24\u0091\3\2\2\2\26\u0095\3\2\2\2\30\u0099\3\2\2\2\32\u009d\3\2"+
+    "\2\2\34\u00a1\3\2\2\2\36\u00a6\3\2\2\2 \u00af\3\2\2\2\"\u00c1\3\2\2\2"+
+    "$\u00ca\3\2\2\2&\u00e7\3\2\2\2(\u00f0\3\2\2\2*\u00f2\3\2\2\2,\u0100\3"+
+    "\2\2\2.\u0106\3\2\2\2\60\u0108\3\2\2\2\62\u010b\3\2\2\2\64\u010d\3\2\2"+
+    "\2\66\u010f\3\2\2\28\u011e\3\2\2\2:\u0120\3\2\2\2<\u0126\3\2\2\2>\u0128"+
+    "\3\2\2\2@\u012a\3\2\2\2BC\5\6\4\2CD\7\2\2\3D\3\3\2\2\2EF\5\36\20\2FG\7"+
+    "\2\2\3G\5\3\2\2\2HL\5\b\5\2IK\5\20\t\2JI\3\2\2\2KN\3\2\2\2LJ\3\2\2\2L"+
+    "M\3\2\2\2M\7\3\2\2\2NL\3\2\2\2OS\5\f\7\2PS\5\16\b\2QS\5\32\16\2RO\3\2"+
+    "\2\2RP\3\2\2\2RQ\3\2\2\2S\t\3\2\2\2TU\7\22\2\2UV\7\t\2\2VW\7\24\2\2WX"+
+    "\5:\36\2X\13\3\2\2\2Yb\7\16\2\2Z\\\5\22\n\2[]\5\n\6\2\\[\3\2\2\2\\]\3"+
+    "\2\2\2]c\3\2\2\2^`\5\n\6\2_a\5\22\n\2`_\3\2\2\2`a\3\2\2\2ac\3\2\2\2bZ"+
+    "\3\2\2\2b^\3\2\2\2bc\3\2\2\2cd\3\2\2\2df\5\26\f\2eg\5\26\f\2fe\3\2\2\2"+
+    "gh\3\2\2\2hf\3\2\2\2hi\3\2\2\2il\3\2\2\2jk\7\20\2\2km\5\26\f\2lj\3\2\2"+
+    "\2lm\3\2\2\2m\r\3\2\2\2np\7\b\2\2oq\5\22\n\2po\3\2\2\2pq\3\2\2\2qr\3\2"+
+    "\2\2rt\5\24\13\2su\5\24\13\2ts\3\2\2\2uv\3\2\2\2vt\3\2\2\2vw\3\2\2\2w"+
+    "z\3\2\2\2xy\7\20\2\2y{\5\24\13\2zx\3\2\2\2z{\3\2\2\2{\17\3\2\2\2|}\7&"+
+    "\2\2}\u0086\7*\2\2~\u0083\5 \21\2\177\u0080\7!\2\2\u0080\u0082\5 \21\2"+
+    "\u0081\177\3\2\2\2\u0082\u0085\3\2\2\2\u0083\u0081\3\2\2\2\u0083\u0084"+
+    "\3\2\2\2\u0084\u0087\3\2\2\2\u0085\u0083\3\2\2\2\u0086~\3\2\2\2\u0086"+
+    "\u0087\3\2\2\2\u0087\21\3\2\2\2\u0088\u0089\7\5\2\2\u0089\u008e\5\36\20"+
+    "\2\u008a\u008b\7!\2\2\u008b\u008d\5\36\20\2\u008c\u008a\3\2\2\2\u008d"+
+    "\u0090\3\2\2\2\u008e\u008c\3\2\2\2\u008e\u008f\3\2\2\2\u008f\23\3\2\2"+
+    "\2\u0090\u008e\3\2\2\2\u0091\u0093\5\30\r\2\u0092\u0094\5\22\n\2\u0093"+
+    "\u0092\3\2\2\2\u0093\u0094\3\2\2\2\u0094\25\3\2\2\2\u0095\u0097\5\30\r"+
+    "\2\u0096\u0098\5\22\n\2\u0097\u0096\3\2\2\2\u0097\u0098\3\2\2\2\u0098"+
+    "\27\3\2\2\2\u0099\u009a\7\"\2\2\u009a\u009b\5\34\17\2\u009b\u009c\7#\2"+
+    "\2\u009c\31\3\2\2\2\u009d\u009e\5\34\17\2\u009e\33\3\2\2\2\u009f\u00a2"+
+    "\7\4\2\2\u00a0\u00a2\5@!\2\u00a1\u009f\3\2\2\2\u00a1\u00a0\3\2\2\2\u00a2"+
+    "\u00a3\3\2\2\2\u00a3\u00a4\7\21\2\2\u00a4\u00a5\5\36\20\2\u00a5\35\3\2"+
+    "\2\2\u00a6\u00a7\5 \21\2\u00a7\37\3\2\2\2\u00a8\u00a9\b\21\1\2\u00a9\u00aa"+
+    "\7\n\2\2\u00aa\u00b0\5 \21\7\u00ab\u00ac\7*\2\2\u00ac\u00ad\7\f\2\2\u00ad"+
+    "\u00b0\5\30\r\2\u00ae\u00b0\5\"\22\2\u00af\u00a8\3\2\2\2\u00af\u00ab\3"+
+    "\2\2\2\u00af\u00ae\3\2\2\2\u00b0\u00b9\3\2\2\2\u00b1\u00b2\f\4\2\2\u00b2"+
+    "\u00b3\7\3\2\2\u00b3\u00b8\5 \21\5\u00b4\u00b5\f\3\2\2\u00b5\u00b6\7\r"+
+    "\2\2\u00b6\u00b8\5 \21\4\u00b7\u00b1\3\2\2\2\u00b7\u00b4\3\2\2\2\u00b8"+
+    "\u00bb\3\2\2\2\u00b9\u00b7\3\2\2\2\u00b9\u00ba\3\2\2\2\u00ba!\3\2\2\2"+
+    "\u00bb\u00b9\3\2\2\2\u00bc\u00c2\5$\23\2\u00bd\u00be\5$\23\2\u00be\u00bf"+
+    "\5\62\32\2\u00bf\u00c0\5$\23\2\u00c0\u00c2\3\2\2\2\u00c1\u00bc\3\2\2\2"+
+    "\u00c1\u00bd\3\2\2\2\u00c2#\3\2\2\2\u00c3\u00c4\b\23\1\2\u00c4\u00c6\5"+
+    "(\25\2\u00c5\u00c7\5&\24\2\u00c6\u00c5\3\2\2\2\u00c6\u00c7\3\2\2\2\u00c7"+
+    "\u00cb\3\2\2\2\u00c8\u00c9\t\2\2\2\u00c9\u00cb\5$\23\5\u00ca\u00c3\3\2"+
+    "\2\2\u00ca\u00c8\3\2\2\2\u00cb\u00d4\3\2\2\2\u00cc\u00cd\f\4\2\2\u00cd"+
+    "\u00ce\t\3\2\2\u00ce\u00d3\5$\23\5\u00cf\u00d0\f\3\2\2\u00d0\u00d1\t\2"+
+    "\2\2\u00d1\u00d3\5$\23\4\u00d2\u00cc\3\2\2\2\u00d2\u00cf\3\2\2\2\u00d3"+
+    "\u00d6\3\2\2\2\u00d4\u00d2\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5%\3\2\2\2"+
+    "\u00d6\u00d4\3\2\2\2\u00d7\u00d9\7\n\2\2\u00d8\u00d7\3\2\2\2\u00d8\u00d9"+
+    "\3\2\2\2\u00d9\u00da\3\2\2\2\u00da\u00db\7\7\2\2\u00db\u00dc\7$\2\2\u00dc"+
+    "\u00e1\5\36\20\2\u00dd\u00de\7!\2\2\u00de\u00e0\5\36\20\2\u00df\u00dd"+
+    "\3\2\2\2\u00e0\u00e3\3\2\2\2\u00e1\u00df\3\2\2\2\u00e1\u00e2\3\2\2\2\u00e2"+
+    "\u00e4\3\2\2\2\u00e3\u00e1\3\2\2\2\u00e4\u00e5\7%\2\2\u00e5\u00e8\3\2"+
+    "\2\2\u00e6\u00e8\5\60\31\2\u00e7\u00d8\3\2\2\2\u00e7\u00e6\3\2\2\2\u00e8"+
+    "\'\3\2\2\2\u00e9\u00f1\5.\30\2\u00ea\u00f1\5*\26\2\u00eb\u00f1\5\66\34"+
+    "\2\u00ec\u00ed\7$\2\2\u00ed\u00ee\5\36\20\2\u00ee\u00ef\7%\2\2\u00ef\u00f1"+
+    "\3\2\2\2\u00f0\u00e9\3\2\2\2\u00f0\u00ea\3\2\2\2\u00f0\u00eb\3\2\2\2\u00f0"+
+    "\u00ec\3\2\2\2\u00f1)\3\2\2\2\u00f2\u00f3\5,\27\2\u00f3\u00fc\7$\2\2\u00f4"+
+    "\u00f9\5\36\20\2\u00f5\u00f6\7!\2\2\u00f6\u00f8\5\36\20\2\u00f7\u00f5"+
+    "\3\2\2\2\u00f8\u00fb\3\2\2\2\u00f9\u00f7\3\2\2\2\u00f9\u00fa\3\2\2\2\u00fa"+
+    "\u00fd\3\2\2\2\u00fb\u00f9\3\2\2\2\u00fc\u00f4\3\2\2\2\u00fc\u00fd\3\2"+
+    "\2\2\u00fd\u00fe\3\2\2\2\u00fe\u00ff\7%\2\2\u00ff+\3\2\2\2\u0100\u0101"+
+    "\7*\2\2\u0101-\3\2\2\2\u0102\u0107\7\13\2\2\u0103\u0107\5<\37\2\u0104"+
+    "\u0107\5\64\33\2\u0105\u0107\5> \2\u0106\u0102\3\2\2\2\u0106\u0103\3\2"+
+    "\2\2\u0106\u0104\3\2\2\2\u0106\u0105\3\2\2\2\u0107/\3\2\2\2\u0108\u0109"+
+    "\7\23\2\2\u0109\u010a\5.\30\2\u010a\61\3\2\2\2\u010b\u010c\t\4\2\2\u010c"+
+    "\63\3\2\2\2\u010d\u010e\t\5\2\2\u010e\65\3\2\2\2\u010f\u011b\58\35\2\u0110"+
+    "\u0111\7 \2\2\u0111\u011a\58\35\2\u0112\u0114\7\"\2\2\u0113\u0115\7(\2"+
+    "\2\u0114\u0113\3\2\2\2\u0115\u0116\3\2\2\2\u0116\u0114\3\2\2\2\u0116\u0117"+
+    "\3\2\2\2\u0117\u0118\3\2\2\2\u0118\u011a\7#\2\2\u0119\u0110\3\2\2\2\u0119"+
+    "\u0112\3\2\2\2\u011a\u011d\3\2\2\2\u011b\u0119\3\2\2\2\u011b\u011c\3\2"+
+    "\2\2\u011c\67\3\2\2\2\u011d\u011b\3\2\2\2\u011e\u011f\t\6\2\2\u011f9\3"+
+    "\2\2\2\u0120\u0122\5<\37\2\u0121\u0123\7*\2\2\u0122\u0121\3\2\2\2\u0122"+
+    "\u0123\3\2\2\2\u0123;\3\2\2\2\u0124\u0127\7)\2\2\u0125\u0127\7(\2\2\u0126"+
+    "\u0124\3\2\2\2\u0126\u0125\3\2\2\2\u0127=\3\2\2\2\u0128\u0129\7\'\2\2"+
+    "\u0129?\3\2\2\2\u012a\u012b\t\7\2\2\u012bA\3\2\2\2&LR\\`bhlpvz\u0083\u0086"+
+    "\u008e\u0093\u0097\u00a1\u00af\u00b7\u00b9\u00c1\u00c6\u00ca\u00d2\u00d4"+
+    "\u00d8\u00e1\u00e7\u00f0\u00f9\u00fc\u0106\u0116\u0119\u011b\u0122\u0126";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseVisitor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseVisitor.java
@@ -238,6 +238,13 @@ interface EqlBaseVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitStringLiteral(EqlBaseParser.StringLiteralContext ctx);
   /**
+   * Visit a parse tree produced by the {@code seqValue}
+   * labeled alternative in {@link EqlBaseParser#seqPredicate}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitSeqValue(EqlBaseParser.SeqValueContext ctx);
+  /**
    * Visit a parse tree produced by {@link EqlBaseParser#comparisonOperator}.
    * @param ctx the parse tree
    * @return the visitor result

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -163,7 +163,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
         EqlBaseParser.SeqPredicateContext seq = predicate.seqPredicate();
         if (seq != null) {
             Expression literal = expression(seq);
-            return new InsensitiveEquals(source, expr, literal);
+            return new InsensitiveEquals(source, expr, literal, zoneId);
         }
         // in expression
         List<Expression> container = expressions(predicate.expression());

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -131,8 +131,6 @@ public class ExpressionBuilder extends IdentifierBuilder {
         ZoneId zoneId = params.zoneId();
 
         switch (op.getSymbol().getType()) {
-            case EqlBaseParser.SEQ:
-                return new InsensitiveEquals(source, left, right, zoneId);
             case EqlBaseParser.EQ:
                 return new Equals(source, left, right, zoneId);
             case EqlBaseParser.NEQ:
@@ -162,10 +160,20 @@ public class ExpressionBuilder extends IdentifierBuilder {
             return expr;
         }
 
+        EqlBaseParser.SeqPredicateContext seq = predicate.seqPredicate();
+        if (seq != null) {
+            Expression literal = expression(seq);
+            return new InsensitiveEquals(source, expr, literal);
+        }
+        // in expression
         List<Expression> container = expressions(predicate.expression());
         Expression checkInSet = new In(source, expr, container, zoneId);
-
         return predicate.NOT() != null ? new Not(source, checkInSet) : checkInSet;
+    }
+
+    @Override
+    public Expression visitSeqValue(EqlBaseParser.SeqValueContext ctx) {
+        return expression(ctx.constant());
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.plan.TableIdentifier;
@@ -128,6 +129,85 @@ public class OptimizerTests extends ESTestCase {
             IsNotNull check = (IsNotNull) condition.right();
             assertEquals(((FieldAttribute) check.field()).name(), "command_line");
         }
+    }
+
+    public void testEqualsWildcardOnRight() {
+        List<String> tests = Arrays.asList(
+            "foo where command_line : \"* bar *\""
+        );
+
+        for (String q : tests) {
+            LogicalPlan plan = defaultPipes(accept(q));
+            assertTrue(plan instanceof Filter);
+
+            Filter filter = (Filter) plan;
+            And condition = (And) filter.condition();
+            assertTrue(condition.right() instanceof Like);
+
+            Like like = (Like) condition.right();
+            assertEquals(((FieldAttribute) like.field()).name(), "command_line");
+            assertEquals(like.pattern().asJavaRegex(), "^.* bar .*$");
+            assertEquals(like.pattern().asLuceneWildcard(), "* bar *");
+            assertEquals(like.pattern().asIndexNameWildcard(), "* bar *");
+        }
+    }
+
+    public void testEqualsWildcardWithLiteralsOnLeft() {
+        List<String> tests = Arrays.asList(
+            "foo where \"abc\": \"*b*\""
+        );
+
+        for (String q : tests) {
+            LogicalPlan plan = accept(q);
+            plan = defaultPipes(plan);
+            assertTrue(plan instanceof Filter);
+            // check the optimizer kicked in and folding was applied
+            Filter filter = (Filter) plan;
+            Equals condition = (Equals) filter.condition();
+            assertEquals("foo", condition.right().fold());
+        }
+    }
+
+    public void testEqualsWildcardIgnoredOnLeftLiteral() {
+        List<String> tests = Arrays.asList(
+            "foo where \"*b*\" : \"abc\"",
+            "foo where \"*b\" : \"abc\"",
+            "foo where \"b*\" : \"abc\""
+        );
+
+        // string comparison that evaluates to false
+        for (String q : tests) {
+            LogicalPlan plan = accept(q);
+            assertTrue(plan instanceof LocalRelation);
+        }
+    }
+
+    public void testEqualsWildcardWithLiteralsOnLeftAndPatternOnRightNotMatching() {
+        List<String> tests = Arrays.asList(
+            "foo where \"abc\": \"*b\"",
+            "foo where \"abc\": \"b*\""
+        );
+
+        // string comparison that evaluates to false
+        for (String q : tests) {
+            LogicalPlan plan = accept(q);
+            assertTrue(plan instanceof LocalRelation);
+        }
+    }
+
+    public void testWildcardEscapes() {
+        LogicalPlan plan = defaultPipes(accept("foo where command_line : \"* %bar_ * \\\\ \\n \\r \\t\""));
+        assertTrue(plan instanceof Filter);
+
+        Filter filter = (Filter) plan;
+        And condition = (And) filter.condition();
+        assertTrue(condition.right() instanceof Like);
+
+        Like like = (Like) condition.right();
+        assertEquals(((FieldAttribute) like.field()).name(), "command_line");
+        assertEquals(like.pattern().asJavaRegex(), "^.* %bar_ .* \\\\ \n \r \t$");
+        assertEquals(like.pattern().asLuceneWildcard(), "* %bar_ * \\\\ \n \r \t");
+        assertEquals(like.pattern().asIndexNameWildcard(), "* %bar_ * \\ \n \r \t");
     }
 
     public void testCombineHeadBigHeadSmall() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
@@ -394,7 +394,7 @@ public class ExpressionTests extends ESTestCase {
         }
         ParsingException e = expectThrows(ParsingException.class, () -> expr(sb.toString()));
         assertEquals("line 1:" + (6 + firstComparator.length()) + ": mismatched input '" + secondComparator +
-                        "' expecting {<EOF>, 'and', 'in', 'not', 'or', '+', '-', '*', '/', '%', '.', '['}",
+                        "' expecting {<EOF>, 'and', 'in', 'not', 'or', ':', '+', '-', '*', '/', '%', '.', '['}",
                 e.getMessage());
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslationTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslationTests.java
@@ -17,11 +17,11 @@ public class QueryTranslationTests extends AbstractQueryFolderTestCase {
         assertThat(asQuery(plan), containsString("\"term\":{\"process_name\""));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63262")
     public void testLikeOptimization() throws Exception {
         PhysicalPlan plan = plan("process where process_name : \"*\" ");
         assertThat(asQuery(plan), containsString("\"exists\":{\"field\":\"process_name\""));
     }
+
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63263")
     public void testMatchOptimization() throws Exception {
         PhysicalPlan plan = plan("process where match(process_name, \".*\") ");

--- a/x-pack/plugin/eql/src/test/resources/queries-supported.eql
+++ b/x-pack/plugin/eql/src/test/resources/queries-supported.eql
@@ -37,13 +37,14 @@ process where command_line : "*.exe *admin*" or command_line : "* a b*";
 
 process where command_line : "*.eXe *aDMin*" or command_line : "* a b*";
 
-process where pid in (1,2,3,4,5,6,7,8) and abc : 100 and def : 200 and ghi : 300 and jkl : x;
+process where pid in (1,2,3,4,5,6,7,8) and abc : 100 and def : 200 and ghi : 300;
+//and jkl : x;
 
 process where ppid != pid;
 
 image_load where not x != y;
 
-image_load where not x : y;
+//image_load where not x : y;
 
 image_load where not not not not x < y;
 
@@ -65,13 +66,13 @@ file where 1 * (-2);
 
 file where 3 * -length(file_path);
 
-network where a * b + c * d + e / f : g + h + i;
+network where a * b + c * d + e / f == g + h + i;
 
-network where a * (b + c * d) + e / f : g + h + i;
+network where a * (b + c * d) + e / f == g + h + i;
 
 process where pid : 4 or pid : 5 or pid : 6 or pid : 7 or pid : 8;
 
-network where pid : 0 or pid : 4 or (ppid : 0 or ppid : 4) or (abc : defgh) and process_name : "*" ;
+network where pid : 0 or pid : 4 or (ppid : 0 or ppid : 4) or (abc == defgh) and process_name : "*" ;
 
 network where pid : 4;
 
@@ -128,7 +129,7 @@ process where 0 > exit_code;
 
 process where (serial_event_id<=8 and serial_event_id > 7) and (opcode:3 and opcode>2);
 
-process where (serial_event_id<9 and serial_event_id >= 7) or (opcode : pid);
+process where (serial_event_id<9 and serial_event_id >= 7) or (opcode == pid);
 
 
 
@@ -229,21 +230,21 @@ file where serial_event_id:88 and substring(file_name, -4) : ".exe"
 file where serial_event_id:88 and substring(file_name, -4, -1) : ".ex"
 ;
 
-process where add(serial_event_id, 0) : 1 and add(0, 1) : serial_event_id;
+process where add(serial_event_id, 0) : 1 and add(0, 1) == serial_event_id;
 
 process where subtract(serial_event_id, -5) : 6;
 
 process where multiply(6, serial_event_id) : 30 and divide(30, 4.0) : 7.5;
 
-process where modulo(11, add(serial_event_id, 1)) : serial_event_id;
+process where modulo(11, add(serial_event_id, 1)) == serial_event_id;
 
-process where serial_event_id : number("5");
+process where serial_event_id == number("5");
 
-process where serial_event_id : number("0x32", 16);
+process where serial_event_id == number("0x32", 16);
 
-process where serial_event_id : number("32", 16);
+process where serial_event_id == number("32", 16);
 
-process where number(serial_event_id) : number(5);
+process where number(serial_event_id) == number(5);
 
 process where concat(serial_event_id, ":", process_name, opcode) : "5:winINIT.exe3"
 ;
@@ -253,7 +254,7 @@ process where concat(serial_event_id, ":", process_name, opcode) : "5:winINIT.ex
 // network where safe(divide(process_name, process_name))
 //;
 
-file where serial_event_id : 82 and (true : (process_name in ("svchost.EXE", "bad.exe", "bad2.exe")))
+file where serial_event_id : 82 and (true == (process_name in ("svchost.EXE", "bad.exe", "bad2.exe")))
 ;
 
 

--- a/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
@@ -75,12 +75,12 @@ process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
 "terms":{"process_name":["python.exe","SMSS.exe","explorer.exe"],
 ;
 
-// equalsAndInFilter
-// process where process_path : "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3)
-// ;
-// "wildcard":{"process_path":{"wildcard":"*\\\\red_ttp\\\\wininit.*","case_insensitive":true,"boost":1.0}}},
-// {"terms":{"opcode":[0,1,2,3],"boost":1.0}}
-// ;
+equalsAndInFilter
+process where process_path : "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3)
+;
+"wildcard":{"process_path":{"wildcard":"*\\\\red_ttp\\\\wininit.*","case_insensitive":true,"boost":1.0}}},
+{"terms":{"opcode":[0,1,2,3],"boost":1.0}}
+;
 
 functionEqualsTrue
 process where cidrMatch(source_address, "10.0.0.0/8") == true
@@ -352,7 +352,7 @@ InternalEqlScriptUtils.cidrMatch(InternalQlScriptUtils.docValue(doc,params.v0),p
 //;
 //"regexp":{"command_line":{"value":"^.*?net.exe"
 //;
-
+//
 //matchFunctionTwo
 //process where match(command_line, "^.*?net.exe", "net\\.exe")
 //;
@@ -364,7 +364,13 @@ InternalEqlScriptUtils.cidrMatch(InternalQlScriptUtils.docValue(doc,params.v0),p
 //;
 //"regexp":{"command_line":{"value":"^.*?net.exe|net\\.exe|C:\\\\Windows\\\\system32\\\\net1\\s+"
 //;
-//
+
+numberFunctionSingleArgument
+process where number(process_name) == 1;
+InternalEqlScriptUtils.number(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)
+"params":{"v0":"process_name","v1":null,"v2":1}
+;
+
 //matchFunctionScalar
 //process where match(substring(command_line, 5), "^.*?net.exe", "net\\.exe", "C:\\\\Windows\\\\system32\\\\net1\\s+")
 //;
@@ -373,11 +379,6 @@ InternalEqlScriptUtils.cidrMatch(InternalQlScriptUtils.docValue(doc,params.v0),p
 //"params":{"v0":"command_line","v1":5,"v2":null,"v3":"^.*?net.exe|net\\.exe|C:\\\\Windows\\\\system32\\\\net1\\s+"}}
 //;
 
-numberFunctionSingleArgument
-process where number(process_name) == 1;
-InternalEqlScriptUtils.number(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)
-"params":{"v0":"process_name","v1":null,"v2":1}
-;
 
 numberFunctionTwoFieldArguments
 process where number(process_name, pid) != null;


### PR DESCRIPTION
Additionally, restrict the grammar to allow only a constant on the right hand side of `:`.

Fix #65154