### PR TITLE
Return an error when a rate aggregation cannot calculate bucket sizes

### DIFF
--- a/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
@@ -261,6 +261,11 @@ convert the bucket size into the rate. By default the interval of the `date_hist
 `"rate": "quarter"`:: compatible with only with `month`, `quarter` and `year` calendar intervals
 `"rate": "year"`:: compatible with only with `month`, `quarter` and `year` calendar intervals
 
+There is also an additional limitations if the date histogram is not a direct parent of the rate histogram. In this case both rate interval
+and histogram interval have to be in the same group: [`second`, ` minute`, `hour`, `day`, `week`] or [`month`, `quarter`, `year`]. For
+example, if the date histogram is `month` based, only rate intervals of `month`, `quarter` or `year` are supported. If the date histogram
+is `day` based, only  `second`, ` minute`, `hour`, `day`, and `week` rate intervals are supported.
+
 ==== Script
 
 The `rate` aggregation also supports scripting. For example, if we need to adjust out prices before calculating rates, we could use

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -290,7 +290,7 @@ public abstract class Rounding implements Writeable {
          * Given the rounded value, returns the size between this value and the
          * next rounded value in specified units if possible.
          */
-        double roundingSize(long utcMillis, DateTimeUnit timeUnit);
+        double roundingSize(Long utcMillis, DateTimeUnit timeUnit);
         /**
          * If this rounding mechanism precalculates rounding points then
          * this array stores dates such that each date between each entry.
@@ -609,16 +609,22 @@ public abstract class Rounding implements Writeable {
 
         private abstract class TimeUnitPreparedRounding extends PreparedRounding {
             @Override
-            public double roundingSize(long utcMillis, DateTimeUnit timeUnit) {
+            public double roundingSize(Long utcMillis, DateTimeUnit timeUnit) {
                 if (timeUnit.isMillisBased == unit.isMillisBased) {
                     return (double) unit.ratio / timeUnit.ratio;
                 } else {
-                    if (unit.isMillisBased == false) {
+                    if (unit.isMillisBased == false && utcMillis != null) {
                         return (double) (nextRoundingValue(utcMillis) - utcMillis) / timeUnit.ratio;
                     } else {
-                        throw new IllegalArgumentException("Cannot use month-based rate unit [" + timeUnit.shortName +
-                            "] with non-month based calendar interval histogram [" + unit.shortName +
-                            "] only week, day, hour, minute and second are supported for this histogram");
+                        if (timeUnit.isMillisBased == false) {
+                            throw new IllegalArgumentException("Cannot use month-based rate unit [" + timeUnit.shortName +
+                                "] with non-month based calendar interval histogram [" + unit.shortName +
+                                "] only week, day, hour, minute and second are supported for this histogram");
+                        } else {
+                            throw new IllegalArgumentException("Cannot use non month-based rate unit [" + timeUnit.shortName +
+                                "] with month-based calendar interval histogram [" + unit.shortName +
+                                "] only month, quarter and year are supported for this histogram");
+                        }
                     }
                 }
             }
@@ -995,7 +1001,7 @@ public abstract class Rounding implements Writeable {
 
         private abstract class TimeIntervalPreparedRounding extends PreparedRounding {
             @Override
-            public double roundingSize(long utcMillis, DateTimeUnit timeUnit) {
+            public double roundingSize(Long utcMillis, DateTimeUnit timeUnit) {
                 if (timeUnit.isMillisBased) {
                     return (double) interval / timeUnit.ratio;
                 } else {
@@ -1262,7 +1268,7 @@ public abstract class Rounding implements Writeable {
                 }
 
                 @Override
-                public double roundingSize(long utcMillis, DateTimeUnit timeUnit) {
+                public double roundingSize(Long utcMillis, DateTimeUnit timeUnit) {
                     return delegatePrepared.roundingSize(utcMillis, timeUnit);
                 }
 
@@ -1350,7 +1356,7 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
-        public double roundingSize(long utcMillis, DateTimeUnit timeUnit) {
+        public double roundingSize(Long utcMillis, DateTimeUnit timeUnit) {
             return delegate.roundingSize(utcMillis, timeUnit);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -347,7 +347,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
     @Override
     public double bucketSize(Rounding.DateTimeUnit unitSize) {
         if (unitSize != null) {
-            return preparedRounding.roundingSize(null, unitSize);
+            return preparedRounding.roundingSize(unitSize);
         } else {
             return 1.0;
         }
@@ -444,7 +444,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         @Override
         public double bucketSize(DateTimeUnit unitSize) {
             if (unitSize != null) {
-                return preparedRounding.roundingSize(null, unitSize);
+                return preparedRounding.roundingSize(unitSize);
             } else {
                 return 1.0;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -344,6 +344,15 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         }
     }
 
+    @Override
+    public double bucketSize(Rounding.DateTimeUnit unitSize) {
+        if (unitSize != null) {
+            return preparedRounding.roundingSize(null, unitSize);
+        } else {
+            return 1.0;
+        }
+    }
+
     static class FromDateRange extends AdaptingAggregator implements SizedBucketAggregator {
         private final DocValueFormat format;
         private final Rounding rounding;
@@ -427,6 +436,15 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
             if (unitSize != null) {
                 long startPoint = bucket < fixedRoundingPoints.length ? fixedRoundingPoints[(int) bucket] : Long.MIN_VALUE;
                 return preparedRounding.roundingSize(startPoint, unitSize);
+            } else {
+                return 1.0;
+            }
+        }
+
+        @Override
+        public double bucketSize(DateTimeUnit unitSize) {
+            if (unitSize != null) {
+                return preparedRounding.roundingSize(null, unitSize);
             } else {
                 return 1.0;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/SizedBucketAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/SizedBucketAggregator.java
@@ -22,8 +22,17 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.elasticsearch.common.Rounding;
 
 /**
- * An aggregator capable of reporting bucket sizes in milliseconds. Used by RateAggregator for calendar-based buckets.
+ * An aggregator capable of reporting bucket sizes in requested units. Used by RateAggregator for calendar-based buckets.
  */
 public interface SizedBucketAggregator {
+    /**
+     * Reports size of the particular bucket in requested units.
+     */
     double bucketSize(long bucket, Rounding.DateTimeUnit unit);
+
+    /**
+     * Reports size of all buckets in requested units. Throws an exception if it is not possible to calculate without knowing
+     * the concrete bucket.
+     */
+    double bucketSize(Rounding.DateTimeUnit unit);
 }

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -979,24 +979,26 @@ public class RoundingTests extends ESTestCase {
     public void testMillisecondsBasedUnitCalendarRoundingSize() {
         Rounding unitRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build();
         Rounding.Prepared prepared = unitRounding.prepare(time("2010-01-01T00:00:00.000Z"), time("2020-01-01T00:00:00.000Z"));
-        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.SECOND_OF_MINUTE),
+        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.SECOND_OF_MINUTE),
             closeTo(3600.0, 0.000001));
-        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MINUTES_OF_HOUR), closeTo(60.0, 0.000001));
-        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.HOUR_OF_DAY), closeTo(1.0, 0.000001));
-        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.DAY_OF_MONTH),
+        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MINUTES_OF_HOUR),
+            closeTo(60.0, 0.000001));
+        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.HOUR_OF_DAY),
+            closeTo(1.0, 0.000001));
+        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.DAY_OF_MONTH),
             closeTo(1 / 24.0, 0.000001));
-        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.WEEK_OF_WEEKYEAR),
+        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.WEEK_OF_WEEKYEAR),
             closeTo(1 / 168.0, 0.000001));
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MONTH_OF_YEAR));
+            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MONTH_OF_YEAR));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [month] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
         ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.QUARTER_OF_YEAR));
+            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.QUARTER_OF_YEAR));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [quarter] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
         ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.YEAR_OF_CENTURY));
+            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.YEAR_OF_CENTURY));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [year] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
     }
@@ -1005,10 +1007,11 @@ public class RoundingTests extends ESTestCase {
         Rounding unitRounding = Rounding.builder(Rounding.DateTimeUnit.QUARTER_OF_YEAR).build();
         Rounding.Prepared prepared = unitRounding.prepare(time("2010-01-01T00:00:00.000Z"), time("2020-01-01T00:00:00.000Z"));
         long firstQuarter = prepared.round(time("2015-01-01T00:00:00.000Z"));
+        Long firstQuarterOrNull = randomBoolean() ? firstQuarter : null;
         // Ratio based
-        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.MONTH_OF_YEAR), closeTo(3.0, 0.000001));
-        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.QUARTER_OF_YEAR), closeTo(1.0, 0.000001));
-        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.YEAR_OF_CENTURY), closeTo(0.25, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.MONTH_OF_YEAR), closeTo(3.0, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.QUARTER_OF_YEAR), closeTo(1.0, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.YEAR_OF_CENTURY), closeTo(0.25, 0.000001));
         // Real interval based
         assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.SECOND_OF_MINUTE), closeTo(7776000.0, 0.000001));
         assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.MINUTES_OF_HOUR), closeTo(129600.0, 0.000001));
@@ -1017,6 +1020,10 @@ public class RoundingTests extends ESTestCase {
         long thirdQuarter = prepared.round(time("2015-07-01T00:00:00.000Z"));
         assertThat(prepared.roundingSize(thirdQuarter, Rounding.DateTimeUnit.DAY_OF_MONTH), closeTo(92.0, 0.000001));
         assertThat(prepared.roundingSize(thirdQuarter, Rounding.DateTimeUnit.HOUR_OF_DAY), closeTo(2208.0, 0.000001));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> prepared.roundingSize(null, Rounding.DateTimeUnit.SECOND_OF_MINUTE));
+        assertThat(ex.getMessage(), equalTo("Cannot use non month-based rate unit [second] with month-based calendar interval histogram " +
+            "[quarter] only month, quarter and year are supported for this histogram"));
     }
 
     public void testFixedRoundingPoints() {
@@ -1137,6 +1144,10 @@ public class RoundingTests extends ESTestCase {
 
     private static long time(String time) {
         return time(time, ZoneOffset.UTC);
+    }
+
+    private static Long timeOrNull(String time) {
+        return randomBoolean() ? time(time, ZoneOffset.UTC) : null;
     }
 
     private static long time(String time, ZoneId zone) {

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -979,26 +979,48 @@ public class RoundingTests extends ESTestCase {
     public void testMillisecondsBasedUnitCalendarRoundingSize() {
         Rounding unitRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).build();
         Rounding.Prepared prepared = unitRounding.prepare(time("2010-01-01T00:00:00.000Z"), time("2020-01-01T00:00:00.000Z"));
-        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.SECOND_OF_MINUTE),
+        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.SECOND_OF_MINUTE),
             closeTo(3600.0, 0.000001));
-        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MINUTES_OF_HOUR),
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.SECOND_OF_MINUTE),
+            closeTo(3600.0, 0.000001));
+        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MINUTES_OF_HOUR),
             closeTo(60.0, 0.000001));
-        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.HOUR_OF_DAY),
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.MINUTES_OF_HOUR),
+            closeTo(60.0, 0.000001));
+        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.HOUR_OF_DAY),
             closeTo(1.0, 0.000001));
-        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.DAY_OF_MONTH),
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.HOUR_OF_DAY),
+            closeTo(1.0, 0.000001));
+        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.DAY_OF_MONTH),
             closeTo(1 / 24.0, 0.000001));
-        assertThat(prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.WEEK_OF_WEEKYEAR),
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.DAY_OF_MONTH),
+            closeTo(1 / 24.0, 0.000001));
+        assertThat(prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.WEEK_OF_WEEKYEAR),
+            closeTo(1 / 168.0, 0.000001));
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.WEEK_OF_WEEKYEAR),
             closeTo(1 / 168.0, 0.000001));
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MONTH_OF_YEAR));
+            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.MONTH_OF_YEAR));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [month] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
         ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.QUARTER_OF_YEAR));
+            () -> prepared.roundingSize(Rounding.DateTimeUnit.MONTH_OF_YEAR));
+        assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [month] with non-month based calendar interval " +
+            "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
+        ex = expectThrows(IllegalArgumentException.class,
+            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.QUARTER_OF_YEAR));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [quarter] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
         ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(timeOrNull("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.YEAR_OF_CENTURY));
+            () -> prepared.roundingSize(Rounding.DateTimeUnit.QUARTER_OF_YEAR));
+        assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [quarter] with non-month based calendar interval " +
+            "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
+        ex = expectThrows(IllegalArgumentException.class,
+            () -> prepared.roundingSize(time("2015-01-01T00:00:00.000Z"), Rounding.DateTimeUnit.YEAR_OF_CENTURY));
+        assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [year] with non-month based calendar interval " +
+            "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
+        ex = expectThrows(IllegalArgumentException.class,
+            () -> prepared.roundingSize(Rounding.DateTimeUnit.YEAR_OF_CENTURY));
         assertThat(ex.getMessage(), equalTo("Cannot use month-based rate unit [year] with non-month based calendar interval " +
             "histogram [hour] only week, day, hour, minute and second are supported for this histogram"));
     }
@@ -1007,11 +1029,13 @@ public class RoundingTests extends ESTestCase {
         Rounding unitRounding = Rounding.builder(Rounding.DateTimeUnit.QUARTER_OF_YEAR).build();
         Rounding.Prepared prepared = unitRounding.prepare(time("2010-01-01T00:00:00.000Z"), time("2020-01-01T00:00:00.000Z"));
         long firstQuarter = prepared.round(time("2015-01-01T00:00:00.000Z"));
-        Long firstQuarterOrNull = randomBoolean() ? firstQuarter : null;
         // Ratio based
-        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.MONTH_OF_YEAR), closeTo(3.0, 0.000001));
-        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.QUARTER_OF_YEAR), closeTo(1.0, 0.000001));
-        assertThat(prepared.roundingSize(firstQuarterOrNull, Rounding.DateTimeUnit.YEAR_OF_CENTURY), closeTo(0.25, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.MONTH_OF_YEAR), closeTo(3.0, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.QUARTER_OF_YEAR), closeTo(1.0, 0.000001));
+        assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.YEAR_OF_CENTURY), closeTo(0.25, 0.000001));
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.MONTH_OF_YEAR), closeTo(3.0, 0.000001));
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.QUARTER_OF_YEAR), closeTo(1.0, 0.000001));
+        assertThat(prepared.roundingSize(Rounding.DateTimeUnit.YEAR_OF_CENTURY), closeTo(0.25, 0.000001));
         // Real interval based
         assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.SECOND_OF_MINUTE), closeTo(7776000.0, 0.000001));
         assertThat(prepared.roundingSize(firstQuarter, Rounding.DateTimeUnit.MINUTES_OF_HOUR), closeTo(129600.0, 0.000001));
@@ -1021,8 +1045,8 @@ public class RoundingTests extends ESTestCase {
         assertThat(prepared.roundingSize(thirdQuarter, Rounding.DateTimeUnit.DAY_OF_MONTH), closeTo(92.0, 0.000001));
         assertThat(prepared.roundingSize(thirdQuarter, Rounding.DateTimeUnit.HOUR_OF_DAY), closeTo(2208.0, 0.000001));
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> prepared.roundingSize(null, Rounding.DateTimeUnit.SECOND_OF_MINUTE));
-        assertThat(ex.getMessage(), equalTo("Cannot use non month-based rate unit [second] with month-based calendar interval histogram " +
+            () -> prepared.roundingSize(Rounding.DateTimeUnit.SECOND_OF_MINUTE));
+        assertThat(ex.getMessage(), equalTo("Cannot use non month-based rate unit [second] with calendar interval histogram " +
             "[quarter] only month, quarter and year are supported for this histogram"));
     }
 
@@ -1144,10 +1168,6 @@ public class RoundingTests extends ESTestCase {
 
     private static long time(String time) {
         return time(time, ZoneOffset.UTC);
-    }
-
-    private static Long timeOrNull(String time) {
-        return randomBoolean() ? time(time, ZoneOffset.UTC) : null;
     }
 
     private static long time(String time, ZoneId zone) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
@@ -80,7 +80,7 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
         if (sizedBucketAggregator == null || valuesSource == null || owningBucketOrd >= sums.size()) {
             return 0.0;
         }
-        return sums.get(owningBucketOrd) / sizedBucketAggregator.bucketSize(owningBucketOrd, rateUnit);
+        return sums.get(owningBucketOrd) / divisor(owningBucketOrd);
     }
 
     @Override
@@ -88,7 +88,15 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
         if (valuesSource == null || bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
-        return new InternalRate(name, sums.get(bucket), sizedBucketAggregator.bucketSize(bucket, rateUnit), format, metadata());
+        return new InternalRate(name, sums.get(bucket), divisor(bucket), format, metadata());
+    }
+
+    private double divisor(long owningBucketOrd) {
+        if (sizedBucketAggregator == parent) {
+            return sizedBucketAggregator.bucketSize(owningBucketOrd, rateUnit);
+        } else {
+            return sizedBucketAggregator.bucketSize(rateUnit);
+        }
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
@@ -440,7 +440,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
             fail("Shouldn't be here");
         }, dateType, numType, keywordType));
         if (millisecondBasedRate) {
-            assertEquals("Cannot use non month-based rate unit [" + rate + "] with month-based calendar interval histogram [" +
+            assertEquals("Cannot use non month-based rate unit [" + rate + "] with calendar interval histogram [" +
                 histogram + "] only month, quarter and year are supported for this histogram", ex.getMessage());
         } else {
             assertEquals("Cannot use month-based rate unit [" + rate + "] with non-month based calendar interval histogram [" +

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
@@ -377,6 +377,77 @@ public class RateAggregatorTests extends AggregatorTestCase {
         }, dateType, numType, keywordType);
     }
 
+    public void testUnsupportedKeywordSandwich() throws IOException {
+        String rate;
+        String histogram;
+        boolean millisecondBasedRate = randomBoolean();
+        if (millisecondBasedRate) {
+            rate = randomFrom("second", "minute", "day", "week");
+            histogram = randomFrom("month", "quarter", "year");
+        } else {
+            rate = randomFrom("month", "quarter", "year");
+            histogram = randomFrom("second", "minute", "day", "week");
+        }
+
+        MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        MappedFieldType dateType = dateFieldType(DATE_FIELD);
+        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit(rate).field("val");
+        if (randomBoolean()) {
+            rateAggregationBuilder.rateMode("sum");
+        }
+        TermsAggregationBuilder termsAggregationBuilder = new TermsAggregationBuilder("my_term").field("term")
+            .subAggregation(rateAggregationBuilder);
+        DateHistogramAggregationBuilder dateHistogramAggregationBuilder = new DateHistogramAggregationBuilder("my_date").field(DATE_FIELD)
+            .calendarInterval(new DateHistogramInterval(histogram))
+            .subAggregation(termsAggregationBuilder);
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class, () -> testCase(dateHistogramAggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            iw.addDocument(
+                doc(
+                    "2010-03-11T01:07:45",
+                    new NumericDocValuesField("val", 1),
+                    new IntPoint("val", 1),
+                    new SortedSetDocValuesField("term", new BytesRef("a"))
+                )
+            );
+            iw.addDocument(
+                doc(
+                    "2010-03-12T01:07:45",
+                    new NumericDocValuesField("val", 2),
+                    new IntPoint("val", 2),
+                    new SortedSetDocValuesField("term", new BytesRef("a"))
+                )
+            );
+            iw.addDocument(
+                doc(
+                    "2010-04-01T03:43:34",
+                    new NumericDocValuesField("val", 3),
+                    new IntPoint("val", 3),
+                    new SortedSetDocValuesField("term", new BytesRef("a"))
+                )
+            );
+            iw.addDocument(
+                doc(
+                    "2010-04-27T03:43:34",
+                    new NumericDocValuesField("val", 4),
+                    new IntPoint("val", 4),
+                    new SortedSetDocValuesField("term", new BytesRef("b"))
+                )
+            );
+        }, (Consumer<InternalDateHistogram>) dh -> {
+            fail("Shouldn't be here");
+        }, dateType, numType, keywordType));
+        if (millisecondBasedRate) {
+            assertEquals("Cannot use non month-based rate unit [" + rate + "] with month-based calendar interval histogram [" +
+                histogram + "] only month, quarter and year are supported for this histogram", ex.getMessage());
+        } else {
+            assertEquals("Cannot use month-based rate unit [" + rate + "] with non-month based calendar interval histogram [" +
+                histogram + "] only week, day, hour, minute and second are supported for this histogram", ex.getMessage());
+        }
+    }
+
     public void testKeywordSandwichWithSorting() throws IOException {
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);


### PR DESCRIPTION
In some cases when the rate aggregation is not a child of a date histogram
aggregation, it is not possible to determine the actual size of the date
histogram bucket. In this case the rate aggregation now throws an exception.

Closes #63703
