### PR TITLE
[Transform] add more debug logging in testUsage IT

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -110,13 +110,13 @@ public class TransformUsageIT extends TransformRestTestCase {
                 // the trigger count can be higher if the scheduler kicked before usage has been called, therefore check for gte
                 if (statName.equals(TransformIndexerStats.NUM_INVOCATIONS.getPreferredName())) {
                     assertThat(
-                        "Incorrect stat " + statName,
+                        "Incorrect stat " + statName + ", got: " + statsMap.get("transform"),
                         extractStatsAsDouble(XContentMapValues.extractValue("transform.stats." + statName, statsMap)),
                         greaterThanOrEqualTo(expectedStats.get(statName).doubleValue())
                     );
                 } else {
                     assertThat(
-                        "Incorrect stat " + statName,
+                        "Incorrect stat " + statName + ", got: " + statsMap.get("transform"),
                         extractStatsAsDouble(XContentMapValues.extractValue("transform.stats." + statName, statsMap)),
                         equalTo(expectedStats.get(statName).doubleValue())
                     );


### PR DESCRIPTION
log the full usage response on failure (individual counts are logged already)

relates #52931

Explain: The test checks that `usage` correctly summarizes (sums) individual counts, these are logged as part of the test. The added information should help, finding out if all counts are off or just 1. The root issue #52931 is not locally reproducible.