### PR TITLE
[DOCS] ILM: Add alloc ex with multiple node attributes

### DIFF
--- a/docs/reference/ilm/actions/ilm-allocate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-allocate.asciidoc
@@ -101,8 +101,9 @@ PUT _ilm/policy/my_policy
 [[ilm-allocate-assign-index-multi-attribute-ex]]
 ===== Assign index to nodes based on multiple attributes
 
-You can also allocate indices based on multiple node attributes. The following
-action allocates indices based on the `box_type` and `storage` node attributes.
+The allocate action can also assign indices to nodes based on multiple node
+attributes. The following action assigns indices based on the `box_type` and
+`storage` node attributes.
 
 [source,console]
 ----
@@ -110,11 +111,11 @@ PUT _ilm/policy/my_policy
 {
   "policy": {
     "phases": {
-      "warm": {
+      "cold": {
         "actions": {
           "allocate" : {
             "include" : {
-              "box_type": "hot,warm",
+              "box_type": "cold",
               "storage": "high"
             }
           }

--- a/docs/reference/ilm/actions/ilm-allocate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-allocate.asciidoc
@@ -114,7 +114,7 @@ PUT _ilm/policy/my_policy
       "cold": {
         "actions": {
           "allocate" : {
-            "include" : {
+            "require" : {
               "box_type": "cold",
               "storage": "high"
             }

--- a/docs/reference/ilm/actions/ilm-allocate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-allocate.asciidoc
@@ -98,6 +98,33 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 
+[[ilm-allocate-assign-index-multi-attribute-ex]]
+===== Assign index to nodes based on multiple attributes
+
+You can also allocate indices based on multiple node attributes. The following
+action allocates indices based on the `box_type` and `storage` node attributes.
+
+[source,console]
+----
+PUT _ilm/policy/my_policy
+{
+  "policy": {
+    "phases": {
+      "warm": {
+        "actions": {
+          "allocate" : {
+            "include" : {
+              "box_type": "hot,warm",
+              "storage": "high"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+----
+
 [[ilm-allocate-assign-index-node-ex]]
 ===== Assign index to a specific node and update replica settings
 


### PR DESCRIPTION
Adds an allocation example that uses multiple node attributes. All the current examples use a single attribute.

Closes #49660

### Preview
https://elasticsearch_65266.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-allocate.html#ilm-allocate-assign-index-multi-attribute-ex