### PR TITLE
QL: Improve expression normalization

### DIFF
--- a/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
@@ -465,8 +465,8 @@ addOperatorReversed
 process where 2 + serial_event_id == 41
 ;
 "script":{"source":"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.eq(
-InternalQlScriptUtils.add(params.v0,InternalQlScriptUtils.docValue(doc,params.v1)),params.v2))",
-"params":{"v0":2,"v1":"serial_event_id","v2":41}
+InternalQlScriptUtils.add(InternalQlScriptUtils.docValue(doc,params.v0),params.v1),params.v2))",
+"params":{"v0":"serial_event_id","v1":2,"v2":41}
 ;
 
 addFunction
@@ -481,8 +481,8 @@ addFunctionReversed
 process where add(2, serial_event_id) == 41
 ;
 "script":{"source":"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.eq(
-InternalQlScriptUtils.add(params.v0,InternalQlScriptUtils.docValue(doc,params.v1)),params.v2))",
-"params":{"v0":2,"v1":"serial_event_id","v2":41}
+InternalQlScriptUtils.add(InternalQlScriptUtils.docValue(doc,params.v0),params.v1),params.v2))",
+"params":{"v0":"serial_event_id","v1":2,"v2":41}
 ;
 
 divideOperator
@@ -561,8 +561,8 @@ multiplyOperatorReversed
 process where 2 * serial_event_id == 41
 ;
 "script":{"source":"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.eq(
-InternalQlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1)),params.v2))",
-"params":{"v0":2,"v1":"serial_event_id","v2":41}
+InternalQlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1),params.v2))",
+"params":{"v0":"serial_event_id","v1":2,"v2":41}
 ;
 
 multiplyFunction
@@ -577,8 +577,8 @@ multiplyFunctionReversed
 process where multiply(2, serial_event_id) == 41
 ;
 "script":{"source":"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.eq(
-InternalQlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1)),params.v2))",
-"params":{"v0":2,"v1":"serial_event_id","v2":41}
+InternalQlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1),params.v2))",
+"params":{"v0":"serial_event_id","v1":2,"v2":41}
 ;
 
 subtractOperator

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/BinaryOperator.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/BinaryOperator.java
@@ -36,4 +36,9 @@ public abstract class BinaryOperator<T, U, R, F extends PredicateBiFunction<T, U
         }
         return resolveInputType(right(), ParamOrdinal.SECOND);
     }
