### PR TITLE
Rework Dockerfile instructions to save space

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -27,7 +27,7 @@
 FROM ${base_image} AS builder
 
 # Install required packages to extract the Elasticsearch distribution
-RUN <%= retry_loop(package_manager, "${package_manager} install -y tar gzip") %>
+RUN <%= retry_loop(package_manager, "${package_manager} install -y findutils tar gzip") %>
 
 # `tini` is a tiny but valid init for containers. This is used to cleanly
 # control how ES and any child processes are shut down.
@@ -204,6 +204,9 @@ RUN rm -rf /rootfs/etc/ld.so.cache /rootfs/var/cache/ldconfig && \\
 
 COPY --from=curl /work/curl /rootfs/usr/bin/curl
 
+# Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
+RUN find /rootfs -xdev -perm -4000 -exec chmod ug-s {} +
+
 ################################################################################
 # Step 3. Fetch the Elasticsearch distribution and configure it for Docker
 ################################################################################
@@ -219,12 +222,25 @@ ${source_elasticsearch}
 
 RUN tar -zxf /opt/elasticsearch.tar.gz --strip-components=1
 
-# Configure the distribution for Docker
-RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
-RUN mkdir -p config config/jvm.options.d data logs plugins
-RUN chmod 0775 config config/jvm.options.d data logs plugins
+# The distribution includes a `config` directory, no need to create it
 COPY ${config_dir}/elasticsearch.yml ${config_dir}/log4j2.properties config/
-RUN chmod 0660 config/elasticsearch.yml config/log4j2.properties
+
+# 1. Configure the distribution for Docker
+# 2. Ensure directories are created. Most already are, but make sure
+# 3. Apply correct permissions
+# 4. Apply more correct permissions
+# 5. The JDK's directories' permissions don't allow `java` to be executed under a different
+#    group to the default. Fix this.
+# 6. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
+# 7. Ensure all files are world-readable by default. It should be possible to
+#    examine the contents of the image under any UID:GID
+RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env && \\
+    mkdir -p config/jvm.options.d data logs plugins && \\
+    chmod 0775 config config/jvm.options.d data logs plugins && \\
+    chmod 0660 config/elasticsearch.yml config/log4j2.properties && \\
+    find ./jdk -type d -exec chmod 0755 {} + && \\
+    find . -xdev -perm -4000 -exec chmod ug-s {} + && \\
+    find . -type f -exec chmod o+r {} +
 
 <% if (docker_base == "ubi" || docker_base == "iron_bank") { %>
 
@@ -293,27 +309,21 @@ COPY --from=builder --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticse
 COPY --from=builder --chown=0:0 /bin/tini /bin/tini
 <% } %>
 
-# Replace OpenJDK's built-in CA certificate keystore with the one from the OS
-# vendor. The latter is superior in several ways.
-# REF: https://github.com/elastic/elasticsearch-docker/issues/171
-RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /usr/share/elasticsearch/jdk/lib/security/cacerts
-
 ENV PATH /usr/share/elasticsearch/bin:\$PATH
 
 COPY ${bin_dir}/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# 1. The JDK's directories' permissions don't allow `java` to be executed under a different
-#    group to the default. Fix this.
-# 2. Sync the user and group permissions of /etc/passwd
-# 3. Set correct permissions of the entrypoint
-# 4. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
-# 5. Ensure all files are world-readable by default. It should be possible to
-#    examine the contents of the image under any UID:GID
-RUN find /usr/share/elasticsearch/jdk -type d -exec chmod 0755 {} + && \\
-    chmod g=u /etc/passwd && \\
+# 1. Sync the user and group permissions of /etc/passwd
+# 2. Set correct permissions of the entrypoint
+# 3. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
+#    We've already run this in previous layers so it ought to be a no-op.
+# 4. Replace OpenJDK's built-in CA certificate keystore with the one from the OS
+#    vendor. The latter is superior in several ways.
+#    REF: https://github.com/elastic/elasticsearch-docker/issues/171
+RUN chmod g=u /etc/passwd && \\
     chmod 0775 /usr/local/bin/docker-entrypoint.sh && \\
     find / -xdev -perm -4000 -exec chmod ug-s {} + && \\
-    find /usr/share/elasticsearch -type f -exec chmod o+r {} +
+    ln -sf /etc/pki/ca-trust/extracted/java/cacerts /usr/share/elasticsearch/jdk/lib/security/cacerts
 
 EXPOSE 9200 9300
 
@@ -349,6 +359,7 @@ LABEL name="Elasticsearch" \\
 RUN mkdir /licenses && \\
     cp LICENSE.txt /licenses/LICENSE
 <% } %>
+
 USER elasticsearch:root
 
 # Our actual entrypoint is `tini`, a minimal but functional init program. It


### PR DESCRIPTION
In PR #64274, we make it possible to run our Docker images more easily
under a different group, but in so doing increased the Docker layer
sizes dramatically, effectively doubling the size of the images.

Fix this by reworking what commands get run and where, in order to bring
down the final size of the images.

cc @mieciu 