### PR TITLE
reduce version bounds for spatial usage info to 7.11

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
@@ -27,7 +27,7 @@ public class SpatialFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public SpatialFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
-        if (input.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (input.getVersion().onOrAfter(Version.V_7_11_0)) {
             this.statsResponse = new SpatialStatsAction.Response(input);
         } else {
             this.statsResponse = null;
@@ -46,7 +46,7 @@ public class SpatialFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
             this.statsResponse.writeTo(out);
         }
     }


### PR DESCRIPTION
with #65391 merged as a backport of #61946.
the version bounds must be changed from 8 to 7.11

relates #61946.