### PR TITLE
[7.x] [DOCS] Format the ilm-migrate doc (#65182)

### DIFF
--- a/docs/reference/ilm/actions/ilm-migrate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-migrate.asciidoc
@@ -70,7 +70,9 @@ PUT _ilm/policy/my_policy
 The migrate action in the following policy is disabled and
 the allocate action assigns the index to nodes that have a
 `rack_id` of _one_ or _two_.
+
 NOTE: Explicitly disabling the migrate action is not required--{ilm-init} does not inject the migrate action if you specify allocation options.
+
 [source,console]
 --------------------------------------------------
 PUT _ilm/policy/my_policy


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Format the ilm-migrate doc (#65182)