### PR TITLE
Reduce ways of checking index version setting.

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch;
 
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -169,25 +167,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             luceneVersion = versions.get(index).luceneVersion;
         }
         return new Version(id, luceneVersion);
-    }
-
-    /**
-     * Return the {@link Version} of Elasticsearch that has been used to create an index given its settings.
-     *
-     * @throws IllegalStateException if the given index settings doesn't contain a value for the key
-     *         {@value IndexMetadata#SETTING_VERSION_CREATED}
-     */
-    public static Version indexCreated(Settings indexSettings) {
-        final Version indexVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(indexSettings);
-        if (indexVersion == V_EMPTY) {
-            final String message = String.format(
-                    Locale.ROOT,
-                    "[%s] is not present in the index settings for index with UUID [%s]",
-                    IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
-                    indexSettings.get(IndexMetadata.SETTING_INDEX_UUID));
-            throw new IllegalStateException(message);
-        }
-        return indexVersion;
     }
 
     public static void writeVersion(Version version, StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1243,7 +1243,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             } else {
                 initialRecoveryFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, initialRecoveryMap);
             }
-            Version indexCreatedVersion = Version.indexCreated(settings);
+            Version indexCreatedVersion = indexCreatedVersion(settings);
             Version indexUpgradedVersion = settings.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, indexCreatedVersion);
 
             if (primaryTerms == null) {
@@ -1530,11 +1530,32 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (Assertions.ENABLED) {
                 assert settingsVersion : "settings version should be present for indices created on or after 6.5.0";
             }
-            if (Assertions.ENABLED && Version.indexCreated(builder.settings).onOrAfter(Version.V_7_2_0)) {
+
+            Version indexVersion = indexCreatedVersion(builder.settings);
+            if (Assertions.ENABLED && indexVersion.onOrAfter(Version.V_7_2_0)) {
                 assert aliasesVersion : "aliases version should be present for indices created on or after 7.2.0";
             }
             return builder.build();
         }
+    }
+
+    /**
+     * Return the {@link Version} of Elasticsearch that has been used to create an index given its settings.
+     *
+     * @throws IllegalArgumentException if the given index settings doesn't contain a value for the key
+     *                                  {@value IndexMetadata#SETTING_VERSION_CREATED}
+     */
+    private static Version indexCreatedVersion(Settings indexSettings) {
+        final Version indexVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(indexSettings);
+        if (indexVersion == Version.V_EMPTY) {
+            final String message = String.format(
+                Locale.ROOT,
+                "[%s] is not present in the index settings for index with UUID [%s]",
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                indexSettings.get(IndexMetadata.SETTING_INDEX_UUID));
+            throw new IllegalArgumentException(message);
+        }
+        return indexVersion;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -676,10 +676,10 @@ public class MetadataCreateIndexService {
         // now, put the request settings, so they override templates
         indexSettingsBuilder.put(requestSettings.build());
 
-        if (indexSettingsBuilder.get(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey()) == null) {
+        if (indexSettingsBuilder.get(IndexMetadata.SETTING_VERSION_CREATED) == null) {
             final DiscoveryNodes nodes = currentState.nodes();
             final Version createdVersion = Version.min(Version.CURRENT, nodes.getSmallestNonClientNodeVersion());
-            indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion);
+            indexSettingsBuilder.put(IndexMetadata.SETTING_VERSION_CREATED, createdVersion);
         }
         if (INDEX_NUMBER_OF_SHARDS_SETTING.exists(indexSettingsBuilder) == false) {
             indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, INDEX_NUMBER_OF_SHARDS_SETTING.get(settings));
@@ -1129,7 +1129,7 @@ public class MetadataCreateIndexService {
         }
 
         indexSettingsBuilder
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), sourceMetadata.getCreationVersion())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, sourceMetadata.getCreationVersion())
             .put(IndexMetadata.SETTING_VERSION_UPGRADED, sourceMetadata.getUpgradedVersion())
             .put(builder.build())
             .put(IndexMetadata.SETTING_ROUTING_PARTITION_SIZE, sourceMetadata.getRoutingPartitionSize())

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -630,7 +630,7 @@ public final class IndexSettings {
 
     /**
      * Returns the version the index was created on.
-     * @see Version#indexCreated(Settings)
+     * @see IndexMetadata#SETTING_VERSION_CREATED
      */
     public Version getIndexVersionCreated() {
         return version;
@@ -676,9 +676,9 @@ public final class IndexSettings {
      */
     public synchronized boolean updateIndexMetadata(IndexMetadata indexMetadata) {
         final Settings newSettings = indexMetadata.getSettings();
-        if (version.equals(Version.indexCreated(newSettings)) == false) {
-            throw new IllegalArgumentException("version mismatch on settings update expected: " + version + " but was: " +
-                Version.indexCreated(newSettings));
+        Version newIndexVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(newSettings);
+        if (version.equals(newIndexVersion) == false) {
+            throw new IllegalArgumentException("version mismatch on settings update expected: " + version + " but was: " + newIndexVersion);
         }
         final String newUUID = newSettings.get(IndexMetadata.SETTING_INDEX_UUID, IndexMetadata.INDEX_UUID_NA_VALUE);
         if (newUUID.equals(getUUID()) == false) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -40,7 +40,7 @@ public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends 
     public AbstractIndexAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        this.version = Analysis.parseAnalysisVersion(this.indexSettings, settings, logger);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
@@ -33,14 +33,14 @@ public abstract class AbstractTokenFilterFactory extends AbstractIndexComponent 
     public AbstractTokenFilterFactory(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        this.version = Analysis.parseAnalysisVersion(indexSettings, settings, logger);
     }
 
     @Override
     public String name() {
         return this.name;
     }
-    
+
     public final Version version() {
         return version;
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
@@ -30,7 +30,7 @@ public abstract class AbstractTokenizerFactory extends AbstractIndexComponent im
 
     public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
         super(indexSettings);
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        this.version = Analysis.parseAnalysisVersion(indexSettings, settings, logger);
         this.name = name;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -60,6 +60,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexSettings;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -79,19 +80,19 @@ import static java.util.Map.entry;
 
 public class Analysis {
 
-    public static Version parseAnalysisVersion(Settings indexSettings, Settings settings, Logger logger) {
+    public static Version parseAnalysisVersion(IndexSettings indexSettings, Settings settings, Logger logger) {
         // check for explicit version on the specific analyzer component
         String sVersion = settings.get("version");
         if (sVersion != null) {
             return Lucene.parseVersion(sVersion, Version.LATEST, logger);
         }
         // check for explicit version on the index itself as default for all analysis components
-        sVersion = indexSettings.get("index.analysis.version");
+        sVersion = indexSettings.getSettings().get("index.analysis.version");
         if (sVersion != null) {
             return Lucene.parseVersion(sVersion, Version.LATEST, logger);
         }
         // resolve the analysis version based on the version the index was created with
-        return org.elasticsearch.Version.indexCreated(indexSettings).luceneVersion;
+        return indexSettings.getIndexVersionCreated().luceneVersion;
     }
 
     public static CharArraySet parseStemExclusion(Settings settings, CharArraySet defaultStemExclusion) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -65,7 +65,7 @@ public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisCompon
                                    Environment environment,
                                    String name,
                                    Settings settings) throws IOException {
-        Version versionCreated = Version.indexCreated(settings);
+        Version versionCreated = indexSettings.getIndexVersionCreated();
         if (Version.CURRENT.equals(versionCreated) == false) {
             return super.get(indexSettings, environment, name, settings);
         } else {

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredAnalysisComponent.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredAnalysisComponent.java
@@ -47,7 +47,7 @@ public abstract class PreConfiguredAnalysisComponent<T> implements AnalysisModul
 
     @Override
     public T get(IndexSettings indexSettings, Environment environment, String name, Settings settings) throws IOException {
-        Version versionCreated = Version.indexCreated(settings);
+        Version versionCreated = indexSettings.getIndexVersionCreated();
         synchronized (this) {
             T factory = cache.get(versionCreated);
             if (factory == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -421,15 +421,15 @@ final class DocumentParser {
     private static void nested(ParseContext context, ObjectMapper.Nested nested) {
         ParseContext.Document nestedDoc = context.doc();
         ParseContext.Document parentDoc = nestedDoc.getParent();
-        Settings settings = context.indexSettings().getSettings();
+        Version indexVersion = context.indexSettings().getIndexVersionCreated();
         if (nested.isIncludeInParent()) {
-            addFields(Version.indexCreated(settings), nestedDoc, parentDoc);
+            addFields(indexVersion, nestedDoc, parentDoc);
         }
         if (nested.isIncludeInRoot()) {
             ParseContext.Document rootDoc = context.rootDoc();
             // don't add it twice, if its included in parent, and we are handling the master doc...
             if (!nested.isIncludeInParent() || parentDoc != rootDoc) {
-                addFields(Version.indexCreated(settings), nestedDoc, rootDoc);
+                addFields(indexVersion, nestedDoc, rootDoc);
             }
         }
     }
@@ -463,7 +463,7 @@ final class DocumentParser {
             throw new IllegalStateException("The root document of a nested document should have an _id field");
         }
 
-        Version version = Version.indexCreated(context.indexSettings().getSettings());
+        Version version = context.indexSettings().getIndexVersionCreated();
         nestedDoc.add(NestedPathFieldMapper.field(version, mapper.nestedTypePath()));
         return context;
     }
@@ -502,7 +502,7 @@ final class DocumentParser {
             } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
                 Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.OBJECT);
                 if (builder == null) {
-                    Version version = Version.indexCreated(context.indexSettings().getSettings());
+                    Version version = context.indexSettings().getIndexVersionCreated();
                     builder = new ObjectMapper.Builder(currentFieldName, version).enabled(true);
                 }
                 objectMapper = builder.build(context.path());
@@ -684,7 +684,7 @@ final class DocumentParser {
                     if (builder == null) {
                         boolean ignoreMalformed = IGNORE_MALFORMED_SETTING.get(context.indexSettings().getSettings());
                         builder = new DateFieldMapper.Builder(currentFieldName, DateFieldMapper.Resolution.MILLISECONDS,
-                            dateTimeFormatter, ignoreMalformed, Version.indexCreated(context.indexSettings().getSettings()));
+                            dateTimeFormatter, ignoreMalformed, context.indexSettings().getIndexVersionCreated());
                     }
                     return builder;
 
@@ -836,7 +836,7 @@ final class DocumentParser {
                     case TRUE:
                         Mapper.Builder builder = context.root().findTemplateBuilder(context, paths[i], XContentFieldType.OBJECT);
                         if (builder == null) {
-                            Version version = Version.indexCreated(context.indexSettings().getSettings());
+                            Version version = context.indexSettings().getIndexVersionCreated();
                             builder = new ObjectMapper.Builder(paths[i], version).enabled(true);
                         }
                         mapper = (ObjectMapper) builder.build(context.path());

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch;
 
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
@@ -147,21 +145,6 @@ public class VersionTests extends ESTestCase {
     public void testWrongVersionFromString() {
         Exception e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("WRONG.VERSION"));
         assertThat(e.getMessage(), containsString("needs to contain major, minor, and revision"));
-    }
-
-    public void testVersionNoPresentInSettings() {
-        Exception e = expectThrows(IllegalStateException.class, () -> Version.indexCreated(Settings.builder().build()));
-        assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
-    }
-
-    public void testIndexCreatedVersion() {
-        // an actual index has a IndexMetadata.SETTING_INDEX_UUID
-        final Version version = VersionUtils.randomVersion(random());
-        assertEquals(version, Version.indexCreated(
-            Settings.builder()
-                .put(IndexMetadata.SETTING_INDEX_UUID, "foo")
-                .put(IndexMetadata.SETTING_VERSION_CREATED, version)
-                .build()));
     }
 
     public void testMinCompatVersion() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -315,6 +315,15 @@ public class IndexMetadataTests extends ESTestCase {
             equalTo("Failed to parse value [" + numberOfShards + "] for setting [index.number_of_shards] must be >= 1"));
     }
 
+    public void testMissingCreatedVersion() {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
+        IllegalStateException e = expectThrows(IllegalStateException.class, () ->
+            IndexMetadata.builder("test").settings(settings).build());
+        assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
+    }
+
     public void testMissingNumberOfReplicas() {
         final Settings settings =
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 8)).build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -319,7 +319,7 @@ public class IndexMetadataTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        IllegalStateException e = expectThrows(IllegalStateException.class, () ->
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
             IndexMetadata.builder("test").settings(settings).build());
         assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -90,10 +90,10 @@ import static java.util.Collections.emptyMap;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_READ_ONLY_BLOCK;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.aggregateIndexSettings;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.buildIndexMetadata;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.clusterStateCreateIndex;
@@ -121,7 +121,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
     public void setupCreateIndexRequestAndAliasValidator() {
         aliasValidator = new AliasValidator();
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
-        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+        Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
         queryShardContext = new QueryShardContext(0,
             new IndexSettings(IndexMetadata.builder("test").settings(indexSettings).build(), indexSettings),
@@ -900,7 +900,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), between(1, 128) + "mb");
         }
         if (randomBoolean()) {
-            settings.put(SETTING_INDEX_VERSION_CREATED.getKey(),
+            settings.put(SETTING_VERSION_CREATED,
                 VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, Version.CURRENT));
         }
         request.settings(settings.build());
@@ -920,7 +920,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         } else {
             settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), between(1, 128) + "mb");
         }
-        settings.put(SETTING_INDEX_VERSION_CREATED.getKey(), VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0));
+        settings.put(SETTING_VERSION_CREATED, VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0));
         request.settings(settings.build());
         aggregateIndexSettings(ClusterState.EMPTY_STATE, request, Settings.EMPTY,
             null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, randomShardLimitService(),

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -560,7 +560,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                                 .settings(Settings.builder()
                                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                                    .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                     .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))))
                         .incrementVersion().build(),
                     clusterState);
@@ -608,7 +608,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                                 .settings(Settings.builder()
                                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                                    .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                     .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID))))
                         .incrementVersion().build(),
                     clusterState);
