### PR TITLE
[DOCS] format the search-explain doc

### DIFF
--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -20,6 +20,7 @@ GET /my-index-000001/_explain/0
 ==== {api-request-title}
 
 `GET /<index>/_explain/<id>`
+
 `POST /<index>/_explain/<id>`
 
 [[sample-api-desc]]


### PR DESCRIPTION
There is a format issue in the search-explain doc: [https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html)， the two urls are on the same line.