### PR TITLE
Fixup reduceRandom tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -68,10 +68,10 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
     @Override
     protected InternalTopHits createTestInstance(String name, Map<String, Object> metadata) {
         if (randomBoolean()) {
-            return createTestInstanceSortedByFields(name, metadata, ESTestCase::randomFloat,
+            return createTestInstanceSortedByFields(name, between(1, 40), metadata, ESTestCase::randomFloat,
                 randomSortFields(), InternalTopHitsTests::randomOfType);
         }
-        return createTestInstanceSortedScore(name, metadata, ESTestCase::randomFloat);
+        return createTestInstanceSortedScore(name, between(1, 40), metadata, ESTestCase::randomFloat);
     }
 
     @Override
@@ -86,6 +86,7 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
             usedScores.add(score);
             return score;
         };
+        int requestedSize = between(1, 40);
         Supplier<InternalTopHits> supplier;
         if (randomBoolean()) {
             SortField[] sortFields = randomSortFields();
@@ -95,16 +96,16 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
                 usedSortFieldValues.add(value);
                 return value;
             };
-            supplier = () -> createTestInstanceSortedByFields(name, null, scoreSupplier, sortFields, sortFieldValueSuppier);
+            supplier = () -> createTestInstanceSortedByFields(name, requestedSize, null, scoreSupplier, sortFields, sortFieldValueSuppier);
         } else {
-            supplier = () -> createTestInstanceSortedScore(name, null, scoreSupplier);
+            supplier = () -> createTestInstanceSortedScore(name, requestedSize, null, scoreSupplier);
         }
         return Stream.generate(supplier).limit(size).collect(toList());
     }
 
-    private InternalTopHits createTestInstanceSortedByFields(String name, Map<String, Object> metadata,
+    private InternalTopHits createTestInstanceSortedByFields(String name, int requestedSize, Map<String, Object> metadata,
             Supplier<Float> scoreSupplier, SortField[] sortFields, Function<SortField.Type, Object> sortFieldValueSupplier) {
-        return createTestInstance(name, metadata, scoreSupplier,
+        return createTestInstance(name, metadata, scoreSupplier, requestedSize,
             (docId, score) -> {
                 Object[] fields = new Object[sortFields.length];
                 for (int f = 0; f < sortFields.length; f++) {
@@ -117,15 +118,15 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
             sortFieldsComparator(sortFields));
     }
 
-    private InternalTopHits createTestInstanceSortedScore(String name, Map<String, Object> metadata, Supplier<Float> scoreSupplier) {
-        return createTestInstance(name, metadata, scoreSupplier, ScoreDoc::new, TopDocs::new, scoreComparator());
+    private InternalTopHits createTestInstanceSortedScore(String name, int requestedSize, Map<String, Object> metadata, Supplier<Float> scoreSupplier) {
+        return createTestInstance(name, metadata, scoreSupplier, requestedSize, ScoreDoc::new, TopDocs::new, scoreComparator());
     }
 
-    private InternalTopHits createTestInstance(String name, Map<String, Object> metadata, Supplier<Float> scoreSupplier, 
+    private InternalTopHits createTestInstance(String name, Map<String, Object> metadata, Supplier<Float> scoreSupplier,
+            int requestedSize,
             BiFunction<Integer, Float, ScoreDoc> docBuilder,
             BiFunction<TotalHits, ScoreDoc[], TopDocs> topDocsBuilder, Comparator<ScoreDoc> comparator) {
         int from = 0;
-        int requestedSize = between(1, 40);
         int actualSize = between(0, requestedSize);
 
         float maxScore = Float.NEGATIVE_INFINITY;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -118,7 +118,12 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
             sortFieldsComparator(sortFields));
     }
 
-    private InternalTopHits createTestInstanceSortedScore(String name, int requestedSize, Map<String, Object> metadata, Supplier<Float> scoreSupplier) {
+    private InternalTopHits createTestInstanceSortedScore(
+        String name,
+        int requestedSize,
+        Map<String, Object> metadata,
+        Supplier<Float> scoreSupplier
+    ) {
         return createTestInstance(name, metadata, scoreSupplier, requestedSize, ScoreDoc::new, TopDocs::new, scoreComparator());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -333,7 +333,6 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     @Override
-
     protected final Class<T> categoryClass() {
         return (Class<T>) InternalAggregation.class;
     }
@@ -353,7 +352,6 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         return inputs;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/65163")
     public void testReduceRandom() throws IOException {
         String name = randomAlphaOfLength(5);
         int size = between(1, 200);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -6,6 +6,8 @@
 
 package org.elasticsearch.xpack.analytics.topmetrics;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.elasticsearch.client.analytics.ParsedTopMetrics;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -328,6 +330,27 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 }
             }
         }
+    }
+
+    @Override
+    protected List<InternalTopMetrics> randomResultsToReduce(String name, int count) {
+        InternalTopMetrics prototype = createTestInstance();
+        return randomList(
+            count,
+            count,
+            () -> new InternalTopMetrics(
+                prototype.getName(),
+                prototype.getSortOrder(),
+                prototype.getMetricNames(),
+                prototype.getSize(),
+                randomTopMetrics(
+                    InternalAggregationTestCase::randomNumericDocValueFormat,
+                    between(0, prototype.getSize()),
+                    prototype.getMetricNames().size()
+                ),
+                prototype.getMetadata()
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -6,8 +6,6 @@
 
 package org.elasticsearch.xpack.analytics.topmetrics;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.elasticsearch.client.analytics.ParsedTopMetrics;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;


### PR DESCRIPTION
In aa1ea96b8698aa12bed1c4e8d704882a2a639791 I made all
`testReduceRandom` tests for aggs mimick production more precisely.
More precisely, they pick the correct "lead" result when performing
partial reduction. This is great, but, sadly, some tests assumed that we
always reduced against the "first" aggregator. This fixes those tests.

Closes #65163