@@ -684,14 +684,14 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                             .settings(Settings.builder()
                                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                 .put(IndexMetadata.SETTING_INDEX_UUID, updatedIndexUuid)))
                     .put(IndexMetadata.builder("deleted")
                         .version(randomLongBetween(0L, Long.MAX_VALUE - 1) - 1) // -1 because it's incremented in .put()
                         .settings(Settings.builder()
                             .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                             .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                             .put(IndexMetadata.SETTING_INDEX_UUID, deletedIndexUuid))))
                     .incrementVersion().build(),
                     clusterState);
@@ -719,7 +719,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                             .settings(Settings.builder()
                                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                 .put(IndexMetadata.SETTING_INDEX_UUID, addedIndexUuid))))
                     .incrementVersion().build(),
                     clusterState);
@@ -755,7 +755,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                                 .settings(Settings.builder()
                                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                                    .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                     .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID()))))
                         .incrementVersion().build(),
                         clusterState);
@@ -837,7 +837,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                             .settings(Settings.builder()
                                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                                 .put(IndexMetadata.SETTING_INDEX_UUID, "test-uuid"))))
                     .incrementVersion().build();
 

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -542,7 +542,7 @@ public class IndexSettingsTests extends ESTestCase {
     public void testSoftDeletesDefaultSetting() {
         // enabled by default on 7.0+ or later
         Version createdVersion = VersionUtils.randomIndexCompatibleVersion(random());
-        Settings settings = Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion).build();
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, createdVersion).build();
         assertTrue(IndexSettings.INDEX_SOFT_DELETES_SETTING.get(settings));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilterTests.java
