### PR TITLE
Correctly serialize search-as-you-type analyzer

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -549,6 +549,8 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
     private final PrefixFieldMapper prefixField;
     private final ShingleFieldMapper[] shingleFields;
 
+    private final Builder builder;
+
     public SearchAsYouTypeFieldMapper(String simpleName,
                                       SearchAsYouTypeFieldType mappedFieldType,
                                       CopyTo copyTo,
@@ -563,6 +565,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
         this.store = builder.store.getValue();
         this.indexOptions = builder.indexOptions.getValue();
         this.termVectors = builder.termVectors.getValue();
+        this.builder = builder;
     }
 
     @Override
@@ -589,7 +592,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), () -> fieldType().indexAnalyzer()).init(this);
+        return new Builder(simpleName(), builder.analyzers.indexAnalyzer::getDefaultValue).init(this);
     }
 
     public static String getShingleFieldName(String parentField, int shingleSize) {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.spans.FieldMaskingSpanQuery;
 import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.IndexSettings;
@@ -552,6 +553,20 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
                 asList("quick brown fox", "brown fox jump", "fox jump lazy", "jump lazy dog")),
             buildBoolPrefixQuery("field._4gram", "field._index_prefix",
                 asList("quick brown fox jump", "brown fox jump lazy", "fox jump lazy dog"))));
+    }
+
+    public void testAnalyzerSerialization() throws IOException {
+        MapperService ms = createMapperService(fieldMapping(b -> {
+            b.field("type", "search_as_you_type");
+            b.field("analyzer", "simple");
+        }));
+        String serialized = Strings.toString(ms.documentMapper());
+        assertEquals(serialized,
+            "{\"_doc\":{\"properties\":{\"field\":" +
+                "{\"type\":\"search_as_you_type\",\"doc_values\":false,\"max_shingle_size\":3,\"analyzer\":\"simple\"}}}}");
+
+        merge(ms, mapping(b -> {}));
+        assertEquals(serialized, Strings.toString(ms.documentMapper()));
     }
 
     private void documentParsingTestCase(Collection<String> values) throws IOException {


### PR DESCRIPTION
The search-as-you-type mapper was using an incorrect default analyzer when
creating its merge builder, which meant that a configured analyzer would not
be included in serialization.  This in turn resulted in the master node
getting an incorrect configuration, and search-as-you-type fields always
using a standard analyzer.

This has already been fixed via subsequent refactorings in 7.11 and master,
so this fix is for 7.10 only.

Resolves #65319 