### PR TITLE
Encapsulate nested identity loading (#65054)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -234,26 +234,14 @@ public final class BitsetFilterCache extends AbstractIndexComponent
                 return TerminationHandle.NO_WAIT;
             }
 
-            boolean hasNested = false;
             final Set<Query> warmUp = new HashSet<>();
             final MapperService mapperService = indexShard.mapperService();
             DocumentMapper docMapper = mapperService.documentMapper();
             if (docMapper != null) {
                 if (docMapper.hasNestedObjects()) {
-                    hasNested = true;
-                    for (ObjectMapper objectMapper : docMapper.mappers().objectMappers().values()) {
-                        if (objectMapper.nested().isNested()) {
-                            ObjectMapper parentObjectMapper = objectMapper.getParentObjectMapper(mapperService::getObjectMapper);
-                            if (parentObjectMapper != null && parentObjectMapper.nested().isNested()) {
-                                warmUp.add(parentObjectMapper.nestedTypeFilter());
-                            }
-                        }
-                    }
+                    warmUp.add(Queries.newNonNestedFilter(indexSettings.getIndexVersionCreated()));
+                    docMapper.getNestedParentMappers().stream().map(ObjectMapper::nestedTypeFilter).forEach(warmUp::add);
                 }
-            }
-
-            if (hasNested) {
-                warmUp.add(Queries.newNonNestedFilter(indexSettings.getIndexVersionCreated()));
             }
 
             final CountDownLatch latch = new CountDownLatch(reader.leaves().size() * warmUp.size());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -20,11 +20,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -37,11 +32,12 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -227,38 +223,88 @@ public class DocumentMapper implements ToXContentFragment {
     }
 
     /**
-     * Returns the best nested {@link ObjectMapper} instances that is in the scope of the specified nested docId.
+     * Given an object path, checks to see if any of its parents are non-nested objects
      */