@@ -77,23 +77,26 @@ public class PreConfiguredTokenFilterTests extends ESTestCase {
                     }
                 });
 
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
 
         Version version1 = VersionUtils.randomVersion(random());
-        Settings settings1 = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version1)
-                .build();
+        IndexSettings indexSettings1 = IndexSettingsModule.newIndexSettings("test", Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version1)
+            .build());
         TokenFilterFactory tff_v1_1 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", settings1);
+                pctf.get(indexSettings1, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", Settings.EMPTY);
         TokenFilterFactory tff_v1_2 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", settings1);
+                pctf.get(indexSettings1, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", Settings.EMPTY);
         assertSame(tff_v1_1, tff_v1_2);
 
         Version version2 = randomValueOtherThan(version1, () -> randomFrom(VersionUtils.allVersions()));
+        IndexSettings indexSettings2 = IndexSettingsModule.newIndexSettings("test", Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version2)
+            .build());
         Settings settings2 = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version2)
                 .build();
 
         TokenFilterFactory tff_v2 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", settings2);
+                pctf.get(indexSettings2, TestEnvironment.newEnvironment(emptyNodeSettings), "elasticsearch_version", settings2);
         assertNotSame(tff_v1_1, tff_v2);
     }
 
@@ -107,24 +110,25 @@ public class PreConfiguredTokenFilterTests extends ESTestCase {
                             }
                         });
 
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
-
         Version version1 = Version.CURRENT;
