### PR TITLE
[DOCS] Correct the url in delete-component-template doc

### DIFF
--- a/docs/reference/indices/delete-component-template.asciidoc
+++ b/docs/reference/indices/delete-component-template.asciidoc
@@ -30,7 +30,7 @@ DELETE _component_template/template_1
 [[delete-component-template-api-request]]
 ==== {api-request-title}
 
-`DELETE /_template/<component-template>`
+`DELETE /_component_template/<component-template>`
 
 
 [[delete-component-template-api-desc]]


### PR DESCRIPTION
The Delete Component Template API's URL in the [doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-component-template.html#delete-component-template-api-query-params) is not correct.