### PR TITLE
[7.10] [DOCS] Correct the url in delete-component-template doc (#65349)

### DIFF
--- a/docs/reference/indices/delete-component-template.asciidoc
+++ b/docs/reference/indices/delete-component-template.asciidoc
@@ -30,7 +30,7 @@ DELETE _component_template/template_1
 [[delete-component-template-api-request]]
 ==== {api-request-title}
 
-`DELETE /_template/<component-template>`
+`DELETE /_component_template/<component-template>`
 
 
 [[delete-component-template-api-desc]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Correct the url in delete-component-template doc (#65349)