### PR TITLE
First cut at TermEnum API for discovering terms in the index.

### DIFF
--- a/docs/reference/search/term-enum.asciidoc
+++ b/docs/reference/search/term-enum.asciidoc
@@ -13,7 +13,6 @@ POST stackoverflow/_terms/list
 }
 --------------------------------------------------
 // TEST[setup:stackoverflow]
-// TEST[continued]
 
 
 The API returns the following response:

--- a/docs/reference/search/term-enum.asciidoc
+++ b/docs/reference/search/term-enum.asciidoc
@@ -1,0 +1,126 @@
+[[search-term-enum]]
+=== Term enum API
+
+The term enum API can be used to discover terms in the index that match
+a pattern. This can be useful for features like auto-complete or regexp authoring tools:
+
+[source,console]
+--------------------------------------------------
+POST stackoverflow/_terms/list
+{
+    "field" : "tags",
+    "pattern" : "kiba"
+}
+--------------------------------------------------
+// TEST[setup:stackoverflow]
+// TEST[continued]
+
+
+The API returns the following response:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "terms": [
+    {
+      "term": "kibana",
+      "doc_count": 8
+    }
+  ]
+}
+--------------------------------------------------
+// TESTRESPONSE[s/"8"/"$body.terms.0.doc_count"/]
+
+[[search-term-enum-api-request]]
+==== {api-request-title}
+
+`GET /<target>/_terms/list`
+
+
+[[search-term-enum-api-desc]]
+==== {api-description-title}
+
+The termenum API  can be used to discover terms in the index that match
+a pattern. By default it looks for terms that begin with the provided
+pattern but more complex pattern matching can be used by setting the
+appropriate flags that control matching.
+
+
+[[search-term-enum-api-path-params]]
+==== {api-path-parms-title}
+
+`<target>`::
+(Mandatory, string)
+Comma-separated list of data streams, indices, and index aliases to search.
+Wildcard (`*`) expressions are supported.
++
+To search all data streams or indices in a cluster, omit this parameter or use
+`_all` or `*`.
+
+[[search-term-enum-api-request-body]]
+==== {api-request-body-title}
+
+[[term-enum-field-param]]
+`field`::
+(Mandatory, string)
+Which field to match
+
+[[term-enum-field-param]]
+`field`::
+(Mandatory, string)
+The string pattern to match in indexed terms
+
+[[term-enum-leading-wildcard-param]]
+`leading_wildcard`::
+(Optional, boolean)
+When true allows for the pattern to be found starting anywhere in the indexed term. This
+can be expensive to run so the default is false.
+
+[[term-enum-trailling-wildcard-param]]
+`trailling_wildcard`::
+(Optional, boolean)
+When true matches index terms that may contain extra characters after the provided pattern. This
+is cheap to run so the default is true and supports auto-complete style use cases.
+
+[[term-enum-size-param]]
+`size`::
+(Optional, integer)
+How many matching terms to return. Defaults to 10
+
+[[term-enum-timeout-param]]
+`timeout`::
+(Optional, integer)
+The maximum length of time in milliseconds to spend collecting results. Defaults to 1000.
+If the timeout is exceeded a `timed_out` flag is set in the response and the results may
+be partial or empty.
+
+[[term-enum-case_insensitive-param]]
+`case_insensitive`::
+(Optional, boolean)
+When true the pattern is matched against index terms without case sensitivity.
+Defaults to false.
+
+[[term-enum-use_regexp_syntax-param]]
+`use_regexp_syntax`::
+(Optional, boolean)
+When true the pattern is matched against index terms as a regular expression.
+This can be expensive to run so the default is false.
+
+[[term-enum-min_shard_doc_freq-param]]
+`min_shard_doc_freq`::
+(Optional, integer)
+Many terms in an index can be one-off typos which you might not want to see. Setting this parameter
+to a value greater than one can be effective in removing undesirable values from results.
+
+[[term-enum-sort_by_popularity-param]]
+`sort_by_popularity`::
+(Optional, boolean)
+When true terms are sorted by popularity, when false they are sorted alphabetically. Sorting
+by popularity can be slower so the default is false
+
+

--- a/docs/reference/search/term-enum.asciidoc
+++ b/docs/reference/search/term-enum.asciidoc
@@ -30,10 +30,11 @@ The API returns the following response:
       "term": "kibana",
       "doc_count": 8
     }
-  ]
+  ],
+  "timed_out" : false
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"8"/"$body.terms.0.doc_count"/]
+// TESTRESPONSE[s/8/$body.terms.0.doc_count/]
 
 [[search-term-enum-api-request]]
 ==== {api-request-title}

--- a/docs/reference/search/term-enum.asciidoc
+++ b/docs/reference/search/term-enum.asciidoc
@@ -70,7 +70,7 @@ To search all data streams or indices in a cluster, omit this parameter or use
 (Mandatory, string)
 Which field to match
 
-[[term-enum-field-param]]
+[[term-enum-pattern-param]]
 `field`::
 (Mandatory, string)
 The string pattern to match in indexed terms

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -222,6 +222,8 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.termenum.TermEnumAction;
+import org.elasticsearch.action.termenum.TransportTermEnumAction;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
 import org.elasticsearch.action.termvectors.TermVectorsAction;
 import org.elasticsearch.action.termvectors.TransportMultiTermVectorsAction;
