### PR TITLE
Fix test failures when checkout path includes a space on Windows

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/http/WaitForHttpResourceTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/http/WaitForHttpResourceTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.gradle.test.GradleUnitTestCase;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -37,7 +39,7 @@ public class WaitForHttpResourceTests extends GradleUnitTestCase {
         final WaitForHttpResource http = new WaitForHttpResource(new URL("https://localhost/"));
         final URL ca = getClass().getResource("/ca.p12");
         assertThat(ca, notNullValue());
-        http.setTrustStoreFile(new File(ca.getPath()));
+        http.setTrustStoreFile(new File(URLDecoder.decode(ca.getPath(), StandardCharsets.UTF_8)));
         http.setTrustStorePassword("password");
         final KeyStore store = http.buildTrustStore();
         final Certificate certificate = store.getCertificate("ca");
@@ -50,7 +52,7 @@ public class WaitForHttpResourceTests extends GradleUnitTestCase {
         final WaitForHttpResource http = new WaitForHttpResource(new URL("https://localhost/"));
         final URL ca = getClass().getResource("/ca.pem");
         assertThat(ca, notNullValue());
-        http.setCertificateAuthorities(new File(ca.getPath()));
+        http.setCertificateAuthorities(new File(URLDecoder.decode(ca.getPath(), StandardCharsets.UTF_8)));
         final KeyStore store = http.buildTrustStore();
         final Certificate certificate = store.getCertificate("cert-0");
         assertThat(certificate, notNullValue());

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/http/WaitForHttpResourceTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/http/WaitForHttpResourceTests.java
@@ -21,10 +21,8 @@ package org.elasticsearch.gradle.http;
 
 import org.elasticsearch.gradle.test.GradleUnitTestCase;
 
-import java.io.File;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -39,7 +37,7 @@ public class WaitForHttpResourceTests extends GradleUnitTestCase {
         final WaitForHttpResource http = new WaitForHttpResource(new URL("https://localhost/"));
         final URL ca = getClass().getResource("/ca.p12");
         assertThat(ca, notNullValue());
-        http.setTrustStoreFile(new File(URLDecoder.decode(ca.getPath(), StandardCharsets.UTF_8)));
+        http.setTrustStoreFile(Paths.get(ca.toURI()).toFile());
         http.setTrustStorePassword("password");
         final KeyStore store = http.buildTrustStore();
         final Certificate certificate = store.getCertificate("ca");
@@ -52,7 +50,7 @@ public class WaitForHttpResourceTests extends GradleUnitTestCase {
         final WaitForHttpResource http = new WaitForHttpResource(new URL("https://localhost/"));
         final URL ca = getClass().getResource("/ca.pem");
         assertThat(ca, notNullValue());
-        http.setCertificateAuthorities(new File(URLDecoder.decode(ca.getPath(), StandardCharsets.UTF_8)));
+        http.setCertificateAuthorities(Paths.get(ca.toURI()).toFile());
         final KeyStore store = http.buildTrustStore();
         final Certificate certificate = store.getCertificate("cert-0");
         assertThat(certificate, notNullValue());


### PR DESCRIPTION
Our `WaitForHttpResourceTests` will fail when run in a checkout location with a space as we pass the raw result of `URL.getPath()` to the `File` constructor. The result of `getPath()` is URL encoded so spaces becoming `%20` which obviously results in an invalid file path. We need to first decode the path string before constructing the `File`.

https://gradle-enterprise.elastic.co/s/gawfa33dohjvk/tests/:build-tools:test/org.elasticsearch.gradle.http.WaitForHttpResourceTests/testBuildTrustStoreFromCA#1