+
+    @Override
+    protected Expression canonicalize() {
+        return left().semanticHash() > right().semanticHash() ? swapLeftAndRight() : this;
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Add.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Add.java
@@ -26,4 +26,8 @@ public class Add extends DateTimeArithmeticOperation {
     protected Add replaceChildren(Expression left, Expression right) {
         return new Add(source(), left, right);
     }
+
+    public Add swapLeftAndRight() {
+        return new Add(source(), right(), left());
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Mul.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Mul.java
@@ -48,4 +48,8 @@ public class Mul extends ArithmeticOperation {
     protected Mul replaceChildren(Expression newLeft, Expression newRight) {
         return new Mul(source(), newLeft, newRight);
     }
+
+    public Mul swapLeftAndRight() {
+        return new Mul(source(), right(), left());
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/BinaryComparison.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/BinaryComparison.java
@@ -37,11 +37,6 @@ public abstract class BinaryComparison extends BinaryOperator<Object, Object, Bo
     }
 
     @Override
-    protected Expression canonicalize() {
-        return left().hashCode() > right().hashCode() ? swapLeftAndRight() : this;
-    }
-
-    @Override
     public DataType dataType() {
         return DataTypes.BOOLEAN;
     }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/predicate/CanonicalizeTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/predicate/CanonicalizeTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ql.expression.predicate;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.ql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Mul;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.xpack.ql.TestUtils.of;
+
+public class CanonicalizeTests extends ESTestCase {
+
+    interface BinaryOperatorFactory {
+        BinaryOperator<?,?,?,?> create(Source source, Expression left, Expression right);
+    }
+
+    public void testBasicOperators() throws Exception {
+        List<BinaryOperatorFactory> list = Arrays.asList(
+            // arithmetic
+            Add::new, Mul::new,
+            // logical
+            Or::new, And::new
+        );
+
+        for (BinaryOperatorFactory factory : list) {
+            Literal left = of(randomInt());
+            Literal right = of(randomInt());
+
+            BinaryOperator<?,?,?,?> first = factory.create(Source.EMPTY, left, right);
+            BinaryOperator<?,?,?,?> second = factory.create(Source.EMPTY, right, left);
+
+            assertNotEquals(first, second);
+            assertTrue(first.semanticEquals(second));
+            assertEquals(first, second.swapLeftAndRight());
+            assertEquals(second, first.swapLeftAndRight());
+        }
+    }
+
+    interface BinaryOperatorWithTzFactory {
+        BinaryOperator<?,?,?,?> create(Source source, Expression left, Expression right, ZoneId zoneId);
+    }
+
+    public void testTimeZoneOperators() throws Exception {
+        List<BinaryOperatorWithTzFactory> list = Arrays.asList(
+            LessThan::new, LessThanOrEqual::new,
+            Equals::new, NotEquals::new,
+            GreaterThan::new, GreaterThanOrEqual::new
+        );
+
+        for (BinaryOperatorWithTzFactory factory : list) {
+            Literal left = of(randomInt());
+            Literal right = of(randomInt());
+            ZoneId zoneId = randomZone();
+
+
+            BinaryOperator<?, ?, ?, ?> first = factory.create(Source.EMPTY, left, right, zoneId);
+            BinaryOperator<?,?,?,?> swap = first.swapLeftAndRight();
+
+            assertNotEquals(first, swap);
+            assertTrue(first.semanticEquals(swap));
+        }
+    }
+}

--- a/x-pack/plugin/ql/test/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.predicate.Range;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
@@ -27,7 +28,9 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEq
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.session.Configuration;
 import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import java.io.BufferedReader;
@@ -45,6 +48,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +56,8 @@ import java.util.jar.JarInputStream;
 import java.util.zip.ZipEntry;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomZone;
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 import static org.junit.Assert.assertEquals;
@@ -116,6 +122,14 @@ public final class TestUtils {
 
     public static Range rangeOf(Expression value, Expression lower, boolean includeLower, Expression upper, boolean includeUpper) {
         return new Range(EMPTY, value, lower, includeLower, upper, includeUpper, randomZone());
+    }
+
+    public static FieldAttribute fieldAttribute() {
+        return fieldAttribute(randomAlphaOfLength(10), randomFrom(DataTypes.types()));
+    }
+
+    public static FieldAttribute fieldAttribute(String name, DataType type) {
+        return new FieldAttribute(EMPTY, name, new EsField(name, type, Collections.emptyMap(), randomBoolean()));
     }
 
     //

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Add.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Add.java
@@ -26,4 +26,9 @@ public class Add extends DateTimeArithmeticOperation {
     protected Add replaceChildren(Expression left, Expression right) {
         return new Add(source(), left, right);
     }
+
+    @Override
+    public Add swapLeftAndRight() {
+        return new Add(source(), right(), left());
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Mul.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Mul.java
@@ -67,4 +67,8 @@ public class Mul extends SqlArithmeticOperation {
     protected Mul replaceChildren(Expression newLeft, Expression newRight) {
         return new Mul(source(), newLeft, newRight);
     }
+
+    public Mul swapLeftAndRight() {
+        return new Mul(source(), right(), left());
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -1800,9 +1800,9 @@ public class QueryTranslatorTests extends ESTestCase {
         assertThat(
             ((EsQueryExec) p).queryContainer().aggs().asAggBuilder().toString()
                 .replaceAll("\\s+", ""),
-                endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1))\","
+                endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)\","
                         +
-                "\"lang\":\"painless\",\"params\":{\"v0\":3.141592653589793,\"v1\":\"int\"}},\"missing_bucket\":true," +
+                "\"lang\":\"painless\",\"params\":{\"v0\":\"int\",\"v1\":3.141592653589793}},\"missing_bucket\":true," +
                 "\"value_type\":\"double\",\"order\":\"asc\"}}}]}}}")
         );
     }
@@ -1818,9 +1818,9 @@ public class QueryTranslatorTests extends ESTestCase {
             assertThat(
                 ((EsQueryExec) p).queryContainer().aggs().asAggBuilder().toString()
                     .replaceAll("\\s+", ""),
-                    endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1))"
+                    endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)"
                             +
-                    "\",\"lang\":\"painless\",\"params\":{\"v0\":3.141592653589793,\"v1\":\"int\"}},\"missing_bucket\":true," +
+                    "\",\"lang\":\"painless\",\"params\":{\"v0\":\"int\",\"v1\":3.141592653589793}},\"missing_bucket\":true," +
                     "\"value_type\":\"double\",\"order\":\"asc\"}}}]}}}")
             );
         }
@@ -1853,9 +1853,9 @@ public class QueryTranslatorTests extends ESTestCase {
             assertThat(
                 ((EsQueryExec) p).queryContainer().aggs().asAggBuilder().toString()
                     .replaceAll("\\s+", ""),
-                    endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1))"
+                    endsWith("{\"script\":{\"source\":\"InternalSqlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)"
                             +
-                    "\",\"lang\":\"painless\",\"params\":{\"v0\":3.141592653589793,\"v1\":\"int\"}},\"missing_bucket\":true," +
+                    "\",\"lang\":\"painless\",\"params\":{\"v0\":\"int\",\"v1\":3.141592653589793}},\"missing_bucket\":true," +
                     "\"value_type\":\"double\",\"order\":\"asc\"}}}]}}}")
             );
         }
@@ -1868,8 +1868,8 @@ public class QueryTranslatorTests extends ESTestCase {
             assertThat(
                 ((EsQueryExec) p).queryContainer().aggs().asAggBuilder().toString()
                     .replaceAll("\\s+", ""),
-                    endsWith("{\"source\":\"InternalSqlScriptUtils.mul(params.v0,InternalQlScriptUtils.docValue(doc,params.v1))\"," +
-                    "\"lang\":\"painless\",\"params\":{\"v0\":3.141592653589793,\"v1\":\"int\"}}," +
+                    endsWith("{\"source\":\"InternalSqlScriptUtils.mul(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)\"," +
+                    "\"lang\":\"painless\",\"params\":{\"v0\":\"int\",\"v1\":3.141592653589793}}," +
                     "\"missing_bucket\":true,\"value_type\":\"double\",\"order\":\"asc\"}}}]}}}")
             );
         }


### PR DESCRIPTION
Add canonical representation to binary logic operator and commutative math. Without this, commutative expressions that are equivalent are not semantically equals which leads to weird behavior such as the tree being modified due to expressions not being equal (a OR b != b OR a).

Relates #65353