@@ -336,6 +338,7 @@ import org.elasticsearch.rest.action.admin.indices.RestRolloverIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestSimulateIndexTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.RestSimulateTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.RestSyncedFlushAction;
+import org.elasticsearch.rest.action.admin.indices.RestTermEnumAction;
 import org.elasticsearch.rest.action.admin.indices.RestUpdateSettingsAction;
 import org.elasticsearch.rest.action.admin.indices.RestValidateQueryAction;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
@@ -542,6 +545,7 @@ public class ActionModule extends AbstractModule {
         actions.register(SimulateIndexTemplateAction.INSTANCE, TransportSimulateIndexTemplateAction.class);
         actions.register(SimulateTemplateAction.INSTANCE, TransportSimulateTemplateAction.class);
         actions.register(ValidateQueryAction.INSTANCE, TransportValidateQueryAction.class);
+        actions.register(TermEnumAction.INSTANCE, TransportTermEnumAction.class);
         actions.register(RefreshAction.INSTANCE, TransportRefreshAction.class);
         actions.register(FlushAction.INSTANCE, TransportFlushAction.class);
         actions.register(ForceMergeAction.INSTANCE, TransportForceMergeAction.class);
@@ -723,6 +727,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestMultiSearchAction(settings));
 
         registerHandler.accept(new RestValidateQueryAction());
+        registerHandler.accept(new RestTermEnumAction());
 
         registerHandler.accept(new RestExplainAction());
 