-    public ObjectMapper findNestedObjectMapper(int nestedDocId, SearchContext sc, LeafReaderContext context) throws IOException {
-        ObjectMapper nestedObjectMapper = null;
-        for (ObjectMapper objectMapper : mappers().objectMappers().values()) {
-            if (!objectMapper.nested().isNested()) {
-                continue;
+    public boolean hasNonNestedParent(String path) {
+        ObjectMapper mapper = mappers().objectMappers().get(path);
+        if (mapper == null) {
+            return false;
+        }
+        while (mapper != null) {
+            if (mapper.nested().isNested() == false) {
+                return true;
             }
+            if (path.contains(".") == false) {
+                return false;
+            }
+            path = path.substring(0, path.lastIndexOf("."));
+            mapper = mappers().objectMappers().get(path);
+        }
+        return false;
+    }
 
-            Query filter = objectMapper.nestedTypeFilter();
-            if (filter == null) {
+    /**
+     * Returns all nested object mappers
+     */
+    public List<ObjectMapper> getNestedMappers() {
+        List<ObjectMapper> childMappers = new ArrayList<>();
+        for (ObjectMapper mapper : mappers().objectMappers().values()) {
+            if (mapper.nested().isNested() == false) {
                 continue;
             }
-            // We can pass down 'null' as acceptedDocs, because nestedDocId is a doc to be fetched and
-            // therefore is guaranteed to be a live doc.
-            final Weight nestedWeight = filter.createWeight(sc.searcher(), ScoreMode.COMPLETE_NO_SCORES, 1f);
-            Scorer scorer = nestedWeight.scorer(context);
-            if (scorer == null) {
-                continue;
-            }
+            childMappers.add(mapper);
+        }
+        return childMappers;
+    }
 
-            if (scorer.iterator().advance(nestedDocId) == nestedDocId) {
-                if (nestedObjectMapper == null) {
-                    nestedObjectMapper = objectMapper;
-                } else {
-                    if (nestedObjectMapper.fullPath().length() < objectMapper.fullPath().length()) {
-                        nestedObjectMapper = objectMapper;
-                    }
-                }
+    /**
+     * Returns all nested object mappers which contain further nested object mappers
+     *
+     * Used by BitSetProducerWarmer
+     */
+    public List<ObjectMapper> getNestedParentMappers() {
+        List<ObjectMapper> parents = new ArrayList<>();
+        for (ObjectMapper mapper : mappers().objectMappers().values()) {
+            String nestedParentPath = getNestedParent(mapper.fullPath());
+            if (nestedParentPath == null) {
+                continue;
+            }
+            ObjectMapper parent = mappers().objectMappers().get(nestedParentPath);
+            if (parent.nested().isNested()) {
+                parents.add(parent);
             }
         }
-        return nestedObjectMapper;
+        return parents;
+    }
+
+    /**
+     * Given a nested object path, returns the path to its nested parent
+     *
+     * In particular, if a nested field `foo` contains an object field
+     * `bar.baz`, then calling this method with `foo.bar.baz` will return
+     * the path `foo`, skipping over the object-but-not-nested `foo.bar`
+     */
+    public String getNestedParent(String path) {
+        ObjectMapper mapper = mappers().objectMappers().get(path);
+        if (mapper == null) {
+            return null;
+        }
+        if (path.contains(".") == false) {
+            return null;
+        }
+        do {
+            path = path.substring(0, path.lastIndexOf("."));
+            mapper = mappers().objectMappers().get(path);
+            if (mapper == null) {
+                return null;
+            }
+            if (mapper.nested().isNested()) {
+                return path;
+            }
+            if (path.contains(".") == false) {
+                return null;
+            }
+        } while(true);
     }
 
     public DocumentMapper merge(Mapping mapping, MergeReason reason) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -43,7 +43,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -441,35 +440,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     public final Dynamic dynamic() {
         return dynamic;
-    }
-
-    /**
-     * Returns the parent {@link ObjectMapper} instance of the specified object mapper or <code>null</code> if there
-     * isn't any.
-     */
-    public ObjectMapper getParentObjectMapper(Function<String, ObjectMapper> objectMapperLookup) {
-        int indexOfLastDot = fullPath().lastIndexOf('.');
-        if (indexOfLastDot != -1) {
-            String parentNestObjectPath = fullPath().substring(0, indexOfLastDot);
-            return objectMapperLookup.apply(parentNestObjectPath);
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Returns whether all parent objects fields are nested too.
-     */
-    public boolean parentObjectMapperAreNested(Function<String, ObjectMapper> objectMapperLookup) {
-        for (ObjectMapper parent = getParentObjectMapper(objectMapperLookup);
-             parent != null;
-             parent = parent.getParentObjectMapper(objectMapperLookup)) {
-
-            if (parent.nested().isNested() == false) {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -483,11 +482,6 @@ final class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService mapperService() {
-        return indexService.mapperService();
-    }
-
-    @Override
     public BigArrays bigArrays() {
         return bigArrays;
     }
@@ -728,6 +722,11 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public QuerySearchResult queryResult() {
         return queryResult;
+    }
+
+    @Override
+    public NestedDocuments getNestedDocuments() {
+        return new NestedDocuments(indexService.mapperService(), bitsetFilterCache()::getBitSetProducer);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/LeafNestedDocuments.java
+++ b/server/src/main/java/org/elasticsearch/search/LeafNestedDocuments.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import java.io.IOException;
+
+/**
+ * Manages loading information about nested documents for a single index segment
+ */
+public interface LeafNestedDocuments {
+
+    /**
+     * Advance to a specific doc, and return its NestedIdentity, or {@code null} if not a child
+     */
+    SearchHit.NestedIdentity advance(int doc) throws IOException;
+
+    /**
+     * The current doc
+     */
+    int doc();
+
+    /**
+     * The ultimate parent of the current doc
+     */
+    int rootDoc();
+
+    /**
+     * The NestedIdentity of the current doc
+     */
+    SearchHit.NestedIdentity nestedIdentity();
+
+    /**
+     * An implementation of LeafNestedDocuments for use when there are no nested field mappers
+     */
+    LeafNestedDocuments NO_NESTED_MAPPERS = new LeafNestedDocuments() {
+        @Override
+        public SearchHit.NestedIdentity advance(int doc) {
+            return null;
+        }
+
+        @Override
+        public int doc() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int rootDoc() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SearchHit.NestedIdentity nestedIdentity() {
+            throw new UnsupportedOperationException();
+        }
+    };
+}

--- a/server/src/main/java/org/elasticsearch/search/NestedDocuments.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedDocuments.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.util.BitSet;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Manages loading information about nested documents
+ */
+public class NestedDocuments {
+
+    private final Map<String, BitSetProducer> parentObjectFilters = new HashMap<>();
+    private final Map<String, Weight> childObjectFilters = new HashMap<>();
+    private final Map<String, ObjectMapper> childObjectMappers = new HashMap<>();
+    private final BitSetProducer parentDocumentFilter;
+    private final MapperService mapperService;
+    private final Version version;
+
+    /**
+     * Create a new NestedDocuments object for an index
+     * @param mapperService     the index's MapperService
+     * @param filterProducer    a function to build BitSetProducers from filter queries
+     */
+    public NestedDocuments(MapperService mapperService, Function<Query, BitSetProducer> filterProducer) {
+        this.mapperService = mapperService;
+        this.version = mapperService.getIndexSettings().getIndexVersionCreated();
+        if (mapperService.hasNested() == false) {
+            this.parentDocumentFilter = null;
+        } else {
+            this.parentDocumentFilter = filterProducer.apply(Queries.newNonNestedFilter(version));
+            for (ObjectMapper mapper : mapperService.documentMapper().getNestedParentMappers()) {
+                parentObjectFilters.put(mapper.name(),
+                    filterProducer.apply(mapper.nestedTypeFilter()));
+            }
+            for (ObjectMapper mapper : mapperService.documentMapper().getNestedMappers()) {
+                childObjectFilters.put(mapper.name(), null);
+                childObjectMappers.put(mapper.name(), mapper);
+            }
+        }
+    }
+
+    /**
+     * Returns a LeafNestedDocuments for an index segment
+     */
+    public LeafNestedDocuments getLeafNestedDocuments(LeafReaderContext ctx) throws IOException {
+        if (parentDocumentFilter == null) {
+            return LeafNestedDocuments.NO_NESTED_MAPPERS;
+        }
+        return new HasNestedDocuments(ctx);
+    }
+
+    private Weight getNestedChildWeight(LeafReaderContext ctx, String path) throws IOException {
+        if (childObjectFilters.containsKey(path) == false || childObjectMappers.containsKey(path) == false) {
+            throw new IllegalStateException("Cannot find object mapper for path " + path);
+        }
+        if (childObjectFilters.get(path) == null) {
+            IndexSearcher searcher = new IndexSearcher(ReaderUtil.getTopLevelContext(ctx));
+            ObjectMapper childMapper = childObjectMappers.get(path);
+            childObjectFilters.put(path,
+                searcher.createWeight(searcher.rewrite(childMapper.nestedTypeFilter()), ScoreMode.COMPLETE_NO_SCORES, 1));
+        }
+        return childObjectFilters.get(path);
+    }
+
+    /**
+     * Given an object path, returns whether or not any of its parents are plain objects
+     */
+    public boolean hasNonNestedParent(String path) {
+        return mapperService.documentMapper().hasNonNestedParent(path);
+    }
+
+    private class HasNestedDocuments implements LeafNestedDocuments {
+
+        final LeafReaderContext ctx;
+        final BitSet parentFilter;
+        final Map<String, BitSet> objectFilters = new HashMap<>();
+        final Map<String, Scorer> childScorers = new HashMap<>();
+
+        int doc = -1;
+        int rootDoc = -1;
+        SearchHit.NestedIdentity nestedIdentity = null;
+
+        private HasNestedDocuments(LeafReaderContext ctx) throws IOException {
+            this.ctx = ctx;
+            this.parentFilter = parentDocumentFilter.getBitSet(ctx);
+            for (Map.Entry<String, BitSetProducer> filter : parentObjectFilters.entrySet()) {
+                BitSet bits = filter.getValue().getBitSet(ctx);
+                if (bits != null) {
+                    objectFilters.put(filter.getKey(), bits);
+                }
+            }
+            for (Map.Entry<String, Weight> childFilter : childObjectFilters.entrySet()) {
+                Scorer scorer = getNestedChildWeight(ctx, childFilter.getKey()).scorer(ctx);
+                if (scorer != null) {
+                    childScorers.put(childFilter.getKey(), scorer);
+                }
+            }
+        }
+
+        @Override
+        public SearchHit.NestedIdentity advance(int doc) throws IOException {
+            assert doc >= 0 && doc < ctx.reader().maxDoc();
+            if (parentFilter.get(doc)) {
+                // parent doc, no nested identity
+                this.nestedIdentity = null;
+                this.doc = doc;
+                this.rootDoc = doc;
+                return null;
+            } else {
+                this.doc = doc;
+                this.rootDoc = parentFilter.nextSetBit(doc);
+                return this.nestedIdentity = loadNestedIdentity();
+            }
+        }
+
+        @Override
+        public int doc() {
+            assert doc != -1 : "Called doc() when unpositioned";
+            return doc;
+        }
+
+        @Override
+        public int rootDoc() {
+            assert doc != -1 : "Called rootDoc() when unpositioned";
+            return rootDoc;
+        }
+
+        @Override
+        public SearchHit.NestedIdentity nestedIdentity() {
+            assert doc != -1 : "Called nestedIdentity() when unpositioned";
+            return nestedIdentity;
+        }
+
+        private String findObjectPath(int doc) throws IOException {
+            String path = null;
+            for (Map.Entry<String, Scorer> objectFilter : childScorers.entrySet()) {
+                DocIdSetIterator it = objectFilter.getValue().iterator();
+                if (it.docID() == doc || it.docID() < doc && it.advance(doc) == doc) {
+                    if (path == null || path.length() > objectFilter.getKey().length()) {
+                        path = objectFilter.getKey();
+                    }
+                }
+            }
+            if (path == null) {
+                throw new IllegalStateException("Cannot find object path for document " + doc);
+            }
+            return path;
+        }
+
+        private SearchHit.NestedIdentity loadNestedIdentity() throws IOException {
+            SearchHit.NestedIdentity ni = null;
+            int currentLevelDoc = doc;
+            int parentNameLength;
+            String path = findObjectPath(doc);
+            while (path != null) {
+                String parent = mapperService.documentMapper().getNestedParent(path);
+                // We have to pull a new scorer for each document here, because we advance from
+                // the last parent which will be behind the doc
+                Scorer childScorer = getNestedChildWeight(ctx, path).scorer(ctx);
+                if (childScorer == null) {
+                    throw new IllegalStateException("Cannot find object mapper for path " + path + " in doc " + doc);
+                }
+                BitSet parentBitSet;
+                if (parent == null) {
+                    parentBitSet = parentFilter;
+                    parentNameLength = 0;
+                } else {
+                    if (objectFilters.containsKey(parent) == false) {
+                        throw new IllegalStateException("Cannot find parent mapper for path " + path + " in doc " + doc);
+                    }
+                    parentBitSet = objectFilters.get(parent);
+                    parentNameLength = parent.length() + 1;
+                }
+                int offset = 0;
+                DocIdSetIterator childIt = childScorer.iterator();
+                if (version.onOrAfter(Version.V_6_5_0)) {
+                    /*
+                     * Starts from the previous parent and finds the offset of the
+                     * <code>nestedSubDocID</code> within the nested children. Nested documents
+                     * are indexed in the same order than in the source array so the offset
+                     * of the nested child is the number of nested document with the same parent
+                     * that appear before him.
+                     */
+                    int lastParent = parentBitSet.prevSetBit(currentLevelDoc);
+                    for (int i = childIt.advance(lastParent + 1); i < currentLevelDoc; i = childIt.nextDoc()) {
+                        offset++;
+                    }
+                } else {
+                    /*
+                     * Nested documents are in reverse order in this version so we start from the current nested document
+                     * and find the number of documents with the same parent that appear after it.
+                     */
+                    int nextParent = parentBitSet.nextSetBit(currentLevelDoc);
+                    for (int docId = childIt.advance(currentLevelDoc + 1); docId < nextParent; docId = childIt.nextDoc()) {
+                        offset++;
+                    }
+                }
+                ni = new SearchHit.NestedIdentity(path.substring(parentNameLength), offset, ni);
+                path = parent;
+                currentLevelDoc = parentBitSet.nextSetBit(currentLevelDoc);
+            }
+            return ni;
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -1008,6 +1008,11 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             return innerToXContent(builder, params);
         }
 
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+
         /**
          * Rendering of the inner XContent object without the leading field name. This way the structure innerToXContent renders and
          * fromXContent parses correspond to each other.

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -355,7 +355,8 @@ public class FetchPhase {
             }
         } else {
             FieldsVisitor rootFieldsVisitor = new FieldsVisitor(needSource);
-            loadStoredFields(queryShardContext::getFieldType, queryShardContext.getType(), storedFieldReader, rootFieldsVisitor, nestedInfo.rootDoc());
+            loadStoredFields(queryShardContext::getFieldType, queryShardContext.getType(),
+                storedFieldReader, rootFieldsVisitor, nestedInfo.rootDoc());
             rootFieldsVisitor.postProcess(queryShardContext::getFieldType, queryShardContext.getType());
             rootId = rootFieldsVisitor.uid();
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -23,34 +23,25 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.BitSet;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.LeafNestedDocuments;
+import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.SearchContextSourcePrinter;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -75,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -123,9 +115,11 @@ public class FetchPhase {
         SearchHit[] hits = new SearchHit[context.docIdsToLoadSize()];
 
         List<FetchSubPhaseProcessor> processors = getProcessors(context.shardTarget(), fetchContext);
+        NestedDocuments nestedDocuments = context.getNestedDocuments();
 
         int currentReaderIndex = -1;
         LeafReaderContext currentReaderContext = null;
+        LeafNestedDocuments leafNestedDocuments = null;
         CheckedBiConsumer<Integer, FieldsVisitor, IOException> fieldReader = null;
         boolean hasSequentialDocs = hasSequentialDocs(docs);
         for (int index = 0; index < context.docIdsToLoadSize(); index++) {
@@ -152,10 +146,13 @@ public class FetchPhase {
                     for (FetchSubPhaseProcessor processor : processors) {
                         processor.setNextReader(currentReaderContext);
                     }
+                    leafNestedDocuments = nestedDocuments.getLeafNestedDocuments(currentReaderContext);
                 }
                 assert currentReaderContext != null;
                 HitContext hit = prepareHitContext(
                     context,
+                    leafNestedDocuments,
+                    nestedDocuments::hasNonNestedParent,
                     fetchContext.searchLookup(),
                     fieldsVisitor,
                     docId,
@@ -261,37 +258,21 @@ public class FetchPhase {
         return context.sourceRequested() || context.fetchFieldsContext() != null;
     }
 
-    private int findRootDocumentIfNested(SearchContext context, LeafReaderContext subReaderContext, int subDocId) throws IOException {
-        if (context.getQueryShardContext().hasNested()) {
-            BitSet bits = context.bitsetFilterCache()
-                .getBitSetProducer(Queries.newNonNestedFilter(context.indexShard().indexSettings().getIndexVersionCreated()))
-                .getBitSet(subReaderContext);
-            if (!bits.get(subDocId)) {
-                return bits.nextSetBit(subDocId);
-            }
-        }
-        return -1;
-    }
-
     private HitContext prepareHitContext(SearchContext context,
+                                         LeafNestedDocuments nestedDocuments,
+                                         Predicate<String> hasNonNestedParent,
                                          SearchLookup lookup,
                                          FieldsVisitor fieldsVisitor,
                                          int docId,
                                          Map<String, Set<String>> storedToRequestedFields,
                                          LeafReaderContext subReaderContext,
                                          CheckedBiConsumer<Integer, FieldsVisitor, IOException> storedFieldReader) throws IOException {
-        int rootDocId = findRootDocumentIfNested(context, subReaderContext, docId - subReaderContext.docBase);
-        if (rootDocId == -1) {
+        if (nestedDocuments.advance(docId - subReaderContext.docBase) == null) {
             return prepareNonNestedHitContext(
-                context,
-                lookup,
-                fieldsVisitor,
-                docId,
-                storedToRequestedFields,
-                subReaderContext,
-                storedFieldReader);
+                context, lookup, fieldsVisitor, docId, storedToRequestedFields, subReaderContext, storedFieldReader);
         } else {
-            return prepareNestedHitContext(context, docId, rootDocId, storedToRequestedFields, subReaderContext, storedFieldReader);
+            return prepareNestedHitContext(context, docId, nestedDocuments, hasNonNestedParent, storedToRequestedFields,
+                subReaderContext, storedFieldReader);
         }
     }
 
@@ -346,8 +327,9 @@ public class FetchPhase {
      */
     @SuppressWarnings("unchecked")
     private HitContext prepareNestedHitContext(SearchContext context,
-                                               int nestedTopDocId,
-                                               int rootDocId,
+                                               int topDocId,
+                                               LeafNestedDocuments nestedInfo,
+                                               Predicate<String> hasNonNestedParent,
                                                Map<String, Set<String>> storedToRequestedFields,
                                                LeafReaderContext subReaderContext,
                                                CheckedBiConsumer<Integer, FieldsVisitor, IOException> storedFieldReader)
@@ -361,7 +343,6 @@ public class FetchPhase {
         Map<String, Object> rootSourceAsMap = null;
         XContentType rootSourceContentType = null;
 
-        int nestedDocId = nestedTopDocId - subReaderContext.docBase;
         QueryShardContext queryShardContext = context.getQueryShardContext();
         if (context instanceof InnerHitsContext.InnerHitSubContext) {
             InnerHitsContext.InnerHitSubContext innerHitsContext = (InnerHitsContext.InnerHitSubContext) context;
@@ -374,9 +355,10 @@ public class FetchPhase {
             }
         } else {
             FieldsVisitor rootFieldsVisitor = new FieldsVisitor(needSource);
-            loadStoredFields(queryShardContext::getFieldType, queryShardContext.getType(), storedFieldReader, rootFieldsVisitor, rootDocId);
+            loadStoredFields(queryShardContext::getFieldType, queryShardContext.getType(), storedFieldReader, rootFieldsVisitor, nestedInfo.rootDoc());
             rootFieldsVisitor.postProcess(queryShardContext::getFieldType, queryShardContext.getType());
             rootId = rootFieldsVisitor.uid();
+
             if (needSource) {
                 BytesReference rootSource = rootFieldsVisitor.source();
                 Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(rootSource, false);
@@ -390,7 +372,7 @@ public class FetchPhase {
         if (context.hasStoredFields() && !context.storedFieldsContext().fieldNames().isEmpty()) {
             FieldsVisitor nestedFieldsVisitor = new CustomFieldsVisitor(storedToRequestedFields.keySet(), false);
             loadStoredFields(queryShardContext::getFieldType, queryShardContext.getType(),
-                storedFieldReader, nestedFieldsVisitor, nestedDocId);
+                storedFieldReader, nestedFieldsVisitor, nestedInfo.doc());
             if (nestedFieldsVisitor.fields().isEmpty() == false) {
                 docFields = new HashMap<>();
                 metaFields = new HashMap<>();
@@ -398,21 +380,16 @@ public class FetchPhase {
             }
         }
 
-        DocumentMapper documentMapper = context.mapperService().documentMapper();
-        ObjectMapper nestedObjectMapper
-            = documentMapper.findNestedObjectMapper(nestedDocId, context, subReaderContext);
-        assert nestedObjectMapper != null;
+        SearchHit.NestedIdentity nestedIdentity = nestedInfo.nestedIdentity();
 
-        SearchHit.NestedIdentity nestedIdentity =
-                getInternalNestedIdentity(context, nestedDocId, subReaderContext, queryShardContext::getObjectMapper, nestedObjectMapper);
-
-        SearchHit hit = new SearchHit(nestedTopDocId, rootId.id(), new Text(queryShardContext.getType()), nestedIdentity,
-            docFields, metaFields);
+        SearchHit hit = new SearchHit(topDocId, rootId.id(), new Text(queryShardContext.getType()),
+            nestedIdentity, docFields, metaFields);
         HitContext hitContext = new HitContext(
             hit,
             subReaderContext,
-            nestedDocId,
-            new SourceLookup());  // Use a clean, fresh SourceLookup for the nested context
+            nestedInfo.doc(),
+            new SourceLookup()  // Use a clean, fresh SourceLookup for the nested context
+        );
 
         if (rootSourceAsMap != null) {
             // Isolate the nested json array object that matches with nested hit and wrap it back into the same json
@@ -436,15 +413,14 @@ public class FetchPhase {
                 } else {
                     throw new IllegalStateException("extracted source isn't an object or an array");
                 }
-                if ((nestedParsedSource.get(0) instanceof Map) == false &&
-                    nestedObjectMapper.parentObjectMapperAreNested(queryShardContext::getObjectMapper) == false) {
+                if ((nestedParsedSource.get(0) instanceof Map) == false && hasNonNestedParent.test(nestedPath)) {
                     // When one of the parent objects are not nested then XContentMapValues.extractValue(...) extracts the values
                     // from two or more layers resulting in a list of list being returned. This is because nestedPath
                     // encapsulates two or more object layers in the _source.
                     //
                     // This is why only the first element of nestedParsedSource needs to be checked.
                     throw new IllegalArgumentException("Cannot execute inner hits. One or more parent object fields of nested field [" +
-                        nestedObjectMapper.name() + "] are not nested. All parent fields need to be nested fields too");
+                        nestedPath + "] are not nested. All parent fields need to be nested fields too");
                 }
                 rootSourceAsMap = (Map<String, Object>) nestedParsedSource.get(nested.getOffset());
                 if (nested.getChild() == null) {
@@ -460,83 +436,6 @@ public class FetchPhase {
             hitContext.sourceLookup().setSourceContentType(rootSourceContentType);
         }
         return hitContext;
-    }
-
-    private static SearchHit.NestedIdentity getInternalNestedIdentity(SearchContext context,
-                                                                      int nestedSubDocId,
-                                                                      LeafReaderContext subReaderContext,
-                                                                      Function<String, ObjectMapper> objectMapperLookup,
-                                                                      ObjectMapper nestedObjectMapper) throws IOException {
-        int currentParent = nestedSubDocId;
-        ObjectMapper nestedParentObjectMapper;
-        ObjectMapper current = nestedObjectMapper;
-        String originalName = nestedObjectMapper.name();
-        SearchHit.NestedIdentity nestedIdentity = null;
-        final IndexSettings indexSettings = context.getQueryShardContext().getIndexSettings();
-        do {
-            Query parentFilter;
-            nestedParentObjectMapper = current.getParentObjectMapper(objectMapperLookup);
-            if (nestedParentObjectMapper != null) {
-                if (nestedParentObjectMapper.nested().isNested() == false) {
-                    current = nestedParentObjectMapper;
-                    continue;
-                }
-                parentFilter = nestedParentObjectMapper.nestedTypeFilter();
-            } else {
-                parentFilter = Queries.newNonNestedFilter(context.indexShard().indexSettings().getIndexVersionCreated());
-            }
-
-            Query childFilter = nestedObjectMapper.nestedTypeFilter();
-            if (childFilter == null) {
-                current = nestedParentObjectMapper;
-                continue;
-            }
-            final Weight childWeight = context.searcher()
-                .createWeight(context.searcher().rewrite(childFilter), ScoreMode.COMPLETE_NO_SCORES, 1f);
-            Scorer childScorer = childWeight.scorer(subReaderContext);
-            if (childScorer == null) {
-                current = nestedParentObjectMapper;
-                continue;
-            }
-            DocIdSetIterator childIter = childScorer.iterator();
-
-            BitSet parentBits = context.bitsetFilterCache().getBitSetProducer(parentFilter).getBitSet(subReaderContext);
-
-            int offset = 0;
-            if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_6_5_0)) {
-                /**
-                 * Starts from the previous parent and finds the offset of the
-                 * <code>nestedSubDocID</code> within the nested children. Nested documents
-                 * are indexed in the same order than in the source array so the offset
-                 * of the nested child is the number of nested document with the same parent
-                 * that appear before him.
-                 */
-                int previousParent = parentBits.prevSetBit(currentParent);
-                for (int docId = childIter.advance(previousParent + 1); docId < nestedSubDocId && docId != DocIdSetIterator.NO_MORE_DOCS;
-                        docId = childIter.nextDoc()) {
-                    offset++;
-                }
-                currentParent = nestedSubDocId;
-            } else {
-                /**
-                 * Nested documents are in reverse order in this version so we start from the current nested document
-                 * and find the number of documents with the same parent that appear after it.
-                 */
-                int nextParent = parentBits.nextSetBit(currentParent);
-                for (int docId = childIter.advance(currentParent + 1); docId < nextParent && docId != DocIdSetIterator.NO_MORE_DOCS;
-                        docId = childIter.nextDoc()) {
-                    offset++;
-                }
-                currentParent = nextParent;
-            }
-            current = nestedObjectMapper = nestedParentObjectMapper;
-            int currentPrefix = current == null ? 0 : current.name().length() + 1;
-            nestedIdentity = new SearchHit.NestedIdentity(originalName.substring(currentPrefix), offset, nestedIdentity);
-            if (current != null) {
-                originalName = current.name();
-            }
-        } while (current != null);
-        return nestedIdentity;
     }
 
     private void loadStoredFields(Function<String, MappedFieldType> fieldTypeLookup,

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -27,10 +27,10 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
@@ -198,11 +198,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public IndexShard indexShard() {
         return in.indexShard();
-    }
-
-    @Override
-    public MapperService mapperService() {
-        return in.mapperService();
     }
 
     @Override
@@ -399,6 +394,11 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public FetchSearchResult fetchResult() {
         return in.fetchResult();
+    }
+
+    @Override
+    public NestedDocuments getNestedDocuments() {
+        return in.getNestedDocuments();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -30,10 +30,10 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.RescoreDocIds;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
@@ -210,8 +210,6 @@ public abstract class SearchContext implements Releasable {
 
     public abstract IndexShard indexShard();
 
-    public abstract MapperService mapperService();
-
     public abstract BigArrays bigArrays();
 
     public abstract BitsetFilterCache bitsetFilterCache();
@@ -315,6 +313,8 @@ public abstract class SearchContext implements Releasable {
     public abstract DfsSearchResult dfsResult();
 
     public abstract QuerySearchResult queryResult();
+
+    public abstract NestedDocuments getNestedDocuments();
 
     public abstract FetchPhase fetchPhase();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedDocumentsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedDocumentsTests.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.search.join.QueryBitSetProducer;
+import org.elasticsearch.search.LeafNestedDocuments;
+import org.elasticsearch.search.NestedDocuments;
+import org.elasticsearch.search.SearchHit;
+
+import java.io.IOException;
+
+public class NestedDocumentsTests extends MapperServiceTestCase {
+
+    public void testSimpleNestedHierarchy() throws IOException {
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("name").field("type", "keyword").endObject();
+            b.startObject("children");
+            {
+                b.field("type", "nested");
+                b.startObject("properties");
+                {
+                    b.startObject("name").field("type", "keyword").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("name", "top1");
+            b.startArray("children");
+            {
+                b.startObject().field("name", "child1").endObject();
+                b.startObject().field("name", "child2").endObject();
+                b.startObject().field("name", "child3").endObject();
+            }
+            b.endArray();
+        }));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(doc.docs()), reader -> {
+            NestedDocuments nested = new NestedDocuments(mapperService, QueryBitSetProducer::new);
+            LeafNestedDocuments leaf = nested.getLeafNestedDocuments(reader.leaves().get(0));
+
+            assertNotNull(leaf.advance(0));
+            assertEquals(0, leaf.doc());
+            assertEquals(3, leaf.rootDoc());
+            assertEquals(new SearchHit.NestedIdentity("children", 0, null), leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(1));
+            assertEquals(1, leaf.doc());
+            assertEquals(3, leaf.rootDoc());
+            assertEquals(new SearchHit.NestedIdentity("children", 1, null), leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(2));
+            assertEquals(2, leaf.doc());
+            assertEquals(3, leaf.rootDoc());
+            assertEquals(new SearchHit.NestedIdentity("children", 2, null), leaf.nestedIdentity());
+
+            assertNull(leaf.advance(3));
+            assertEquals(3, leaf.doc());
+            assertEquals(3, leaf.rootDoc());
+            assertNull(leaf.nestedIdentity());
+        });
+
+    }
+
+    public void testMultiLevelNestedHierarchy() throws IOException {
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("name").field("type", "keyword").endObject();
+            b.startObject("children");
+            {
+                b.field("type", "nested");
+                b.startObject("properties");
+                {
+                    b.startObject("name").field("type", "keyword").endObject();
+                    b.startObject("grandchildren");
+                    {
+                        b.field("type", "nested");
+                        b.startObject("properties");
+                        {
+                            b.startObject("name").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("name", "top1");
+            b.startArray("children");
+            {
+                b.startObject();
+                {
+                    b.field("name", "child1");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild1").endObject();
+                        b.startObject().field("name", "grandchild2").endObject();
+                        b.startObject().field("name", "grandchild3").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.field("name", "child2");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild21").endObject();
+                        b.startObject().field("name", "grandchild22").endObject();
+                        b.startObject().field("name", "grandchild23").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.field("name", "child3");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild31").endObject();
+                        b.startObject().field("name", "grandchild32").endObject();
+                        b.startObject().field("name", "grandchild33").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        }));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(doc.docs()), reader -> {
+            NestedDocuments nested = new NestedDocuments(mapperService, QueryBitSetProducer::new);
+            LeafNestedDocuments leaf = nested.getLeafNestedDocuments(reader.leaves().get(0));
+
+            assertNotNull(leaf.advance(0));
+            assertEquals(0, leaf.doc());
+            assertEquals(12, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children", 0, new SearchHit.NestedIdentity("grandchildren", 0, null)),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(2));
+            assertEquals(2, leaf.doc());
+            assertEquals(12, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children", 0, new SearchHit.NestedIdentity("grandchildren", 2, null)),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(3));
+            assertEquals(3, leaf.doc());
+            assertEquals(12, leaf.rootDoc());
+            assertEquals(new SearchHit.NestedIdentity("children", 0, null), leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(4));
+            assertEquals(4, leaf.doc());
+            assertEquals(12, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children", 1, new SearchHit.NestedIdentity("grandchildren", 0, null)),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(5));
+            assertEquals(5, leaf.doc());
+            assertEquals(12, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children", 1, new SearchHit.NestedIdentity("grandchildren", 1, null)),
+                leaf.nestedIdentity());
+
+            assertNull(leaf.advance(12));
+            assertNull(leaf.nestedIdentity());
+        });
+    }
+
+    public void testNestedObjectWithinNonNestedObject() throws IOException {
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("name").field("type", "keyword").endObject();
+            b.startObject("children");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("name").field("type", "keyword").endObject();
+                    b.startObject("grandchildren");
+                    {
+                        b.field("type", "nested");
+                        b.startObject("properties");
+                        {
+                            b.startObject("name").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("name", "top1");
+            b.startArray("children");
+            {
+                b.startObject();
+                {
+                    b.field("name", "child1");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild1").endObject();
+                        b.startObject().field("name", "grandchild2").endObject();
+                        b.startObject().field("name", "grandchild3").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.field("name", "child2");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild21").endObject();
+                        b.startObject().field("name", "grandchild22").endObject();
+                        b.startObject().field("name", "grandchild23").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.field("name", "child3");
+                    b.startArray("grandchildren");
+                    {
+                        b.startObject().field("name", "grandchild31").endObject();
+                        b.startObject().field("name", "grandchild32").endObject();
+                        b.startObject().field("name", "grandchild33").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        }));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(doc.docs()), reader -> {
+            NestedDocuments nested = new NestedDocuments(mapperService, QueryBitSetProducer::new);
+            LeafNestedDocuments leaf = nested.getLeafNestedDocuments(reader.leaves().get(0));
+
+            assertNotNull(leaf.advance(0));
+            assertEquals(0, leaf.doc());
+            assertEquals(9, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children.grandchildren", 0, null),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(2));
+            assertEquals(2, leaf.doc());
+            assertEquals(9, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children.grandchildren", 2, null),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(3));
+            assertEquals(3, leaf.doc());
+            assertEquals(9, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children.grandchildren", 3, null),
+                leaf.nestedIdentity());
+
+            assertNotNull(leaf.advance(5));
+            assertEquals(5, leaf.doc());
+            assertEquals(9, leaf.rootDoc());
+            assertEquals(
+                new SearchHit.NestedIdentity("children.grandchildren", 5, null),
+                leaf.nestedIdentity());
+
+            assertNull(leaf.advance(9));
+            assertNull(leaf.nestedIdentity());
+        });
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -333,6 +333,10 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
             b.endObject();
         }));
 
+        assertEquals("nested1", docMapper.getNestedParent("nested1.nested2"));
+        assertNull(docMapper.getNestedParent("nonexistent"));
+        assertNull(docMapper.getNestedParent("nested1"));
+
         assertThat(docMapper.hasNestedObjects(), equalTo(true));
         ObjectMapper nested1Mapper = docMapper.mappers().objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
@@ -613,8 +617,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        ObjectMapper objectMapper = mapperService.getObjectMapper("comments.messages");
-        assertTrue(objectMapper.parentObjectMapperAreNested(mapperService::getObjectMapper));
+        assertFalse(mapperService.documentMapper().hasNonNestedParent("comments.messages"));
 
         mapperService = createMapperService(mapping(b -> {
             b.startObject("comments");
@@ -628,8 +631,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        objectMapper = mapperService.getObjectMapper("comments.messages");
-        assertFalse(objectMapper.parentObjectMapperAreNested(mapperService::getObjectMapper));
+        assertTrue(mapperService.documentMapper().hasNonNestedParent("comments.messages"));
     }
 
     public void testLimitNestedDocsDefaultSettings() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -100,6 +100,7 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
@@ -291,6 +292,10 @@ public abstract class AggregatorTestCase extends ESTestCase {
             }
             return null;
         });
+
+        NestedDocuments nestedDocuments = new NestedDocuments(mapperService, searchContext.bitsetFilterCache()::getBitSetProducer);
+        when(searchContext.getNestedDocuments())
+            .thenReturn(nestedDocuments);
 
         Map<String, MappedFieldType> fieldNameToType = new HashMap<>();
         fieldNameToType.putAll(Arrays.stream(fieldTypes)

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -28,11 +28,11 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
@@ -278,11 +278,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public MapperService mapperService() {
-        return indexService == null ? null : indexService.mapperService();
-    }
-
-    @Override
     public BigArrays bigArrays() {
         return bigArrays;
     }
@@ -514,6 +509,11 @@ public class TestSearchContext extends SearchContext {
     @Override
     public FetchSearchResult fetchResult() {
         return null;
+    }
+
+    @Override
+    public NestedDocuments getNestedDocuments() {
+        return new NestedDocuments(indexService.mapperService(), bitsetFilterCache()::getBitSetProducer);
     }
 
     @Override


### PR DESCRIPTION
When handling nested documents in the Fetch phase, we currently find
a document's nested identity by loading ObjectMappers from a MapperService,
and iterating over their filters. This logic is difficult to follow, end requires
exposing internals of the mappers that we would rather hide away.

This commit refactors all NestedIdentity loading into a single NestedDocuments
object, with per-segment iterators to handle the individual documents. This way
of iterating over documents allows us to share parent filters, meaning that we
can avoid rebuilding the filter for every nested level of every visited document.