### PR TITLE
[7.10] [DOCS] Remote reindex is not fwd compatible (#65207)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -973,6 +973,9 @@ you are likely to find. This should allow you to upgrade from any version of
 Elasticsearch to the current version by reindexing from a cluster of the old
 version.
 
+WARNING: {es} does not support forward compatibility across major versions. For
+example, you cannot reindex from a 7.x cluster into a 6.x cluster.
+
 To enable queries sent to older versions of Elasticsearch the `query` parameter
 is sent directly to the remote host without validation or modification.
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Remote reindex is not fwd compatible (#65207)