### PR TITLE
Ensure correct jdbc driver version is passed to bwc tests

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -91,9 +91,10 @@ subprojects {
           "jdbcDriver${baseName}"(driverDependency)
         }
 
+        final String bwcVersionString = bwcVersion.toString()
         tasks.register(bwcTaskName(bwcVersion), RestIntegTestTask) {
             classpath += driverConfiguration
-            systemProperty 'jdbc.driver.version', bwcVersion.toString()
+            systemProperty 'jdbc.driver.version', bwcVersionString
         }
       }
     }


### PR DESCRIPTION
We pass a system property to the BWC tests for our JDBC driver indicating the current version of the driver under test. Due to some oddness in how lazy task configuration works in Gradle, references to enhanced loop references can be wrong so we instead store this in an intermediary final variable.