### PR TITLE
Ignore system indices from mapping stats and analysis stats.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -63,6 +63,11 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         final Map<String, IndexFeatureStats> usedBuiltInAnalyzers = new HashMap<>();
 
         for (IndexMetadata indexMetadata : metadata) {
+            if (indexMetadata.isSystem()) {
+                // Don't include system indices in statistics about analysis,
+                // we care about the user's indices.
+                continue;
+            }
             Set<String> indexAnalyzers = new HashSet<>();
             MappingMetadata mappingMetadata = indexMetadata.mapping();
             if (mappingMetadata != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -52,6 +52,11 @@ public final class MappingStats implements ToXContentFragment, Writeable {
     public static MappingStats of(Metadata metadata) {
         Map<String, IndexFeatureStats> fieldTypes = new HashMap<>();
         for (IndexMetadata indexMetadata : metadata) {
+            if (indexMetadata.isSystem()) {
+                // Don't include system indices in statistics about mappings,
+                // we care about the user's indices.
+                continue;
+            }
             Set<String> indexFieldTypes = new HashSet<>();
             MappingMetadata mappingMetadata = indexMetadata.mapping();
             if (mappingMetadata != null) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
@@ -19,10 +19,15 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -166,5 +171,45 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
             throw new AssertionError();
         }
 
+    }
+
+    public void testAccountsRegularIndices() {
+        String mapping = "{\"properties\":{\"bar\":{\"type\":\"text\",\"analyzer\":\"german\"}}}";
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings)
+                .putMapping(mapping);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        AnalysisStats analysisStats = AnalysisStats.of(metadata);
+        IndexFeatureStats expectedStats = new IndexFeatureStats("german");
+        expectedStats.count = 1;
+        expectedStats.indexCount = 1;
+        assertEquals(
+                Collections.singleton(expectedStats),
+                analysisStats.getUsedBuiltInAnalyzers());
+    }
+
+    public void testIgnoreSystemIndices() {
+        String mapping = "{\"properties\":{\"bar\":{\"type\":\"text\",\"analyzer\":\"german\"}}}";
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings)
+                .putMapping(mapping)
+                .system(true);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        AnalysisStats analysisStats = AnalysisStats.of(metadata);
+        assertEquals(Collections.emptySet(), analysisStats.getUsedBuiltInAnalyzers());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -173,7 +174,7 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
 
     }
 
-    public void testAccountsRegularIndices() {
+    public void testAccountsRegularIndices() throws IOException {
         String mapping = "{\"properties\":{\"bar\":{\"type\":\"text\",\"analyzer\":\"german\"}}}";
         Settings settings = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -182,7 +183,7 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
                 .build();
         IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
                 .settings(settings)
-                .putMapping(mapping);
+                .putMapping(MapperService.SINGLE_MAPPING_NAME, mapping);
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
@@ -195,7 +196,7 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
                 analysisStats.getUsedBuiltInAnalyzers());
     }
 
-    public void testIgnoreSystemIndices() {
+    public void testIgnoreSystemIndices() throws IOException {
         String mapping = "{\"properties\":{\"bar\":{\"type\":\"text\",\"analyzer\":\"german\"}}}";
         Settings settings = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -204,7 +205,7 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
                 .build();
         IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
                 .settings(settings)
-                .putMapping(mapping)
+                .putMapping(MapperService.SINGLE_MAPPING_NAME, mapping)
                 .system(true);
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -19,12 +19,17 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingStats> {
@@ -66,5 +71,45 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
             fieldTypes.add(s);
         }
         return new MappingStats(fieldTypes);
+    }
+
+    public void testAccountsRegularIndices() {
+        String mapping = "{\"properties\":{\"bar\":{\"type\":\"long\"}}}";
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings)
+                .putMapping(mapping);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        MappingStats mappingStats = MappingStats.of(metadata);
+        IndexFeatureStats expectedStats = new IndexFeatureStats("long");
+        expectedStats.count = 1;
+        expectedStats.indexCount = 1;
+        assertEquals(
+                Collections.singleton(expectedStats),
+                mappingStats.getFieldTypeStats());
+    }
+
+    public void testIgnoreSystemIndices() {
+        String mapping = "{\"properties\":{\"bar\":{\"type\":\"long\"}}}";
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings)
+                .putMapping(mapping)
+                .system(true);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        MappingStats mappingStats = MappingStats.of(metadata);
+        assertEquals(Collections.emptySet(), mappingStats.getFieldTypeStats());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -73,7 +74,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         return new MappingStats(fieldTypes);
     }
 
-    public void testAccountsRegularIndices() {
+    public void testAccountsRegularIndices() throws IOException {
         String mapping = "{\"properties\":{\"bar\":{\"type\":\"long\"}}}";
         Settings settings = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -82,7 +83,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                 .build();
         IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
                 .settings(settings)
-                .putMapping(mapping);
+                .putMapping(MapperService.SINGLE_MAPPING_NAME, mapping);
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
@@ -95,7 +96,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                 mappingStats.getFieldTypeStats());
     }
 
-    public void testIgnoreSystemIndices() {
+    public void testIgnoreSystemIndices() throws IOException {
         String mapping = "{\"properties\":{\"bar\":{\"type\":\"long\"}}}";
         Settings settings = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -104,7 +105,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                 .build();
         IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
                 .settings(settings)
-                .putMapping(mapping)
+                .putMapping(MapperService.SINGLE_MAPPING_NAME, mapping)
                 .system(true);
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)


### PR DESCRIPTION
When collecting information about analyzers or field types, we do not care much
about usage in system indices which are managed by Elasticsearch, however we
care about indices that are created by users.

Backport of #65220.