### PR TITLE
Better handling of item errors in _mtermvectors API (#65324)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -55,3 +55,59 @@ setup:
 
   - match: {docs.0.term_vectors.text.terms.brown.term_freq: 2}
   - match: {docs.0.term_vectors.text.terms.brown.ttf: 2}
+
+---
+"Tests index not found error in item":
+
+  - do:
+        mtermvectors:
+          "term_statistics" : true
+          "body" :
+            "docs":
+              -
+                 "_id" : "testing_document"
+                 "_index" : "testidx"
+              -
+                 "_id" : "testing_document"
+                 "_index" : "wrong_idx"
+
+  - match: {docs.0.term_vectors.text.terms.brown.term_freq: 2}
+  - match: {docs.0.term_vectors.text.terms.brown.ttf: 2}
+  - match: {docs.1.error.type: "index_not_found_exception"}
+  - match: {docs.1.error.reason: "no such index [wrong_idx]"}
+
+---
+"Tests catching other exceptions per item":
+
+  - do:
+      indices.create:
+          index: testidx2
+
+  - do:
+      indices.put_alias:
+        index: testidx
+        name: test_alias
+
+  - do:
+      indices.put_alias:
+        index: testidx2
+        name: test_alias
+
+  - do:
+        mtermvectors:
+          "term_statistics" : true
+          "body" :
+            "docs":
+              -
+                 "_id" : "testing_document"
+                 "_index" : "testidx"
+              -
+                 "_id" : "testing_document"
+                 "_index" : "test_alias"
+
+  - match: {docs.0.term_vectors.text.terms.brown.term_freq: 2}
+  - match: {docs.0.term_vectors.text.terms.brown.ttf: 2}
+  - match: {docs.1.error.type: "illegal_argument_exception"}
+  - match: {docs.1.error.reason: "/Alias.\\[test_alias\\].has.more.than.one.index.associated.with.it.\\[\\[testidx2?,.testidx2?\\]\\].*/"}
+
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -59,6 +59,9 @@ setup:
 ---
 "Tests index not found error in item":
 
+  - skip:
+      version: " - 7.10.99"
+      reason: bug fixed in 7.11
   - do:
         mtermvectors:
           "term_statistics" : true
@@ -79,6 +82,9 @@ setup:
 ---
 "Tests catching other exceptions per item":
 
+  - skip:
+      version: " - 7.10.99"
+      reason: bug fixed in 7.11
   - do:
       indices.create:
           index: testidx2

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -78,8 +78,18 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
                     continue;
                 }
             } catch (Exception e) {
-                responses.set(i, new MultiTermVectorsItemResponse(null,
-                    new MultiTermVectorsResponse.Failure(termVectorsRequest.index(), termVectorsRequest.type(), termVectorsRequest.id(), e)));
+                responses.set(
+                    i,
+                    new MultiTermVectorsItemResponse(
+                        null,
+                        new MultiTermVectorsResponse.Failure(
+                            termVectorsRequest.index(),
+                            termVectorsRequest.type(),
+                            termVectorsRequest.id(),
+                            e
+                        )
+                    )
+                );
                 continue;
             }
 

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -65,22 +64,25 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
         Map<ShardId, MultiTermVectorsShardRequest> shardRequests = new HashMap<>();
         for (int i = 0; i < request.requests.size(); i++) {
             TermVectorsRequest termVectorsRequest = request.requests.get(i);
-            termVectorsRequest.routing(clusterState.metadata().resolveIndexRouting(termVectorsRequest.routing(),
-                termVectorsRequest.index()));
-            if (!clusterState.metadata().hasConcreteIndex(termVectorsRequest.index())) {
+
+            String concreteSingleIndex;
+            try {
+                termVectorsRequest.routing(clusterState.metadata().resolveIndexRouting(termVectorsRequest.routing(),
+                    termVectorsRequest.index()));
+                concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, termVectorsRequest).getName();
+                if (termVectorsRequest.routing() == null &&
+                    clusterState.getMetadata().routingRequired(concreteSingleIndex)) {
+                    responses.set(i, new MultiTermVectorsItemResponse(null,
+                            new MultiTermVectorsResponse.Failure(concreteSingleIndex, termVectorsRequest.type(), termVectorsRequest.id(),
+                                    new RoutingMissingException(concreteSingleIndex, termVectorsRequest.type(), termVectorsRequest.id()))));
+                    continue;
+                }
+            } catch (Exception e) {
                 responses.set(i, new MultiTermVectorsItemResponse(null,
-                    new MultiTermVectorsResponse.Failure(termVectorsRequest.index(), termVectorsRequest.type(), termVectorsRequest.id(),
-                        new IndexNotFoundException(termVectorsRequest.index()))));
+                    new MultiTermVectorsResponse.Failure(termVectorsRequest.index(), termVectorsRequest.type(), termVectorsRequest.id(), e)));
                 continue;
             }
-            String concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, termVectorsRequest).getName();
-            if (termVectorsRequest.routing() == null &&
-                clusterState.getMetadata().routingRequired(concreteSingleIndex)) {
-                responses.set(i, new MultiTermVectorsItemResponse(null,
-                    new MultiTermVectorsResponse.Failure(concreteSingleIndex, termVectorsRequest.type(), termVectorsRequest.id(),
-                        new RoutingMissingException(concreteSingleIndex, termVectorsRequest.type(), termVectorsRequest.id()))));
-                continue;
-            }
+
             ShardId shardId = clusterService.operationRouting().shardId(clusterState, concreteSingleIndex,
                     termVectorsRequest.id(), termVectorsRequest.routing());
             MultiTermVectorsShardRequest shardRequest = shardRequests.get(shardId);


### PR DESCRIPTION
Currently an error in a `_mtermvectors`, for example because querying through an
alias that has several indices assigned to it, fails the whole request. Instead
we should only fail the problematic item in the multi item request, like we e.g.
do in same situations in _mget.

Backport of #65324 