### PR TITLE
[7.x] [DOCS] Document get data stream API's _meta prop (#65221)

### DIFF
--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -40,6 +40,9 @@ PUT /_index_template/my-index-template
     "settings": {
       "index.lifecycle.name": "my-lifecycle-policy"
     }
+  },
+  "_meta": {
+    "my-meta-field": "foo"
   }
 }
 
@@ -136,6 +139,12 @@ Universally unique identifier (UUID) for the index.
 Current <<data-streams-generation,generation>> for the data stream. This number
 acts as a cumulative count of the stream's rollovers, starting at `1`.
 
+`_meta`::
+(object)
+Custom metadata for the stream, copied from the `_meta` object of the
+stream's matching <<create-a-data-stream-template,index template>>. If empty,
+the response omits this property.
+
 `status`::
 (string)
 <<cluster-health,Health status>> of the data stream.
@@ -207,6 +216,9 @@ The API returns the following response:
         }
       ],
       "generation": 2,
+      "_meta": {
+        "my-meta-field": "foo"
+      },
       "status": "GREEN",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",
@@ -224,6 +236,9 @@ The API returns the following response:
         }
       ],
       "generation": 1,
+      "_meta": {
+        "my-meta-field": "foo"
+      },
       "status": "YELLOW",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document get data stream API's _meta prop (#65221)