### PR TITLE
[7.x][ML] Provide a way to revert an AD job to an empty snapshot (#65…

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
@@ -509,7 +510,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             builder.setCustomSettings(customSettings);
         }
         if (modelSnapshotId != null) {
-            builder.setModelSnapshotId(modelSnapshotId);
+            builder.setModelSnapshotId(ModelSnapshot.isTheEmptySnapshot(modelSnapshotId) ? null : modelSnapshotId);
         }
         if (modelSnapshotMinVersion != null) {
             builder.setModelSnapshotMinVersion(modelSnapshotMinVersion);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
@@ -80,6 +80,7 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
         return parser;
     }
 
+    private static String EMPTY_SNAPSHOT_ID = "empty";
 
     private final String jobId;
 
@@ -291,6 +292,14 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
         return stateDocumentIds;
     }
 
+    public boolean isTheEmptySnapshot() {
+        return isTheEmptySnapshot(snapshotId);
+    }
+
+    public static boolean isTheEmptySnapshot(String snapshotId) {
+        return EMPTY_SNAPSHOT_ID.equals(snapshotId);
+    }
+
     public static String documentIdPrefix(String jobId) {
         return jobId + "_" + TYPE + "_";
     }
@@ -440,5 +449,10 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
             return new ModelSnapshot(jobId, minVersion, timestamp, description, snapshotId, snapshotDocCount, modelSizeStats,
                     latestRecordTimeStamp, latestResultTimeStamp, quantiles, retain);
         }
+    }
+
+    public static ModelSnapshot emptySnapshot(String jobId) {
+        return new ModelSnapshot(jobId, Version.CURRENT, new Date(), "empty snapshot", EMPTY_SNAPSHOT_ID, 0,
+            new ModelSizeStats.Builder(jobId).build(), null, null, null, false);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +26,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
 public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
@@ -367,5 +370,24 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
                 e.getMessage());
 
         updateAboveMaxLimit.mergeWithJob(jobBuilder.build(), new ByteSizeValue(10000L, ByteSizeUnit.MB));
