### PR TITLE
[7.x] Do not interpret SecurityException in KeystoreAwareCommand (#65366)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cli/KeyStoreAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/cli/KeyStoreAwareCommand.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.env.Environment;
 
-import javax.crypto.AEADBadTagException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
@@ -76,9 +75,7 @@ public abstract class KeyStoreAwareCommand extends EnvironmentAwareCommand {
             readPassword(terminal, false) : new SecureString(new char[0])) {
             keyStore.decrypt(keystorePassword.getChars());
         } catch (SecurityException e) {
-            if (e.getCause() instanceof AEADBadTagException) {
-                throw new UserException(ExitCodes.DATA_ERROR, "Wrong password for elasticsearch.keystore");
-            }
+            throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
@@ -39,7 +39,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-import javax.crypto.AEADBadTagException;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -152,7 +151,7 @@ public class SetupPasswordToolTests extends CommandTestCase {
         if (isPasswordProtected) {
             when(keyStore.hasPassword()).thenReturn(true);
             doNothing().when(keyStore).decrypt("keystore-password".toCharArray());
-            doThrow(new SecurityException("Provided keystore password was incorrect", new AEADBadTagException()))
+            doThrow(new SecurityException("Provided keystore password was incorrect", new IOException()))
                 .when(keyStore).decrypt("wrong-password".toCharArray());
         }
         return keyStore;
@@ -488,7 +487,7 @@ public class SetupPasswordToolTests extends CommandTestCase {
                 execute(commandWithPasswordProtectedKeystore, "auto", pathHomeParameter);
             }
         });
-        assertThat(e.getMessage(), containsString("Wrong password for elasticsearch.keystore"));
+        assertThat(e.getMessage(), containsString("Provided keystore password was incorrect"));
     }
 
     private URL authenticateUrl(URL url) throws MalformedURLException, URISyntaxException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
@@ -34,7 +34,8 @@ import org.opensaml.xmlsec.signature.X509Certificate;
 import org.opensaml.xmlsec.signature.X509Data;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
 
-import javax.crypto.AEADBadTagException;
+
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -75,7 +76,7 @@ public class SamlMetadataCommandTests extends SamlTestCase {
         when(passwordProtectedKeystore.isLoaded()).thenReturn(true);
         when(passwordProtectedKeystore.hasPassword()).thenReturn(true);
         doNothing().when(passwordProtectedKeystore).decrypt("keystore-password".toCharArray());
-        doThrow(new SecurityException("Provided keystore password was incorrect", new AEADBadTagException()))
+        doThrow(new SecurityException("Provided keystore password was incorrect", new IOException()))
             .when(passwordProtectedKeystore).decrypt("wrong-password".toCharArray());
     }
 
@@ -714,7 +715,7 @@ public class SamlMetadataCommandTests extends SamlTestCase {
         UserException e = expectThrows(UserException.class, () -> {
             command.buildEntityDescriptor(terminal, options, env);
         });
-        assertThat(e.getMessage(), CoreMatchers.containsString("Wrong password for elasticsearch.keystore"));
+        assertThat(e.getMessage(), CoreMatchers.containsString("Provided keystore password was incorrect"));
     }
 
     private String getAliasName(final Tuple<java.security.cert.X509Certificate, PrivateKey> certKeyPair) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Do not interpret SecurityException in KeystoreAwareCommand (#65366)