### PR TITLE
Use different security policies for eclipse vs intellij

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -146,8 +146,10 @@ public class BootstrapForTesting {
                 final Policy runnerPolicy;
                 if (System.getProperty("tests.gradle") != null) {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("gradle.policy"), codebases);
-                } else {
+                } else if (codebases.containsKey("junit-rt.jar")) {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("intellij.policy"), codebases);
+                } else {
+                    runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("eclipse.policy"), codebases);
                 }
                 // this mimicks the recursive data path permission added in Security.java
                 Permissions fastPathPermissions = new Permissions();
@@ -191,6 +193,7 @@ public class BootstrapForTesting {
         addClassCodebase(codebases,"elasticsearch-nio", "org.elasticsearch.nio.ChannelFactory");
         addClassCodebase(codebases, "elasticsearch-secure-sm", "org.elasticsearch.secure_sm.SecureSM");
         addClassCodebase(codebases, "elasticsearch-rest-client", "org.elasticsearch.client.RestClient");
+        addClassCodebase(codebases, "junit", );
         return codebases;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -147,6 +147,7 @@ public class BootstrapForTesting {
                 if (System.getProperty("tests.gradle") != null) {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("gradle.policy"), codebases);
                 } else if (codebases.containsKey("junit-rt.jar")) {
+                    System.out.println("USING INTELLIJ POLICY");
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("intellij.policy"), codebases);
                 } else {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("eclipse.policy"), codebases);
@@ -193,7 +194,6 @@ public class BootstrapForTesting {
         addClassCodebase(codebases,"elasticsearch-nio", "org.elasticsearch.nio.ChannelFactory");
         addClassCodebase(codebases, "elasticsearch-secure-sm", "org.elasticsearch.secure_sm.SecureSM");
         addClassCodebase(codebases, "elasticsearch-rest-client", "org.elasticsearch.client.RestClient");
-        addClassCodebase(codebases, "junit", );
         return codebases;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -147,7 +147,6 @@ public class BootstrapForTesting {
                 if (System.getProperty("tests.gradle") != null) {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("gradle.policy"), codebases);
                 } else if (codebases.containsKey("junit-rt.jar")) {
-                    System.out.println("USING INTELLIJ POLICY");
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("intellij.policy"), codebases);
                 } else {
                     runnerPolicy = PolicyUtil.readPolicy(Bootstrap.class.getResource("eclipse.policy"), codebases);


### PR DESCRIPTION
Intellij has a special junit runner jar that needs additional security
manager permissions. However, this jar is not present in eclipse. This
commit adds a new (empty) policy for eclipse, and then chooses which to
load based on the presence of the special intellij junit jar. This is a
bit of a hack, but there are no special system properties for intellij
or eclipse that I could find (there are substrings that could be
searched for in existing properties, but looking for a specific key is
much easier to do that searching a substring).

closes #65231