### PR TITLE
RootObjectMapper to clone the runtime fields map (#65378)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -241,6 +241,13 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     @Override
+    protected ObjectMapper clone() {
+        ObjectMapper clone = super.clone();
+        ((RootObjectMapper) clone).runtimeFieldTypes = new HashMap<>(this.runtimeFieldTypes);
+        return clone;
+    }
+
+    @Override
     public ObjectMapper mappingUpdate(Mapper mapper) {
         RootObjectMapper update = (RootObjectMapper) super.mappingUpdate(mapper);
         // for dynamic updates, no need to carry root-specific options, we just
@@ -250,7 +257,8 @@ public class RootObjectMapper extends ObjectMapper {
         update.dynamicDateTimeFormatters = new Explicit<>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
         update.dateDetection = new Explicit<>(Defaults.DATE_DETECTION, false);
         update.numericDetection = new Explicit<>(Defaults.NUMERIC_DETECTION, false);
-        update.runtimeFieldTypes = new HashMap<>();
+        //also no need to carry the already defined runtime fields, only new ones need to be added
+        update.runtimeFieldTypes.clear();
         return update;
     }
 
@@ -355,7 +363,7 @@ public class RootObjectMapper extends ObjectMapper {
                 this.dynamicTemplates = mergeWithObject.dynamicTemplates;
             }
         }
-
+        assert this.runtimeFieldTypes != mergeWithObject.runtimeFieldTypes;
         this.runtimeFieldTypes.putAll(mergeWithObject.runtimeFieldTypes);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -489,6 +489,48 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         assertEquals(mapping, mapperService.documentMapper().mappingSource().toString());
     }
 
+    public void testRuntimeSectionRejectedUpdate() throws IOException {
+        MapperService mapperService;
+        {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
+            builder.startObject("runtime");
+            builder.startObject("field").field("type", "test").endObject();
+            builder.endObject();
+            builder.startObject("properties");
+            builder.startObject("concrete").field("type", "keyword").endObject();
+            builder.endObject();
+            builder.endObject().endObject();
+            mapperService = createMapperService(builder);
+            assertEquals(Strings.toString(builder), mapperService.documentMapper().mappingSource().toString());
+            MappedFieldType concrete = mapperService.fieldType("concrete");
+            assertThat(concrete, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
+            MappedFieldType field = mapperService.fieldType("field");
+            assertThat(field, instanceOf(RuntimeField.class));
+        }
+        {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
+            builder.startObject("runtime");
+            builder.startObject("another_field").field("type", "test").endObject();
+            builder.endObject();
+            builder.startObject("properties");
+            //try changing the type of the existing concrete field, so that merge fails
+            builder.startObject("concrete").field("type", "text").endObject();
+            builder.endObject();
+            builder.endObject().endObject();
+
+            expectThrows(IllegalArgumentException.class, () -> merge(mapperService, builder));
+
+            //make sure that the whole rejected update, including changes to runtime fields, has not been applied
+            MappedFieldType concrete = mapperService.fieldType("concrete");
+            assertThat(concrete, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
+            MappedFieldType field = mapperService.fieldType("field");
+            assertThat(field, instanceOf(RuntimeField.class));
+            assertNull(mapperService.fieldType("another_field"));
+            assertEquals("{\"_doc\":{\"runtime\":{\"field\":{\"type\":\"test\"}},\"properties\":{\"concrete\":{\"type\":\"keyword\"}}}}",
+                Strings.toString(mapperService.documentMapper().mapping().root));
+        }
+    }
+
     public void testRuntimeSectionMerge() throws IOException {
         MapperService mapperService;
         {


### PR DESCRIPTION
ObjectMappers clone themselves as part of their merge method, and also as part of dynamic mapping updates. As part of its clone, RootObjectMapper should clone its map of runtime fields, otherwise changes to the cloned root around runtime fields are reflected in the original root, which is not desirable.