### PR TITLE
Fix missing job in watcher tests

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
@@ -73,6 +73,7 @@ public class ScheduleTriggerEngineMock extends ScheduleTriggerEngine {
     @Override
     public void pauseExecution() {
         paused.set(true);
+        watches.get().clear();
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
@@ -54,9 +54,7 @@ public class ScheduleTriggerEngineMock extends ScheduleTriggerEngine {
     @Override
     public synchronized void start(Collection<Watch> jobs) {
         logger.info("starting scheduler");
-        Map<String, Watch> newWatches = new ConcurrentHashMap<>();
-        jobs.forEach((watch) -> newWatches.put(watch.id(), watch));
-        watches.set(newWatches);
+        jobs.forEach((watch) -> watches.get().put(watch.id(), watch));
         paused.set(false);
     }
 


### PR DESCRIPTION
This change fixes problem with `ScheduleTriggerEngineMock` where watcher job can be missing because of watcher reloading which leads to tests failures.
Fix is to use the same technique as in `TickerScheduleTriggerEngine` (reuse existing map instead of creating new one).