-        Settings settings1 = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version1)
-                .build();
+        IndexSettings indexSettings1 = IndexSettingsModule.newIndexSettings("test", Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version1)
+            .build());
+
         TokenFilterFactory tff_v1_1 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", settings1);
+                pctf.get(indexSettings1, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", Settings.EMPTY);
         TokenFilterFactory tff_v1_2 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", settings1);
+                pctf.get(indexSettings1, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", Settings.EMPTY);
         assertSame(tff_v1_1, tff_v1_2);
 
         byte major = VersionUtils.getFirstVersion().major;
         Version version2 = Version.fromString(major - 1 + ".0.0");
-        Settings settings2 = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version2)
-                .build();
+        IndexSettings indexSettings2 = IndexSettingsModule.newIndexSettings("test", Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version2)
+            .build());
 
         TokenFilterFactory tff_v2 =
-                pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", settings2);
+                pctf.get(indexSettings2, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", Settings.EMPTY);
         assertNotSame(tff_v1_1, tff_v2);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -122,7 +122,7 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper docMapper = createIndex("test",
                 Settings.builder()
-                        .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                        .put(IndexMetadata.SETTING_VERSION_CREATED,
                                 VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0))
                         .build()).mapperService()
             .parse("type", new CompressedXContent(mapping));
@@ -151,7 +151,7 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("_field_names").field("enabled", false).endObject()
             .endObject().endObject());
         MapperService mapperService = createIndex("test", Settings.builder()
-                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                .put(IndexMetadata.SETTING_VERSION_CREATED,
                         VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0))
                 .build()).mapperService();
 
