### PR TITLE
Add codebases hints for testing

### DIFF
--- a/modules/reindex/src/main/plugin-metadata/plugin-security.codebases
+++ b/modules/reindex/src/main/plugin-metadata/plugin-security.codebases
@@ -1,0 +1,2 @@
+elasticsearch-rest-client: org.elasticsearch.client.RestClient
+httpasyncclient: org.apache.http.nio.client.HttpAsyncClient

--- a/modules/transport-netty4/src/main/plugin-metadata/plugin-security.codebases
+++ b/modules/transport-netty4/src/main/plugin-metadata/plugin-security.codebases
@@ -1,0 +1,1 @@
+netty-transport: io.netty.channel.Channel

--- a/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.codebases
+++ b/x-pack/plugin/core/src/main/plugin-metadata/plugin-security.codebases
@@ -1,0 +1,3 @@
+netty-common: io.netty.util.NettyRuntime
+netty-transport: io.netty.channel.Channel
+httpasyncclient: org.apache.http.nio.client.HttpAsyncClient

--- a/x-pack/plugin/monitoring/src/main/plugin-metadata/plugin-security.codebases
+++ b/x-pack/plugin/monitoring/src/main/plugin-metadata/plugin-security.codebases
@@ -1,0 +1,1 @@
+elasticsearch-rest-client: org.elasticsearch.client.RestClient


### PR DESCRIPTION
This commit adds codebases files for the remaining plugin security
policies that use jar specific grants.