### PR TITLE
Lower severity of dangling indices log message

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -90,7 +90,7 @@ public class DanglingIndicesState implements ClusterStateListener {
         if (this.isAutoImportDanglingIndicesEnabled) {
             clusterService.addListener(this);
         } else {
-            logger.warn(
+            logger.info(
                 AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey()
                     + " is disabled, dangling indices will not be automatically detected or imported and must be managed manually"
             );


### PR DESCRIPTION
Closes #65032.

When the `DanglingIndicesState` component starts, it emits a warning log message if the
`gateway.auto_import_dangling_indices` setting is `false`. However, this is the default value for this setting, so the log level should be lowered.