### PR TITLE
[7.x] ILM: validate policy and actions against current license (#65412)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -5,8 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diffable;
@@ -41,7 +39,6 @@ import java.util.stream.Collectors;
  */
 public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         implements ToXContentObject, Diffable<LifecyclePolicy> {
-    private static final Logger logger = LogManager.getLogger(LifecyclePolicy.class);
     private static final int MAX_INDEX_NAME_BYTES = 255;
 
     public static final ParseField PHASES_FIELD = new ParseField("phases");

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/LifecycleLicenseIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/LifecycleLicenseIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ilm;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.TestUtils;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.core.ilm.ErrorStep;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
+import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.createComposableTemplate;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.createSnapshotRepo;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.rolloverMaxOneDocCondition;
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+public class LifecycleLicenseIT extends ESRestTestCase {
+
+    private String policy;
+    private String dataStream;
+
+    @Before
+    public void refreshDatastream() {
+        dataStream = "logs-" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        policy = "policy-" + randomAlphaOfLength(5);
+    }
+
+    @After
+    public void resetLicenseToTrial() throws Exception {
+        putTrialLicense();
+        checkCurrentLicenseIs("trial");
+    }
+
+    public void testCreatePolicyUsingActionAndNonCompliantLicense() throws Exception {
+        String snapshotRepo = randomAlphaOfLengthBetween(4, 10);
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+
+        assertOK(client().performRequest(new Request("DELETE", "/_license")));
+        checkCurrentLicenseIs("basic");
+
+        ResponseException exception = expectThrows(ResponseException.class,
+            () -> createNewSingletonPolicy(client(), policy, "cold", new SearchableSnapshotAction(snapshotRepo, true)));
+        assertThat(EntityUtils.toString(exception.getResponse().getEntity()),
+            containsStringIgnoringCase("policy [" + policy + "] defines the [" + SearchableSnapshotAction.NAME + "] action but the " +
+                "current license is non-compliant for [searchable-snapshots]"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSearchableSnapshotActionErrorsOnInvalidLicense() throws Exception {
+        String snapshotRepo = randomAlphaOfLengthBetween(4, 10);
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        createNewSingletonPolicy(client(), policy, "cold", new SearchableSnapshotAction(snapshotRepo, true));
+
+        createComposableTemplate(client(), "template-name", dataStream,
+            new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null));
+
+        assertOK(client().performRequest(new Request("DELETE", "/_license")));
+        checkCurrentLicenseIs("basic");
+
+        indexDocument(client(), dataStream, true);
+
+        // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1L);
+        // the searchable_snapshot action should start failing (and retrying) due to invalid license
+        assertBusy(() -> {
+            Map<String, Object> explainIndex = explainIndex(client(), backingIndexName);
+            assertThat(explainIndex.get("action"), is(SearchableSnapshotAction.NAME));
+            assertThat((Integer) explainIndex.get("failed_step_retry_count"), greaterThanOrEqualTo(1));
+
+            // this check is lenient to avoid test flakiness (when we retry steps we move ILM between the ERROR step and the
+            // failed step - the `failed_step_retry_count` field is present in both steps until we move to the next step (ie.
+            // until the failed step is executed successfully).
+            // So, *if* we catch ILM in the ERROR step, we check the failed message
+            if (ErrorStep.NAME.equals(explainIndex.get("step"))) {
+                assertThat(((Map<String, String>) explainIndex.get("step_info")).get("reason"),
+                    containsStringIgnoringCase("current license is non-compliant for [searchable-snapshots]"));
+            }
+        }, 30, TimeUnit.SECONDS);
+
+        // switching back to trial so searchable_snapshot is permitted
+        putTrialLicense();
+        checkCurrentLicenseIs("trial");
+
+        String restoredIndexName = SearchableSnapshotAction.RESTORED_INDEX_PREFIX + backingIndexName;
+        assertTrue(waitUntil(() -> {
+            try {
+                return indexExists(restoredIndexName);
+            } catch (IOException e) {
+                return false;
+            }
+        }, 30, TimeUnit.SECONDS));
+
+        assertBusy(() -> assertThat(explainIndex(client(), restoredIndexName).get("step"), is(PhaseCompleteStep.NAME)), 30,
+            TimeUnit.SECONDS);
+    }
+
+    private void putTrialLicense() throws Exception {
+        License signedLicense = TestUtils.generateSignedLicense("trial", License.VERSION_CURRENT, -1, TimeValue.timeValueDays(7));
+        Request putTrialRequest = new Request("PUT", "/_license");
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder = signedLicense.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        putTrialRequest.setJsonEntity("{\"licenses\":[\n " + Strings.toString(builder) + "\n]}");
+        client().performRequest(putTrialRequest);
+    }
+
+    private void checkCurrentLicenseIs(String type) throws Exception {
+        assertBusy(() -> assertThat(EntityUtils.toString(client().performRequest(new Request("GET", "/_license")).getEntity()),
+            containsStringIgnoringCase("\"type\" : \"" + type + "\"")));
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -38,7 +39,9 @@ import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
+import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.Step;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction.Request;
@@ -64,14 +67,16 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
     private static final Logger logger = LogManager.getLogger(TransportPutLifecycleAction.class);
     private final NamedXContentRegistry xContentRegistry;
     private final Client client;
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportPutLifecycleAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                        ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                       NamedXContentRegistry namedXContentRegistry, Client client) {
+                                       NamedXContentRegistry namedXContentRegistry, XPackLicenseState licenseState, Client client) {
         super(PutLifecycleAction.NAME, transportService, clusterService, threadPool, actionFilters, Request::new,
             indexNameExpressionResolver, AcknowledgedResponse::readFrom, ThreadPool.Names.SAME);
         this.xContentRegistry = namedXContentRegistry;
+        this.licenseState = licenseState;
         this.client = client;
     }
 
@@ -85,6 +90,15 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
             .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         LifecyclePolicy.validatePolicyName(request.getPolicy().getName());
+        List<Phase> phasesDefiningSearchableSnapshot = request.getPolicy().getPhases().values().stream()
+            .filter(phase -> phase.getActions().containsKey(SearchableSnapshotAction.NAME))
+            .collect(Collectors.toList());
+        if (phasesDefiningSearchableSnapshot.isEmpty() == false) {
+            if (licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS) == false) {
+                throw new IllegalArgumentException("policy [" + request.getPolicy().getName() + "] defines the [" +
+                    SearchableSnapshotAction.NAME + "] action but the current license is non-compliant for [searchable-snapshots]");
+            }
+        }
         clusterService.submitStateUpdateTask("put-lifecycle-" + request.getPolicy().getName(),
                 new AckedClusterStateUpdateTask(request, listener) {
                     @Override


### PR DESCRIPTION
This adds support to validate the ILM policies against the current
cluster action. If the policy contains licensed actions (like
searchable_snapshot) and the license doesn't support this feature, creating
or updating a policy to contain `searchable_snapshot` will error.

Equally, the `searchable_snapshot` action will check when executing if
the license is valid and supports the feature. If it doesn't, the action
will move into the `ERROR` state. This will be retried using our usual
ILM retrying mechanism so that when the license has been fixed the
action can proceed.

(cherry picked from commit b36f818ce1ce62fdeb5ddfb8da84b3bb635521dc)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #65412 