### PR TITLE
Remove note on marking copy_to fields as stored.

### DIFF
--- a/docs/reference/mapping/params/store.asciidoc
+++ b/docs/reference/mapping/params/store.asciidoc
@@ -65,6 +65,3 @@ If you need the original value, you should retrieve it from the `_source`
 field instead.
 
 ======================================
-
-Another situation where it can make sense to make a field stored is for those
-that don't appear in the `_source` field (such as <<copy-to,`copy_to` fields>>).


### PR DESCRIPTION
During highlighting, we now load all values that were copied into the field
through copy_to. So there's no longer a reason to set 'store: true' to account
for fields not available in _source.

Relates to #59931.