### PR TITLE
Ml Autoscaling Named Writables fix

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1098,6 +1098,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     }
 
     @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return MlAutoscalingNamedWritableProvider.getNamedWriteables();
+    }
+
+    @Override
     public List<NamedXContentRegistry.Entry> getNamedXContent() {
         List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
         namedXContent.addAll(new MlEvaluationNamedXContentProvider().getNamedXContentParsers());


### PR DESCRIPTION
Named writeables were not registered.

This looks like it was a backport failure when backporting #59309 in #65151, since this is the first named writable registered by the ml module in 7.x.