### PR TITLE
Add snapshots to important config list

### DIFF
--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -14,7 +14,7 @@ of items which *must* be considered before using your cluster in production:
 * <<gc-logging,GC logging settings>>
 * <<es-tmpdir,Temporary directory settings>>
 * <<error-file-path,JVM fatal error log setting>>
-* <<important-settings-snapshot,Snapshot configuration>>
+* <<important-settings-backups,Cluster backups>>
 
 Our {ess-trial}[{ecloud}] service configures these items automatically, making
 your cluster production-ready by default.

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -16,8 +16,8 @@ of items which *must* be considered before using your cluster in production:
 * <<error-file-path,JVM fatal error log setting>>
 * <<important-settings-snapshot,Snapshot configuration>>
 
-The {ess-trial}[Elastic Cloud] service automatically configures all of these
-items, preparing your cluster for production use by default.
+Our {ess-trial}[{ecloud}] service configures these items automatically, making
+your cluster production-ready by default.
 
 include::important-settings/path-settings.asciidoc[]
 

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -1,10 +1,8 @@
 [[important-settings]]
 == Important Elasticsearch configuration
 
-While Elasticsearch requires very little configuration, there are a number of
-settings which need to be considered before going into production.
-
-The following settings *must* be considered before going to production:
+{es} requires very little configuration to get started, but there are a number
+of items which *must* be considered before using your cluster in production:
 
 * <<path-settings,Path settings>>
 * <<cluster-name,Cluster name setting>>
@@ -16,6 +14,10 @@ The following settings *must* be considered before going to production:
 * <<gc-logging,GC logging settings>>
 * <<es-tmpdir,Temporary directory settings>>
 * <<error-file-path,JVM fatal error log setting>>
+* <<important-settings-snapshot,Snapshot configuration>>
+
+The {ess-trial}[Elastic Cloud] service automatically configures all of these
+items, preparing your cluster for production use by default.
 
 include::important-settings/path-settings.asciidoc[]
 
@@ -36,3 +38,5 @@ include::important-settings/gc-logging.asciidoc[]
 include::important-settings/es-tmpdir.asciidoc[]
 
 include::important-settings/error-file.asciidoc[]
+
+include::important-settings/snapshot.asciidoc[]

--- a/docs/reference/setup/important-settings/snapshot.asciidoc
+++ b/docs/reference/setup/important-settings/snapshot.asciidoc
@@ -1,12 +1,9 @@
-[[important-settings-snapshot]]
+[[important-settings-backups]]
 [discrete]
-=== Snapshot configuration
+=== Cluster backups
 
-<<snapshot-restore,Snapshots>> are the last line of defence against data loss
-in the event of a disaster. You must not move to production without configuring
-{es} to take snapshots regularly. The simplest way to do this is using
-<<snapshot-lifecycle-management,{slm}>>. For more information on recovering
-from snapshots see <<backup-cluster>>.
+In a disaster, <<snapshot-restore,snapshot backups>> can prevent permanent data
+loss. <<snapshot-lifecycle-management,{slm-cap}>> is the easiest way to take
+regular backups of your cluster. For more information, see <<backup-cluster>>.
 
 include::../../snapshot-restore/index.asciidoc[tag=backup-warning]
-

--- a/docs/reference/setup/important-settings/snapshot.asciidoc
+++ b/docs/reference/setup/important-settings/snapshot.asciidoc
@@ -1,0 +1,12 @@
+[[important-settings-snapshot]]
+[discrete]
+=== Snapshot configuration
+
+<<snapshot-restore,Snapshots>> are the last line of defence against data loss
+in the event of a disaster. You must not move to production without configuring
+{es} to take snapshots regularly. The simplest way to do this is using
+<<snapshot-lifecycle-management,{slm}>>. For more information on recovering
+from snapshots see <<backup-cluster>>.
+
+include::../snapshot-restore/index.asciidoc[tag=backup-warning]
+

--- a/docs/reference/setup/important-settings/snapshot.asciidoc
+++ b/docs/reference/setup/important-settings/snapshot.asciidoc
@@ -2,8 +2,8 @@
 [discrete]
 === Cluster backups
 
-In a disaster, <<snapshot-restore,snapshot backups>> can prevent permanent data
-loss. <<snapshot-lifecycle-management,{slm-cap}>> is the easiest way to take
-regular backups of your cluster. For more information, see <<backup-cluster>>.
+In a disaster, <<snapshot-restore,snapshots>> can prevent permanent data loss.
+<<snapshot-lifecycle-management,{slm-cap}>> is the easiest way to take regular
+backups of your cluster. For more information, see <<backup-cluster>>.
 
 include::../../snapshot-restore/index.asciidoc[tag=backup-warning]

--- a/docs/reference/setup/important-settings/snapshot.asciidoc
+++ b/docs/reference/setup/important-settings/snapshot.asciidoc
@@ -8,5 +8,5 @@ in the event of a disaster. You must not move to production without configuring
 <<snapshot-lifecycle-management,{slm}>>. For more information on recovering
 from snapshots see <<backup-cluster>>.
 
-include::../snapshot-restore/index.asciidoc[tag=backup-warning]
+include::../../snapshot-restore/index.asciidoc[tag=backup-warning]
 


### PR DESCRIPTION
The _Important Elasticsearch configuration_ docs lists a number of items
that you should consider before moving to production. Today this list
does not include configuring snapshots, even though they're very
important to have in production. This commit addresses that omission,
removes some repetition from the introductory paragraphs, and notes that
this config is handled for you on Cloud.