+    }
+
+    public void testUpdate_givenEmptySnapshot() {
+        Job.Builder jobBuilder = new Job.Builder("my_job");
+        Detector.Builder d1 = new Detector.Builder("count", null);
+        AnalysisConfig.Builder ac = new AnalysisConfig.Builder(Collections.singletonList(d1.build()));
+        jobBuilder.setAnalysisConfig(ac);
+        jobBuilder.setDataDescription(new DataDescription.Builder());
+        jobBuilder.setCreateTime(new Date());
+        jobBuilder.setModelSnapshotId("some_snapshot_id");
+        Job job = jobBuilder.build();
+        assertThat(job.getModelSnapshotId(), equalTo("some_snapshot_id"));
+
+        JobUpdate update = new JobUpdate.Builder(job.getId())
+            .setModelSnapshotId(ModelSnapshot.emptySnapshot(job.getId()).getSnapshotId())
+            .build();
+
+        Job updatedJob = update.mergeWithJob(job, ByteSizeValue.ofMb(100));
+        assertThat(updatedJob.getModelSnapshotId(), is(nullValue()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshotTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshotTests.java
@@ -18,6 +18,8 @@ import java.util.Date;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ModelSnapshotTests extends AbstractSerializingTestCase<ModelSnapshot> {
     private static final Date DEFAULT_TIMESTAMP = new Date();
@@ -155,7 +157,7 @@ public class ModelSnapshotTests extends AbstractSerializingTestCase<ModelSnapsho
         modelSnapshot.setMinVersion(Version.CURRENT);
         modelSnapshot.setTimestamp(new Date(TimeValue.parseTimeValue(randomTimeValue(), "test").millis()));
         modelSnapshot.setDescription(randomAlphaOfLengthBetween(1, 20));
-        modelSnapshot.setSnapshotId(randomAlphaOfLengthBetween(1, 20));
+        modelSnapshot.setSnapshotId(randomAlphaOfLength(10));
         modelSnapshot.setSnapshotDocCount(randomInt());
         modelSnapshot.setModelSizeStats(ModelSizeStatsTests.createRandomized());
         modelSnapshot.setLatestResultTimeStamp(
@@ -213,5 +215,19 @@ public class ModelSnapshotTests extends AbstractSerializingTestCase<ModelSnapsho
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
             ModelSnapshot.LENIENT_PARSER.apply(parser, null);
         }
+    }
+
+    public void testEmptySnapshot() {
+        ModelSnapshot modelSnapshot = ModelSnapshot.emptySnapshot("my_job");
+        assertThat(modelSnapshot.getSnapshotId(), equalTo("empty"));
+        assertThat(modelSnapshot.isTheEmptySnapshot(), is(true));
+        assertThat(modelSnapshot.getMinVersion(), equalTo(Version.CURRENT));
+        assertThat(modelSnapshot.getLatestRecordTimeStamp(), is(nullValue()));
+        assertThat(modelSnapshot.getLatestResultTimeStamp(), is(nullValue()));
+    }
+
+    public void testIsEmpty_GivenNonEmptySnapshot() {
+        ModelSnapshot modelSnapshot = createRandomized();
+        assertThat(modelSnapshot.isTheEmptySnapshot(), is(false));
     }
 }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -760,7 +760,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         AtomicReference<Exception> errorHolder = new AtomicReference<>();
         AtomicReference<Optional<Quantiles>> resultHolder = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
-        jobResultsProvider.getAutodetectParams(JobTests.buildJobBuilder(JOB_ID).build(), params -> {
+        jobResultsProvider.getAutodetectParams(JobTests.buildJobBuilder(JOB_ID).setModelSnapshotId("test_snapshot").build(), params -> {
             resultHolder.set(Optional.ofNullable(params.quantiles()));
             latch.countDown();
         }, e -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -127,13 +127,22 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                                   Consumer<Exception> errorHandler) {
         logger.info("Reverting to snapshot '" + request.getSnapshotId() + "'");
 
+        if (ModelSnapshot.isTheEmptySnapshot(request.getSnapshotId())) {
+            handler.accept(ModelSnapshot.emptySnapshot(request.getJobId()));
+            return;
+        }
+
         provider.getModelSnapshot(request.getJobId(), request.getSnapshotId(), modelSnapshot -> {
             if (modelSnapshot == null) {
-                throw new ResourceNotFoundException(Messages.getMessage(Messages.REST_NO_SUCH_MODEL_SNAPSHOT, request.getSnapshotId(),
-                        request.getJobId()));
+                throw missingSnapshotException(request);
             }
             handler.accept(modelSnapshot.result);
         }, errorHandler);
+    }
+
+    private static ResourceNotFoundException missingSnapshotException(RevertModelSnapshotAction.Request request) {
+        return new ResourceNotFoundException(Messages.getMessage(Messages.REST_NO_SUCH_MODEL_SNAPSHOT, request.getSnapshotId(),
+            request.getJobId()));
     }
 
     private ActionListener<RevertModelSnapshotAction.Response> wrapDeleteOldAnnotationsListener(
@@ -142,7 +151,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
             String jobId) {
 
         return ActionListener.wrap(response -> {
-            Date deleteAfter = modelSnapshot.getLatestResultTimeStamp();
+            Date deleteAfter = modelSnapshot.getLatestResultTimeStamp() == null ? new Date(0) : modelSnapshot.getLatestResultTimeStamp();
             logger.info("[{}] Removing intervening annotations after reverting model: deleting annotations after [{}]", jobId, deleteAfter);
 
             JobDataDeleter dataDeleter = new JobDataDeleter(client, jobId);
@@ -175,7 +184,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
         // wrap the listener with one that invokes the OldDataRemover on
         // acknowledged responses
         return ActionListener.wrap(response -> {
-            Date deleteAfter = modelSnapshot.getLatestResultTimeStamp();
+            Date deleteAfter = modelSnapshot.getLatestResultTimeStamp() == null ? new Date(0) : modelSnapshot.getLatestResultTimeStamp();
             logger.info("[{}] Removing intervening records after reverting model: deleting results after [{}]", jobId, deleteAfter);
 
             JobDataDeleter dataDeleter = new JobDataDeleter(client, jobId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -602,11 +602,12 @@ public class JobResultsProvider {
         MultiSearchRequestBuilder msearch = client.prepareMultiSearch()
             .add(createLatestDataCountsSearch(resultsIndex, jobId))
             .add(createLatestModelSizeStatsSearch(resultsIndex))
-            .add(createLatestTimingStatsSearch(resultsIndex, jobId))
-            // These next two document IDs never need to be the legacy ones due to the rule
-            // that you cannot open a 5.4 job in a subsequent version of the product
-            .add(createDocIdSearch(resultsIndex, ModelSnapshot.documentId(jobId, snapshotId)))
-            .add(createDocIdSearch(stateIndex, Quantiles.documentId(jobId)));
+            .add(createLatestTimingStatsSearch(resultsIndex, jobId));
+
+        if (snapshotId != null) {
+            msearch.add(createDocIdSearch(resultsIndex, ModelSnapshot.documentId(jobId, snapshotId)));
+            msearch.add(createDocIdSearch(stateIndex, Quantiles.documentId(jobId)));
+        }
 
         for (String filterId : job.getAnalysisConfig().extractReferencedFilters()) {
             msearch.add(createDocIdSearch(MlMetaIndex.indexName(), MlFilter.documentId(filterId)));


### PR DESCRIPTION
…431)

This commit adds a way to revert an anomaly detection job to
the empty snapshot. Combining this with `delete_intervening_results`
to `true`, the user can now reset the job and start over.

The API call looks like this:

POST _ml/anomaly_detectors/<job_id>/model_snapshots/empty/_revert

Backport of #65431
