### PR TITLE
[ML] Adjusting soft_limit description

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1030,7 +1030,8 @@ values:
 --
 * `ok`: The models stayed below the configured value.
 * `soft_limit`: The models used more than 60% of the configured memory limit
-and older unused models will be pruned to free up space.
+and older unused models will be pruned to free up space. Additionally, in
+categorization jobs no further category examples will be stored.
 * `hard_limit`: The models used more space than the configured memory limit.
 As a result, not all incoming data was processed.
 --


### PR DESCRIPTION
This PR adds detail to the explanation of the soft_limit
memory_status in ML job stats. A consequence that was not
mentioned before is that examples are not added to category
definitions.

Relates elastic/ml-cpp#1590