### PR TITLE
Add apparently-unnecessary generic type

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -160,7 +160,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         "index.number_of_routing_shards",
         INDEX_NUMBER_OF_SHARDS_SETTING,
         1,
-        new Setting.Validator<>() {
+        //noinspection Convert2Diamond since some IntelliJs mysteriously report an error if the <Integer> is replaced with <> here:
+        new Setting.Validator<Integer>() {
 
             @Override
             public void validate(final Integer value) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -156,11 +156,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Integer> INDEX_ROUTING_PARTITION_SIZE_SETTING =
             Setting.intSetting(SETTING_ROUTING_PARTITION_SIZE, 1, 1, Property.IndexScope);
 
+    @SuppressWarnings("Convert2Diamond") // since some IntelliJs mysteriously report an error if an <Integer> is replaced with <> here:
     public static final Setting<Integer> INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING = Setting.intSetting(
         "index.number_of_routing_shards",
         INDEX_NUMBER_OF_SHARDS_SETTING,
         1,
-        //noinspection Convert2Diamond since some IntelliJs mysteriously report an error if the <Integer> is replaced with <> here:
         new Setting.Validator<Integer>() {
 
             @Override


### PR DESCRIPTION
Some IntelliJ installations report a mysterious error if this type
parameter is replaced with `<>`, even though the code compiles and runs
just fine. The search for the reason behind this error has proved
fruitless. For those installations this commit improves it to a mere
warning about the unnecessary suppression, and the suppression avoids
any extra noise for installations that are working properly