### PR TITLE
Fix Allocation `include` Filter Docs (#65202)

### DIFF
--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -59,16 +59,23 @@ PUT test/_settings
 ------------------------
 // TEST[s/^/PUT test\n/]
 
-If you specify multiple filters, all conditions must be satisfied for shards to
-be relocated. For example, to move the `test` index to `big` nodes in `rack1`,
-you could specify:
+If you specify multiple filters the following conditions must be satisfied
+simultaneously by a node in order for shards to be relocated to it:
+
+* If any `require` type conditions are specified, all of them must be satisfied
+* If any `exclude` type conditions are specified, none of them may be satisfied
+* If any `include` type conditions are specified, at least one of them must be
+satisfied
+
+For example, to move the `test` index to `big` nodes in `rack1`, you could
+specify:
 
 [source,console]
 ------------------------
 PUT test/_settings
 {
-  "index.routing.allocation.include.size": "big",
-  "index.routing.allocation.include.rack": "rack1"
+  "index.routing.allocation.require.size": "big",
+  "index.routing.allocation.require.rack": "rack1"
 }
 ------------------------
 // TEST[s/^/PUT test\n/]


### PR DESCRIPTION
Fix documentation to match actual behavior of `include` type filters.

Closes #65113

backport of #65202 