### PR TITLE
Fix Broken Error Handling in CacheFile#acquire (#65342)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -138,12 +138,12 @@ public class CacheFile {
             try {
                 synchronized (listeners) {
                     ensureOpen();
-                    final boolean added = listeners.add(listener);
-                    assert added : "listener already exists " + listener;
-                    if (listeners.size() == 1) {
+                    if (listeners.isEmpty()) {
                         assert channelRef == null;
                         channelRef = new FileChannelReference();
                     }
+                    final boolean added = listeners.add(listener);
+                    assert added : "listener already exists " + listener;
                 }
                 success = true;
             } finally {


### PR DESCRIPTION
If we fail to create the `FileChannelReference` (e.g. because the directory it should be created in
was deleted in a test) we have to remove the listener from the `listeners` set to not trip internal
consistency assertions.

Relates #65302 (does not fix it though, but reduces noise from failures by removing secondary
tripped assertions after the test fails)

backport of #65342 