### PR TITLE
the rollup action must adhere to common admin-level rollup action names

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class RollupAction extends ActionType<RollupAction.Response> {
 
     public static final RollupAction INSTANCE = new RollupAction();
-    public static final String NAME = "cluster:admin/xpack/rollupV2";
+    public static final String NAME = "cluster:admin/xpack/rollup/action";
 
     private RollupAction() {
         super(NAME, RollupAction.Response::new);


### PR DESCRIPTION
the name of this rollup action is associated to security privileges.

renaming `rollupV2` to `rollup/action` will have this action match
the appropriate rollup privileges.