### PR TITLE
Correctly set test runtime classpath on standalone rest tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.java
@@ -74,7 +74,10 @@ public class StandaloneRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         final SourceSet testSourceSet = sourceSets.create("test");
 
-        project.getTasks().withType(Test.class).configureEach(test -> test.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs()));
+        project.getTasks().withType(Test.class).configureEach(test -> {
+            test.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
+            test.setClasspath(testSourceSet.getRuntimeClasspath());
+        });
 
         // create a compileOnly configuration as others might expect it
         project.getConfigurations().create("compileOnly");

--- a/gradle/bwc-test.gradle
+++ b/gradle/bwc-test.gradle
@@ -22,6 +22,7 @@ tasks.register("bwcTest") {
 
 tasks.withType(Test).configureEach {
   onlyIf { project.bwc_tests_enabled }
+  nonInputProperties.systemProperty 'tests.bwc', 'true'
 }
 
 tasks.named("check").configure {

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -78,15 +78,22 @@ public class ReproduceInfoPrinter extends RunListener {
         final String gradlew = Constants.WINDOWS ? "gradlew" : "./gradlew";
         final StringBuilder b = new StringBuilder("REPRODUCE WITH: " + gradlew + " ");
         String task = System.getProperty("tests.task");
+        boolean isBwcTest = Boolean.parseBoolean(System.getProperty("tests.bwc", "false"));
 
         // append Gradle test runner test filter string
         b.append("'" + task + "'");
-        b.append(" --tests \"");
+        if (isBwcTest) {
+            // Use "legacy" method for bwc tests so that it applies globally to all upstream bwc test tasks
+            b.append(" -Dtests.class=\"");
+        } else {
+            b.append(" --tests \"");
+        }
         b.append(failure.getDescription().getClassName());
+
         final String methodName = failure.getDescription().getMethodName();
         if (methodName != null) {
             // fallback to system property filter when tests contain "."
-            if (methodName.contains(".")) {
+            if (methodName.contains(".") || isBwcTest) {
                 b.append("\" -Dtests.method=\"");
                 b.append(methodName);
             } else {


### PR DESCRIPTION
This is a follow up to #65310 where the configuration of the test runtime classpath mistakenly got lost in the migration. As part of this we also improve the construction of reproduce lines when running BWC tests.

Closes https://github.com/elastic/elasticsearch/issues/53993