### PR TITLE
[backport] Adds a new Rollup Action (#64900)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -146,7 +146,7 @@ public class ClusterModule extends AbstractModule {
             ComposableIndexTemplateMetadata::readDiffFrom);
         registerMetadataCustom(entries, DataStreamMetadata.TYPE, DataStreamMetadata::new, DataStreamMetadata::readDiffFrom);
 
-        if (RollupV2.ROLLUPV2_FEATURE_FLAG_REGISTERED != null && RollupV2.ROLLUPV2_FEATURE_FLAG_REGISTERED) {
+        if (RollupV2.isEnabled()) {
             registerMetadataCustom(entries, RollupMetadata.TYPE, RollupMetadata::new, RollupMetadata::readDiffFrom);
         }
         // Task Status (not Diffable)
@@ -202,7 +202,7 @@ public class ClusterModule extends AbstractModule {
             ComposableIndexTemplateMetadata::fromXContent));
         entries.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(DataStreamMetadata.TYPE),
             DataStreamMetadata::fromXContent));
-        if (RollupV2.ROLLUPV2_FEATURE_FLAG_REGISTERED != null && RollupV2.ROLLUPV2_FEATURE_FLAG_REGISTERED) {
+        if (RollupV2.isEnabled()) {
             entries.add(new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(RollupMetadata.TYPE),
                 RollupMetadata::fromXContent));
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RollupGroup.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RollupGroup.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,12 @@ public class RollupGroup extends AbstractDiffable<RollupGroup> implements ToXCon
         this.group = group;
         this.dateInterval = dateInterval;
         this.dateTimezone = dateTimezone;
+    }
+
+    public RollupGroup() {
+        this.group = new ArrayList<>();
+        this.dateInterval = new HashMap<>();
+        this.dateTimezone = new HashMap<>();
     }
 
     public RollupGroup(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/rollup/RollupV2.java
+++ b/server/src/main/java/org/elasticsearch/rollup/RollupV2.java
@@ -19,26 +19,10 @@
 
 package org.elasticsearch.rollup;
 
-import org.elasticsearch.Build;
-
 public class RollupV2 {
-    public static final Boolean ROLLUPV2_FEATURE_FLAG_REGISTERED;
+    public static final boolean ROLLUP_V2_FEATURE_FLAG_ENABLED = "true".equals(System.getProperty("es.rollup_v2_feature_flag_enabled"));
 
-    static {
-        final String property = System.getProperty("es.rollupv2_feature_flag_registered");
-        if (Build.CURRENT.isSnapshot() && property != null) {
-            throw new IllegalArgumentException("es.rollupv2_feature_flag_registered is only supported in non-snapshot builds");
-        }
-        if ("true".equals(property)) {
-            ROLLUPV2_FEATURE_FLAG_REGISTERED = true;
-        } else if ("false".equals(property)) {
-            ROLLUPV2_FEATURE_FLAG_REGISTERED = false;
-        } else if (property == null) {
-            ROLLUPV2_FEATURE_FLAG_REGISTERED = null;
-        } else {
-            throw new IllegalArgumentException(
-                "expected es.rollupv2_feature_flag_registered to be unset or [true|false] but was [" + property + "]"
-            );
-        }
+    public static boolean isEnabled() {
+        return ROLLUP_V2_FEATURE_FLAG_ENABLED;
     }
 }

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -185,6 +185,10 @@ public class Task {
         return headers.get(header);
     }
 
+    public Map<String, String> headers() {
+        return headers;
+    }
+
     public TaskResult result(DiscoveryNode node, Exception error) throws IOException {
         return new TaskResult(taskInfo(node.getId(), true), error);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -34,6 +34,7 @@ import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rollup.RollupV2;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.SharedGroupFactory;
@@ -193,6 +194,7 @@ import org.elasticsearch.xpack.core.rollup.action.GetRollupCapsAction;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction;
 import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupAction;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
@@ -337,7 +339,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
 
     @Override
     public List<ActionType<? extends ActionResponse>> getClientActions() {
-        return Arrays.asList(
+        List<ActionType<? extends ActionResponse>> actions = new ArrayList(Arrays.asList(
                 // deprecation
                 DeprecationInfoAction.INSTANCE,
                 // graph
@@ -495,7 +497,14 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 // Point in time
                 OpenPointInTimeAction.INSTANCE,
                 ClosePointInTimeAction.INSTANCE
-        );
+        ));
+
+        // rollupV2
+        if (RollupV2.isEnabled()) {
+            actions.add(RollupAction.INSTANCE);
+        }
+
+        return actions;
     }
 
     @Override
@@ -701,7 +710,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                         RollupJobStatus::fromXContent),
                 new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(RollupJobStatus.NAME),
                         RollupJobStatus::fromXContent),
-                // Transforms
+            // Transforms
                 new NamedXContentRegistry.Entry(PersistentTaskParams.class, new ParseField(TransformField.TASK_NAME),
                         TransformTaskParams::fromXContent),
                 new NamedXContentRegistry.Entry(Task.Status.class, new ParseField(TransformField.TASK_NAME),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
@@ -50,8 +50,8 @@ public class MetricConfig implements Writeable, ToXContentObject {
     public static final ParseField SUM = new ParseField("sum");
     public static final ParseField AVG = new ParseField("avg");
     public static final ParseField VALUE_COUNT = new ParseField("value_count");
+    public static final String NAME = "metrics";
 
-    static final String NAME = "metrics";
     private static final String FIELD = "field";
     private static final String METRICS = "metrics";
     private static final ConstructingObjectParser<MetricConfig, Void> PARSER;
@@ -84,7 +84,7 @@ public class MetricConfig implements Writeable, ToXContentObject {
         this.metrics = metrics;
     }
 
-    MetricConfig(final StreamInput in) throws IOException {
+    public MetricConfig(final StreamInput in) throws IOException {
         field = in.readString();
         metrics = in.readStringList();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class RollupAction extends ActionType<RollupAction.Response> {
+
+    public static final RollupAction INSTANCE = new RollupAction();
+    public static final String NAME = "cluster:admin/xpack/rollupV2";
+
+    private RollupAction() {
+        super(NAME, RollupAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+        private RollupV2Config rollupConfig;
+
+        public Request(RollupV2Config rollupConfig) {
+            this.rollupConfig = rollupConfig;
+        }
+
+        public Request() {}
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            rollupConfig = new RollupV2Config(in);
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new RollupTask(id, type, action, parentTaskId, rollupConfig, headers);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            rollupConfig.writeTo(out);
+        }
+
+        public RollupV2Config getRollupConfig() {
+            return rollupConfig;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            rollupConfig.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rollupConfig);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(rollupConfig, other.rollupConfig);
+        }
+    }
+
+    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
+
+        protected RequestBuilder(ElasticsearchClient client, RollupAction action) {
+            super(client, action, new Request());
+        }
+    }
+
+    public static class Response extends ActionResponse implements Writeable, ToXContentObject {
+
+        private final boolean created;
+
+        public Response(boolean created) {
+            this.created = created;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            created = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(created);
+        }
+
+        public boolean isCreated() {
+            return created;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("created", created);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return created == response.created;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(created);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupTask.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.RollupJobStatus;
+
+import java.util.Map;
+
+/**
+ * This class contains the high-level logic that drives the rollup job. The allocated task contains transient state
+ * which drives the indexing, and periodically updates it's parent PersistentTask with the indexing's current position.
+ */
+public class RollupTask extends CancellableTask {
+    private static final Logger logger = LogManager.getLogger(RollupTask.class.getName());
+
+    private RollupV2Config config;
+    private RollupJobStatus status;
+
+    RollupTask(long id, String type, String action, TaskId parentTask, RollupV2Config config, Map<String, String> headers) {
+        super(id, type, action, RollupField.NAME + "_" + config.getRollupIndex(), parentTask, headers);
+        this.config = config;
+    }
+
+    public RollupV2Config config() {
+        return config;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public boolean shouldCancelChildrenOnCancellation() {
+        return true;
+    }
+
+    @Override
+    public void onCancelled() {
+        // TODO(talevy): make things cancellable
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2Config.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * This class holds the configuration details of a rollup V2 job, such as the groupings, metrics, what
+ * index to rollup and where to roll them to.
+ */
+public class RollupV2Config implements NamedWriteable, ToXContentObject {
+
+    private static final String NAME = "xpack/rollupv2/config";
+    private static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(20);
+    private static final String TIMEOUT = "timeout";
+    private static final String ROLLUP_INDEX = "rollup_index";
+
+    private final GroupConfig groupConfig;
+    private final List<MetricConfig> metricsConfig;
+    private final TimeValue timeout;
+    private String rollupIndex;
+    private String sourceIndex;
+
+    private static final ConstructingObjectParser<RollupV2Config, String> PARSER;
+    static {
+        PARSER = new ConstructingObjectParser<>(NAME, false, (args, sourceIndex) -> {
+            String rollupIndex = (String) args[0];
+            GroupConfig groupConfig = (GroupConfig) args[1];
+            @SuppressWarnings("unchecked")
+            List<MetricConfig> metricsConfig = (List<MetricConfig>) args[2];
+            TimeValue timeout = (TimeValue) args[3];
+            return new RollupV2Config(sourceIndex, groupConfig, metricsConfig, timeout, rollupIndex);
+        });
+        PARSER.declareString(constructorArg(), new ParseField(ROLLUP_INDEX));
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> GroupConfig.fromXContent(p), new ParseField(GroupConfig.NAME));
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> MetricConfig.fromXContent(p), new ParseField(MetricConfig.NAME));
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> TimeValue.parseTimeValue(p.textOrNull(), TIMEOUT),
+            new ParseField(TIMEOUT), ObjectParser.ValueType.STRING_OR_NULL);
+    }
+
+    public RollupV2Config(String sourceIndex, final GroupConfig groupConfig, final List<MetricConfig> metricsConfig,
+                          final @Nullable TimeValue timeout, final String rollupIndex) {
+        if (sourceIndex == null || sourceIndex.isEmpty()) {
+            throw new IllegalArgumentException("The source index must be a non-null, non-empty string");
+        }
+        if (rollupIndex == null || rollupIndex.isEmpty()) {
+            throw new IllegalArgumentException("Rollup index must be a non-null, non-empty string");
+        }
+        if (groupConfig == null && (metricsConfig == null || metricsConfig.isEmpty())) {
+            throw new IllegalArgumentException("At least one grouping or metric must be configured");
+        }
+        this.sourceIndex = sourceIndex;
+        this.rollupIndex = rollupIndex;
+        this.groupConfig = groupConfig;
+        this.metricsConfig = metricsConfig != null ? metricsConfig : Collections.emptyList();
+        this.timeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
+    }
+
+    public RollupV2Config(final StreamInput in) throws IOException {
+        this.sourceIndex = in.readString();
+        rollupIndex = in.readString();
+        groupConfig = in.readOptionalWriteable(GroupConfig::new);
+        metricsConfig = in.readList(MetricConfig::new);
+        timeout = in.readTimeValue();
+    }
+
+    public String getId() {
+        return RollupField.NAME + "_" + sourceIndex + "_" + rollupIndex;
+    }
+
+    public String getSourceIndex() {
+        return sourceIndex;
+    }
+
+    public void setSourceIndex(String sourceIndex) {
+        this.sourceIndex = sourceIndex;
+    }
+
+    public void setRollupIndex(String rollupIndex) {
+        this.rollupIndex = rollupIndex;
+    }
+
+    public GroupConfig getGroupConfig() {
+        return groupConfig;
+    }
+
+    public List<MetricConfig> getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    public String getRollupIndex() {
+        return rollupIndex;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public Set<String> getAllFields() {
+        final Set<String> fields = new HashSet<>();
+        if (groupConfig != null) {
+            fields.addAll(groupConfig.getAllFields());
+        }
+        if (metricsConfig != null) {
+            for (MetricConfig metric : metricsConfig) {
+                fields.add(metric.getField());
+            }
+        }
+        return Collections.unmodifiableSet(fields);
+    }
+
+    public void validateMappings(final Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,
+                                 final ActionRequestValidationException validationException) {
+        groupConfig.validateMappings(fieldCapsResponse, validationException);
+        for (MetricConfig m : metricsConfig) {
+            m.validateMappings(fieldCapsResponse, validationException);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(ROLLUP_INDEX, rollupIndex);
+            if (groupConfig != null) {
+                builder.field(GroupConfig.NAME, groupConfig);
+            }
+            if (metricsConfig != null) {
+                builder.startArray(MetricConfig.NAME);
+                for (MetricConfig metric : metricsConfig) {
+                    metric.toXContent(builder, params);
+                }
+                builder.endArray();
+            }
+            if (timeout != null) {
+                builder.field(TIMEOUT, timeout.getStringRep());
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeString(sourceIndex);
+        out.writeString(rollupIndex);
+        out.writeOptionalWriteable(groupConfig);
+        out.writeList(metricsConfig);
+        out.writeTimeValue(timeout);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        final RollupV2Config that = (RollupV2Config) other;
+        return Objects.equals(this.sourceIndex, that.sourceIndex)
+                && Objects.equals(this.rollupIndex, that.rollupIndex)
+                && Objects.equals(this.groupConfig, that.groupConfig)
+                && Objects.equals(this.metricsConfig, that.metricsConfig)
+                && Objects.equals(this.timeout, that.timeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceIndex, rollupIndex, groupConfig, metricsConfig, timeout);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
+    }
+
+    /**
+     * Same as toString() but more explicitly named so the caller knows this is turned into JSON
+     */
+    public String toJSONString() {
+        return toString();
+    }
+
+    public static RollupV2Config fromXContent(final XContentParser parser, final String sourceIndex) throws IOException {
+        return PARSER.parse(parser, sourceIndex);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupV2ConfigTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.rollup.v2;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+
+
+public class RollupV2ConfigTests extends AbstractSerializingTestCase<RollupV2Config> {
+
+    String sourceIndex;
+
+    @Before
+    void setUpSourceIndex() {
+        sourceIndex = randomAlphaOfLength(10);
+    }
+
+    @Override
+    protected RollupV2Config createTestInstance() {
+        return randomConfig(random(), sourceIndex);
+    }
+
+    public static RollupV2Config randomConfig(Random random, String sourceIndex) {
+        final String rollupIndex = "rollup-" + sourceIndex;
+        final TimeValue timeout = random.nextBoolean() ? null : ConfigTestHelpers.randomTimeout(random);
+        final GroupConfig groupConfig = ConfigTestHelpers.randomGroupConfig(random);
+        final List<MetricConfig> metricConfigs = ConfigTestHelpers.randomMetricsConfigs(random);
+        return new RollupV2Config(sourceIndex, groupConfig, metricConfigs, timeout, rollupIndex);
+    }
+
+    @Override
+    protected Writeable.Reader<RollupV2Config> instanceReader() {
+        return RollupV2Config::new;
+    }
+
+    @Override
+    protected RollupV2Config doParseInstance(final XContentParser parser) throws IOException {
+        return RollupV2Config.fromXContent(parser, sourceIndex);
+    }
+
+    public void testEmptySourceIndex() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(randomBoolean() ? null : "", sample.getGroupConfig(), sample.getMetricsConfig(), sample.getTimeout(),
+                sample.getRollupIndex()));
+        assertThat(e.getMessage(), equalTo("The source index must be a non-null, non-empty string"));
+    }
+
+    public void testEmptyRollupIndex() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(sample.getSourceIndex(), sample.getGroupConfig(), sample.getMetricsConfig(), sample.getTimeout(),
+                randomBoolean() ? null : ""));
+        assertThat(e.getMessage(), equalTo("Rollup index must be a non-null, non-empty string"));
+    }
+
+    public void testEmptyGroupAndMetrics() {
+        final RollupV2Config sample = createTestInstance();
+        Exception e = expectThrows(IllegalArgumentException.class, () ->
+            new RollupV2Config(sample.getSourceIndex(), null, randomBoolean() ? null : emptyList(), sample.getTimeout(),
+                sample.getRollupIndex()));
+        assertThat(e.getMessage(), equalTo("At least one grouping or metric must be configured"));
+    }
+}

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.esplugin'
 esplugin {
   name 'x-pack-rollup'
@@ -5,12 +7,25 @@ esplugin {
   classname 'org.elasticsearch.xpack.rollup.Rollup'
   extendedPlugins = ['x-pack-core']
 }
+
 archivesBaseName = 'x-pack-rollup'
 
 dependencies {
   compileOnly project(":server")
-
   compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('analytics'), configuration: 'default')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
+// add all sub-projects of the qa sub-project
+gradle.projectsEvaluated {
+  project.subprojects
+    .find { it.path == project.path + ":qa" }
+    .subprojects
+    .findAll { it.path.startsWith(project.path + ":qa") }
+    .each { check.dependsOn it.check }
+}
+
+test {
+  systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+}

--- a/x-pack/plugin/rollup/qa/build.gradle
+++ b/x-pack/plugin/rollup/qa/build.gradle
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import org.elasticsearch.gradle.test.RestIntegTestTask
+
+apply plugin: 'elasticsearch.build'
+
+test.enabled = false
+
+dependencies {
+  api project(':test:framework')
+}

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.rest-resources'
+
+dependencies {
+  testImplementation project(path: xpackModule('rollup'))
+}
+
+restResources {
+  restApi {
+    includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
+    includeXpack 'rollup'
+  }
+}
+
+testClusters.integTest {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.license.self_generated.type', 'basic'
+  systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+}
+

--- a/x-pack/plugin/rollup/qa/rest/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupRestIT.java
+++ b/x-pack/plugin/rollup/qa/rest/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupRestIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.rollup.v2;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+public class RollupRestIT extends ESClientYamlSuiteTestCase {
+
+    public RollupRestIT(final ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+}

--- a/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -1,0 +1,87 @@
+setup:
+  - skip:
+      features: headers
+  - do:
+      indices.create:
+        index: docs
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              color:
+                type: keyword
+              price:
+                type: integer
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: docs
+              _id:    1
+          - timestamp: "2020-01-01T05:10:00Z"
+            color: "blue"
+            price: 10
+          - index:
+              _index: docs
+              _id:    2
+          - timestamp: "2020-01-01T05:30:00Z"
+            color: "blue"
+            price: 20
+          - index:
+              _index: docs
+              _id:    3
+          - timestamp: "2020-01-01T06:10:00Z"
+            color: "red"
+            price: 30
+          - index:
+              _index: docs
+              _id:    4
+          - timestamp: "2020-01-01T06:30:00Z"
+            color: "green"
+            price: 40
+
+---
+"Rollup index":
+  - skip:
+      version: " - 7.99.99"
+      reason: "rolling up an index directly is only supported in 8.0+"
+  - do:
+      rollup.rollup:
+        index: docs
+        body:  >
+          {
+            "rollup_index": "rollup_docs",
+            "groups" : {
+              "date_histogram": {
+                "field": "timestamp",
+                "calendar_interval": "1h"
+              },
+              "terms": {
+                "fields": ["color"]
+              }
+            },
+            "metrics": [
+              {
+                "field": "price",
+                "metrics": ["max", "sum", "avg"]
+              }
+            ]
+          }
+  - is_true: created
+
+  - do:
+      indices.forcemerge:
+        index: rollup_docs
+        max_num_segments: 1
+
+  - do:
+      search:
+        index: rollup_docs
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 3  }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -30,6 +30,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rollup.RollupV2;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
@@ -45,6 +46,7 @@ import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupAction;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.rollup.action.TransportDeleteRollupJobAction;
 import org.elasticsearch.xpack.rollup.action.TransportGetRollupCapsAction;
@@ -63,6 +65,8 @@ import org.elasticsearch.xpack.rollup.rest.RestPutRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestRollupSearchAction;
 import org.elasticsearch.xpack.rollup.rest.RestStartRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestStopRollupJobAction;
+import org.elasticsearch.xpack.rollup.v2.RestRollupAction;
+import org.elasticsearch.xpack.rollup.v2.TransportRollupAction;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -131,7 +135,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
                                              IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter,
                                              IndexNameExpressionResolver indexNameExpressionResolver,
                                              Supplier<DiscoveryNodes> nodesInCluster) {
-        return Arrays.asList(
+        List<RestHandler> handlers = new ArrayList<>(Arrays.asList(
             new RestRollupSearchAction(),
             new RestPutRollupJobAction(),
             new RestStartRollupJobAction(),
@@ -139,14 +143,18 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
             new RestDeleteRollupJobAction(),
             new RestGetRollupJobsAction(),
             new RestGetRollupCapsAction(),
-            new RestGetRollupIndexCapsAction()
-        );
+            new RestGetRollupIndexCapsAction()));
 
+        if (RollupV2.isEnabled()) {
+            handlers.add(new RestRollupAction());
+        }
+
+        return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return Arrays.asList(
+        List<ActionHandler<?, ?>> actions = new ArrayList<>(Arrays.asList(
             new ActionHandler<>(RollupSearchAction.INSTANCE, TransportRollupSearchAction.class),
             new ActionHandler<>(PutRollupJobAction.INSTANCE, TransportPutRollupJobAction.class),
             new ActionHandler<>(StartRollupJobAction.INSTANCE, TransportStartRollupAction.class),
@@ -155,7 +163,13 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
             new ActionHandler<>(GetRollupJobsAction.INSTANCE, TransportGetRollupJobAction.class),
             new ActionHandler<>(GetRollupCapsAction.INSTANCE, TransportGetRollupCapsAction.class),
             new ActionHandler<>(GetRollupIndexCapsAction.INSTANCE, TransportGetRollupIndexCapsAction.class)
-        );
+        ));
+
+        if (RollupV2.isEnabled()) {
+            actions.add(new ActionHandler<>(RollupAction.INSTANCE, TransportRollupAction.class));
+        }
+
+        return actions;
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.rollup.v2.RollupAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestRollupAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return Collections.singletonList(new Route(POST, "/{index}/_rollup"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String index = restRequest.param("index");
+        RollupV2Config job = RollupV2Config.fromXContent(restRequest.contentParser(), index);
+        RollupAction.Request request = new RollupAction.Request(job);
+        return channel -> client.execute(RollupAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "rollup_action";
+    }
+
+}

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.shrink.ResizeAction;
+import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
+import org.elasticsearch.action.admin.indices.shrink.ResizeType;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.indexing.IterationResult;
+import org.elasticsearch.xpack.core.rollup.RollupField;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
+import org.elasticsearch.xpack.core.rollup.job.RollupIndexerJobStats;
+import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
+import org.elasticsearch.xpack.core.rollup.v2.RollupV2Config;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract implementation of {@link AsyncTwoPhaseIndexer} that builds a rollup index incrementally.
+ */
+public class RollupV2Indexer extends AsyncTwoPhaseIndexer<Map<String, Object>, RollupIndexerJobStats> {
+    private static final Logger logger = LogManager.getLogger(RollupV2Indexer.class);
+
+    static final String AGGREGATION_NAME = RollupField.NAME;
+    static final int PAGE_SIZE = 1000;
+
+    private final RollupV2Config job;
+    private final Client client;
+    private final Map<String, String> headers;
+    private final CompositeAggregationBuilder compositeBuilder;
+    private final String tmpIndex;
+    private final ActionListener<Void> completionListener;
+
+    /**
+     * Ctr
+     * @param client The Transport client
+     * @param threadPool ThreadPool to use to fire the first request of a background job.
+     * @param executorName Name of the executor to use to fire the first request of a background job.
+     * @param job The rollup job
+     */
+    RollupV2Indexer(Client client, ThreadPool threadPool, String executorName, RollupV2Config job, Map<String, String> headers,
+                    ActionListener<Void> completionListener) {
+        super(threadPool, executorName, new AtomicReference<>(IndexerState.STOPPED), null, new RollupIndexerJobStats());
+        this.client = client;
+        this.job = job;
+        this.headers = headers;
+        this.compositeBuilder = createCompositeBuilder(job);
+        this.tmpIndex = ".rolluptmp-" + job.getRollupIndex();
+        this.completionListener = completionListener;
+    }
+
+    @Override
+    protected String getJobId() {
+        return job.getId();
+    }
+
+    @Override
+    protected void onStart(long now, ActionListener<Boolean> listener) {
+        try {
+            createTempRollupIndex(ActionListener.wrap(resp -> listener.onResponse(true), e -> {
+                completionListener.onFailure(new ElasticsearchException("Unable to start rollup. index creation failed", e));
+                listener.onFailure(e);
+            }));
+        } catch (IOException e) {
+            listener.onFailure(new ElasticsearchException("Unable to start rollup. index creation failed", e));
+        }
+    }
+
+    XContentBuilder getMapping() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        String dateField = job.getGroupConfig().getDateHistogram().getField();
+        HistogramGroupConfig histogramGroupConfig = job.getGroupConfig().getHistogram();
+        TermsGroupConfig termsGroupConfig = job.getGroupConfig().getTerms();
+        List<MetricConfig> metricConfigs = job.getMetricsConfig();
+
+        builder.startObject(dateField).field("type", DateFieldMapper.CONTENT_TYPE).endObject();
+
+        if (histogramGroupConfig != null) {
+            for (String field : histogramGroupConfig.getFields()) {
+                builder.startObject(field).field("type", HistogramFieldMapper.CONTENT_TYPE).endObject();
+            }
+        }
+
+        if (termsGroupConfig != null) {
+            for (String field : termsGroupConfig.getFields()) {
+                // TODO(talevy): not just keyword, can be a number?
+                builder.startObject(field).field("type", KeywordFieldMapper.CONTENT_TYPE).endObject();
+            }
+        }
+
+        for (MetricConfig metricConfig : metricConfigs) {
+            List<String> metrics = normalizeMetrics(metricConfig.getMetrics());
+            String defaultMetric = metrics.contains("value_count") ? "value_count" : metrics.get(0);
+            builder.startObject(metricConfig.getField())
+                .field("type", "aggregate_metric_double")
+                .array("metrics", metrics.toArray())
+                .field("default_metric", defaultMetric)
+                .endObject();
+        }
+
+
+        return builder.endObject().endObject();
+    }
+
+    void createTempRollupIndex(ActionListener<CreateIndexResponse> listener) throws IOException {
+        CreateIndexRequest req = new CreateIndexRequest(tmpIndex, Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_HIDDEN, true).build())
+            .mapping("_doc", getMapping());
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, CreateIndexAction.INSTANCE, req, listener);
+    }
+
+    @Override
+    protected void doNextSearch(long waitTimeInNanos, ActionListener<SearchResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, SearchAction.INSTANCE,
+            buildSearchRequest(waitTimeInNanos), nextPhase);
+    }
+
+    @Override
+    protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client, BulkAction.INSTANCE, request, nextPhase);
+    }
+
+    @Override
+    protected void doSaveState(IndexerState state, Map<String, Object> stringObjectMap, Runnable next) {
+        assert state == IndexerState.INDEXING || state == IndexerState.STARTED || state == IndexerState.STOPPED;
+        next.run();
+    }
+
+    @Override
+    protected void onFailure(Exception exc) {
+        completionListener.onFailure(exc);
+    }
+
+    @Override
+    protected void onFinish(ActionListener<Void> listener) {
+        // "shrink index"
+        ResizeRequest resizeRequest = new ResizeRequest(job.getRollupIndex(), tmpIndex);
+        resizeRequest.setResizeType(ResizeType.CLONE);
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build());
+        UpdateSettingsRequest updateSettingsReq = new UpdateSettingsRequest(
+            Settings.builder().put("index.blocks.write", true).build(), tmpIndex);
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+            UpdateSettingsAction.INSTANCE, updateSettingsReq,
+            ActionListener.wrap(r -> {
+                ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+                    ResizeAction.INSTANCE, resizeRequest,
+                    ActionListener.wrap(rr -> { deleteTmpIndex(listener); }, e -> { deleteTmpIndex(listener); }));
+                }, e -> { deleteTmpIndex(listener); }));
+    }
+
+    private void deleteTmpIndex(ActionListener<Void> listener) {
+        ClientHelper.executeWithHeadersAsync(headers, ClientHelper.ROLLUP_ORIGIN, client,
+            DeleteIndexAction.INSTANCE, new DeleteIndexRequest(tmpIndex),
+            ActionListener.wrap(r -> {
+                listener.onResponse(null);
+                completionListener.onResponse(null);
+            }, e -> {
+                listener.onFailure(e);
+                completionListener.onFailure(e);
+            }));
+    }
+
+    @Override
+    protected void onStop() {
+        completionListener.onFailure(new ElasticsearchException("rollup stopped before completion"));
+    }
+
+    @Override
+    protected void onAbort() {
+        completionListener.onFailure(new ElasticsearchException("rollup stopped before completion"));
+    }
+
+    protected SearchRequest buildSearchRequest(long waitTimeInNanos) {
+        final Map<String, Object> position = getPosition();
+        SearchSourceBuilder searchSource = new SearchSourceBuilder()
+                .size(0)
+                .trackTotalHits(false)
+                .aggregation(compositeBuilder.aggregateAfter(position));
+        return new SearchRequest(job.getSourceIndex()).source(searchSource);
+    }
+
+    @Override
+    protected IterationResult<Map<String, Object>> doProcess(SearchResponse searchResponse) {
+        final CompositeAggregation response = searchResponse.getAggregations().get(AGGREGATION_NAME);
+
+        if (response.getBuckets().isEmpty()) {
+            // do not reset the position as we want to continue from where we stopped
+            return new IterationResult<>(Collections.emptyList(), getPosition(), true);
+        }
+
+        return new IterationResult<>(processBuckets(response, tmpIndex, getStats()),
+                response.afterKey(), response.getBuckets().isEmpty());
+    }
+
+    static List<IndexRequest> processBuckets(CompositeAggregation agg, String rollupIndex, RollupIndexerJobStats stats) {
+
+        return agg.getBuckets().stream().map(b ->{
+            stats.incrementNumDocuments(b.getDocCount());
+
+            // Put the composite keys into a treemap so that the key iteration order is consistent
+            // TODO would be nice to avoid allocating this treemap in the future
+            TreeMap<String, Object> keys = new TreeMap<>(b.getKey());
+            List<Aggregation> metrics = b.getAggregations().asList();
+
+            Map<String, Object> doc = new HashMap<>(1 + keys.size() + metrics.size());
+            doc.put("_doc_count", b.getDocCount());
+            keys.forEach(doc::put);
+            Map<String, Map<String, Double>> metricFields = new HashMap<>();
+            metrics.forEach(a -> {
+                String name = a.getName();
+                int split = name.lastIndexOf("-");
+                assert split > 0;
+                String fieldName = name.substring(0, split);
+                String metricType = name.substring(split + 1);
+                if (a instanceof InternalNumericMetricsAggregation.SingleValue) {
+                    double value = ((InternalNumericMetricsAggregation.SingleValue) a).value();
+                    if (metricFields.containsKey(fieldName)) {
+                        metricFields.get(fieldName).put(metricType, value);
+                    } else {
+                        Map<String, Double> vals = new HashMap<>();
+                        vals.put(metricType, value);
+                        metricFields.put(fieldName, vals);
+                    }
+                } else {
+                    throw new IllegalStateException("invalid metric type [" + a.getClass().getName() + "]");
+                }
+            });
+            doc.putAll(metricFields);
+            IndexRequest request = new IndexRequest(rollupIndex);
+            request.source(doc);
+            return request;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Creates a skeleton {@link CompositeAggregationBuilder} from the provided job config.
+     * @param config The config for the job.
+     * @return The composite aggregation that creates the rollup buckets
+     */
+    private CompositeAggregationBuilder createCompositeBuilder(RollupV2Config config) {
+        final GroupConfig groupConfig = config.getGroupConfig();
+        List<CompositeValuesSourceBuilder<?>> builders = createValueSourceBuilders(groupConfig);
+
+        CompositeAggregationBuilder composite = new CompositeAggregationBuilder(AGGREGATION_NAME, builders);
+
+        List<AggregationBuilder> aggregations = createAggregationBuilders(config.getMetricsConfig());
+        aggregations.forEach(composite::subAggregation);
+
+        final Map<String, Object> metadata = createMetadata(groupConfig);
+        if (metadata.isEmpty() == false) {
+            composite.setMetadata(metadata);
+        }
+        composite.size(PAGE_SIZE);
+
+        return composite;
+    }
+
+    static Map<String, Object> createMetadata(final GroupConfig groupConfig) {
+        final Map<String, Object> metadata = new HashMap<>();
+        if (groupConfig != null) {
+            // Add all the metadata in order: date_histo -> histo
+            final DateHistogramGroupConfig dateHistogram = groupConfig.getDateHistogram();
+            metadata.put(RollupField.formatMetaField(RollupField.INTERVAL), dateHistogram.getInterval().toString());
+
+            final HistogramGroupConfig histogram = groupConfig.getHistogram();
+            if (histogram != null) {
+                metadata.put(RollupField.formatMetaField(RollupField.INTERVAL), histogram.getInterval());
+            }
+        }
+        return metadata;
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final GroupConfig groupConfig) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        // Add all the agg builders to our request in order: date_histo -> histo -> terms
+        if (groupConfig != null) {
+            final DateHistogramGroupConfig dateHistogram = groupConfig.getDateHistogram();
+            builders.addAll(createValueSourceBuilders(dateHistogram));
+
+            final HistogramGroupConfig histogram = groupConfig.getHistogram();
+            builders.addAll(createValueSourceBuilders(histogram));
+
+            final TermsGroupConfig terms = groupConfig.getTerms();
+            builders.addAll(createValueSourceBuilders(terms));
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final DateHistogramGroupConfig dateHistogram) {
+        final String dateHistogramField = dateHistogram.getField();
+        final DateHistogramValuesSourceBuilder dateHistogramBuilder = new DateHistogramValuesSourceBuilder(dateHistogramField);
+        if (dateHistogram instanceof DateHistogramGroupConfig.FixedInterval) {
+            dateHistogramBuilder.fixedInterval(dateHistogram.getInterval());
+        } else if (dateHistogram instanceof DateHistogramGroupConfig.CalendarInterval) {
+            dateHistogramBuilder.calendarInterval(dateHistogram.getInterval());
+        } else {
+            dateHistogramBuilder.dateHistogramInterval(dateHistogram.getInterval());
+        }
+        dateHistogramBuilder.field(dateHistogramField);
+        dateHistogramBuilder.timeZone(ZoneId.of(dateHistogram.getTimeZone()));
+        return Collections.singletonList(dateHistogramBuilder);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final HistogramGroupConfig histogram) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        if (histogram != null) {
+            for (String field : histogram.getFields()) {
+                final HistogramValuesSourceBuilder histogramBuilder = new HistogramValuesSourceBuilder(field);
+                histogramBuilder.interval(histogram.getInterval());
+                histogramBuilder.field(field);
+                histogramBuilder.missingBucket(true);
+                builders.add(histogramBuilder);
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    public static List<CompositeValuesSourceBuilder<?>> createValueSourceBuilders(final TermsGroupConfig terms) {
+        final List<CompositeValuesSourceBuilder<?>> builders = new ArrayList<>();
+        if (terms != null) {
+            for (String field : terms.getFields()) {
+                final TermsValuesSourceBuilder termsBuilder = new TermsValuesSourceBuilder(field);
+                termsBuilder.field(field);
+                termsBuilder.missingBucket(true);
+                builders.add(termsBuilder);
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    /**
+     * This returns a set of aggregation builders which represent the configured
+     * set of metrics. Used to iterate over historical data.
+     */
+    static List<AggregationBuilder> createAggregationBuilders(final List<MetricConfig> metricsConfigs) {
+        final List<AggregationBuilder> builders = new ArrayList<>();
+        if (metricsConfigs != null) {
+            for (MetricConfig metricConfig : metricsConfigs) {
+                final List<String> metrics = metricConfig.getMetrics();
+                final List<String> normalizedMetrics = normalizeMetrics(metrics);
+                if (normalizedMetrics.isEmpty() == false) {
+                    final String field = metricConfig.getField();
+                    for (String metric : normalizedMetrics) {
+                        ValuesSourceAggregationBuilder.LeafOnly<? extends ValuesSource, ? extends AggregationBuilder> newBuilder;
+                        if (metric.equals(MetricConfig.MIN.getPreferredName())) {
+                            newBuilder = new MinAggregationBuilder(field + "-min");
+                        } else if (metric.equals(MetricConfig.MAX.getPreferredName())) {
+                            newBuilder = new MaxAggregationBuilder(field + "-max");
+                        } else if (metric.equals(MetricConfig.SUM.getPreferredName())) {
+                            newBuilder = new SumAggregationBuilder(field + "-sum");
+                        } else if (metric.equals(MetricConfig.VALUE_COUNT.getPreferredName())) {
+                            newBuilder = new ValueCountAggregationBuilder(field + "-value_count");
+                        } else {
+                            throw new IllegalArgumentException("Unsupported metric type [" + metric + "]");
+                        }
+                        newBuilder.field(field);
+                        builders.add(newBuilder);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableList(builders);
+    }
+
+    static List<String> normalizeMetrics(List<String> metrics) {
+        List<String> newMetrics = new ArrayList<>(metrics);
+        // avg = sum + value_count
+        if (newMetrics.remove(MetricConfig.AVG.getPreferredName())) {
+            if (newMetrics.contains(MetricConfig.VALUE_COUNT.getPreferredName()) == false) {
+                newMetrics.add(MetricConfig.VALUE_COUNT.getPreferredName());
+            }
+            if (newMetrics.contains(MetricConfig.SUM.getPreferredName()) == false) {
+                newMetrics.add(MetricConfig.SUM.getPreferredName());
+            }
+        }
+        return newMetrics;
+    }
+}
+

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RollupGroup;
+import org.elasticsearch.cluster.metadata.RollupMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.time.WriteableZoneId;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.v2.RollupAction;
+import org.elasticsearch.xpack.core.rollup.v2.RollupTask;
+import org.elasticsearch.xpack.rollup.Rollup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// TODO(talevy): enforce that rollup-indices of indices backing a datastream must be hidden
+public class TransportRollupAction extends HandledTransportAction<RollupAction.Request, RollupAction.Response> {
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final ClusterService clusterService;
+
+    @Inject
+    public TransportRollupAction(
+            final Client client,
+            final ClusterService clusterService,
+            final ThreadPool threadPool,
+            final TransportService transportService,
+            final ActionFilters actionFilters
+    ) {
+        super(RollupAction.NAME, transportService, actionFilters, RollupAction.Request::new);
+        this.client = client;
+        this.threadPool = threadPool;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    protected void doExecute(Task task, RollupAction.Request request, ActionListener<RollupAction.Response> listener) {
+        RollupTask rollupTask = (RollupTask) task;
+        RollupV2Indexer indexer = new RollupV2Indexer(client, threadPool, Rollup.TASK_THREAD_POOL_NAME,
+            rollupTask.config(), rollupTask.headers(), ActionListener.wrap(c -> {
+            // update Rollup metadata to include this index
+            clusterService.submitStateUpdateTask("update-rollup-metadata", new ClusterStateUpdateTask() {
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    listener.onResponse(new RollupAction.Response(true));
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    String rollupIndexName = rollupTask.config().getRollupIndex();
+                    IndexMetadata rollupIndexMetadata = currentState.getMetadata().index(rollupIndexName);
+                    Index rollupIndex = rollupIndexMetadata.getIndex();
+                    // TODO(talevy): find better spot to get the original index name
+                    // extract created rollup index original index name to be used as metadata key
+                    String originalIndexName = rollupTask.config().getSourceIndex();
+                    Map<String, String> idxMetadata = currentState.getMetadata().index(originalIndexName)
+                        .getCustomData(RollupMetadata.TYPE);
+                    String rollupGroupKeyName = (idxMetadata == null) ?
+                        originalIndexName : idxMetadata.get(RollupMetadata.SOURCE_INDEX_NAME_META_FIELD);
+                    Map<String, String> rollupIndexRollupMetadata = new HashMap<>();
+                    rollupIndexRollupMetadata.put(RollupMetadata.SOURCE_INDEX_NAME_META_FIELD, rollupGroupKeyName);
+                    final RollupMetadata rollupMetadata = currentState.metadata().custom(RollupMetadata.TYPE);
+                    final Map<String, RollupGroup> rollupGroups;
+                    if (rollupMetadata == null) {
+                        rollupGroups = new HashMap<>();
+                    } else {
+                        rollupGroups = new HashMap<>(rollupMetadata.rollupGroups());
+                    }
+                    DateHistogramGroupConfig dateConfig = rollupTask.config().getGroupConfig().getDateHistogram();
+                    WriteableZoneId rollupDateZoneId = WriteableZoneId.of(dateConfig.getTimeZone());
+                    if (rollupGroups.containsKey(rollupGroupKeyName)) {
+                        RollupGroup group = rollupGroups.get(rollupGroupKeyName);
+                        group.add(rollupIndexName, dateConfig.getInterval(), rollupDateZoneId);
+                    } else {
+                        RollupGroup group = new RollupGroup();
+                        group.add(rollupIndexName, dateConfig.getInterval(), rollupDateZoneId);
+                        rollupGroups.put(rollupGroupKeyName, group);
+                    }
+                    // add rolled up index to backing datastream if rolling up a backing index of a datastream
+                    IndexAbstraction originalIndex = currentState.getMetadata().getIndicesLookup().get(originalIndexName);
+                    DataStream dataStream = null;
+                    if (originalIndex.getParentDataStream() != null) {
+                        DataStream originalDataStream = originalIndex.getParentDataStream().getDataStream();
+                        List<Index> backingIndices = new ArrayList<>(originalDataStream.getIndices());
+                        backingIndices.add(backingIndices.size() - 1, rollupIndex);
+                        dataStream = new DataStream(originalDataStream.getName(), originalDataStream.getTimeStampField(),
+                            backingIndices, originalDataStream.getGeneration(), null);
+                    }
+                    Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata())
+                        .put(IndexMetadata.builder(rollupIndexMetadata).putCustom(RollupMetadata.TYPE, rollupIndexRollupMetadata))
+                        .putCustom(RollupMetadata.TYPE, new RollupMetadata(rollupGroups));
+                    if (dataStream != null) {
+                        metadataBuilder.put(dataStream);
+                    }
+                    return ClusterState.builder(currentState).metadata(metadataBuilder.build()).build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(new ElasticsearchException("failed to publish new cluster state with rollup metadata", e));
+                }
+            });
+        }, e -> listener.onFailure(
+            new ElasticsearchException("Failed to rollup index [" + rollupTask.config().getSourceIndex() + "]", e))));
+        if (indexer.start() == IndexerState.STARTED) {
+            indexer.maybeTriggerAsyncJob(Long.MAX_VALUE);
+        } else {
+            listener.onFailure(new ElasticsearchException("failed to start rollup task"));
+        }
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -1,0 +1,31 @@
+{
+  "rollup.rollup":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup.html",
+      "description":"Rollup an index"
+    },
+    "stability":"stable",
+    "url": {
+      "paths": [
+        {
+          "path": "/{index}/_rollup",
+          "methods": [
+            "POST"
+          ],
+          "parts": {
+            "index": {
+              "type": "string",
+              "description": "The index to roll up",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "params":{},
+    "body":{
+      "description":"The rollup configuration",
+      "required":true
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a new endpoint for Rollup V2, a new way to rollup indices.

Instead of relying on a cron-job, this action will rollup a whole index on the spot.

When an index is rolled up using a Rollup Config, it does the following

1. check that original index is read-only
2. runs an aggregation and indexes results into a temporary hidden rollup index
3. "resizes" the temporary index into the final rollup-index (in-place segment pointer juggling)
4. adds RollupMetadata about the rollup-group (keyed by original index name) and adds
    custom index-metadata with data about what the rollup index's original index is so that its
    group information in RollupMetadata can be looked up

example usage:

```
POST /_rollup_vtwo/index
{
    "rollup_index": "index_rolled",
    "groups": {
        "date_histogram": {
            "field": "date",
            "calendar_interval": "1M"
        },
        "terms": {
            "fields": ["unit"]
        }
    },
    "metrics": [
        {
            "field": "temperature",
            "metrics": ["sum"]
        }
    ]
}
```

relates #42720.