### PR TITLE
Fixes documentation link in rollup.json

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -1,7 +1,7 @@
 {
   "rollup.rollup":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-rollup.html",
       "description":"Rollup an index"
     },
     "stability":"stable",


### PR DESCRIPTION
## Overview

This PR fixes a link in the `rollup.rollup.json` API spec that pointed to a nonexisting page.