### PR TITLE
Fix cacheability of custom LongValuesSource in TermsSetQueryBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
@@ -346,10 +346,12 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
     // doc values, because that is what is being used in NumberFieldMapper.
     static class FieldValuesSource extends LongValuesSource {
 
-        private final IndexNumericFieldData field;
+        private final String fieldName;
+        private final IndexNumericFieldData fieldData;
 
-        FieldValuesSource(IndexNumericFieldData field) {
-            this.field = field;
+        FieldValuesSource(IndexNumericFieldData fieldData) {
+            this.fieldData = fieldData;
+            this.fieldName = fieldData.getFieldName();
         }
 
         @Override
@@ -357,22 +359,22 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             FieldValuesSource that = (FieldValuesSource) o;
-            return Objects.equals(field, that.field);
+            return Objects.equals(fieldName, that.fieldName);
         }
 
         @Override
         public String toString() {
-            return "long(" + field + ")";
+            return "long(" + fieldName + ")";
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(field);
+            return Objects.hash(fieldName);
         }
 
         @Override
         public LongValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
-            SortedNumericDocValues values = field.load(ctx).getLongValues();
+            SortedNumericDocValues values = fieldData.load(ctx).getLongValues();
             return new LongValues() {
 
                 long current = -1;

--- a/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
@@ -148,10 +148,6 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         assertFalse("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
-    @Override
-    protected boolean builderGeneratesCacheableQueries() {
-        return false;
-    }
 
     @Override
     public TermsSetQueryBuilder mutateInstance(final TermsSetQueryBuilder instance) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -48,6 +48,11 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     }
 
     @Override
+    protected boolean builderGeneratesCacheableQueries() {
+        return false;
+    }
+
+    @Override
     protected WrapperQueryBuilder doCreateTestQueryBuilder() {
         QueryBuilder wrappedQuery = RandomQueryBuilder.createQuery(random());
         BytesReference bytes;

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -450,8 +450,10 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             assertLuceneQuery(secondQuery, secondLuceneQuery, context);
 
             if (builderGeneratesCacheableQueries()) {
+                assertEquals("two equivalent query builders lead to different lucene queries hashcode",
+                    secondLuceneQuery.hashCode(), firstLuceneQuery.hashCode());
                 assertEquals("two equivalent query builders lead to different lucene queries",
-                        rewrite(secondLuceneQuery), rewrite(firstLuceneQuery));
+                    rewrite(secondLuceneQuery), rewrite(firstLuceneQuery));
             }
 
             if (supportsBoost() && firstLuceneQuery instanceof MatchNoDocsQuery == false) {


### PR DESCRIPTION
Backport of #65367