### PR TITLE
Fix array handling in XContentMapValues.extractRawValues()

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -77,9 +77,7 @@ public class XContentMapValues {
         } else if (currentValue instanceof List) {
             extractRawValues(values, (List) currentValue, pathElements, nextIndex);
         } else {
-            if (nextIndex == pathElements.length) {
-                values.add(currentValue);
-            }
+            values.add(currentValue);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -77,7 +77,9 @@ public class XContentMapValues {
         } else if (currentValue instanceof List) {
             extractRawValues(values, (List) currentValue, pathElements, nextIndex);
         } else {
-            values.add(currentValue);
+            if (nextIndex == pathElements.length) {
+                values.add(currentValue);
+            }
         }
     }
 
@@ -92,7 +94,9 @@ public class XContentMapValues {
             } else if (value instanceof List) {
                 extractRawValues(values, (List) value, pathElements, index);
             } else {
-                values.add(value);
+                if (index == pathElements.length) {
+                    values.add(value);
+                }
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -205,7 +205,7 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("test", map).get(0).toString(), equalTo("value"));
-        assertThat(XContentMapValues.extractRawValues("test.dummy", map), hasSize(0));
+        assertThat(XContentMapValues.extractRawValues("test.dummy", map), contains("value"));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .field("test.me", "value")

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -203,6 +205,7 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("test", map).get(0).toString(), equalTo("value"));
+        assertThat(XContentMapValues.extractRawValues("test.dummy", map), hasSize(0));
 
         builder = XContentFactory.jsonBuilder().startObject()
                 .field("test.me", "value")
@@ -230,6 +233,18 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("path1.xxx.path2.yyy.test", map).get(0).toString(), equalTo("value"));
+    }
+
+    public void testExtractRawValueLeafOnly() throws IOException {
+        Map<String, Object> map;
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .startArray("path1").value(9).startObject().field("path2", "value").endObject().value(7).endArray()
+            .endObject();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
+            map = parser.map();
+        }
+        assertThat(XContentMapValues.extractRawValues("path1", map), contains(9, 7));
+        assertThat(XContentMapValues.extractRawValues("path1.path2", map), Matchers.contains("value"));
     }
 
     public void testPrefixedNamesFilteringTest() {


### PR DESCRIPTION
When an array is encountered while following a path through the map,
we should only add array values if we're at the final path.  So following the
path `foo.bar.baz` shouldn't add concrete values that sit in the array
at `foo.bar`.