### PR TITLE
[7.10][DOCS] Adds UI related limitation to configuring aggs docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -47,7 +47,7 @@ functions, set the interval to the same value as the bucket span.
 
 If your {dfeed} uses aggregations, then the **Anomaly Explorer** in {kib} cannot 
 plot and display an anomaly chart for the job. If model plot is disabled, then 
-neither the **Single Metric Viewer** can plot and display the chart for the 
+neither can the **Single Metric Viewer** plot and display the chart for the 
 {anomaly-job}. This limitation does not apply to single metric jobs that have 
 aggregations with names that match the fields that they operate on. Refer to 
 <<aggs-in-dfeed, this snippet>> for an example.

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,11 +45,11 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
-If your {dfeed} uses aggregations and model plot is not enabled for the 
-{anomaly-job}, then the **Single Metric Viewer** in {kib} cannot plot and 
-display an anomaly chart for the job. This limitation does not apply to single 
-metric jobs that have aggregations with names that match the fields that they 
-operate on. Refer to <<aggs-in-dfeed, this snippet>> for an example.
+If your {dfeed} uses aggregations, then neither the **Single Metric Viewer** nor 
+the **Anomaly Explorer** in {kib} can plot and display an anomaly chart for the 
+job. This limitation does not apply to single metric jobs that have aggregations 
+with names that match the fields that they operate on. Refer to 
+<<aggs-in-dfeed, this snippet>> for an example.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,10 +45,11 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
-If your {dfeed} uses aggregations, then neither the **Single Metric Viewer** nor 
-the **Anomaly Explorer** in {kib} can plot and display an anomaly chart for the 
-job. This limitation does not apply to single metric jobs that have aggregations 
-with names that match the fields that they operate on. Refer to 
+If your {dfeed} uses aggregations, then the **Anomaly Explorer** in {kib} cannot 
+plot and display an anomaly chart for the job. If model plot is disabled, then 
+neither the **Single Metric Viewer** can plot and display the chart for the 
+{anomaly-job}. This limitation does not apply to single metric jobs that have 
+aggregations with names that match the fields that they operate on. Refer to 
 <<aggs-in-dfeed, this snippet>> for an example.
 
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -45,6 +45,12 @@ finer, more granular time buckets, which are ideal for this type of analysis. If
 your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
 functions, set the interval to the same value as the bucket span.
 
+If your {dfeed} uses aggregations and model plot is not enabled for the 
+{anomaly-job}, then the **Single Metric Viewer** in {kib} cannot plot and 
+display an anomaly chart for the job. This limitation does not apply to single 
+metric jobs that have aggregations with names that match the fields that they 
+operate on. Refer to <<aggs-in-dfeed, this snippet>> for an example.
+
 
 [discrete]
 [[aggs-include-jobs]]
@@ -82,6 +88,7 @@ the job expects to receive aggregated input. The property must be set to the
 name of the field that contains the count of raw data points that have been
 aggregated. It applies to all detectors in the job.
 
+[[aggs-in-dfeed]]
 The aggregations are defined in the {dfeed} as follows:
 
 [source,console]


### PR DESCRIPTION
## Overview

This PR adds a UI related limitation to the `Requirements and limitations` section of the Aggregating data for faster performance doc. The limitation is about aggregation types in ML jobs that are not supported by the Single Metric Viewer in Kibana.

**Applies to 7.10 and below.** 
(https://github.com/elastic/elasticsearch/pull/65184 handles 7.11 and above.)

### Preview

[Requirements and limitations](https://elasticsearch_65190.docs-preview.app.elstc.co/guide/en/machine-learning/7.10/ml-configuring-aggregation.html#aggs-limits-dfeeds)