--- a/server/src/main/java/org/elasticsearch/action/termenum/ShardTermEnumRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/ShardTermEnumRequest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.internal.AliasFilter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Internal termenum request executed directly against a specific index shard.
+ */
+public class ShardTermEnumRequest extends BroadcastShardRequest {
+
+    private String field;
+    private String pattern;
+    private long nowInMillis;
+    private AliasFilter filteringAliases;
+    private boolean leadingWildcard;
+    private boolean traillingWildcard;
+    private boolean caseInsensitive;
+    private boolean useRegexpSyntax;
+    private boolean sortByPopularity;
+    private int minShardDocFreq;
+    private int size;
+    private int timeout;
+
+    public ShardTermEnumRequest(StreamInput in) throws IOException {
+        super(in);
+        filteringAliases = new AliasFilter(in);
+        field = in.readString();
+        pattern = in.readString();
+        leadingWildcard = in.readBoolean();
+        traillingWildcard = in.readBoolean();
+        caseInsensitive = in.readBoolean();
+        useRegexpSyntax = in.readBoolean();
+        sortByPopularity = in.readBoolean();
+        minShardDocFreq = in.readVInt();
+        size = in.readVInt();
+        timeout = in.readVInt();
+        nowInMillis = in.readVLong();
+
+    }
+
+    public ShardTermEnumRequest(ShardId shardId, AliasFilter filteringAliases, TermEnumRequest request) {
+        super(shardId, request);
+        this.field = request.field();
+        this.pattern = request.pattern();
+        this.leadingWildcard = request.leadingWildcard();
+        this.traillingWildcard = request.traillingWildcard();
+        this.caseInsensitive = request.caseInsensitive();
+        this.useRegexpSyntax = request.useRegexpSyntax();
+        this.minShardDocFreq = request.minShardDocFreq();
+        this.size = request.size();
+        this.timeout = request.timeout();
+        this.sortByPopularity = request.sortByPopularity();
+        this.filteringAliases = Objects.requireNonNull(filteringAliases, "filteringAliases must not be null");
+        this.nowInMillis = request.nowInMillis;
+    }
+
+    public String field() {
+        return field;
+    }
+
+    public String pattern() {
+        return pattern;
+    }
+
+    public AliasFilter filteringAliases() {
+        return filteringAliases;
+    }
+
+    public long nowInMillis() {
+        return this.nowInMillis;
+    }
+
+    public boolean leadingWildcard() {
+        return leadingWildcard;
+    }
+
+    public boolean traillingWildcard() {
+        return traillingWildcard;
+    }
+
+    public boolean caseInsensitive() {
+        return caseInsensitive;
+    }
+
+    public boolean useRegexpSyntax() {
+        return useRegexpSyntax;
+    }
+
+    public boolean sortByPopularity() {
+        return sortByPopularity;
+    }
+
+    public int minShardDocFreq() {
+        return minShardDocFreq;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int timeout() {
+        return timeout;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        filteringAliases.writeTo(out);
+        out.writeString(field);
+        out.writeString(pattern);
+        out.writeBoolean(leadingWildcard);
+        out.writeBoolean(traillingWildcard);
+        out.writeBoolean(caseInsensitive);
+        out.writeBoolean(useRegexpSyntax);
+        out.writeBoolean(sortByPopularity);
+        out.writeVInt(minShardDocFreq);
+        out.writeVInt(size);
+        out.writeVInt(timeout);
+        out.writeVLong(nowInMillis);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/ShardTermEnumResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/ShardTermEnumResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Internal response of a term enum request executed directly against a specific shard.
+ *
+ *
+ */
+class ShardTermEnumResponse extends BroadcastShardResponse {
+
+    private String error;
+    private boolean timedOut;
+
+    private List<TermCount> terms;
+
+    ShardTermEnumResponse(StreamInput in) throws IOException {
+        super(in);
+        terms = in.readList(TermCount::new);
+        error = in.readOptionalString();
+        timedOut = in.readBoolean();
+    }
+
+    ShardTermEnumResponse(ShardId shardId, List<TermCount> terms, String error, boolean timedOut) {
+        super(shardId);
+        this.terms = terms;
+        this.error = error;
+        this.timedOut = timedOut;
+    }
+
+    public List<TermCount> terms() {
+        return this.terms;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public boolean getTimedOut() {
+        return timedOut;
+    }
+
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeCollection(terms);
+        out.writeOptionalString(error);
+        out.writeBoolean(timedOut);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TermCount.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TermCount.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class TermCount implements Writeable, ToXContentFragment {
+
+    public static final String TERM_FIELD = "term";
+    public static final String DOC_COUNT_FIELD = "doc_count";
+
+    static final ConstructingObjectParser<TermCount, Void> PARSER = new ConstructingObjectParser<>(
+        "term_count",
+        true,
+        a -> { return new TermCount((String) a[0], (int) a[1]); }
+    );
+    static {
+        PARSER.declareString(optionalConstructorArg(), new ParseField(TERM_FIELD));
+        PARSER.declareInt(optionalConstructorArg(), new ParseField(DOC_COUNT_FIELD));
+    }
+
+    private String term;
+
+    private int docCount;
+
+    public TermCount(StreamInput in) throws IOException {
+        term = in.readString();
+        docCount = in.readInt();
+    }
+
+    public TermCount(String term, int count) {
+        this.term = term;
+        this.docCount = count;
+    }
+
+    public String getTerm() {
+        return this.term;
+    }
+
+    public int getDocCount() {
+        return this.docCount;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(term);
+        out.writeInt(docCount);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(TERM_FIELD, getTerm());
+        builder.field(DOC_COUNT_FIELD, getDocCount());
+        return builder;
+    }
+
+    public static TermCount fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermCount other = (TermCount) o;
+        return Objects.equals(getTerm(), other.getTerm()) && Objects.equals(getDocCount(), other.getDocCount());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTerm(), getDocCount());
+    }
+
+    void addToDocCount(int extra) {
+        docCount += extra;
+    }
+
+    void setTerm(String term) {
+        this.term = term;
+    }
+
+    void setDocCount(int docCount) {
+        this.docCount = docCount;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TermEnumAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TermEnumAction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class TermEnumAction extends ActionType<TermEnumResponse> {
+
+    public static final TermEnumAction INSTANCE = new TermEnumAction();
+    public static final String NAME = "indices:admin/termsenum/list";
+
+    private TermEnumAction() {
+        super(NAME, TermEnumResponse::new);
+    }
+
+    public static TermEnumRequest fromXContent(XContentParser parser, String... indices) throws IOException {
+        TermEnumRequest request = new TermEnumRequest(indices);
+        PARSER.parse(parser, request, null);
+        return request;
+    }
+
+    private static final ObjectParser<TermEnumRequest, Void> PARSER = new ObjectParser<>("terms_enum_request");
+    static {
+        PARSER.declareString(TermEnumRequest::field, new ParseField("field"));
+        PARSER.declareString(TermEnumRequest::pattern, new ParseField("pattern"));
+        PARSER.declareInt(TermEnumRequest::size, new ParseField("size"));
+        PARSER.declareBoolean(TermEnumRequest::leadingWildcard, new ParseField("leading_wildcard"));
+        PARSER.declareBoolean(TermEnumRequest::traillingWildcard, new ParseField("trailling_wildcard"));
+        PARSER.declareBoolean(TermEnumRequest::caseInsensitive, new ParseField("case_insensitive"));
+        PARSER.declareBoolean(TermEnumRequest::useRegexpSyntax, new ParseField("use_regexp_syntax"));
+        PARSER.declareBoolean(TermEnumRequest::sortByPopularity, new ParseField("sort_by_popularity"));
+        PARSER.declareInt(TermEnumRequest::minShardDocFreq, new ParseField("min_shard_doc_freq"));
+        PARSER.declareInt(TermEnumRequest::timeout, new ParseField("timeout"));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TermEnumRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TermEnumRequest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A request to gather terms for a given field matching a pattern
+ */
+public class TermEnumRequest extends BroadcastRequest<TermEnumRequest> implements ToXContentObject {
+
+    public static int DEFAULT_SIZE = 10;
+    public static int DEFAULT_TIMEOUT_MILLIS = 1000;
+
+    private String field;
+    private String pattern;
+    private int minShardDocFreq;
+    private int size = DEFAULT_SIZE;
+    private int timeout = DEFAULT_TIMEOUT_MILLIS;
+    private boolean leadingWildcard;
+    private boolean traillingWildcard = true;
+    private boolean caseInsensitive;
+    private boolean useRegexpSyntax;
+    private boolean sortByPopularity;
+
+    long nowInMillis;
+
+    public TermEnumRequest() {
+        this(Strings.EMPTY_ARRAY);
+    }
+
+    public TermEnumRequest(StreamInput in) throws IOException {
+        super(in);
+        field = in.readString();
+        pattern = in.readString();
+        leadingWildcard = in.readBoolean();
+        traillingWildcard = in.readBoolean();
+        caseInsensitive = in.readBoolean();
+        useRegexpSyntax = in.readBoolean();
+        sortByPopularity = in.readBoolean();
+        minShardDocFreq = in.readVInt();
+        size = in.readVInt();
+        timeout = in.readVInt();
+    }
+
+    /**
+     * Constructs a new term enum request against the provided indices. No indices provided means it will
+     * run against all indices.
+     */
+    public TermEnumRequest(String... indices) {
+        super(indices);
+        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = super.validate();
+        if (field == null) {
+            validationException = ValidateActions.addValidationError("field cannot be null", validationException);
+        } else if (useRegexpSyntax) {
+            try {
+                new RegExp(pattern);
+            } catch (IllegalArgumentException ia) {
+                validationException = ValidateActions.addValidationError(
+                    "Bad regular expression: [" + pattern + "] " + ia.getMessage(),
+                    validationException
+                );
+            }
+        }
+        return validationException;
+    }
+
+    /**
+     * The field to look inside for values
+     */
+    public void field(String field) {
+        this.field = field;
+    }
+
+    /**
+     * Indicates if detailed information about query is requested
+     */
+    public String field() {
+        return field;
+    }
+
+    /**
+     * The pattern required in matching field values
+     */
+    public void pattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    /**
+     * The pattern required in matching field values
+     */
+    public String pattern() {
+        return pattern;
+    }
+
+    /**
+     * True if characters are allowed before pattern in string
+     */
+    public void leadingWildcard(boolean leadingWildcard) {
+        this.leadingWildcard = leadingWildcard;
+    }
+
+    /**
+     * If characters are allowed before pattern in string
+     */
+    public boolean leadingWildcard() {
+        return leadingWildcard;
+    }
+
+    /**
+     * True if characters are allowed after pattern in string
+     */
+    public void traillingWildcard(boolean traillingWildcard) {
+        this.traillingWildcard = traillingWildcard;
+    }
+
+    /**
+     * If characters are allowed after pattern in string
+     */
+    public boolean traillingWildcard() {
+        return traillingWildcard;
+    }
+
+    /**
+     * sort terms by popularity
+     */
+    public boolean sortByPopularity() {
+        return sortByPopularity;
+    }
+
+    /**
+     * sort terms by popularity
+     */
+    public void sortByPopularity(boolean sortByPopularity) {
+        this.sortByPopularity = sortByPopularity;
+    }
+
+    /**
+     * The minimum number of docs on a shard having a term, defaults to 1
+     */
+    public int minShardDocFreq() {
+        return minShardDocFreq;
+    }
+
+    /**
+     * The minimum number of docs on a shard having a term, defaults to 1
+     */
+    public void minShardDocFreq(int minShardDocFreq) {
+        this.minShardDocFreq = minShardDocFreq;
+    }
+
+    /**
+     *  The number of terms to return
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * The number of terms to return
+     */
+    public void size(int size) {
+        this.size = size;
+    }
+
+    /**
+     *  The max time in milliseconds to spend gathering terms
+     */
+    public int timeout() {
+        return timeout;
+    }
+
+    /**
+     * TThe max time in milliseconds to spend gathering terms
+     */
+    public void timeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * If case insensitive matching is required
+     */
+    public void caseInsensitive(boolean caseInsensitive) {
+        this.caseInsensitive = caseInsensitive;
+    }
+
+    /**
+     * If case insensitive matching is required
+     */
+    public boolean caseInsensitive() {
+        return caseInsensitive;
+    }
+
+    /**
+     * If regex syntax is used
+     */
+    public void useRegexpSyntax(boolean useRegexSyntax) {
+        this.useRegexpSyntax = useRegexSyntax;
+    }
+
+    /**
+     * If case insensitive matching is required
+     */
+    public boolean useRegexpSyntax() {
+        return useRegexpSyntax;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(field);
+        out.writeString(pattern);
+        out.writeBoolean(leadingWildcard);
+        out.writeBoolean(traillingWildcard);
+        out.writeBoolean(caseInsensitive);
+        out.writeBoolean(useRegexpSyntax);
+        out.writeBoolean(sortByPopularity);
+        out.writeVInt(minShardDocFreq);
+        out.writeVInt(size);
+        out.writeVInt(timeout);
+
+    }
+
+    @Override
+    public String toString() {
+        return "[" + Arrays.toString(indices) + "] field[" + field + "], pattern[" + pattern + "] " + " leading_wildcard=" + leadingWildcard
+            + " trailling_wildcard=" + traillingWildcard + " min_shard_doc_freq=" + minShardDocFreq + " size=" + size + " timeout="
+            + timeout + " use_regexp_syntax = " + useRegexpSyntax + " sort_by_popularity = " + sortByPopularity + " case_insensitive="
+            + caseInsensitive;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("field", field);
+        builder.field("pattern", pattern);
+        builder.field("leading_wildcard", leadingWildcard);
+        builder.field("trailling_wildcard", traillingWildcard);
+        builder.field("min_shard_doc_freq", minShardDocFreq);
+        builder.field("size", size);
+        builder.field("timeout", timeout);
+        builder.field("case_insensitive", caseInsensitive);
+        builder.field("sort_by_popularity", sortByPopularity);
+        builder.field("use_regexp_syntax", useRegexpSyntax);
+        return builder.endObject();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TermEnumRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TermEnumRequestBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class TermEnumRequestBuilder extends BroadcastOperationRequestBuilder<TermEnumRequest, TermEnumResponse, TermEnumRequestBuilder> {
+
+    public TermEnumRequestBuilder(ElasticsearchClient client, TermEnumAction action) {
+        super(client, action, new TermEnumRequest());
+    }
+
+    public TermEnumRequestBuilder setField(String field) {
+        request.field(field);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setPattern(String pattern) {
+        request.pattern(pattern);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setLeadingWildcard(boolean leadingWildcard) {
+        request.leadingWildcard(leadingWildcard);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setSortByPopularity(boolean sortByPopularity) {
+        request.sortByPopularity(sortByPopularity);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setMinShardDocFreq(int minShardDocFreq) {
+        request.minShardDocFreq(minShardDocFreq);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setSize(int size) {
+        request.size(size);
+        return this;
+    }
+
+    public TermEnumRequestBuilder setTraillingWildcard(boolean traillingWildcard) {
+        request.traillingWildcard(traillingWildcard);
+        return this;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TermEnumResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TermEnumResponse.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * The response of the termenum/list action.
+ */
+public class TermEnumResponse extends BroadcastResponse {
+
+    public static final String TERMS_FIELD = "terms";
+    public static final String TIMED_OUT_FIELD = "timed_out";
+
+    @SuppressWarnings("unchecked")
+    static final ConstructingObjectParser<TermEnumResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "term_enum_results",
+        true,
+        arg -> {
+            BroadcastResponse response = (BroadcastResponse) arg[0];
+            return new TermEnumResponse(
+                (List<TermCount>) arg[1],
+                response.getTotalShards(),
+                response.getSuccessfulShards(),
+                response.getFailedShards(),
+                Arrays.asList(response.getShardFailures()),
+                (Boolean) arg[2]
+            );
+        }
+    );
+    static {
+        declareBroadcastFields(PARSER);
+        PARSER.declareObjectArray(optionalConstructorArg(), TermCount.PARSER, new ParseField(TERMS_FIELD));
+        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(TIMED_OUT_FIELD));
+    }
+
+    private final List<TermCount> terms;
+
+    private boolean timedOut;
+
+    TermEnumResponse(StreamInput in) throws IOException {
+        super(in);
+        terms = in.readList(TermCount::new);
+        timedOut = in.readBoolean();
+    }
+
+    TermEnumResponse(
+        List<TermCount> terms,
+        int totalShards,
+        int successfulShards,
+        int failedShards,
+        List<DefaultShardOperationFailedException> shardFailures, boolean timedOut
+    ) {
+        super(totalShards, successfulShards, failedShards, shardFailures);
+        this.terms = terms == null ? Collections.emptyList() : terms;
+        this.timedOut = timedOut;
+    }
+
+    /**
+     * The list of terms.
+     */
+    public List<TermCount> getTerms() {
+        return terms;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeCollection(terms);
+        out.writeBoolean(timedOut);
+
+    }
+
+    @Override
+    protected void addCustomXContentFields(XContentBuilder builder, Params params) throws IOException {
+        if (getTerms() != null && !getTerms().isEmpty()) {
+            builder.startArray(TERMS_FIELD);
+            for (TermCount term : getTerms()) {
+                builder.startObject();
+                term.toXContent(builder, params);
+                builder.endObject();
+            }
+            builder.endArray();
+        }
+        builder.field("timed_out", timedOut);
+    }
+
+    public static TermEnumResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TransportTermEnumAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TransportTermEnumAction.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiTerms;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.apache.lucene.util.automaton.MinimizationOperations;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
+import org.elasticsearch.search.SearchService;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+public class TransportTermEnumAction extends TransportBroadcastAction<
+    TermEnumRequest,
+    TermEnumResponse,
+    ShardTermEnumRequest,
+    ShardTermEnumResponse> {
+
+    private final SearchService searchService;
+
+    @Inject
+    public TransportTermEnumAction(
+        ClusterService clusterService,
+        TransportService transportService,
+        SearchService searchService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            TermEnumAction.NAME,
+            clusterService,
+            transportService,
+            actionFilters,
+            indexNameExpressionResolver,
+            TermEnumRequest::new,
+            ShardTermEnumRequest::new,
+            ThreadPool.Names.SEARCH
+        );
+        this.searchService = searchService;
+    }
+
+    @Override
+    protected ShardTermEnumRequest newShardRequest(int numShards, ShardRouting shard, TermEnumRequest request) {
+        final ClusterState clusterState = clusterService.state();
+        final Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());
+        final AliasFilter aliasFilter = searchService.buildAliasFilter(clusterState, shard.getIndexName(), indicesAndAliases);
+        return new ShardTermEnumRequest(shard.shardId(), aliasFilter, request);
+    }
+
+    @Override
+    protected ShardTermEnumResponse readShardResponse(StreamInput in) throws IOException {
+        return new ShardTermEnumResponse(in);
+    }
+
+    @Override
+    protected GroupShardsIterator shards(ClusterState clusterState, TermEnumRequest request, String[] concreteIndices) {
+        final String routing;
+
+        // TODO filter out cold/frozen shards and those with DLS or FLS on the target field.
+
+        // if (request.allShards()) {
+        routing = null;
+        // } else {
+        // // Random routing to limit request to a single shard
+        // routing = Integer.toString(Randomness.get().nextInt(1000));
+        // }
+        Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, routing, request.indices());
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, routingMap, "_local");
+    }
+
+    @Override
+    protected ClusterBlockException checkGlobalBlock(ClusterState state, TermEnumRequest request) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
+    }
+
+    @Override
+    protected ClusterBlockException checkRequestBlock(ClusterState state, TermEnumRequest countRequest, String[] concreteIndices) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, concreteIndices);
+    }
+
+    @Override
+    protected TermEnumResponse newResponse(TermEnumRequest request, AtomicReferenceArray shardsResponses, ClusterState clusterState) {
+        int successfulShards = 0;
+        int failedShards = 0;
+        boolean timedOut = false;
+        List<DefaultShardOperationFailedException> shardFailures = null;
+        Map<String, TermCount> combinedResults = new HashMap<String, TermCount>();
+        for (int i = 0; i < shardsResponses.length(); i++) {
+            Object shardResponse = shardsResponses.get(i);
+            if (shardResponse == null) {
+                // simply ignore non active shards
+            } else if (shardResponse instanceof BroadcastShardOperationFailedException) {
+                failedShards++;
+                if (shardFailures == null) {
+                    shardFailures = new ArrayList<>();
+                }
+                shardFailures.add(new DefaultShardOperationFailedException((BroadcastShardOperationFailedException) shardResponse));
+            } else {
+                ShardTermEnumResponse str = (ShardTermEnumResponse) shardResponse;
+                if (str.getTimedOut()) {
+                    timedOut = true;
+                }
+                for (TermCount term : str.terms()) {
+                    TermCount existingTc = combinedResults.get(term.getTerm());
+                    if (existingTc == null) {
+                        combinedResults.put(term.getTerm(), term);
+                    } else {
+                        // add counts
+                        existingTc.addToDocCount(term.getDocCount());
+                    }
+                }
+                successfulShards++;
+            }
+        }
+        int size = Math.min(request.size(), combinedResults.size());
+        List<TermCount> terms = new ArrayList<>(size);
+        TermCount[] sortedCombinedResults = combinedResults.values().toArray(new TermCount[0]);
+        if (request.sortByPopularity()) {
+            // Sort by doc count descending
+            Arrays.sort(sortedCombinedResults, new Comparator<TermCount>() {
+                public int compare(TermCount t1, TermCount t2) {
+                    return Integer.compare(t2.getDocCount(), t1.getDocCount());
+                }
+            });
+        } else {
+            // Sort alphabetically
+            Arrays.sort(sortedCombinedResults, new Comparator<TermCount>() {
+                public int compare(TermCount t1, TermCount t2) {
+                    return t1.getTerm().compareTo(t2.getTerm());
+                }
+            });
+        }
+
+        for (TermCount term : sortedCombinedResults) {
+            terms.add(term);
+            if (terms.size() == size) {
+                break;
+            }
+        }
+
+        return new TermEnumResponse(terms, shardsResponses.length(), successfulShards, failedShards, shardFailures, timedOut);
+    }
+
+    static class TermCountPriorityQueue extends PriorityQueue<TermCount> {
+
+        public TermCountPriorityQueue(int maxSize) {
+            super(maxSize);
+        }
+
+        @Override
+        protected boolean lessThan(TermCount a, TermCount b) {
+            return a.getDocCount() < b.getDocCount();
+        }
+
+    }
+
+    @Override
+    protected ShardTermEnumResponse shardOperation(ShardTermEnumRequest request, Task task) throws IOException {
+        List<TermCount> termsList = new ArrayList<>();
+        String error = null;
+        ShardSearchRequest shardSearchLocalRequest = new ShardSearchRequest(
+            request.shardId(),
+            request.nowInMillis(),
+            request.filteringAliases()
+        );
+        SearchContext searchContext = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT);
+        try {
+            int timeout_millis = request.timeout();
+            // SearchContext has a timer check facility but the granularity of the clock ticks is
+            // tailored for longer-running searches and not necessarily those of short auto-complete style
+            // term lookups like this API offers. We use our own timer here.
+            long scheduledEnd = System.currentTimeMillis() + timeout_millis;
+
+            IndexReader reader = searchContext.getQueryShardContext().searcher().getTopReaderContext().reader();
+            Terms terms = MultiTerms.getTerms(reader, request.field());
+            TermsEnum te = MultiTerms.getTerms(reader, request.field()).iterator();
+            Automaton a;
+            if (request.useRegexpSyntax()) {
+                int matchFlag = request.caseInsensitive() ? RegExp.ASCII_CASE_INSENSITIVE : 0;
+                RegExp re = new RegExp(request.pattern(), RegExp.ALL, matchFlag);
+                a = re.toAutomaton();
+            } else {
+                a = request.caseInsensitive()
+                    ? AutomatonQueries.caseInsensitivePrefix(request.pattern())
+                    : Automata.makeString(request.pattern());
+            }
+
+            if (request.leadingWildcard()) {
+                a = Operations.concatenate(Automata.makeAnyString(), a);
+            }
+            if (request.traillingWildcard()) {
+                a = Operations.concatenate(a, Automata.makeAnyString());
+            }
+            a = MinimizationOperations.minimize(a, Integer.MAX_VALUE);
+
+            // TODO make this a param and scale up based on num shards like we do with terms aggs?
+            int shard_size = request.size();
+
+            CompiledAutomaton automaton = new CompiledAutomaton(a);
+            te = terms.intersect(automaton, null);
+
+            // All the above prep might take a while - do a timer check now before we continue further.
+            if (System.currentTimeMillis() > scheduledEnd) {
+                return new ShardTermEnumResponse(request.shardId(), termsList, error, true);
+            }
+
+            int numTermsBetweenClockChecks = 100;
+            int termCount = 0;
+            if (request.sortByPopularity()) {
+                // Collect most popular matches
+                TermCountPriorityQueue pq = new TermCountPriorityQueue(shard_size);
+                TermCount spare = null;
+                while (te.next() != null) {
+                    termCount++;
+                    if (termCount > numTermsBetweenClockChecks) {
+                        if (System.currentTimeMillis() > scheduledEnd) {
+                            return new ShardTermEnumResponse(request.shardId(), termsList, error, true);
+                        }
+                        termCount = 0;
+                    }
+                    int df = te.docFreq();
+                    if (df < request.minShardDocFreq()) {
+                        continue;
+                    }
+                    BytesRef bytes = te.term();
+
+                    if (spare == null) {
+                        spare = new TermCount(bytes.utf8ToString(), df);
+                    } else {
+                        spare.setTerm(bytes.utf8ToString());
+                        spare.setDocCount(df);
+                    }
+                    spare = pq.insertWithOverflow(spare);
+                }
+                while (pq.size() > 0) {
+                    termsList.add(pq.pop());
+                }
+            } else {
+                // Collect in alphabetical order
+                while (te.next() != null) {
+                    termCount++;
+                    if (termCount > numTermsBetweenClockChecks) {
+                        if (System.currentTimeMillis() > scheduledEnd) {
+                            return new ShardTermEnumResponse(request.shardId(), termsList, error, true);
+                        }
+                        termCount = 0;
+                    }
+                    int df = te.docFreq();
+                    if (df < request.minShardDocFreq()) {
+                        continue;
+                    }
+                    BytesRef bytes = te.term();
+                    termsList.add(new TermCount(bytes.utf8ToString(), df));
+                    if (termsList.size() >= shard_size) {
+                        break;
+                    }
+                }
+            }
+
+        } catch (AssertionError e) {
+            error = e.getMessage();
+        } finally {
+            Releasables.close(searchContext);
+        }
+
+        return new ShardTermEnumResponse(request.shardId(), termsList, error, false);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/termenum/TransportTermEnumAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/TransportTermEnumAction.java
@@ -197,7 +197,7 @@ public class TransportTermEnumAction extends TransportBroadcastAction<
 
     static class TermCountPriorityQueue extends PriorityQueue<TermCount> {
 
-        public TermCountPriorityQueue(int maxSize) {
+        TermCountPriorityQueue(int maxSize) {
             super(maxSize);
         }
 

--- a/server/src/main/java/org/elasticsearch/action/termenum/package-info.java
+++ b/server/src/main/java/org/elasticsearch/action/termenum/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Enumerate a field's terms action.
+ */
+package org.elasticsearch.action.termenum;

--- a/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -100,6 +100,8 @@ import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryReques
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequestBuilder;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.termenum.TermEnumRequest;
+import org.elasticsearch.action.termenum.TermEnumResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock;
 import org.elasticsearch.common.Nullable;
 
@@ -627,6 +629,26 @@ public interface IndicesAdminClient extends ElasticsearchClient {
      * @param listener A listener to be notified of the result
      */
     void validateQuery(ValidateQueryRequest request, ActionListener<ValidateQueryResponse> listener);
+    
+    
+
+    /**
+     * Collect terms from a field
+     *
+     * @param request The termEnum request
+     * @return The result future
+     */
+    ActionFuture<TermEnumResponse> termEnum(TermEnumRequest request);
+
+    /**
+     * Collect terms from a field
+     *
+     * @param request  The termEnum request
+     * @param listener A listener to be notified of the result
+     */
+    void termEnum(TermEnumRequest request, ActionListener<TermEnumResponse> listener);    
+    
+    
 
     /**
      * Validate a query for correctness.

--- a/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -309,6 +309,9 @@ import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.termenum.TermEnumAction;
+import org.elasticsearch.action.termenum.TermEnumRequest;
+import org.elasticsearch.action.termenum.TermEnumResponse;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequestBuilder;
@@ -1639,6 +1642,17 @@ public abstract class AbstractClient implements Client {
         public void validateQuery(final ValidateQueryRequest request, final ActionListener<ValidateQueryResponse> listener) {
             execute(ValidateQueryAction.INSTANCE, request, listener);
         }
+        
+        @Override
+        public ActionFuture<TermEnumResponse> termEnum(final TermEnumRequest request) {
+            return execute(TermEnumAction.INSTANCE, request);
+        }
+
+        @Override
+        public void termEnum(final TermEnumRequest request, final ActionListener<TermEnumResponse> listener) {
+            execute(TermEnumAction.INSTANCE, request, listener);
+        }
+        
 
         @Override
         public ValidateQueryRequestBuilder prepareValidateQuery(String... indices) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestTermEnumAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestTermEnumAction.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.action.termenum.TermEnumAction;
+import org.elasticsearch.action.termenum.TermEnumRequest;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestTermEnumAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, "/{index}/_terms/list"),
+            new Route(POST, "/{index}/_terms/list"));
+    }
+
+    @Override
+    public String getName() {
+        return "term_enum_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        try (XContentParser parser = request.contentOrSourceParamParser()) {
+            TermEnumRequest termEnumRequest = TermEnumAction.fromXContent(parser, 
+                Strings.splitStringByCommaToArray(request.param("index")));
+            return channel -> client.admin().indices().termEnum(termEnumRequest, new RestToXContentListener<>(channel));
+        }        
+
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/action/termenum/TermCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termenum/TermCountTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class TermCountTests extends AbstractSerializingTestCase<TermCount> {
+
+    static TermCount createRandomQueryExplanation(boolean isValid) {
+        int docCount = randomInt(100);
+        String term = randomAlphaOfLength(randomIntBetween(10, 100));
+        return new TermCount(term, docCount);
+    }
+
+    static TermCount createRandomQueryExplanation() {
+        return createRandomQueryExplanation(randomBoolean());
+    }
+
+    @Override
+    protected TermCount doParseInstance(XContentParser parser) throws IOException {
+        return TermCount.fromXContent(parser);
+    }
+
+    @Override
+    protected TermCount createTestInstance() {
+        return createRandomQueryExplanation();
+    }
+
+    @Override
+    protected Writeable.Reader<TermCount> instanceReader() {
+        return TermCount::new;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/termenum/TermEnumResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termenum/TermEnumResponseTests.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TermEnumResponseTests extends AbstractBroadcastResponseTestCase<TermEnumResponse> {
+
+    protected static List<TermCount> getRandomTerms() {
+        int termCount = randomIntBetween(0, 100);
+        Map<String, TermCount> uniqueTerms = new HashMap<>(termCount);
+        while (uniqueTerms.size() < termCount) {
+            String s = randomAlphaOfLengthBetween(1, 10);
+            uniqueTerms.put(s, new TermCount(s, randomIntBetween(1, 100)));
+        }
+        List<TermCount> terms = new ArrayList<>(uniqueTerms.values());
+        return terms;
+    }
+
+    private static TermEnumResponse createRandomTermEnumResponse() {
+        int totalShards = randomIntBetween(1, 10);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int failedShards = totalShards - successfulShards;
+        List<DefaultShardOperationFailedException> shardFailures = new ArrayList<>(failedShards);
+        for (int i=0; i<failedShards; i++) {
+            ElasticsearchException exc = new ElasticsearchException("some_error_" + randomInt());
+            String index = "index_" + randomInt(1000);
+            int shard = randomInt(100);
+            shardFailures.add(
+                new DefaultShardOperationFailedException(index, shard, exc)
+            );
+        }
+        return new TermEnumResponse(getRandomTerms(), totalShards, successfulShards, failedShards, shardFailures, randomBoolean());
+    }
+
+    @Override
+    protected TermEnumResponse doParseInstance(XContentParser parser) throws IOException {
+        return TermEnumResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected TermEnumResponse createTestInstance() {
+        return createRandomTermEnumResponse();
+    }
+
+    @Override
+    protected void assertEqualInstances(TermEnumResponse response, TermEnumResponse parsedResponse) {
+        super.assertEqualInstances(response, parsedResponse);
+        Set<TermCount> terms = new HashSet<>(response.getTerms());
+        assertEquals(response.getTerms().size(), parsedResponse.getTerms().size());
+        assertTrue(terms.containsAll(parsedResponse.getTerms()));
+    }
+
+    @Override
+    protected TermEnumResponse createTestInstance(int totalShards, int successfulShards, int failedShards,
+                                                       List<DefaultShardOperationFailedException> failures) {
+        return new TermEnumResponse(getRandomTerms(), totalShards, successfulShards, failedShards, failures, randomBoolean());
+
+    }
+
+    @Override
+    public void testToXContent() {
+        TermCount tc = new TermCount(randomAlphaOfLengthBetween(1, 10), randomIntBetween(1,  Integer.MAX_VALUE));
+        List<TermCount> terms = new ArrayList<>();
+        terms.add(tc);
+        TermEnumResponse response = new TermEnumResponse(terms, 10, 10, 0, new ArrayList<>(), true);
+
+        String output = Strings.toString(response);
+        assertEquals("{\"_shards\":{\"total\":10,\"successful\":10,\"failed\":0},\"terms\":[{" +
+            "\"term\":\""+tc.getTerm()+"\","+
+            "\"doc_count\":"+tc.getDocCount()+
+            "}],\"timed_out\":true}", output);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/termenum/TransportValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termenum/TransportValidateQueryActionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termenum;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportValidateQueryActionTests extends ESSingleNodeTestCase {
+
+    /*
+     * Copy of test that tripped up similarly broadcast ValidateQuery
+     */
+    public void testListenerOnlyInvokedOnceWhenIndexDoesNotExist() {
+        final AtomicBoolean invoked = new AtomicBoolean();
+        final ActionListener<TermEnumResponse> listener = new ActionListener<>() {
+
+            @Override
+            public void onResponse(final TermEnumResponse validateQueryResponse) {
+                fail("onResponse should not be invoked in this failure case");
+            }
+
+            @Override
+            public void onFailure(final Exception e) {
+                if (invoked.compareAndSet(false, true) == false) {
+                    fail("onFailure invoked more than once");
+                }
+            }
+
+        };
+        client().admin().indices().termEnum(new TermEnumRequest("non-existent-index"), listener);
+        assertThat(invoked.get(), equalTo(true)); // ensure that onFailure was invoked
+    }
+
+}


### PR DESCRIPTION
Patterns can be provided with a variety of flags similar to those used in term, prefix, wildcard and regexp queries.
Matching terms can be returned in alphabetical order or by popularity,
A timeout can limit the amount of time spent looking for matches.

Expected to be useful in auto-complete or regex debugging use cases.
