### PR TITLE
Allow to create SparseFileTracker with ranges already present

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
@@ -37,11 +37,55 @@ public class SparseFileTracker {
 
     private final long length;
 
+    /**
+     * Creates a new empty {@link SparseFileTracker}
+     *
+     * @param description a description for the sparse file tracker
+     * @param length      the length of the file tracked by the sparse file tracker
+     */
     public SparseFileTracker(String description, long length) {
+        this(description, length, Collections.emptySortedSet());
+    }
+
+    /**
+     * Creates a {@link SparseFileTracker} with some ranges already present
+     *
+     * @param description a description for the sparse file tracker
+     * @param length      the length of the file tracked by the sparse file tracker
+     * @param ranges      the set of ranges to be considered present
+     */
+    public SparseFileTracker(String description, long length, SortedSet<Tuple<Long, Long>> ranges) {
         this.description = description;
         this.length = length;
         if (length < 0) {
             throw new IllegalArgumentException("Length [" + length + "] must be equal to or greater than 0 for [" + description + "]");
+        }
+        if (ranges.isEmpty() == false) {
+            synchronized (mutex) {
+                for (Tuple<Long, Long> next : ranges) {
+                    final Range range = new Range(next.v1(), next.v2(), null);
+                    if (range.end <= range.start) {
+                        throw new IllegalArgumentException("Range " + range + " cannot be empty");
+                    }
+                    if (length < range.end) {
+                        throw new IllegalArgumentException("Range " + range + " is exceeding maximum length [" + length + ']');
+                    }
+
+                    final SortedSet<Range> previousRanges = this.ranges.headSet(range);
+                    if (previousRanges.isEmpty() == false) {
+                        final Range previous = previousRanges.last();
+                        if (range.start <= previous.end) {
+                            throw new IllegalArgumentException("Range " + range + " is overlapping a previous range " + previous);
+                        }
+                    }
+                    final boolean added = this.ranges.add(range);
+                    if (added == false) {
+                        assert false : range + " already exist in " + this.ranges;
+                        throw new IllegalArgumentException("Range [" + range + "] already exists");
+                    }
+                }
+                assert invariant();
+            }
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -573,7 +573,7 @@ public class SparseFileTrackerTests extends ESTestCase {
             long start = randomLongBetween(i, Math.max(0L, length - 1L));
             long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
             randomRanges.add(Tuple.tuple(start, end));
-            i = end + 2L + randomLongBetween(0L, Math.max(0L, length - end)); // +2 for non contiguous ranges
+            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
         }
         return randomRanges;
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SparseFileTrackerTests extends ESTestCase {
 
@@ -414,7 +415,33 @@ public class SparseFileTrackerTests extends ESTestCase {
         checkThread.join();
     }
 
-    public void testCompletedRanges() {
+    public void testSparseFileTrackerCreatedWithCompletedRanges() {
+        final long fileLength = between(0, 1000);
+        final SortedSet<Tuple<Long, Long>> completedRanges = randomRanges(fileLength);
+
+        final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", fileLength, completedRanges);
+        assertThat(sparseFileTracker.getCompletedRanges(), equalTo(completedRanges));
+
+        for (Tuple<Long, Long> completedRange : completedRanges) {
+            assertThat(sparseFileTracker.getAbsentRangeWithin(completedRange.v1(), completedRange.v2()), nullValue());
+
+            final AtomicBoolean listenerCalled = new AtomicBoolean();
+            assertThat(sparseFileTracker.waitForRange(completedRange, completedRange, new ActionListener<>() {
+                @Override
+                public void onResponse(Void aVoid) {
+                    listenerCalled.set(true);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError(e);
+                }
+            }), hasSize(0));
+            assertThat(listenerCalled.get(), is(true));
+        }
+    }
+
+    public void testGetCompletedRanges() {
         final byte[] fileContents = new byte[between(0, 1000)];
         final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", fileContents.length);
 
@@ -535,5 +562,19 @@ public class SparseFileTrackerTests extends ESTestCase {
             gap.onCompletion();
             return true;
         }
+    }
+
+    /**
+     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
+     */
+    private static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
+        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+        for (long i = 0L; i < length;) {
+            long start = randomLongBetween(i, Math.max(0L, length - 1L));
+            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
+            randomRanges.add(Tuple.tuple(start, end));
+            i = end + 2L + randomLongBetween(0L, Math.max(0L, length - end)); // +2 for non contiguous ranges
+        }
+        return randomRanges;
     }
 }


### PR DESCRIPTION
This pull request allows to create `SparseFileTracker` instances with already completed/available ranges. Creating non empty sparse file tracker will be required for the searchable snapshots cache to be initialized with existing information on cache files.