### PR TITLE
[DOCS] Document get data stream API's _meta prop

### DIFF
--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -141,7 +141,7 @@ acts as a cumulative count of the stream's rollovers, starting at `1`.
 
 `_meta`::
 (object)
-Custom metadata for the stream, pulled from the `_meta` object of the
+Custom metadata for the stream, copied from the `_meta` object of the
 stream's matching <<create-a-data-stream-template,index template>>. If empty,
 the response omits this property.
 

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -40,6 +40,9 @@ PUT /_index_template/my-index-template
     "settings": {
       "index.lifecycle.name": "my-lifecycle-policy"
     }
+  },
+  "_meta": {
+    "my-meta-field": true
   }
 }
 
@@ -136,6 +139,12 @@ Universally unique identifier (UUID) for the index.
 Current <<data-streams-generation,generation>> for the data stream. This number
 acts as a cumulative count of the stream's rollovers, starting at `1`.
 
+`_meta`::
+(object)
+Custom metadata for the stream, pulled from the `_meta` object of the
+stream's matching <<create-a-data-stream-template,index template>>. If empty,
+the response omits this property.
+
 `status`::
 (string)
 <<cluster-health,Health status>> of the data stream.
@@ -207,6 +216,9 @@ The API returns the following response:
         }
       ],
       "generation": 2,
+      "_meta": {
+        "my-meta-field": true
+      },
       "status": "GREEN",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",
@@ -224,6 +236,9 @@ The API returns the following response:
         }
       ],
       "generation": 1,
+      "_meta": {
+        "my-meta-field": true
+      },
       "status": "YELLOW",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -42,7 +42,7 @@ PUT /_index_template/my-index-template
     }
   },
   "_meta": {
-    "my-meta-field": true
+    "my-meta-field": "foo"
   }
 }
 
@@ -217,7 +217,7 @@ The API returns the following response:
       ],
       "generation": 2,
       "_meta": {
-        "my-meta-field": true
+        "my-meta-field": "foo"
       },
       "status": "GREEN",
       "template": "my-index-template",
@@ -237,7 +237,7 @@ The API returns the following response:
       ],
       "generation": 1,
       "_meta": {
-        "my-meta-field": true
+        "my-meta-field": "foo"
       },
       "status": "YELLOW",
       "template": "my-index-template",


### PR DESCRIPTION
Relates to #63991. Noticed this was missing while reviewing https://github.com/elastic/kibana/pull/83049.

### Preview
https://elasticsearch_65221.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-get-data-stream.html#get-data-stream-api-response-body