### PR TITLE
Remove unnecessary method AbstractFieldScript#getSource.

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
@@ -95,13 +95,6 @@ public abstract class AbstractFieldScript {
     }
 
     /**
-     * A non-public convenience method that's used in testing.
-     */
-    protected final Map<String, Object> getSource() {
-        return leafSearchLookup.source();
-    }
-
-    /**
      * Check if the we can add another value to the list of values.
      * @param currentSize the current size of the list
      */

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
@@ -88,17 +88,17 @@ public abstract class AbstractFieldScript {
     }
 
     /**
-     * Expose the {@code _source} to the script.
-     */
-    protected final Map<String, Object> getSource() {
-        return leafSearchLookup.source();
-    }
-
-    /**
      * Expose field data to the script as {@code doc}.
      */
     public final Map<String, ScriptDocValues<?>> getDoc() {
         return leafSearchLookup.doc();
+    }
+
+    /**
+     * A non-public convenience method that's used in testing.
+     */
+    protected final Map<String, Object> getSource() {
+        return leafSearchLookup.source();
     }
 
     /**

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -437,7 +437,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
                                 return (fieldName, params, lookup) -> (ctx) -> new BooleanFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit((Boolean) foo);
                                         }
                                     }
@@ -446,7 +446,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
                                 return (fieldName, params, lookup) -> (ctx) -> new BooleanFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit((Boolean) foo ^ ((Boolean) getParams().get("param")));
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
@@ -497,7 +497,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                 ) {
                                     @Override
                                     public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                        for (Object timestamp : (List<?>) lookup.source().get("timestamp")) {
                                             DateFieldScript.Parse parse = new DateFieldScript.Parse(this);
                                             emit(parse.parse(timestamp));
                                         }
@@ -513,7 +513,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                 ) {
                                     @Override
                                     public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                        for (Object timestamp : (List<?>) lookup.source().get("timestamp")) {
                                             long epoch = (Long) timestamp;
                                             ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneId.of("UTC"));
                                             dt = dt.plus(((Number) params.get("days")).longValue(), ChronoUnit.DAYS);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
@@ -279,7 +279,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
                                 return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(((Number) foo).doubleValue());
                                         }
                                     }
@@ -288,7 +288,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
                                 return (fieldName, params, lookup) -> (ctx) -> new DoubleFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(((Number) foo).doubleValue() + ((Number) getParams().get("param")).doubleValue());
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
@@ -249,7 +249,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
                                 return (fieldName, params, lookup) -> (ctx) -> new GeoPointFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        Map<?, ?> foo = (Map<?, ?>) getSource().get("foo");
+                                        Map<?, ?> foo = (Map<?, ?>) lookup.source().get("foo");
                                         emit(((Number) foo.get("lat")).doubleValue(), ((Number) foo.get("lon")).doubleValue());
                                     }
                                 };

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
@@ -296,7 +296,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
                                 return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(foo.toString());
                                         }
                                     }
@@ -305,7 +305,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
                                 return (fieldName, params, lookup) -> (ctx) -> new IpFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(foo.toString() + getParams().get("param"));
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
@@ -397,7 +397,7 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
                                 return (fieldName, params, lookup) -> ctx -> new StringFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(foo.toString());
                                         }
                                     }
@@ -406,7 +406,7 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
                                 return (fieldName, params, lookup) -> ctx -> new StringFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(foo.toString() + getParams().get("param").toString());
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
@@ -298,7 +298,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                 return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(((Number) foo).longValue());
                                         }
                                     }
@@ -307,7 +307,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                 return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object foo : (List<?>) getSource().get("foo")) {
+                                        for (Object foo : (List<?>) lookup.source().get("foo")) {
                                             emit(((Number) foo).longValue() + ((Number) getParams().get("param")).longValue());
                                         }
                                     }
@@ -318,7 +318,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
                                 return (fieldName, params, lookup) -> (ctx) -> new LongFieldScript(fieldName, params, lookup, ctx) {
                                     @Override
                                     public void execute() {
-                                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                                        for (Object timestamp : (List<?>) lookup.source().get("timestamp")) {
                                             emit(now - ((Number) timestamp).longValue());
                                         }
                                     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/LongScriptFieldDistanceFeatureQueryTests.java
@@ -75,16 +75,17 @@ public class LongScriptFieldDistanceFeatureQueryTests extends AbstractScriptFiel
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181351]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
+                SearchLookup searchLookup = new SearchLookup(null, null);
                 Function<LeafReaderContext, AbstractLongFieldScript> leafFactory = ctx -> new DateFieldScript(
                     "test",
                     Map.of(),
-                    new SearchLookup(null, null),
+                    searchLookup,
                     null,
                     ctx
                 ) {
                     @Override
                     public void execute() {
-                        for (Object timestamp : (List<?>) getSource().get("timestamp")) {
+                        for (Object timestamp : (List<?>) searchLookup.source().get("timestamp")) {
                             emit(((Number) timestamp).longValue());
                         }
                     }


### PR DESCRIPTION
Previously it looked like `_source` was exposed as a top-level parameter in
runtime field scripts. The method is only used in tests and can be removed
altogether.