### PR TITLE
Fix GeoLineAggregatorTests searcher wrapping

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
@@ -211,7 +211,7 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
         buildIndex.accept(indexWriter);
         indexWriter.close();
         IndexReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
+        IndexSearcher indexSearcher = newIndexSearcher(indexReader);
 
         try {
             MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("value_field");


### PR DESCRIPTION
The searcher was randomly wrapping its reader as slow, parallel, or filtered.
This was causing casting issues in the geolineaggregator tests. By removing the
wrapping, the problem goes away.

Closes #65470.