### PR TITLE
Cleanup TransportRequestOptions Usage (#65248)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportRequestOptions;
 
 /**
@@ -57,7 +56,7 @@ public class ActionType<Response extends ActionResponse> {
     /**
      * Optional request options for the action.
      */
-    public TransportRequestOptions transportOptions(Settings settings) {
+    public TransportRequestOptions transportOptions() {
         return TransportRequestOptions.EMPTY;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
+++ b/server/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
@@ -33,10 +32,10 @@ public class TransportActionNodeProxy<Request extends ActionRequest, Response ex
     private final ActionType<Response> action;
     private final TransportRequestOptions transportOptions;
 
-    public TransportActionNodeProxy(Settings settings, ActionType<Response> action, TransportService transportService) {
+    public TransportActionNodeProxy(ActionType<Response> action, TransportService transportService) {
         this.action = action;
         this.transportService = transportService;
-        this.transportOptions = action.transportOptions(settings);
+        this.transportOptions = action.transportOptions();
     }
 
     public void execute(final DiscoveryNode node, final Request request, final ActionListener<Response> listener) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -96,10 +96,6 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
      * {@link #getFinishedTaskFromIndex(Task, GetTaskRequest, ActionListener)} on this node.
      */
     private void runOnNodeWithTaskIfPossible(Task thisTask, GetTaskRequest request, ActionListener<GetTaskResponse> listener) {
-        TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-        if (request.getTimeout() != null) {
-            builder.withTimeout(request.getTimeout());
-        }
         DiscoveryNode node = clusterService.state().nodes().get(request.getTaskId().getNodeId());
         if (node == null) {
             // Node is no longer part of the cluster! Try and look the task up from the results index.
@@ -115,7 +111,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
             return;
         }
         GetTaskRequest nodeRequest = request.nodeRequest(clusterService.localNode().getId(), thisTask.getId());
-        transportService.sendRequest(node, GetTaskAction.NAME, nodeRequest, builder.build(),
+        transportService.sendRequest(node, GetTaskAction.NAME, nodeRequest, TransportRequestOptions.timeout(request.getTimeout()),
             new ActionListenerResponseHandler<>(listener, GetTaskResponse::new, ThreadPool.Names.SAME));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportRequestOptions;
 
 public class BulkAction extends ActionType<BulkResponse> {
@@ -28,12 +27,15 @@ public class BulkAction extends ActionType<BulkResponse> {
     public static final BulkAction INSTANCE = new BulkAction();
     public static final String NAME = "indices:data/write/bulk";
 
+    private static final TransportRequestOptions TRANSPORT_REQUEST_OPTIONS =
+            TransportRequestOptions.of(null, TransportRequestOptions.Type.BULK);
+
     private BulkAction() {
         super(NAME, BulkResponse::new);
     }
 
     @Override
-    public TransportRequestOptions transportOptions(Settings settings) {
-        return TransportRequestOptions.builder().withType(TransportRequestOptions.Type.BULK).build();
+    public TransportRequestOptions transportOptions() {
+        return TRANSPORT_REQUEST_OPTIONS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -110,8 +110,8 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
     }
 
     @Override
-    protected TransportRequestOptions transportOptions(Settings settings) {
-        return BulkAction.INSTANCE.transportOptions(settings);
+    protected TransportRequestOptions transportOptions() {
+        return BulkAction.INSTANCE.transportOptions();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -200,10 +200,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                 threadPool.generic().execute(() -> listener.onResponse(newResponse(request, responses)));
                 return;
             }
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            if (request.timeout() != null) {
-                builder.withTimeout(request.timeout());
-            }
+            final TransportRequestOptions transportRequestOptions = TransportRequestOptions.timeout(request.timeout());
             for (int i = 0; i < nodes.length; i++) {
                 final int idx = i;
                 final DiscoveryNode node = nodes[i];
@@ -214,7 +211,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                         nodeRequest.setParentTask(clusterService.localNode().getId(), task.getId());
                     }
 
-                    transportService.sendRequest(node, getTransportNodeAction(node), nodeRequest, builder.build(),
+                    transportService.sendRequest(node, getTransportNodeAction(node), nodeRequest, transportRequestOptions,
                             new TransportResponseHandler<NodeResponse>() {
                                 @Override
                                 public NodeResponse read(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -170,7 +170,7 @@ public abstract class TransportReplicationAction<
         transportService.registerRequestHandler(transportReplicaAction, executor, true, true,
             in -> new ConcreteReplicaRequest<>(replicaRequestReader, in), this::handleReplicaRequest);
 
-        this.transportOptions = transportOptions(settings);
+        this.transportOptions = transportOptions();
 
         this.syncGlobalCheckpointAfterOperation = syncGlobalCheckpointAfterOperation;
 
@@ -249,7 +249,7 @@ public abstract class TransportReplicationAction<
         return null;
     }
 
-    protected TransportRequestOptions transportOptions(Settings settings) {
+    protected TransportRequestOptions transportOptions() {
         return TransportRequestOptions.EMPTY;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -246,10 +246,7 @@ public abstract class TransportTasksAction<
                     listener.onFailure(e);
                 }
             } else {
-                TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-                if (request.getTimeout() != null) {
-                    builder.withTimeout(request.getTimeout());
-                }
+                final TransportRequestOptions transportRequestOptions = TransportRequestOptions.timeout(request.getTimeout());
                 for (int i = 0; i < nodesIds.length; i++) {
                     final String nodeId = nodesIds[i];
                     final int idx = i;
@@ -260,7 +257,7 @@ public abstract class TransportTasksAction<
                         } else {
                             NodeTaskRequest nodeRequest = new NodeTaskRequest(request);
                             nodeRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-                            transportService.sendRequest(node, transportNodeAction, nodeRequest, builder.build(),
+                            transportService.sendRequest(node, transportNodeAction, nodeRequest, transportRequestOptions,
                                 new TransportResponseHandler<NodeTasksResponse>() {
                                     @Override
                                     public NodeTasksResponse read(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -223,7 +223,7 @@ public abstract class TransportClient extends AbstractClient {
             final List<? extends ActionType<?>> baseActions =
                     actionModule.getActions().values().stream().map(ActionPlugin.ActionHandler::getAction).collect(Collectors.toList());
             clientActions.addAll(baseActions);
-            final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService, clientActions);
+            final TransportProxyClient proxy = new TransportProxyClient(transportService, nodesService, clientActions);
 
             List<LifecycleComponent> pluginLifecycleComponents = new ArrayList<>(pluginsService.getGuiceServiceClasses().stream()
                 .map(injector::getInstance).collect(Collectors.toList()));

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -76,7 +76,7 @@ final class TransportClientNodesService implements Closeable {
 
     private final TimeValue nodesSamplerInterval;
 
-    private final long pingTimeout;
+    private final TimeValue pingTimeout;
 
     private final ClusterName clusterName;
 
@@ -132,7 +132,7 @@ final class TransportClientNodesService implements Closeable {
         this.minCompatibilityVersion = Version.CURRENT.minimumCompatibilityVersion();
 
         this.nodesSamplerInterval = TransportClient.CLIENT_TRANSPORT_NODES_SAMPLER_INTERVAL.get(settings);
-        this.pingTimeout = TransportClient.CLIENT_TRANSPORT_PING_TIMEOUT.get(settings).millis();
+        this.pingTimeout = TransportClient.CLIENT_TRANSPORT_PING_TIMEOUT.get(settings);
         this.ignoreClusterName = TransportClient.CLIENT_TRANSPORT_IGNORE_CLUSTER_NAME.get(settings);
 
         if (logger.isDebugEnabled()) {
@@ -417,7 +417,7 @@ final class TransportClientNodesService implements Closeable {
                             }
                         });
                     transportService.sendRequest(connection, TransportLivenessAction.NAME, new LivenessRequest(),
-                        TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STATE).withTimeout(pingTimeout).build(),
+                        TransportRequestOptions.of(pingTimeout, TransportRequestOptions.Type.STATE),
                         handler);
                     final LivenessResponse livenessResponse = handler.txGet();
                     if (!ignoreClusterName && !clusterName.equals(livenessResponse.getClusterName())) {
@@ -507,8 +507,7 @@ final class TransportClientNodesService implements Closeable {
                             }
                             transportService.sendRequest(pingConnection, ClusterStateAction.NAME,
                                 Requests.clusterStateRequest().clear().nodes(true).local(true),
-                                TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STATE)
-                                    .withTimeout(pingTimeout).build(),
+                                TransportRequestOptions.of(pingTimeout, TransportRequestOptions.Type.STATE),
                                 new TransportResponseHandler<ClusterStateResponse>() {
 
                                     @Override

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportProxyClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportProxyClient.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.TransportActionNodeProxy;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.HashMap;
@@ -39,12 +38,11 @@ final class TransportProxyClient {
     private final TransportClientNodesService nodesService;
     private final Map<ActionType, TransportActionNodeProxy> proxies;
 
-    TransportProxyClient(Settings settings, TransportService transportService,
-                                TransportClientNodesService nodesService, List<ActionType> actions) {
+    TransportProxyClient(TransportService transportService, TransportClientNodesService nodesService, List<ActionType> actions) {
         this.nodesService = nodesService;
         Map<ActionType, TransportActionNodeProxy> proxies = new HashMap<>();
         for (ActionType action : actions) {
-            proxies.put(action, new TransportActionNodeProxy(settings, action, transportService));
+            proxies.put(action, new TransportActionNodeProxy(action, transportService));
         }
         this.proxies = unmodifiableMap(proxies);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/DiscoveryUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/DiscoveryUpgradeService.java
@@ -283,7 +283,7 @@ public class DiscoveryUpgradeService {
                                 new UnicastPingRequest(0, TimeValue.ZERO,
                                     new PingResponse(createDiscoveryNodeWithImpossiblyHighId(transportService.getLocalNode()),
                                         null, clusterName, UNKNOWN_VERSION)),
-                                TransportRequestOptions.builder().withTimeout(bwcPingTimeout).build(),
+                                TransportRequestOptions.timeout(bwcPingTimeout),
                                 new TransportResponseHandler<UnicastPingResponse>() {
                                     @Override
                                     public void handleResponse(UnicastPingResponse response) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -316,7 +316,7 @@ public class FollowersChecker {
                 transportRequest = request;
             }
             transportService.sendRequest(discoveryNode, actionName, transportRequest,
-                TransportRequestOptions.builder().withTimeout(followerCheckTimeout).withType(Type.PING).build(),
+                TransportRequestOptions.of(followerCheckTimeout, Type.PING),
                 new TransportResponseHandler.Empty() {
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -293,7 +293,7 @@ public class JoinHelper {
             if (Coordinator.isZen1Node(destination)) {
                 actionName = MembershipAction.DISCOVERY_JOIN_ACTION_NAME;
                 transportRequest = new MembershipAction.JoinRequest(transportService.getLocalNode());
-                transportRequestOptions = TransportRequestOptions.builder().withTimeout(joinTimeout).build();
+                transportRequestOptions = TransportRequestOptions.timeout(joinTimeout);
             } else {
                 actionName = JOIN_ACTION_NAME;
                 transportRequest = joinRequest;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -245,8 +245,7 @@ public class LeaderChecker {
             // In the PoC, the leader sent its current version to the follower in the response to a LeaderCheck, so the follower
             // could detect if it was lagging. We'd prefer this to be implemented on the leader, so the response is just
             // TransportResponse.Empty here.
-            transportService.sendRequest(leader, actionName, transportRequest,
-                TransportRequestOptions.builder().withTimeout(leaderCheckTimeout).withType(Type.PING).build(),
+            transportService.sendRequest(leader, actionName, transportRequest, TransportRequestOptions.of(leaderCheckTimeout, Type.PING),
                 new TransportResponseHandler.Empty() {
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -88,8 +88,8 @@ public class PublicationTransportHandler {
     private final AtomicLong compatibleClusterStateDiffReceivedCount = new AtomicLong();
     // -> no need to put a timeout on the options here, because we want the response to eventually be received
     //  and not log an error if it arrives after the timeout
-    private final TransportRequestOptions stateRequestOptions = TransportRequestOptions.builder()
-        .withType(TransportRequestOptions.Type.STATE).build();
+    private static final TransportRequestOptions STATE_REQUEST_OPTIONS =
+            TransportRequestOptions.of(null, TransportRequestOptions.Type.STATE);
 
     public PublicationTransportHandler(TransportService transportService, NamedWriteableRegistry namedWriteableRegistry,
                                        Function<PublishRequest, PublishWithJoinResponse> handlePublishRequest,
@@ -358,7 +358,7 @@ public class PublicationTransportHandler {
                     actionName = COMMIT_STATE_ACTION_NAME;
                     transportRequest = applyCommitRequest;
                 }
-                transportService.sendRequest(destination, actionName, transportRequest, stateRequestOptions,
+                transportService.sendRequest(destination, actionName, transportRequest, STATE_REQUEST_OPTIONS,
                 new TransportResponseHandler<TransportResponse.Empty>() {
 
                     @Override
@@ -454,7 +454,7 @@ public class PublicationTransportHandler {
                     actionName = PUBLISH_STATE_ACTION_NAME;
                     transportResponseHandler = responseHandler;
                 }
-                transportService.sendRequest(destination, actionName, request, stateRequestOptions, transportResponseHandler);
+                transportService.sendRequest(destination, actionName, request, STATE_REQUEST_OPTIONS, transportResponseHandler);
             } catch (Exception e) {
                 logger.warn(() -> new ParameterizedMessage("error sending cluster state to {}", destination), e);
                 listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -92,7 +92,7 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
                             // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
                             // the connection is closed in the onResponse handler
-                            transportService.handshake(connection, probeHandshakeTimeout.millis(), new NotifyOnceListener<DiscoveryNode>() {
+                            transportService.handshake(connection, probeHandshakeTimeout, new NotifyOnceListener<DiscoveryNode>() {
 
                                 @Override
                                 protected void innerOnResponse(DiscoveryNode remoteNode) {

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -481,7 +481,7 @@ public abstract class PeerFinder {
             }
             transportService.sendRequest(discoveryNode, actionName,
                 transportRequest,
-                TransportRequestOptions.builder().withTimeout(requestPeersTimeout).build(),
+                TransportRequestOptions.timeout(requestPeersTimeout),
                 transportResponseHandler);
         }
 

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
@@ -224,8 +224,7 @@ public class MasterFaultDetection extends FaultDetection {
 
             final MasterPingRequest request = new MasterPingRequest(
                 clusterStateSupplier.get().nodes().getLocalNode(), masterToPing, clusterName);
-            final TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.PING)
-                .withTimeout(pingRetryTimeout).build();
+            final TransportRequestOptions options = TransportRequestOptions.of(pingRetryTimeout, TransportRequestOptions.Type.PING);
             transportService.sendRequest(masterToPing, MASTER_PING_ACTION_NAME, request, options,
                 new TransportResponseHandler<MasterPingResponseResponse>() {
                         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
@@ -226,8 +226,7 @@ public class NodesFaultDetection extends FaultDetection {
             if (!running()) {
                 return;
             }
-            final TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.PING)
-                .withTimeout(pingRetryTimeout).build();
+            final TransportRequestOptions options = TransportRequestOptions.of(pingRetryTimeout, TransportRequestOptions.Type.PING);
             transportService.sendRequest(node, PING_ACTION_NAME, newPingRequest(), options, new TransportResponseHandler<PingResponse>() {
                         @Override
                         public PingResponse read(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.discovery.AckClusterStatePublishResponseHandler;
@@ -81,8 +80,8 @@ public class PublishClusterStateAction {
 
     // -> no need to put a timeout on the options, because we want the state response to eventually be received
     //  and not log an error if it arrives after the timeout
-    private final TransportRequestOptions stateRequestOptions = TransportRequestOptions.builder()
-        .withType(TransportRequestOptions.Type.STATE).build();
+    private static final TransportRequestOptions STATE_REQUEST_OPTIONS =
+            TransportRequestOptions.of(null, TransportRequestOptions.Type.STATE);
 
     public interface IncomingClusterStateListener {
 
@@ -294,7 +293,7 @@ public class PublishClusterStateAction {
 
             transportService.sendRequest(node, SEND_ACTION_NAME,
                     new BytesTransportRequest(bytes, node.getVersion()),
-                    stateRequestOptions,
+                    STATE_REQUEST_OPTIONS,
                     new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
 
                         @Override
@@ -329,7 +328,7 @@ public class PublishClusterStateAction {
                 clusterState.stateUUID(), clusterState.version(), node);
             transportService.sendRequest(node, COMMIT_ACTION_NAME,
                     new CommitClusterStateRequest(clusterState.stateUUID()),
-                    stateRequestOptions,
+                    STATE_REQUEST_OPTIONS,
                     new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
 
                         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -295,7 +295,7 @@ public class UnicastZenPing implements ZenPing {
                     try {
                         Connection finalResult = result;
                         PlainActionFuture.get(fut ->
-                            transportService.handshake(finalResult, connectionProfile.getHandshakeTimeout().millis(),
+                            transportService.handshake(finalResult, connectionProfile.getHandshakeTimeout(),
                                 ActionListener.map(fut, x -> null)));
                         synchronized (this) {
                             // acquire lock and check if closed, to prevent leaving an open connection after closing
@@ -406,7 +406,7 @@ public class UnicastZenPing implements ZenPing {
 
                 logger.trace("[{}] sending to {}", pingingRound.id(), node);
                 transportService.sendRequest(connection, ACTION_NAME, pingRequest,
-                    TransportRequestOptions.builder().withTimeout((long) (timeout.millis() * 1.25)).build(),
+                    TransportRequestOptions.timeout(TimeValue.timeValueMillis((long) (timeout.millis() * 1.25))),
                     getPingResponseHandler(pingingRound, node));
             }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -71,6 +71,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
 
     private final TransportRequestOptions translogOpsRequestOptions;
     private final TransportRequestOptions fileChunkRequestOptions;
+    private final TransportRequestOptions standardTimeoutRequestOptions;
 
     private final AtomicLong bytesSinceLastPause = new AtomicLong();
     private final AtomicLong requestSeqNoGenerator = new AtomicLong(0);
@@ -88,14 +89,11 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         this.targetNode = targetNode;
         this.recoverySettings = recoverySettings;
         this.onSourceThrottle = onSourceThrottle;
-        this.translogOpsRequestOptions = TransportRequestOptions.builder()
-                .withType(TransportRequestOptions.Type.RECOVERY)
-                .withTimeout(recoverySettings.internalActionLongTimeout())
-                .build();
-        this.fileChunkRequestOptions = TransportRequestOptions.builder()
-                .withType(TransportRequestOptions.Type.RECOVERY)
-                .withTimeout(recoverySettings.internalActionTimeout())
-                .build();
+        this.translogOpsRequestOptions =
+                TransportRequestOptions.of(recoverySettings.internalActionLongTimeout(), TransportRequestOptions.Type.RECOVERY);
+        this.fileChunkRequestOptions =
+                TransportRequestOptions.of(recoverySettings.internalActionTimeout(), TransportRequestOptions.Type.RECOVERY);
+        this.standardTimeoutRequestOptions = TransportRequestOptions.timeout(recoverySettings.internalActionTimeout());
         this.retriesSupported = targetNode.getVersion().onOrAfter(Version.V_7_9_0);
     }
 
@@ -109,11 +107,9 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
         final RecoveryPrepareForTranslogOperationsRequest request =
             new RecoveryPrepareForTranslogOperationsRequest(recoveryId, requestSeqNo, shardId, totalTranslogOps);
-        final TransportRequestOptions options =
-            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionTimeout()).build();
         final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
         final ActionListener<TransportResponse.Empty> responseListener = ActionListener.map(listener, r -> null);
-        executeRetryableAction(action, request, options, responseListener, reader);
+        executeRetryableAction(action, request, standardTimeoutRequestOptions, responseListener, reader);
     }
 
     @Override
@@ -122,11 +118,10 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
         final RecoveryFinalizeRecoveryRequest request =
             new RecoveryFinalizeRecoveryRequest(recoveryId, requestSeqNo, shardId, globalCheckpoint, trimAboveSeqNo);
-        final TransportRequestOptions options =
-            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionLongTimeout()).build();
         final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
         final ActionListener<TransportResponse.Empty> responseListener = ActionListener.map(listener, r -> null);
-        executeRetryableAction(action, request, options, responseListener, reader);
+        executeRetryableAction(action, request, TransportRequestOptions.timeout(recoverySettings.internalActionLongTimeout()),
+                responseListener, reader);
     }
 
     @Override
@@ -135,7 +130,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
                 targetNode,
                 PeerRecoveryTargetService.Actions.HANDOFF_PRIMARY_CONTEXT,
                 new RecoveryHandoffPrimaryContextRequest(recoveryId, shardId, primaryContext),
-                TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionTimeout()).build(),
+                standardTimeoutRequestOptions,
                 EmptyTransportResponseHandler.INSTANCE_SAME).txGet();
     }
 
@@ -172,11 +167,9 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
         RecoveryFilesInfoRequest request = new RecoveryFilesInfoRequest(recoveryId, requestSeqNo, shardId, phase1FileNames, phase1FileSizes,
             phase1ExistingFileNames, phase1ExistingFileSizes, totalTranslogOps);
-        final TransportRequestOptions options =
-            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionTimeout()).build();
         final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
         final ActionListener<TransportResponse.Empty> responseListener = ActionListener.map(listener, r -> null);
-        executeRetryableAction(action, request, options, responseListener, reader);
+        executeRetryableAction(action, request, standardTimeoutRequestOptions, responseListener, reader);
     }
 
     @Override
@@ -186,11 +179,9 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
         final RecoveryCleanFilesRequest request =
             new RecoveryCleanFilesRequest(recoveryId, requestSeqNo, shardId, sourceMetadata, totalTranslogOps, globalCheckpoint);
-        final TransportRequestOptions options =
-            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionTimeout()).build();
         final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
         final ActionListener<TransportResponse.Empty> responseListener = ActionListener.map(listener, r -> null);
-        executeRetryableAction(action, request, options, responseListener, reader);
+        executeRetryableAction(action, request, standardTimeoutRequestOptions, responseListener, reader);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -123,7 +123,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         assert Strings.isEmpty(configuredAddress) == false : "Cannot use proxy connection strategy with no configured addresses";
         this.address = address;
         this.clusterNameValidator = (newConnection, actualProfile, listener) ->
-            transportService.handshake(newConnection, actualProfile.getHandshakeTimeout().millis(), cn -> true,
+            transportService.handshake(newConnection, actualProfile.getHandshakeTimeout(), cn -> true,
                 ActionListener.map(listener, resp -> {
                     ClusterName remote = resp.getClusterName();
                     if (remoteClusterName.compareAndSet(null, remote)) {

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -313,7 +313,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
             final StepListener<TransportService.HandshakeResponse> handshakeStep = new StepListener<>();
             openConnectionStep.whenComplete(connection -> {
                 ConnectionProfile connectionProfile = connectionManager.getConnectionProfile();
-                transportService.handshake(connection, connectionProfile.getHandshakeTimeout().millis(),
+                transportService.handshake(connection, connectionProfile.getHandshakeTimeout(),
                     getRemoteClusterNamePredicate(), handshakeStep);
             }, onFailure);
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
@@ -19,18 +19,32 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 
 public class TransportRequestOptions {
 
+    @Nullable
     private final TimeValue timeout;
     private final Type type;
 
-    private TransportRequestOptions(TimeValue timeout, Type type) {
+    public static TransportRequestOptions timeout(@Nullable TimeValue timeout) {
+        return of(timeout, Type.REG);
+    }
+
+    public static TransportRequestOptions of(@Nullable TimeValue timeout, Type type) {
+        if (timeout == null && type == Type.REG) {
+            return EMPTY;
+        }
+        return new TransportRequestOptions(timeout, type);
+    }
+
+    private TransportRequestOptions(@Nullable TimeValue timeout, Type type) {
         this.timeout = timeout;
         this.type = type;
     }
 
+    @Nullable
     public TimeValue timeout() {
         return this.timeout;
     }
@@ -39,7 +53,7 @@ public class TransportRequestOptions {
         return this.type;
     }
 
-    public static final TransportRequestOptions EMPTY = new TransportRequestOptions.Builder().build();
+    public static final TransportRequestOptions EMPTY = new TransportRequestOptions(null, Type.REG);
 
     public enum Type {
         RECOVERY,
@@ -47,35 +61,5 @@ public class TransportRequestOptions {
         REG,
         STATE,
         PING
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private TimeValue timeout;
-        private Type type = Type.REG;
-
-        private Builder() {
-        }
-
-        public Builder withTimeout(long timeout) {
-            return withTimeout(TimeValue.timeValueMillis(timeout));
-        }
-
-        public Builder withTimeout(TimeValue timeout) {
-            this.timeout = timeout;
-            return this;
-        }
-
-        public Builder withType(Type type) {
-            this.type = type;
-            return this;
-        }
-
-        public TransportRequestOptions build() {
-            return new TransportRequestOptions(timeout, type);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -383,7 +383,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
     public ConnectionManager.ConnectionValidator connectionValidator(DiscoveryNode node) {
         return (newConnection, actualProfile, listener) -> {
             // We don't validate cluster names to allow for CCS connections.
-            handshake(newConnection, actualProfile.getHandshakeTimeout().millis(), cn -> true, ActionListener.map(listener, resp -> {
+            handshake(newConnection, actualProfile.getHandshakeTimeout(), cn -> true, ActionListener.map(listener, resp -> {
                 final DiscoveryNode remote = resp.discoveryNode;
                 if (validateConnections && node.equals(remote) == false) {
                     throw new ConnectTransportException(node, "handshake failed. unexpected remote node " + remote);
@@ -436,7 +436,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
      */
     public void handshake(
         final Transport.Connection connection,
-        final long handshakeTimeout,
+        final TimeValue handshakeTimeout,
         final ActionListener<DiscoveryNode> listener) {
         handshake(connection, handshakeTimeout, clusterName.getEqualityPredicate(),
             ActionListener.map(listener, HandshakeResponse::getDiscoveryNode));
@@ -457,11 +457,11 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
      */
     public void handshake(
         final Transport.Connection connection,
-        final long handshakeTimeout, Predicate<ClusterName> clusterNamePredicate,
+        final TimeValue handshakeTimeout, Predicate<ClusterName> clusterNamePredicate,
         final ActionListener<HandshakeResponse> listener) {
         final DiscoveryNode node = connection.getNode();
         sendRequest(connection, HANDSHAKE_ACTION_NAME, HandshakeRequest.INSTANCE,
-            TransportRequestOptions.builder().withTimeout(handshakeTimeout).build(),
+            TransportRequestOptions.timeout(handshakeTimeout),
             new ActionListenerResponseHandler<>(
                 new ActionListener<HandshakeResponse>() {
                     @Override
@@ -582,15 +582,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
     public <T extends TransportResponse> void sendRequest(final DiscoveryNode node, final String action,
                                                                 final TransportRequest request,
                                                                 final TransportResponseHandler<T> handler) {
-        final Transport.Connection connection;
-        try {
-            connection = getConnection(node);
-        } catch (final NodeNotConnectedException ex) {
-            // the caller might not handle this so we invoke the handler
-            handler.handleException(ex);
-            return;
-        }
-        sendRequest(connection, action, request, TransportRequestOptions.EMPTY, handler);
+        sendRequest(node, action, request, TransportRequestOptions.EMPTY, handler);
     }
 
     public final <T extends TransportResponse> void sendRequest(final DiscoveryNode node, final String action,

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -476,7 +477,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }
 
         @Override
-        public void handshake(Transport.Connection connection, long timeout, Predicate<ClusterName> clusterNamePredicate,
+        public void handshake(Transport.Connection connection, TimeValue timeout, Predicate<ClusterName> clusterNamePredicate,
                               ActionListener<HandshakeResponse> listener) {
             listener.onResponse(new HandshakeResponse(connection.getNode(), new ClusterName(""), Version.CURRENT));
         }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -513,8 +513,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                         if (type != TransportRequestOptions.Type.REG) {
                             assertThat(expectThrows(IllegalStateException.class,
                                     () -> connection.getConnection().sendRequest(randomNonNegativeLong(),
-                                    "arbitrary", TransportRequest.Empty.INSTANCE,
-                                    TransportRequestOptions.builder().withType(type).build())).getMessage(),
+                                    "arbitrary", TransportRequest.Empty.INSTANCE, TransportRequestOptions.of(null, type))).getMessage(),
                                     allOf(containsString("can't select"), containsString(type.toString())));
                         }
                     }

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -53,7 +54,7 @@ import static org.hamcrest.Matchers.containsString;
 public class TransportServiceHandshakeTests extends ESTestCase {
 
     private static ThreadPool threadPool;
-    private static final long timeout = Long.MAX_VALUE;
+    private static final TimeValue timeout = TimeValue.MAX_VALUE;
 
     @BeforeClass
     public static void startThreadPool() {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -107,6 +107,8 @@ import static org.hamcrest.Matchers.startsWith;
 
 public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
+    private static final TimeValue HUNDRED_MS = TimeValue.timeValueMillis(100L);
+
     protected ThreadPool threadPool;
     // we use always a non-alpha or beta version here otherwise minimumCompatibilityVersion will be different for the two used versions
     private static final Version CURRENT_VERSION = Version.fromString(String.valueOf(Version.CURRENT.major) + ".0.0");
@@ -880,7 +882,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             });
 
         TransportFuture<StringMessageResponse> res = serviceB.submitRequest(nodeA, "internal:sayHelloTimeoutNoResponse",
-            new StringMessageRequest("moshe"), TransportRequestOptions.builder().withTimeout(100).build(),
+            new StringMessageRequest("moshe"), TransportRequestOptions.timeout(HUNDRED_MS),
             new TransportResponseHandler<StringMessageResponse>() {
                 @Override
                 public StringMessageResponse read(StreamInput in) throws IOException {
@@ -944,7 +946,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             });
         final CountDownLatch latch = new CountDownLatch(1);
         TransportFuture<StringMessageResponse> res = serviceB.submitRequest(nodeA, "internal:sayHelloTimeoutDelayedResponse",
-            new StringMessageRequest("forever"), TransportRequestOptions.builder().withTimeout(100).build(),
+            new StringMessageRequest("forever"), TransportRequestOptions.timeout(HUNDRED_MS),
             new TransportResponseHandler<StringMessageResponse>() {
                 @Override
                 public StringMessageResponse read(StreamInput in) throws IOException {
@@ -982,7 +984,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             final int counter = i;
             // now, try and send another request, this times, with a short timeout
             TransportFuture<StringMessageResponse> result = serviceB.submitRequest(nodeA, "internal:sayHelloTimeoutDelayedResponse",
-                new StringMessageRequest(counter + "ms"), TransportRequestOptions.builder().withTimeout(3000).build(),
+                new StringMessageRequest(counter + "ms"), TransportRequestOptions.timeout(TimeValue.timeValueSeconds(3)),
                 new TransportResponseHandler<StringMessageResponse>() {
                     @Override
                     public StringMessageResponse read(StreamInput in) throws IOException {
@@ -1494,7 +1496,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceB.addUnresponsiveRule(serviceA);
 
         TransportFuture<StringMessageResponse> res = serviceB.submitRequest(nodeA, "internal:sayHello",
-            new StringMessageRequest("moshe"), TransportRequestOptions.builder().withTimeout(100).build(),
+            new StringMessageRequest("moshe"), TransportRequestOptions.timeout(HUNDRED_MS),
             new TransportResponseHandler<StringMessageResponse>() {
                 @Override
                 public StringMessageResponse read(StreamInput in) throws IOException {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncResultsService;
@@ -60,8 +59,7 @@ public class TransportGetAsyncSearchAction extends HandledTransportAction<GetAsy
         if (node == null || resultsService.isLocalNode(node)) {
             resultsService.retrieveResult(request, listener);
         } else {
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            transportService.sendRequest(node, GetAsyncSearchAction.NAME, request, builder.build(),
+            transportService.sendRequest(node, GetAsyncSearchAction.NAME, request,
                 new ActionListenerResponseHandler<>(listener, AsyncSearchResponse::new, ThreadPool.Names.SAME));
         }
     }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
@@ -58,8 +57,7 @@ public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsy
         if (node == null || Objects.equals(node, clusterService.localNode())) {
             retrieveStatus(request, listener);
         } else {
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            transportService.sendRequest(node, GetAsyncStatusAction.NAME, request, builder.build(),
+            transportService.sendRequest(node, GetAsyncStatusAction.NAME, request,
                 new ActionListenerResponseHandler<>(listener, AsyncStatusResponse::new, ThreadPool.Names.SAME));
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
@@ -52,8 +51,7 @@ public class TransportDeleteAsyncResultAction extends HandledTransportAction<Del
         if (clusterService.localNode().getId().equals(searchId.getTaskId().getNodeId()) || node == null) {
             deleteResultsService.deleteResult(request, listener);
         } else {
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            transportService.sendRequest(node, DeleteAsyncResultAction.NAME, request, builder.build(),
+            transportService.sendRequest(node, DeleteAsyncResultAction.NAME, request,
                 new ActionListenerResponseHandler<>(listener, AcknowledgedResponse::readFrom, ThreadPool.Names.SAME));
         }
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncResultsService;
@@ -76,8 +75,7 @@ public class TransportEqlAsyncGetResultAction extends HandledTransportAction<Get
                 listener::onFailure
             ));
         } else {
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            transportService.sendRequest(node, EqlAsyncActionNames.EQL_ASYNC_GET_RESULT_ACTION_NAME, request, builder.build(),
+            transportService.sendRequest(node, EqlAsyncActionNames.EQL_ASYNC_GET_RESULT_ACTION_NAME, request,
                 new ActionListenerResponseHandler<>(listener, EqlSearchResponse::new, ThreadPool.Names.SAME));
         }
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.node.MockNode;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
@@ -159,7 +160,8 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
             try (Transport.Connection connection = instance.openConnection(new DiscoveryNode("theNode", transportAddress, Version.CURRENT),
                     ConnectionProfile.buildSingleChannelProfile(TransportRequestOptions.Type.REG))) {
                 // handshake should be ok
-                final DiscoveryNode handshake = PlainActionFuture.get(fut -> instance.handshake(connection, 10000, fut));
+                final DiscoveryNode handshake =
+                        PlainActionFuture.get(fut -> instance.handshake(connection, TimeValue.timeValueSeconds(10), fut));
                 assertEquals(transport.boundAddress().publishAddress(), handshake.getAddress());
                 CountDownLatch latch = new CountDownLatch(1);
                 instance.sendRequest(connection, NodeMappingRefreshAction.ACTION_NAME,


### PR DESCRIPTION
A class with 2 fields does not need a builder, especially
when in many cases the builder result is just equivalent to the
`EMPTY` singleton to begin with.
Removed the builder and simplified related code accordingly.

backport of #65248 