### PR TITLE
QL: Stop duplicating children in InnerAggregate (#65401)

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/CompoundAggregate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/CompoundAggregate.java
@@ -17,5 +17,5 @@ public interface CompoundAggregate {
 
     Expression field();
 
-    List<Expression> arguments();
+    List<? extends Expression> parameters();
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
@@ -27,7 +27,7 @@ public class InnerAggregate extends AggregateFunction {
     }
 
     public InnerAggregate(Source source, AggregateFunction inner, CompoundAggregate outer, Expression innerKey) {
-        super(source, outer.field(), outer.arguments());
+        super(source, outer.field(), outer.parameters());
         this.inner = inner;
         this.outer = outer;
         Check.isTrue(inner instanceof EnclosedAgg, "Inner function is not marked as Enclosed");


### PR DESCRIPTION
Instead of the `arguments()` that is the synonym of the `children()`,
use the `parameters()` (everything except the field) to avoid
duplicating the `field` in the `children` collection.