### PR TITLE
Enhance byte-size setting validation

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
@@ -74,7 +74,7 @@ public class BytesProcessorTests extends AbstractStringProcessorTestCase<Long> {
         Processor processor = newProcessor(fieldName, randomBoolean(), fieldName);
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> processor.execute(ingestDocument));
         assertThat(exception.getMessage(),
-            CoreMatchers.equalTo("failed to parse [junk]"));
+            CoreMatchers.equalTo("failed to parse setting [Ingest Field] with value [junk]"));
     }
 
     public void testMissingUnits() {

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -264,7 +264,7 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
                          initialInput, settingName);
                     return new ByteSizeValue((long) (doubleValue * unit.toBytes(1)));
                 } catch (final NumberFormatException ignored) {
-                    throw new ElasticsearchParseException("failed to parse [{}]", e, initialInput);
+                    throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}]", e, settingName, initialInput);
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -148,7 +148,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     public void testFailOnEmptyNumberParsing() {
         Exception e = expectThrows(ElasticsearchParseException.class,
                 () -> assertThat(ByteSizeValue.parseBytesSizeValue("g", "emptyNumberParsing").toString(), is("23b")));
-        assertThat(e.getMessage(), containsString("failed to parse [g]"));
+        assertThat(e.getMessage(), containsString("failed to parse setting [emptyNumberParsing] with value [g]"));
     }
 
     public void testNoDotsAllowed() {
@@ -302,7 +302,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
                 exception.getMessage());
 
         exception = expectThrows(ElasticsearchParseException.class, () -> ByteSizeValue.parseBytesSizeValue("notANumberMB", "test"));
-        assertEquals("failed to parse [notANumberMB]", exception.getMessage());
+        assertEquals("failed to parse setting [test] with value [notANumberMB]", exception.getMessage());
     }
 
     public void testParseFractionalNumber() throws IOException {


### PR DESCRIPTION
When a byte-size setting validation fails, the name of the setting is
now included in the message.

Relates #64428
