### PR TITLE
Autoscaling: add nodes to capacity response (#64915)

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
@@ -11,7 +11,8 @@
       autoscaling.put_autoscaling_policy:
         name: my_autoscaling_policy
         body:
-          roles : []
+          # voting_only requires master to start so we are sure no nodes match
+          roles: ["voting_only"]
           deciders:
             fixed:
               storage: 1337b
@@ -32,6 +33,8 @@
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.storage: 1337b }
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.memory: 7331b }
   - match: { policies.my_autoscaling_policy.deciders.fixed.reason_summary: "fixed storage [1.3kb] memory [7.1kb] nodes [10]" }
+  - length: { policies.my_autoscaling_policy.current_nodes: 0 }
+
 
   # test cleanup
   - do:

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -50,7 +51,7 @@ public abstract class AutoscalingTestCase extends ESTestCase {
             .mapToObj(i -> Tuple.tuple(Integer.toString(i), randomAutoscalingDeciderResult()))
             .collect(Collectors.toMap(Tuple::v1, Tuple::v2, (a, b) -> { throw new IllegalStateException(); }, TreeMap::new));
         AutoscalingCapacity capacity = new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources());
-        return new AutoscalingDeciderResults(capacity, results);
+        return new AutoscalingDeciderResults(capacity, randomNodes(), results);
     }
 
     public static AutoscalingCapacity randomAutoscalingCapacity() {
@@ -81,6 +82,21 @@ public abstract class AutoscalingTestCase extends ESTestCase {
             addStorage ? randomByteSizeValue() : null,
             addMemory ? randomByteSizeValue() : null
         );
+    }
+
+    public static SortedSet<DiscoveryNode> randomNodes() {
+        String prefix = randomAlphaOfLength(5);
+        return IntStream.range(0, randomIntBetween(1, 10))
+            .mapToObj(
+                i -> new DiscoveryNode(
+                    prefix + i,
+                    buildNewFakeTransportAddress(),
+                    org.elasticsearch.common.collect.Map.of(),
+                    randomRoles().stream().map(DiscoveryNode::getRoleFromRoleName).collect(Collectors.toSet()),
+                    Version.CURRENT
+                )
+            )
+            .collect(Collectors.toCollection(() -> new TreeSet<>(AutoscalingDeciderResults.DISCOVERY_NODE_COMPARATOR)));
     }
 
     public static ByteSizeValue randomByteSizeValue() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -79,6 +80,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
 
             // there is no nodes in any tier.
             assertThat(results.currentCapacity(), equalTo(AutoscalingCapacity.ZERO));
+            assertThat(results.currentNodes(), equalTo(Collections.emptySortedSet()));
         }
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
@@ -7,11 +7,21 @@
 package org.elasticsearch.xpack.autoscaling.capacity;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
 
@@ -28,6 +39,7 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
             IllegalArgumentException.class,
             () -> new AutoscalingDeciderResults(
                 new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources()),
+                randomNodes(),
                 new TreeMap<>()
             )
         );
@@ -61,6 +73,51 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
         verifySingleMetricLarger(node, large, largerMemory, autoscalingCapacities, largerMemory);
     }
 
+    public void testToXContent() {
+        AutoscalingDeciderResults results = randomAutoscalingDeciderResults();
+        Map<String, Object> map = toMap(results);
+        boolean hasRequiredCapacity = results.requiredCapacity() != null;
+        Set<String> roots = hasRequiredCapacity
+            ? org.elasticsearch.common.collect.Set.of("current_capacity", "current_nodes", "deciders", "required_capacity")
+            : org.elasticsearch.common.collect.Set.of("current_capacity", "current_nodes", "deciders");
+        assertThat(map.keySet(), equalTo(roots));
+        assertThat(map.get("current_nodes"), instanceOf(List.class));
+        List<?> expectedNodes = results.currentNodes()
+            .stream()
+            .map(dn -> org.elasticsearch.common.collect.Map.of("name", dn.getName()))
+            .collect(Collectors.toList());
+        assertThat(map.get("current_nodes"), equalTo(expectedNodes));
+        if (hasRequiredCapacity) {
+            assertThat(map.get("required_capacity"), equalTo(toMap(results.requiredCapacity())));
+        }
+
+        assertThat(map.get("current_capacity"), equalTo(toMap(results.currentCapacity())));
+        assertThat(
+            map.get("deciders"),
+            equalTo(results.results().entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> toMap(e.getValue()))))
+        );
+    }
+
+    public Map<String, Object> toMap(ToXContent tox) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            if (tox.isFragment()) {
+                builder.startObject();
+            }
+            tox.toXContent(builder, null);
+            if (tox.isFragment()) {
+                builder.endObject();
+            }
+            try (
+                XContentParser parser = XContentType.JSON.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput())
+            ) {
+                return parser.map();
+            }
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private void verifySingleMetricLarger(
         boolean node,
         AutoscalingCapacity expectedStorage,
@@ -91,7 +148,10 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
                     TreeMap::new
                 )
             );
-        assertThat(new AutoscalingDeciderResults(randomAutoscalingCapacity(), results).requiredCapacity(), equalTo(expected));
+        assertThat(
+            new AutoscalingDeciderResults(randomAutoscalingCapacity(), randomNodes(), results).requiredCapacity(),
+            equalTo(expected)
+        );
     }
 
     private AutoscalingCapacity randomCapacity(boolean node, boolean storage, boolean memory, int lower, int upper) {


### PR DESCRIPTION
Backport of #64915 

When an autoscaling capacity is calculated, we base this on information
about the current nodes in the cluster. In some cases, we may return
too small or too large a capacity if nodes are missing in the cluster.
The current_nodes returned in the capacity response allows the client
of the autoscaling capacity API to detect this by comparing to the
expected set of nodes. This in turn allows the client to disregard the
capacity for a policy as long as there is a discrepancy.