@@ -169,7 +169,7 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
     @Override
     protected boolean forbidPrivateIndexSettings() {
         /**
-         * This is needed to force the index version with {@link IndexMetadata.SETTING_INDEX_VERSION_CREATED}.
+         * This is needed to force the index version with {@link IndexMetadata.SETTING_VERSION_CREATED}.
          */
         return false;
     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -445,7 +445,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         settings.remove(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey());
         // soft deletes setting is checked manually
         settings.remove(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey());
-        settings.remove(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey());
+        settings.remove(IndexMetadata.SETTING_VERSION_CREATED);
         settings.remove(IndexMetadata.SETTING_INDEX_UUID);
         settings.remove(IndexMetadata.SETTING_HISTORY_UUID);
         settings.remove(IndexMetadata.SETTING_INDEX_PROVIDED_NAME);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowActionTests.java
@@ -232,7 +232,7 @@ public class TransportResumeFollowActionTests extends ESTestCase {
         Settings.Builder settings = Settings.builder();
         settings.put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), "");
         settings.put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "");
-        settings.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), "");
+        settings.put(IndexMetadata.SETTING_VERSION_CREATED, "");
         settings.put(IndexMetadata.SETTING_INDEX_UUID, "");
         settings.put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, "");
         settings.put(IndexMetadata.SETTING_CREATION_DATE, "");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -323,7 +323,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
             Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
         IndexMetadata.Builder builder = IndexMetadata.builder(indexName)
             .settings(settings);

--- a/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/internalClusterTest/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -55,7 +55,7 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
     public void testSparseVectorWith8xIndex() throws Exception {
         Version version = VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, Version.CURRENT);
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), version)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version)
             .build();
 
         IndexService indexService = createIndex("index", settings);
@@ -79,7 +79,7 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
     public void testSparseVectorWith7xIndex() throws Exception {
         Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), version)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version)
             .build();
 
         IndexService indexService = createIndex("index", settings);


### PR DESCRIPTION
This PR removes the public method `Version#indexCreated(Settings)`. Now, the
index version is always checked through `IndexSettings#indexCreatedVersion`,
except in rare lower-level cases where the setting is accessed directly.

This makes it easier to understand what logic depends on the index version.
It's a step towards the goal of streamlining how/ where index versions are
accessed.

Relates to #65399.