### PR TITLE
Remove skip from deactivated integration test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -76,9 +76,6 @@ setup:
 
 ---
 "Tests catching other exceptions per item":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/65385"
 
   - do:
       indices.create:


### PR DESCRIPTION
The failing mixed cluster test in #65385 was missing backport of a bug fix to 7.11.
With https://github.com/elastic/elasticsearch/pull/65369 in now it should pass. 
Opening this issue just to have a full CI run before merging.

Closes #65385 