### PR TITLE
Deprecate specifying the same percentile multiple times in percentiles

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -122,7 +122,7 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
             }
 
             if (percent == previousPercent) {
-                deprecationLogger.deprecate("percents", "percent [{}] has been specified twice, percents must be unique", percent);
+                deprecationLogger.deprecate("percents", "percent [{}] has been specified more than once, percents must be unique", percent);
             }
             previousPercent = percent;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -44,6 +45,7 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
 
     private static final double[] DEFAULT_PERCENTS = new double[] { 1, 5, 25, 50, 75, 95, 99 };
     private static final ParseField PERCENTS_FIELD = new ParseField("percents");
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(PercentilesAggregationBuilder.class);
 
     private static final ConstructingObjectParser<PercentilesAggregationBuilder, String> PARSER;
     static {
@@ -112,11 +114,17 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
             throw new IllegalArgumentException("[percents] must not be empty: [" + aggName + "]");
         }
         double[] sortedPercents = Arrays.copyOf(percents, percents.length);
+        double previousPercent = -1.0;
         Arrays.sort(sortedPercents);
         for (double percent : sortedPercents) {
             if (percent < 0.0 || percent > 100.0) {
                 throw new IllegalArgumentException("percent must be in [0,100], got [" + percent + "]: [" + aggName + "]");
             }
+
+            if (percent == previousPercent) {
+                deprecationLogger.deprecate("percents", "percent [{}] has been specified twice, percents must be unique", percent);
+            }
+            previousPercent = percent;
         }
         return sortedPercents;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -84,7 +84,13 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
         // throws in 8.x, deprecated in 7.x
         builder.percentiles(5, 42, 10, 99, 42, 87);
 
-        assertWarnings("percent [42.0] has been specified twice, percents must be unique");
+        assertWarnings("percent [42.0] has been specified more than once, percents must be unique");
+
+        builder.percentiles(5, 42, 42, 43, 43, 87);
+        assertWarnings(
+            "percent [42.0] has been specified more than once, percents must be unique",
+            "percent [43.0] has been specified more than once, percents must be unique"
+        );
     }
 
     public void testExceptionMultipleMethods() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -78,6 +78,15 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
         assertEquals("percent must be in [0,100], got [104.0]: [testAgg]", ex.getMessage());
     }
 
+    public void testDuplicatePercentilesDeprecated() throws IOException {
+        PercentilesAggregationBuilder builder = new PercentilesAggregationBuilder("testAgg");
+
+        // throws in 8.x, deprecated in 7.x
+        builder.percentiles(5, 42, 10, 99, 42, 87);
+
+        assertWarnings("percent [42.0] has been specified twice, percents must be unique");
+    }
+
     public void testExceptionMultipleMethods() throws IOException {
         final String illegalAgg = "{\n" +
             "       \"percentiles\": {\n" +

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -151,7 +151,7 @@ public class TransformAggregationsTests extends ESTestCase {
         assertEquals("percentiles", outputTypes.get("percentiles.10"));
 
         // note: using the constructor, omits validation, in reality this test might fail
-        percentialAggregationBuilder = new PercentilesAggregationBuilder("percentiles").percentiles(1.0, 5.0, 5.0, 10.0);
+        percentialAggregationBuilder = new PercentilesAggregationBuilder("percentiles", new double[] { 1, 5, 5, 10 }, null);
 
         inputAndOutputTypes = TransformAggregations.getAggregationInputAndOutputTypes(percentialAggregationBuilder);
         assertTrue(inputAndOutputTypes.v1().isEmpty());


### PR DESCRIPTION
Deprecate specifying the same percentile multiple times in percentiles aggregation

Regression of: #52257
Fixes: #65240

Flagging this as non-issue: its not a bug, neither is it breaking (#52257 already is), no need to get this into the rn.