### PR TITLE
[7.10] [DOCS] Fix formatting issue in search explain docs (#65303)

### DIFF
--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -20,6 +20,7 @@ GET /my-index-000001/_explain/0
 ==== {api-request-title}
 
 `GET /<index>/_explain/<id>`
+
 `POST /<index>/_explain/<id>`
 
 [[sample-api-desc]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix formatting issue in search explain docs (#65303)