### PR TITLE
[ML] adding some better logging on inference model storage failure

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
@@ -186,16 +186,17 @@ public class ChunkedTrainedModelPersister {
                 LOGGER.error(new ParameterizedMessage(
                     "[{}] error storing trained model definition chunk [{}] with id [{}]",
                         analytics.getId(),
-                        trainedModelDefinitionDoc.getModelId(),
-                        trainedModelDefinitionDoc.getDocNum()
+                        trainedModelDefinitionDoc.getDocNum(),
+                        trainedModelDefinitionDoc.getModelId()
                     ),
                     e);
                 this.readyToStoreNewModel.set(true);
                 failureHandler.accept(ExceptionsHelper.serverError(
                     "error storing trained model definition chunk [{}] with id [{}]",
                     e,
-                    trainedModelDefinitionDoc.getModelId(),
-                    trainedModelDefinitionDoc.getDocNum()));
+                    trainedModelDefinitionDoc.getDocNum(),
+                    trainedModelDefinitionDoc.getModelId()
+                ));
                 refreshListener.onResponse(null);
             }
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
@@ -183,6 +183,13 @@ public class ChunkedTrainedModelPersister {
                 provider.refreshInferenceIndex(refreshListener);
             },
             e -> {
+                LOGGER.error(new ParameterizedMessage(
+                    "[{}] error storing trained model definition chunk [{}] with id [{}]",
+                        analytics.getId(),
+                        trainedModelDefinitionDoc.getModelId(),
+                        trainedModelDefinitionDoc.getDocNum()
+                    ),
+                    e);
                 this.readyToStoreNewModel.set(true);
                 failureHandler.accept(ExceptionsHelper.serverError(
                     "error storing trained model definition chunk [{}] with id [{}]",
@@ -225,6 +232,13 @@ public class ChunkedTrainedModelPersister {
                 provider.refreshInferenceIndex(refreshListener);
             },
             e -> {
+                LOGGER.error(
+                    new ParameterizedMessage(
+                        "[{}] error storing trained model metadata with id [{}]",
+                        analytics.getId(),
+                        trainedModelMetadata.getModelId()
+                    ),
+                    e);
                 this.readyToStoreNewModel.set(true);
                 failureHandler.accept(ExceptionsHelper.serverError(
                     "error storing trained model metadata with id [{}]",
@@ -250,6 +264,13 @@ public class ChunkedTrainedModelPersister {
                 }
             },
             e -> {
+                LOGGER.error(
+                    new ParameterizedMessage(
+                        "[{}] error storing trained model config with id [{}]",
+                        analytics.getId(),
+                        trainedModelConfig.getModelId()
+                    ),
+                    e);
                 readyToStoreNewModel.set(true);
                 failureHandler.accept(ExceptionsHelper.serverError("error storing trained model config with id [{}]",
                     e,


### PR DESCRIPTION
While we do log the failure when we fail the analytics task, having a log message here adds some nice noise as this can be a tricky failure path to troubleshoot.