### PR TITLE
Extract Source interface from SourceLookup

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -95,7 +95,7 @@ public class TokenCountFieldMapper extends FieldMapper {
         @Override
         public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
             if (hasDocValues() == false) {
-                return lookup -> List.of();
+                return (doc, lookup) -> List.of();
             }
             return new DocValueFetcher(docValueFormat(format, null), searchLookup.doc().getForField(this));
         }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
@@ -33,7 +34,6 @@ import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -96,8 +96,7 @@ final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
                                 new SearchHit(slot, "unknown", Collections.emptyMap(), Collections.emptyMap()),
                                 percolatorLeafReaderContext,
                                 slot,
-                                new SourceLookup());
-                            subContext.sourceLookup().setSource(document);
+                                Source.fromBytes(slot, document));
                             // force source because MemoryIndex does not store fields
                             SearchHighlightContext highlight = new SearchHighlightContext(fetchContext.highlight().fields(), true);
                             FetchSubPhaseProcessor processor = highlightPhase.getProcessor(fetchContext, highlight, query);

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -96,7 +96,7 @@ final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
                                 new SearchHit(slot, "unknown", Collections.emptyMap(), Collections.emptyMap()),
                                 percolatorLeafReaderContext,
                                 slot,
-                                Source.fromBytes(slot, document));
+                                Source.fromBytes(document));
                             // force source because MemoryIndex does not store fields
                             SearchHighlightContext highlight = new SearchHighlightContext(fetchContext.highlight().fields(), true);
                             FetchSubPhaseProcessor processor = highlightPhase.getProcessor(fetchContext, highlight, query);

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -289,7 +289,7 @@ public class UpdateHelper {
 
         BytesReference sourceFilteredAsBytes = sourceAsBytes;
         if (request.fetchSource().includes().length > 0 || request.fetchSource().excludes().length > 0) {
-            Source s = Source.fromMap(0, source, sourceContentType);
+            Source s = Source.fromMap(source, sourceContentType);
             Object value = s.filter(request.fetchSource());
             try {
                 final int initialCapacity = Math.min(1024, sourceAsBytes.length());

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -45,7 +45,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.UpdateScript;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -289,9 +289,8 @@ public class UpdateHelper {
 
         BytesReference sourceFilteredAsBytes = sourceAsBytes;
         if (request.fetchSource().includes().length > 0 || request.fetchSource().excludes().length > 0) {
-            SourceLookup sourceLookup = new SourceLookup();
-            sourceLookup.setSource(source);
-            Object value = sourceLookup.filter(request.fetchSource());
+            Source s = Source.fromMap(0, source, sourceContentType);
+            Object value = s.filter(request.fetchSource());
             try {
                 final int initialCapacity = Math.min(1024, sourceAsBytes.length());
                 BytesStreamOutput streamOutput = new BytesStreamOutput(initialCapacity);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.Source;
 
@@ -57,7 +58,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     public List<Object> fetchValues(int doc, Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
-            Object sourceValue = source.extractValue(path, nullValue);
+            Object sourceValue = XContentMapValues.extractValue(path, source.source(), nullValue);
             if (sourceValue == null) {
                 return List.of();
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -54,7 +54,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(Source source) {
+    public List<Object> fetchValues(int doc, Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
             Object sourceValue = source.extractValue(path, nullValue);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,10 +54,10 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(SourceLookup lookup) {
+    public List<Object> fetchValues(Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
-            Object sourceValue = lookup.extractValue(path, nullValue);
+            Object sourceValue = source.extractValue(path, nullValue);
             if (sourceValue == null) {
                 return List.of();
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
@@ -48,8 +48,8 @@ public final class DocValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(Source source) throws IOException {
-        if (false == leaf.advanceExact(source.docId())) {
+    public List<Object> fetchValues(int doc, Source source) throws IOException {
+        if (false == leaf.advanceExact(doc)) {
             return emptyList();
         }
         List<Object> result = new ArrayList<Object>(leaf.docValueCount());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,8 +48,8 @@ public final class DocValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(SourceLookup lookup) throws IOException {
-        if (false == leaf.advanceExact(lookup.docId())) {
+    public List<Object> fetchValues(Source source) throws IOException {
+        if (false == leaf.advanceExact(source.docId())) {
             return emptyList();
         }
         List<Object> result = new ArrayList<Object>(leaf.docValueCount());

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -55,7 +55,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(Source source) {
+    public List<Object> fetchValues(int doc, Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
             Object sourceValue = source.extractValue(path, nullValue);

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -55,10 +55,10 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     }
 
     @Override
-    public List<Object> fetchValues(SourceLookup lookup) {
+    public List<Object> fetchValues(Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
-            Object sourceValue = lookup.extractValue(path, nullValue);
+            Object sourceValue = source.extractValue(path, nullValue);
             if (sourceValue == null) {
                 return List.of();
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.Source;
 
@@ -58,7 +59,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     public List<Object> fetchValues(int doc, Source source) {
         List<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
-            Object sourceValue = source.extractValue(path, nullValue);
+            Object sourceValue = XContentMapValues.extractValue(path, source.source(), nullValue);
             if (sourceValue == null) {
                 return List.of();
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
@@ -41,10 +41,11 @@ public interface ValueFetcher {
      * Note that for array values, the order in which values are returned is undefined and
      * should not be relied on.
      *
+     * @param docId the document's per-segment lucene id
      * @param source the document's source.
      * @return a list a standardized field values.
      */
-    List<Object> fetchValues(Source source) throws IOException;
+    List<Object> fetchValues(int docId, Source source) throws IOException;
 
     /**
      * Update the leaf reader used to fetch values.

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValueFetcher.java
@@ -20,8 +20,8 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,10 +41,10 @@ public interface ValueFetcher {
      * Note that for array values, the order in which values are returned is undefined and
      * should not be relied on.
      *
-     * @param lookup a lookup structure over the document's source.
+     * @param source the document's source.
      * @return a list a standardized field values.
      */
-    List<Object> fetchValues(SourceLookup lookup) throws IOException;
+    List<Object> fetchValues(Source source) throws IOException;
 
     /**
      * Update the leaf reader used to fetch values.

--- a/server/src/main/java/org/elasticsearch/search/Source.java
+++ b/server/src/main/java/org/elasticsearch/search/Source.java
@@ -35,38 +35,26 @@ import java.util.Map;
  */
 public interface Source {
 
-    static Source emptySource(int docId) {
-        return new Source() {
-            @Override
-            public int docId() {
-                return docId;
-            }
+    Source EMPTY_SOURCE = new Source() {
+        @Override
+        public Map<String, Object> source() {
+            return null;
+        }
 
-            @Override
-            public Map<String, Object> source() {
-                return null;
-            }
+        @Override
+        public BytesReference internalSourceRef() {
+            return null;
+        }
 
-            @Override
-            public BytesReference internalSourceRef() {
-                return null;
-            }
-
-            @Override
-            public XContentType sourceContentType() {
-                return null;
-            }
-        };
-    }
+        @Override
+        public XContentType sourceContentType() {
+            return null;
+        }
+    };
 
     // TODO used in upserts, would be nice to remove this entirely
-    static Source fromMap(int docId, Map<String, Object> map, XContentType xContentType) {
+    static Source fromMap(Map<String, Object> map, XContentType xContentType) {
         return new Source() {
-            @Override
-            public int docId() {
-                return docId;
-            }
-
             @Override
             public Map<String, Object> source() {
                 return map;
@@ -84,15 +72,10 @@ public interface Source {
         };
     }
 
-    static Source fromBytes(int docId, BytesReference bytes) {
+    static Source fromBytes(BytesReference bytes) {
         return new Source() {
             Map<String, Object> parsedSource = null;
             XContentType xContentType;
-
-            @Override
-            public int docId() {
-                return docId;
-            }
 
             @Override
             public Map<String, Object> source() {
@@ -117,11 +100,6 @@ public interface Source {
             }
         };
     }
-
-    /**
-     * The per-segment id of the document pertaining to this source object
-     */
-    int docId();
 
     /**
      * The source represented as a map of maps

--- a/server/src/main/java/org/elasticsearch/search/Source.java
+++ b/server/src/main/java/org/elasticsearch/search/Source.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +39,7 @@ public interface Source {
     Source EMPTY_SOURCE = new Source() {
         @Override
         public Map<String, Object> source() {
-            return null;
+            return Collections.emptyMap();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/Source.java
+++ b/server/src/main/java/org/elasticsearch/search/Source.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mediates access to a document's source map
+ */
+public interface Source {
+
+    static Source emptySource(int docId) {
+        return new Source() {
+            @Override
+            public int docId() {
+                return docId;
+            }
+
+            @Override
+            public Map<String, Object> source() {
+                return null;
+            }
+
+            @Override
+            public BytesReference internalSourceRef() {
+                return null;
+            }
+
+            @Override
+            public XContentType sourceContentType() {
+                return null;
+            }
+        };
+    }
+
+    // TODO used in upserts, would be nice to remove this entirely
+    static Source fromMap(int docId, Map<String, Object> map, XContentType xContentType) {
+        return new Source() {
+            @Override
+            public int docId() {
+                return docId;
+            }
+
+            @Override
+            public Map<String, Object> source() {
+                return map;
+            }
+
+            @Override
+            public BytesReference internalSourceRef() {
+                return null;
+            }
+
+            @Override
+            public XContentType sourceContentType() {
+                return xContentType;
+            }
+        };
+    }
+
+    static Source fromBytes(int docId, BytesReference bytes) {
+        return new Source() {
+            Map<String, Object> parsedSource = null;
+            XContentType xContentType;
+
+            @Override
+            public int docId() {
+                return docId;
+            }
+
+            @Override
+            public Map<String, Object> source() {
+                if (parsedSource == null) {
+                    // TODO can we be cleverer here and not need to use XContentType? Only used in FetchSourcePhase
+                    Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(bytes, false);
+                    parsedSource = tuple.v2();
+                    xContentType = tuple.v1();
+                }
+                return parsedSource;
+            }
+
+            @Override
+            public BytesReference internalSourceRef() {
+                return bytes;
+            }
+
+            @Override
+            public XContentType sourceContentType() {
+                source();   // parse if need be
+                return xContentType;
+            }
+        };
+    }
+
+    /**
+     * The per-segment id of the document pertaining to this source object
+     */
+    int docId();
+
+    /**
+     * The source represented as a map of maps
+     */
+    Map<String, Object> source();
+
+    /**
+     * The source represented as a BytesReference
+     */
+    BytesReference internalSourceRef();
+
+    /**
+     * The XContentType of the source
+     */
+    XContentType sourceContentType();
+
+    /**
+     * For the provided path, return its value in the source.
+     *
+     * Note that in contrast with {@link #extractRawValues}, array and object values
+     * can be returned.
+     *
+     * @param path the value's path in the source.
+     * @param nullValue a value to return if the path exists, but the value is 'null'. This helps
+     *                  in distinguishing between a path that doesn't exist vs. a value of 'null'.
+     *
+     * @return the value associated with the path in the source or 'null' if the path does not exist.
+     */
+    default Object extractValue(String path, @Nullable Object nullValue) {
+        return XContentMapValues.extractValue(path, source(), nullValue);
+    }
+
+    /**
+     * Returns the values associated with the path. Those are "low" level values, and it can
+     * handle path expression where an array/list is navigated within.
+     */
+    default List<Object> extractRawValues(String path) {
+        return XContentMapValues.extractRawValues(path, source());
+    }
+
+    // TODO make this return a BytesReference instead
+    default Object filter(FetchSourceContext context) {
+        return context.getFilter().apply(source());
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/search/Source.java
+++ b/server/src/main/java/org/elasticsearch/search/Source.java
@@ -19,16 +19,13 @@
 
 package org.elasticsearch.search;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -117,31 +114,7 @@ public interface Source {
      */
     XContentType sourceContentType();
 
-    /**
-     * For the provided path, return its value in the source.
-     *
-     * Note that in contrast with {@link #extractRawValues}, array and object values
-     * can be returned.
-     *
-     * @param path the value's path in the source.
-     * @param nullValue a value to return if the path exists, but the value is 'null'. This helps
-     *                  in distinguishing between a path that doesn't exist vs. a value of 'null'.
-     *
-     * @return the value associated with the path in the source or 'null' if the path does not exist.
-     */
-    default Object extractValue(String path, @Nullable Object nullValue) {
-        return XContentMapValues.extractValue(path, source(), nullValue);
-    }
-
-    /**
-     * Returns the values associated with the path. Those are "low" level values, and it can
-     * handle path expression where an array/list is navigated within.
-     */
-    default List<Object> extractRawValues(String path) {
-        return XContentMapValues.extractRawValues(path, source());
-    }
-
-    // TODO make this return a BytesReference instead
+    // TODO make this return a BytesReference instead and merge with internalSourceRef()
     default Object filter(FetchSourceContext context) {
         return context.getFilter().apply(source());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -216,7 +217,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
 
                     try {
                         for (String sourceField : sourceFieldNames) {
-                            Iterator<String> itr = sourceLookup.extractRawValues(sourceField).stream()
+                            Iterator<String> itr = XContentMapValues.extractRawValues(sourceField, sourceLookup.source()).stream()
                                 .map(obj -> {
                                     if (obj == null) {
                                         return null;

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -308,6 +308,7 @@ public class FetchPhase {
         int subDocId = docId - subReaderContext.docBase;
         if (fieldsVisitor == null) {
             SearchHit hit = new SearchHit(docId, null, null, null);
+            lookup.source().setSegmentAndDocument(subReaderContext, subDocId);
             return new HitContext(hit, subReaderContext, subDocId, lookup.source());
         } else {
             SearchHit hit;

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -322,8 +322,8 @@ public class FetchPhase {
             }
 
             Source source = fieldsVisitor.source() == null
-                ? Source.emptySource(hit.docId())
-                : Source.fromBytes(hit.docId(), fieldsVisitor.source());
+                ? Source.EMPTY_SOURCE
+                : Source.fromBytes(fieldsVisitor.source());
             return new HitContext(hit, subReaderContext, subDocId, source);
         }
     }
@@ -445,10 +445,10 @@ public class FetchPhase {
                 hit,
                 subReaderContext,
                 nestedDocId,
-                Source.fromMap(hit.docId(), nestedSourceAsMap, rootSourceContentType)
+                Source.fromMap(nestedSourceAsMap, rootSourceContentType)
             );
         }
-        return new HitContext(hit, subReaderContext, nestedDocId, Source.emptySource(hit.docId()));
+        return new HitContext(hit, subReaderContext, nestedDocId, Source.EMPTY_SOURCE);
     }
 
     private static SearchHit.NestedIdentity getInternalNestedIdentity(SearchContext context,

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -23,7 +23,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.io.IOException;
 
@@ -36,19 +36,18 @@ public interface FetchSubPhase {
         private final SearchHit hit;
         private final LeafReaderContext readerContext;
         private final int docId;
-        private final SourceLookup sourceLookup;
+        private final Source source;
 
         public HitContext(
             SearchHit hit,
             LeafReaderContext context,
             int docId,
-            SourceLookup sourceLookup
+            Source source
         ) {
             this.hit = hit;
             this.readerContext = context;
             this.docId = docId;
-            this.sourceLookup = sourceLookup;
-            sourceLookup.setSegmentAndDocument(context, docId);
+            this.source = source;
         }
 
         public SearchHit hit() {
@@ -77,8 +76,8 @@ public interface FetchSubPhase {
          * In most cases, the hit document's source is loaded eagerly at the start of the
          * {@link FetchPhase}. This lookup will contain the preloaded source.
          */
-        public SourceLookup sourceLookup() {
-            return sourceLookup;
+        public Source source() {
+            return source;
         }
 
         public IndexReader topLevelReader() {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -81,7 +81,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
                         // docValues fields will still be document fields, and put under "fields" section of a hit.
                         hit.hit().setDocumentField(f.field, hitField);
                     }
-                    hitField.getValues().addAll(f.fetcher.fetchValues(hit.sourceLookup()));
+                    hitField.getValues().addAll(f.fetcher.fetchValues(hit.source()));
                 }
             }
         };

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -81,7 +81,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
                         // docValues fields will still be document fields, and put under "fields" section of a hit.
                         hit.hit().setDocumentField(f.field, hitField);
                     }
-                    hitField.getValues().addAll(f.fetcher.fetchValues(hit.source()));
+                    hitField.getValues().addAll(f.fetcher.fetchValues(hit.docId(), hit.source()));
                 }
             }
         };

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -63,10 +62,8 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             @Override
             public void process(HitContext hitContext) throws IOException {
                 SearchHit hit = hitContext.hit();
-                SourceLookup sourceLookup = hitContext.sourceLookup();
-
                 Set<String> ignoredFields = getIgnoredFields(hit);
-                Map<String, DocumentField> documentFields = fieldFetcher.fetch(sourceLookup, ignoredFields);
+                Map<String, DocumentField> documentFields = fieldFetcher.fetch(hitContext.source(), ignoredFields);
                 for (Map.Entry<String, DocumentField> entry : documentFields.entrySet()) {
                     hit.setDocumentField(entry.getKey(), entry.getValue());
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -63,7 +63,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             public void process(HitContext hitContext) throws IOException {
                 SearchHit hit = hitContext.hit();
                 Set<String> ignoredFields = getIgnoredFields(hit);
-                Map<String, DocumentField> documentFields = fieldFetcher.fetch(hitContext.source(), ignoredFields);
+                Map<String, DocumentField> documentFields = fieldFetcher.fetch(hitContext, ignoredFields);
                 for (Map.Entry<String, DocumentField> entry : documentFields.entrySet()) {
                     hit.setDocumentField(entry.getKey(), entry.getValue());
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
@@ -25,10 +25,10 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Map;
@@ -60,7 +60,7 @@ public final class FetchSourcePhase implements FetchSubPhase {
     private void hitExecute(String index, FetchSourceContext fetchSourceContext, HitContext hitContext) {
 
         final boolean nestedHit = hitContext.hit().getNestedIdentity() != null;
-        SourceLookup source = hitContext.sourceLookup();
+        Source source = hitContext.source();
 
         // If source is disabled in the mapping, then attempt to return early.
         if (source.source() == null && source.internalSourceRef() == null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
@@ -63,7 +63,7 @@ public final class FetchSourcePhase implements FetchSubPhase {
         Source source = hitContext.source();
 
         // If source is disabled in the mapping, then attempt to return early.
-        if (source.source() == null && source.internalSourceRef() == null) {
+        if (source == Source.EMPTY_SOURCE) {
             if (containsFilters(fetchSourceContext)) {
                 throw new IllegalArgumentException("unable to fetch fields from _source field: _source is disabled in the mappings " +
                     "for index [" + index + "]");

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.Source;
+import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -70,7 +70,7 @@ public class FieldFetcher {
         this.fieldContexts = fieldContexts;
     }
 
-    public Map<String, DocumentField> fetch(Source source, Set<String> ignoredFields) throws IOException {
+    public Map<String, DocumentField> fetch(FetchSubPhase.HitContext hitContext, Set<String> ignoredFields) throws IOException {
         Map<String, DocumentField> documentFields = new HashMap<>();
         for (FieldContext context : fieldContexts) {
             String field = context.fieldName;
@@ -79,7 +79,7 @@ public class FieldFetcher {
             }
 
             ValueFetcher valueFetcher = context.valueFetcher;
-            List<Object> parsedValues = valueFetcher.fetchValues(source);
+            List<Object> parsedValues = valueFetcher.fetchValues(hitContext.docId(), hitContext.source());
 
             if (parsedValues.isEmpty() == false) {
                 documentFields.put(field, new DocumentField(field, parsedValues));

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -24,8 +24,8 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,7 +70,7 @@ public class FieldFetcher {
         this.fieldContexts = fieldContexts;
     }
 
-    public Map<String, DocumentField> fetch(SourceLookup sourceLookup, Set<String> ignoredFields) throws IOException {
+    public Map<String, DocumentField> fetch(Source source, Set<String> ignoredFields) throws IOException {
         Map<String, DocumentField> documentFields = new HashMap<>();
         for (FieldContext context : fieldContexts) {
             String field = context.fieldName;
@@ -79,7 +79,7 @@ public class FieldFetcher {
             }
 
             ValueFetcher valueFetcher = context.valueFetcher;
-            List<Object> parsedValues = valueFetcher.fetchValues(sourceLookup);
+            List<Object> parsedValues = valueFetcher.fetchValues(source);
 
             if (parsedValues.isEmpty() == false) {
                 documentFields.put(field, new DocumentField(field, parsedValues));

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -49,6 +49,7 @@ import java.util.Objects;
  * Context used for inner hits retrieval
  */
 public final class InnerHitsContext {
+
     private final Map<String, InnerHitSubContext> innerHits;
 
     public InnerHitsContext() {
@@ -137,9 +138,10 @@ public final class InnerHitsContext {
          */
         public Source getRootSource() {
             if (rootSource == Source.EMPTY_SOURCE) {
+                // If loading source has been disabled on the root but asked for on an inner
+                // hit, then we need to load it here
                 SourceLookup lookup = new SourceLookup();
                 lookup.setSegmentAndDocument(parentHit.readerContext(), parentHit.docId());
-                lookup.loadSourceIfNeeded();
                 rootSource = lookup;
             }
             return rootSource;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -33,9 +33,9 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public final class InnerHitsContext {
         private Weight innerHitQueryWeight;
 
         private String rootId;
-        private SourceLookup rootLookup;
+        private Source rootSource;
 
         protected InnerHitSubContext(String name, SearchContext context) {
             super(context);
@@ -136,12 +136,12 @@ public final class InnerHitsContext {
          *
          * This shared lookup allows inner hits to avoid re-loading the root _source.
          */
-        public SourceLookup getRootLookup() {
-            return rootLookup;
+        public Source getRootSource() {
+            return rootSource;
         }
 
-        public void setRootLookup(SourceLookup rootLookup) {
-            this.rootLookup = rootLookup;
+        public void setRootSource(Source rootSource) {
+            this.rootSource = rootSource;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -25,12 +25,12 @@ import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -66,7 +66,7 @@ public final class InnerHitsPhase implements FetchSubPhase {
     private void hitExecute(Map<String, InnerHitsContext.InnerHitSubContext> innerHits, HitContext hitContext) throws IOException {
 
         SearchHit hit = hitContext.hit();
-        SourceLookup sourceLookup = hitContext.sourceLookup();
+        Source source = hitContext.source();
 
         for (Map.Entry<String, InnerHitsContext.InnerHitSubContext> entry : innerHits.entrySet()) {
             InnerHitsContext.InnerHitSubContext innerHitsContext = entry.getValue();
@@ -83,7 +83,7 @@ public final class InnerHitsPhase implements FetchSubPhase {
             }
             innerHitsContext.docIdsToLoad(docIdsToLoad, docIdsToLoad.length);
             innerHitsContext.setRootId(hit.getId());
-            innerHitsContext.setRootLookup(sourceLookup);
+            innerHitsContext.setRootSource(source);
 
             fetchPhase.execute(innerHitsContext);
             FetchSearchResult fetchResult = innerHitsContext.fetchResult();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -25,7 +25,6 @@ import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
@@ -66,7 +65,6 @@ public final class InnerHitsPhase implements FetchSubPhase {
     private void hitExecute(Map<String, InnerHitsContext.InnerHitSubContext> innerHits, HitContext hitContext) throws IOException {
 
         SearchHit hit = hitContext.hit();
-        Source source = hitContext.source();
 
         for (Map.Entry<String, InnerHitsContext.InnerHitSubContext> entry : innerHits.entrySet()) {
             InnerHitsContext.InnerHitSubContext innerHitsContext = entry.getValue();
@@ -82,8 +80,7 @@ public final class InnerHitsPhase implements FetchSubPhase {
                 docIdsToLoad[j] = topDoc.topDocs.scoreDocs[j].doc;
             }
             innerHitsContext.docIdsToLoad(docIdsToLoad, docIdsToLoad.length);
-            innerHitsContext.setRootId(hit.getId());
-            innerHitsContext.setRootSource(source);
+            innerHitsContext.setRootHit(hitContext);
 
             fetchPhase.execute(innerHitsContext);
             FetchSearchResult fetchResult = innerHitsContext.fetchResult();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -99,7 +99,7 @@ public class FastVectorHighlighter implements Highlighter {
                     fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, field.fieldOptions().preTags(),
                         field.fieldOptions().postTags(), boundaryScanner);
                 } else {
-                    fragmentsBuilder = new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
+                    fragmentsBuilder = new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.source(),
                         field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                 }
             } else {
@@ -110,7 +110,7 @@ public class FastVectorHighlighter implements Highlighter {
                         fragmentsBuilder = new ScoreOrderFragmentsBuilder(field.fieldOptions().preTags(),
                             field.fieldOptions().postTags(), boundaryScanner);
                     } else {
-                        fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
+                        fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.source(),
                             field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                     }
                 } else {
@@ -119,7 +119,7 @@ public class FastVectorHighlighter implements Highlighter {
                             field.fieldOptions().postTags(), boundaryScanner);
                     } else {
                         fragmentsBuilder =
-                            new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.sourceLookup(),
+                            new SourceSimpleFragmentsBuilder(fieldType, fixBrokenAnalysis, hitContext.source(),
                                 field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -23,8 +23,8 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchSubPhase;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -59,8 +59,8 @@ public final class HighlightUtils {
                 textsToHighlight = Collections.emptyList();
             }
         } else {
-            SourceLookup sourceLookup = hitContext.sourceLookup();
-            textsToHighlight = sourceLookup.extractRawValues(fieldType.name());
+            Source source = hitContext.source();
+            textsToHighlight = source.extractRawValues(fieldType.name());
         }
         assert textsToHighlight != null;
         return textsToHighlight;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.fetch.subphase.highlight;
 import org.apache.lucene.search.highlight.DefaultEncoder;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.Source;
@@ -60,9 +61,8 @@ public final class HighlightUtils {
             }
         } else {
             Source source = hitContext.source();
-            textsToHighlight = source.extractRawValues(fieldType.name());
+            textsToHighlight = XContentMapValues.extractRawValues(fieldType.name(), source.source());
         }
-        assert textsToHighlight != null;
         return textsToHighlight;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.apache.lucene.search.vectorhighlight.ScoreOrderFragmentsBuilder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.Source;
 
@@ -52,7 +53,7 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
     @Override
     protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        List<Object> values = source.extractRawValues(fieldType.name());
+        List<Object> values = XContentMapValues.extractRawValues(fieldType.name(), source.source());
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
             fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.apache.lucene.search.vectorhighlight.ScoreOrderFragmentsBuilder;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,25 +34,25 @@ import java.util.List;
 public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder {
 
     private final MappedFieldType fieldType;
-    private final SourceLookup sourceLookup;
+    private final Source source;
     private final boolean fixBrokenAnalysis;
 
     public SourceScoreOrderFragmentsBuilder(MappedFieldType fieldType,
                                             boolean fixBrokenAnalysis,
-                                            SourceLookup sourceLookup,
+                                            Source source,
                                             String[] preTags,
                                             String[] postTags,
                                             BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
         this.fieldType = fieldType;
-        this.sourceLookup = sourceLookup;
+        this.source = source;
         this.fixBrokenAnalysis = fixBrokenAnalysis;
     }
 
     @Override
     protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
+        List<Object> values = source.extractRawValues(fieldType.name());
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
             fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
@@ -23,23 +23,23 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 
 import java.io.IOException;
 import java.util.List;
 
 public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
 
-    private final SourceLookup sourceLookup;
+    private final Source source;
 
     public SourceSimpleFragmentsBuilder(MappedFieldType fieldType,
                                         boolean fixBrokenAnalysis,
-                                        SourceLookup sourceLookup,
+                                        Source source,
                                         String[] preTags,
                                         String[] postTags,
                                         BoundaryScanner boundaryScanner) {
         super(fieldType, fixBrokenAnalysis, preTags, postTags, boundaryScanner);
-        this.sourceLookup = sourceLookup;
+        this.source = source;
     }
 
     public static final Field[] EMPTY_FIELDS = new Field[0];
@@ -47,7 +47,7 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
     @Override
     protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
+        List<Object> values = source.extractRawValues(fieldType.name());
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
@@ -22,10 +22,10 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.Source;
 
-import java.io.IOException;
 import java.util.List;
 
 public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
@@ -45,9 +45,9 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
     public static final Field[] EMPTY_FIELDS = new Field[0];
 
     @Override
-    protected Field[] getFields(IndexReader reader, int docId, String fieldName) throws IOException {
+    protected Field[] getFields(IndexReader reader, int docId, String fieldName) {
         // we know its low level reader, and matching docId, since that's how we call the highlighter with
-        List<Object> values = source.extractRawValues(fieldType.name());
+        List<Object> values = XContentMapValues.extractRawValues(fieldType.name(), source.source());
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -62,11 +62,6 @@ public class SourceLookup implements Map<String, Object>, Source {
         return sourceContentType;
     }
 
-    @Override
-    public int docId() {
-        return docId;
-    }
-
     // Scripting requires this method to be public. Using source()
     // is not possible because certain checks use source == null as
     // as a determination if source is enabled/disabled, but it should
@@ -137,7 +132,7 @@ public class SourceLookup implements Map<String, Object>, Source {
         this.sourceAsBytes = null;
         this.docId = docId;
     }
-    
+
     /**
      * Internal source representation, might be compressed....
      */

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -55,7 +55,7 @@ public class SourceLookup implements Map<String, Object>, Source {
 
     @Override
     public Map<String, Object> source() {
-        return source;
+        return loadSourceIfNeeded();
     }
 
     public XContentType sourceContentType() {

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -22,13 +22,11 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -36,7 +34,6 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -139,16 +136,6 @@ public class SourceLookup implements Map<String, Object>, Source {
     @Override
     public BytesReference internalSourceRef() {
         return sourceAsBytes;
-    }
-
-    @Override
-    public List<Object> extractRawValues(String path) {
-        return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
-    }
-
-    @Override
-    public Object extractValue(String path, @Nullable Object nullValue) {
-        return XContentMapValues.extractValue(path, loadSourceIfNeeded(), nullValue);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.fetch.subphase;
 
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.memory.MemoryIndex;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -155,14 +153,11 @@ public class FetchSourcePhaseTests extends ESTestCase {
 
         final SearchHit searchHit = new SearchHit(1, null, nestedIdentity, null, null);
 
-        // We don't need a real index, just a LeafReaderContext which cannot be mocked.
-        MemoryIndex index = new MemoryIndex();
-        LeafReaderContext leafReaderContext = index.createSearcher().getIndexReader().leaves().get(0);
         HitContext hitContext = new HitContext(
             searchHit,
-            leafReaderContext,
+            null,
             1,
-            source == null ? Source.emptySource(1) : Source.fromBytes(1, BytesReference.bytes(source)));
+            source == null ? Source.EMPTY_SOURCE : Source.fromBytes(BytesReference.bytes(source)));
 
         FetchSourcePhase phase = new FetchSourcePhase();
         FetchSubPhaseProcessor processor = phase.getProcessor(fetchContext);

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
@@ -26,10 +26,10 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
-import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -162,8 +162,7 @@ public class FetchSourcePhaseTests extends ESTestCase {
             searchHit,
             leafReaderContext,
             1,
-            new SourceLookup());
-        hitContext.sourceLookup().setSource(source == null ? null : BytesReference.bytes(source));
+            source == null ? Source.emptySource(1) : Source.fromBytes(1, BytesReference.bytes(source)));
 
         FetchSourcePhase phase = new FetchSourcePhase();
         FetchSubPhaseProcessor processor = phase.getProcessor(fetchContext);

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
@@ -404,11 +404,8 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
     private static Map<String, DocumentField> fetchFields(MapperService mapperService, XContentBuilder source, List<FieldAndFormat> fields)
         throws IOException {
 
-        SourceLookup sourceLookup = new SourceLookup();
-        sourceLookup.setSource(BytesReference.bytes(source));
-
         FieldFetcher fieldFetcher = FieldFetcher.create(createQueryShardContext(mapperService), null, fields);
-        return fieldFetcher.fetch(sourceLookup, Set.of());
+        return fieldFetcher.fetch(Source.fromBytes(0, BytesReference.bytes(source)), Set.of());
     }
 
     public MapperService createMapperService() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -30,7 +30,9 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.Source;
+import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
@@ -403,9 +405,10 @@ public class FieldFetcherTests extends ESSingleNodeTestCase {
 
     private static Map<String, DocumentField> fetchFields(MapperService mapperService, XContentBuilder source, List<FieldAndFormat> fields)
         throws IOException {
-
+        FetchSubPhase.HitContext hitContext
+            = new FetchSubPhase.HitContext(new SearchHit(0), null, 0, Source.fromBytes(BytesReference.bytes(source)));
         FieldFetcher fieldFetcher = FieldFetcher.create(createQueryShardContext(mapperService), null, fields);
-        return fieldFetcher.fetch(Source.fromBytes(0, BytesReference.bytes(source)), Set.of());
+        return fieldFetcher.fetch(hitContext, Set.of());
     }
 
     public MapperService createMapperService() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -56,8 +56,6 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         when(queryShardContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(queryShardContext, null, format);
-        SourceLookup lookup = new SourceLookup();
-        lookup.setSource(Collections.singletonMap(field, sourceValue));
-        return fetcher.fetchValues(lookup);
+        return fetcher.fetchValues(Source.fromMap(0, Collections.singletonMap(field, sourceValue), null));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -56,6 +56,6 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         when(queryShardContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(queryShardContext, null, format);
-        return fetcher.fetchValues(Source.fromMap(0, Collections.singletonMap(field, sourceValue), null));
+        return fetcher.fetchValues(0, Source.fromMap(Collections.singletonMap(field, sourceValue), null));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -320,7 +320,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
             lookup.source().setSegmentAndDocument(context, 0);
             valueFetcher.setNextReader(context);
-            result.set(valueFetcher.fetchValues(lookup.source()));
+            result.set(valueFetcher.fetchValues(0, lookup.source()));
         });
         return result.get();
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -136,8 +136,8 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             }
 
             return value == null
-                ? lookup -> List.of()
-                : lookup -> List.of(value);
+                ? (doc, lookup) -> List.of()
+                : (doc, lookup) -> List.of(value);
         }
 
         @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
@@ -112,15 +112,15 @@ public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
 
         SourceLookup missingValueLookup = new SourceLookup();
 
-        Source nullSource = Source.fromMap(0, Collections.singletonMap("field", null), null);
+        Source nullSource = Source.fromMap(Collections.singletonMap("field", null), null);
 
-        assertTrue(fetcher.fetchValues(missingValueLookup).isEmpty());
-        assertTrue(fetcher.fetchValues(nullSource).isEmpty());
+        assertTrue(fetcher.fetchValues(0, missingValueLookup).isEmpty());
+        assertTrue(fetcher.fetchValues(0, nullSource).isEmpty());
 
         MappedFieldType valued = new ConstantKeywordFieldMapper.ConstantKeywordFieldType("field", "foo");
         fetcher = valued.valueFetcher(null, null, null);
 
-        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup));
-        assertEquals(List.of("foo"), fetcher.fetchValues(nullSource));
+        assertEquals(List.of("foo"), fetcher.fetchValues(0, missingValueLookup));
+        assertEquals(List.of("foo"), fetcher.fetchValues(0, nullSource));
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.search.Source;
 import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.constantkeyword.mapper.ConstantKeywordFieldMapper.ConstantKeywordFieldType;
 
@@ -110,16 +111,16 @@ public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
         ValueFetcher fetcher = fieldType.valueFetcher(null, null, null);
 
         SourceLookup missingValueLookup = new SourceLookup();
-        SourceLookup nullValueLookup = new SourceLookup();
-        nullValueLookup.setSource(Collections.singletonMap("field", null));
+
+        Source nullSource = Source.fromMap(0, Collections.singletonMap("field", null), null);
 
         assertTrue(fetcher.fetchValues(missingValueLookup).isEmpty());
-        assertTrue(fetcher.fetchValues(nullValueLookup).isEmpty());
+        assertTrue(fetcher.fetchValues(nullSource).isEmpty());
 
         MappedFieldType valued = new ConstantKeywordFieldMapper.ConstantKeywordFieldType("field", "foo");
         fetcher = valued.valueFetcher(null, null, null);
 
         assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup));
-        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup));
+        assertEquals(List.of("foo"), fetcher.fetchValues(nullSource));
     }
 }

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
@@ -258,7 +258,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         @Override
         public ValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
             // This is an internal field but it can match a field pattern so we return an empty list.
-            return lookup -> List.of();
+            return (doc, lookup) -> List.of();
         }
     }
 


### PR DESCRIPTION
SourceLookup currently does two things:
- mediates access to the source for a given document
- advances across multiple documents

Generally speaking, things that directly access the source (FetchSubPhases,
ValueFetchers) shouldn't be able to advance the underlying lookup.  This commit
makes this explicit by extracting a `Source` interface from `SourceLookup`,
containing the methods `source()`, `internalSourceRef()` and `sourceContentType()`.

HitContext is updated to contain a reference to a `Source` rather than a `SourceLookup`,
and `ValueFetcher.fetchValues` now takes a docId and a Source.