### PR TITLE
[7.x][DOCS] Fix links to Fleet overview (#65174)

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -73,7 +73,7 @@ template is used for data streams.
 ====
 {es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and
 `synthetics-*-*` index patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{ingest-guide}/fleet-overview.html[{agent}] uses these templates to
 create data streams.
 
 If you use {agent}, assign your index templates a priority lower than `100` to

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -173,7 +173,7 @@ the operation automatically creates the index and applies any matching
 ====
 {es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{ingest-guide}/fleet-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid overriding the built-in templates.
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -24,7 +24,7 @@ If a new data stream or index matches more than one index template, the index te
 ====
 {es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{ingest-guide}/fleet-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid an overriding the built-in templates.
 

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -88,7 +88,7 @@ used to match the names of data streams and indices during creation.
 ====
 {es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{ingest-guide}/fleet-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid an overriding the built-in templates.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix links to Fleet overview (#65174)