### PR TITLE
Fix Broken Error Handling in CacheFile#acquire

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -148,20 +148,14 @@ public class CacheFile {
             try {
                 synchronized (listeners) {
                     ensureOpen();
-                    final boolean added = listeners.add(listener);
-                    try {
-                        assert added : "listener already exists " + listener;
-                        if (listeners.size() == 1) {
-                            assert channelRef == null;
-                            channelRef = new FileChannelReference();
-                        }
-                        success = true;
-                    } finally {
-                        if (success == false && added) {
-                            listeners.remove(listener);
-                        }
+                    if (listeners.isEmpty()) {
+                        assert channelRef == null;
+                        channelRef = new FileChannelReference();
                     }
+                    final boolean added = listeners.add(listener);
+                    assert added : "listener already exists " + listener;
                 }
+                success = true;
             } finally {
                 if (success == false) {
                     decrementRefCount();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -149,13 +149,19 @@ public class CacheFile {
                 synchronized (listeners) {
                     ensureOpen();
                     final boolean added = listeners.add(listener);
-                    assert added : "listener already exists " + listener;
-                    if (listeners.size() == 1) {
-                        assert channelRef == null;
-                        channelRef = new FileChannelReference();
+                    try {
+                        assert added : "listener already exists " + listener;
+                        if (listeners.size() == 1) {
+                            assert channelRef == null;
+                            channelRef = new FileChannelReference();
+                        }
+                        success = true;
+                    } finally {
+                        if (success == false && added) {
+                            listeners.remove(listener);
+                        }
                     }
                 }
-                success = true;
             } finally {
                 if (success == false) {
                     decrementRefCount();


### PR DESCRIPTION
If we fail to create the `FileChannelReference` (e.g. because the directory it should be created in
was deleted in a test) we have to remove the listener from the `listeners` set to not trip internal
consistency assertions.

Relates #65302 (does not fix it though, but reduces noise from failures by removing secondary
tripped assertions after the test fails)

