### PR TITLE
[7.10] [DOCS] Flatten EQL syntax headings (#65497)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -30,7 +30,7 @@ process where process.name == "svchost.exe"
 
 [discrete]
 [[eql-syntax-event-categories]]
-==== Event categories
+=== Event categories
 
 An event category is a valid, indexed value of the
 <<eql-required-fields,event category field>>. You can set the event category
@@ -38,7 +38,7 @@ field using the `event_category_field` parameter of the EQL search API.
 
 [discrete]
 [[eql-syntax-match-any-event-category]]
-===== Match any event category
+==== Match any event category
 
 To match events of any category, use the `any` keyword. You can also use the
 `any` keyword to search for documents without a event category field.
@@ -53,7 +53,7 @@ any where network.protocol == "http"
 
 [discrete]
 [[eql-syntax-escape-an-event-category]]
-===== Escape an event category
+==== Escape an event category
 
 Use enclosing double quotes (`"`) or three enclosing double quotes (`"""`) to
 escape event categories that:
@@ -77,7 +77,7 @@ escape event categories that:
 
 [discrete]
 [[eql-syntax-escape-a-field-name]]
-===== Escape a field name
+==== Escape a field name
 
 Use enclosing enclosing backticks (+++`+++) to escape field names that:
 
@@ -102,7 +102,7 @@ my`field -> `my``field`
 
 [discrete]
 [[eql-syntax-conditions]]
-==== Conditions
+=== Conditions
 
 A condition consists of one or more criteria an event must match.
 You can specify and combine these criteria using the following operators. Most
@@ -110,7 +110,7 @@ EQL operators are case-sensitive by default.
 
 [discrete]
 [[eql-syntax-comparison-operators]]
-===== Comparison operators
+==== Comparison operators
 
 [source,eql]
 ----
@@ -194,7 +194,7 @@ process where process.parent.name == "foo" and process.name == "foo"
 
 [discrete]
 [[eql-syntax-logical-operators]]
-===== Logical operators
+==== Logical operators
 
 [source,eql]
 ----
@@ -214,7 +214,7 @@ Returns `true` if the condition to the right is `false`.
 
 [discrete]
 [[eql-syntax-lookup-operators]]
-===== Lookup operators
+==== Lookup operators
 
 [source,eql]
 ----
@@ -232,7 +232,7 @@ matching is case-sensitive.
 
 [discrete]
 [[eql-syntax-math-operators]]
-===== Math operators
+==== Math operators
 
 [source,eql]
 ----
@@ -292,7 +292,7 @@ Divides the value to the left of the operator by the value to the right. Returns
 
 [discrete]
 [[eql-syntax-match-any-condition]]
-==== Match any condition
+=== Match any condition
 
 To match events solely on event category, use the `where true` condition.
 
@@ -313,7 +313,7 @@ any where true
 
 [discrete]
 [[eql-syntax-strings]]
-==== Strings
+=== Strings
 
 Strings are enclosed in double quotes (`"`).
 
@@ -326,7 +326,7 @@ Strings enclosed in single quotes (`'`) are not supported.
 
 [discrete]
 [[eql-syntax-escape-characters]]
-===== Escape characters in a string
+==== Escape characters in a string
 
 When used within a string, special characters, such as a carriage return or
 double quote (`"`), must be escaped with a preceding backslash (`\`).
@@ -352,7 +352,7 @@ double quote (`\"`) instead.
 
 [discrete]
 [[eql-syntax-raw-strings]]
-===== Raw strings
+==== Raw strings
 
 Raw strings treat special characters, such as backslashes (`\`), as literal
 characters. Raw strings are enclosed in three double quotes (`"""`).
@@ -407,7 +407,7 @@ sequence
 
 [discrete]
 [[eql-with-maxspan-keywords]]
-==== `with maxspan` keywords
+=== `with maxspan` keywords
 
 You can use the `with maxspan` keywords to constrain a sequence to a specified
 timespan. All events in a matching sequence must occur within this duration,
@@ -437,7 +437,7 @@ sequence with maxspan=15m
 
 [discrete]
 [[eql-by-keyword]]
-==== `by` keyword
+=== `by` keyword
 
 You can use the `by` keyword with sequences to only match events that share the
 same field values. If a field value should be shared across all events, you
@@ -504,7 +504,7 @@ sequence by user.name with maxspan=15m
 
 [discrete]
 [[eql-until-keyword]]
-==== `until` keyword
+=== `until` keyword
 
 You can use the `until` keyword to specify an expiration event for a sequence.
 If this expiration event occurs _between_ matching events in a sequence, the


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Flatten EQL syntax headings (#65497)