### PR TITLE
Reimplement QuotaAwarePath.toFile()

### DIFF
--- a/plugins/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwarePath.java
+++ b/plugins/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwarePath.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
@@ -179,7 +180,11 @@ public final class QuotaAwarePath implements Path {
     @SuppressForbidden(reason = "Implementation required by super type")
     @Override
     public File toFile() {
-        return delegate.toFile();
+        if (getFileSystem() == FileSystems.getDefault()) {
+            return new File(toString());
+        } else {
+            throw new UnsupportedOperationException("Path not associated with default file system.");
+        }
     }
 
     @Override


### PR DESCRIPTION
An issue was observed where calling `QuotaAwarePath.toFile()` caused `UnsupportedOperationException: Path not associated with default file system.` Replacing the implementation with that of the interface's default implementation in a later JDK prevents the exception.

As to why, I suspect that whatever implementation was being called before, or the location of that code, caused an incorrect default filesystem to be picked for comparison.

~This problem only appeared on 7.11.0.~ The problem can manifest on 7.11 and 6.8.14