### PR TITLE
Optimzie primary shard allocation decision logic.

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -178,9 +178,8 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
         if (explain) {
             nodeResults = buildNodeDecisions(nodesToAllocate, shardState, inSyncAllocationIds);
         }
-        if (allocation.hasPendingAsyncFetch()) {
-            return AllocateUnassignedDecision.no(AllocationStatus.FETCHING_SHARD_DATA, nodeResults);
-        } else if (node != null) {
+        assert !allocation.hasPendingAsyncFetch() : "Pending async fetch should be returned early.";
+        if (node != null) {
             return AllocateUnassignedDecision.yes(node, allocationId, nodeResults, false);
         } else if (throttled) {
             return AllocateUnassignedDecision.throttle(nodeResults);

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -195,9 +195,8 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         assert explain == false || matchingNodes.nodeDecisions != null : "in explain mode, we must have individual node decisions";
 
         List<NodeAllocationResult> nodeDecisions = augmentExplanationsWithStoreInfo(result.v2(), matchingNodes.nodeDecisions);
-        if (allocateDecision.type() != Decision.Type.YES) {
-            return AllocateUnassignedDecision.no(UnassignedInfo.AllocationStatus.fromDecision(allocateDecision.type()), nodeDecisions);
-        } else if (matchingNodes.getNodeWithHighestMatch() != null) {
+        assert allocateDecision.type() == Decision.Type.YES : "Decision no should be returned early.";
+        if (matchingNodes.getNodeWithHighestMatch() != null) {
             RoutingNode nodeWithHighestMatch = allocation.routingNodes().node(matchingNodes.getNodeWithHighestMatch().getId());
             // we only check on THROTTLE since we checked before before on NO
             Decision decision = allocation.deciders().canAllocate(unassignedShard, nodeWithHighestMatch, allocation);


### PR DESCRIPTION
If we have pending async fetching operation, we would return early, this PR removes the unnecessary check in the end of `makeAllocationDecision`.
https://github.com/elastic/elasticsearch/blob/01c83ceb5ce4655591f576e504545c87926168b0/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java#L98-L105

Also remove the same dup check logic in replica allocation.