### PR TITLE
Fix CcrRepositoryIT.testIndividualActionsTimeout()

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -438,7 +438,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         final String leaderIndex = index.getName();
         final IndicesStatsResponse response = getRemoteClusterClient().admin().indices().prepareStats(leaderIndex)
             .clear().setStore(true)
-            .get(ccrSettings.getRecoveryActionTimeout());
+            .get(ccrSettings.getShardSizeFetchingTimeout());
         for (ShardStats shardStats : response.getIndex(leaderIndex).getShards()) {
             final ShardRouting shardRouting = shardStats.getShardRouting();
             if (shardRouting.shardId().id() == shardId.getId()

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrSettingsTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrSettingsTests.java
@@ -8,8 +8,11 @@ package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class CcrSettingsTests extends ESTestCase {
 
@@ -18,7 +21,8 @@ public class CcrSettingsTests extends ESTestCase {
         final CcrSettings ccrSettings = new CcrSettings(settings,
             new ClusterSettings(settings, Sets.newHashSet(CcrSettings.RECOVERY_CHUNK_SIZE,
                 CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND, CcrSettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING,
-                CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING)));
+                CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING,
+                CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING)));
         assertEquals(CcrSettings.RECOVERY_CHUNK_SIZE.get(settings), ccrSettings.getChunkSize());
         assertEquals(CcrSettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings).intValue(),
             ccrSettings.getMaxConcurrentFileChunks());
@@ -26,7 +30,35 @@ public class CcrSettingsTests extends ESTestCase {
             ccrSettings.getRecoveryActivityTimeout());
         assertEquals(CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.get(settings),
             ccrSettings.getRecoveryActionTimeout());
+        assertEquals(CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING.get(settings),
+            ccrSettings.getShardSizeFetchingTimeout());
         assertEquals(CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND.get(settings).getMbFrac(),
             ccrSettings.getRateLimiter().getMBPerSec(), 0.0d);
+    }
+
+    public void testShardSizeFetchingTimeoutSetting() {
+        final Settings.Builder builder = Settings.builder();
+        final String recoveryActionTimeout = randomPositiveTimeValue();
+        builder.put(CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.getKey(), recoveryActionTimeout);
+        final String shardSizeFetchingTimeout;
+        if (randomBoolean()) {
+            shardSizeFetchingTimeout = randomPositiveTimeValue();
+            builder.put(CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING.getKey(), shardSizeFetchingTimeout);
+        } else {
+            shardSizeFetchingTimeout = recoveryActionTimeout;
+            if (randomBoolean()) {
+                builder.put(CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING.getKey(), shardSizeFetchingTimeout);
+            }
+        }
+        final Settings settings = builder.build();
+        final CcrSettings ccrSettings = new CcrSettings(settings,
+            new ClusterSettings(settings, Sets.newHashSet(CcrSettings.RECOVERY_CHUNK_SIZE,
+                CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND, CcrSettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING,
+                CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING, CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING,
+                CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING)));
+        assertThat(CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.get(settings), equalTo(ccrSettings.getRecoveryActionTimeout()));
+        assertThat(ccrSettings.getRecoveryActionTimeout(), equalTo(TimeValue.parseTimeValue(recoveryActionTimeout, getTestName())));
+        assertThat(CcrSettings.SHARD_SIZE_FETCHING_TIMEOUT_SETTING.get(settings), equalTo(ccrSettings.getShardSizeFetchingTimeout()));
+        assertThat(ccrSettings.getShardSizeFetchingTimeout(), equalTo(TimeValue.parseTimeValue(shardSizeFetchingTimeout, getTestName())));
     }
 }


### PR DESCRIPTION
The test `CcrRepositoryIT.testIndividualActionsTimeout()` started to exceed suite timeout (see issue #64372) after the change #61906 has been merged. In this last change we introduced an additional step to the allocation process that tries to fetch the size of the future shard to restore before assigning that shard. For CCR it means fetching the size of the store of the shard to follow, which translates to an indices stats request to the leader cluster. Like other CCR recovery actions this request uses the timeout defined by the `ccr.indices.recovery.internal_action_timeout` setting. 

But the test `CcrRepositoryIT.testIndividualActionsTimeout()` sets a low value for this setting and then tries to restore a shard, expecting that the CCR restore will fail with a timeout exception at some point.

With the change added in #61906 the indices stats request executed to fetch the shard size before allocation can now also times out, leaving the shard unassigned. When implementing #61906 we decided to not explicitly trigger reroute if such a situation occurs as we feared to trigger too many of those and add load to the cluster, expecting that such situations may resolve by themselves on real clusters (that are likely to receive more cluster state updates, or manual reroute)

Because `testIndividualActionsTimeout()` does not trigger any additional cluster updates the shard is left unassigned for too long and the whole suite times out. 

This pull request introduces a different setting to configure the timeout for fetching the shard size (which default to `ccr.indices.recovery.internal_action_timeout`). 

Another solution to force the shard to be assigned in this test would be to trigger reroute in the background, but with the same low timeout used for fetching and restoring that would mean a thread trying to assign the shard while most operations are expecting to time out.

@dnhatn @henningandersen I'm not a big fan of this workaround but I still find this ok. I'd appreciate any opinion (or ideas).