### PR TITLE
Add 6.8 branch to packer cache script

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -29,7 +29,7 @@ rm -rf checkout/6.8
 git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
 export JAVA_HOME="${JAVA11_HOME}"
 ./checkout/6.8/gradlew --project-dir ./checkout/6.8 --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true --stacktrace resolveAllDependencies
-
+rm -rf ./checkout/6.8
 ## Gradle is able to resolve dependencies resolved with earlier gradle versions
 ## therefore we run master _AFTER_ we run 6.8 which uses an earlier gradle version
 export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -26,7 +26,7 @@ export JAVA14_HOME="${HOME}"/.java/openjdk14
 ## 6.8 branch is not referenced from any bwc project in master so we need to
 ## resolve its dependencies explicitly
 rm -rf checkout/6.8
-git clone https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
+git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
 export JAVA_HOME="${JAVA11_HOME}"
 ./checkout/6.8/gradlew --project-dir ./checkout/6.8 --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true --stacktrace resolveAllDependencies
 

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -16,12 +16,21 @@ while [ -h "$SCRIPT" ] ; do
 done
 
 source $(dirname "${SCRIPT}")/java-versions.properties
-export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
-# We are caching BWC versions too, need these so we can build those
+## We are caching BWC versions too, need these so we can build those
 export JAVA8_HOME="${HOME}"/.java/java8
 export JAVA11_HOME="${HOME}"/.java/java11
 export JAVA12_HOME="${HOME}"/.java/openjdk12
 export JAVA13_HOME="${HOME}"/.java/openjdk13
 export JAVA14_HOME="${HOME}"/.java/openjdk14
-./gradlew --parallel clean -s resolveAllDependencies
 
+## 6.8 branch is not referenced from any bwc project in master so we need to
+## resolve its dependencies explicitly
+rm -rf checkout/6.8
+git clone https://github.com/elastic/elasticsearch.git --branch 6.8 --single-branch checkout/6.8
+export JAVA_HOME="${JAVA11_HOME}"
+./checkout/6.8/gradlew --project-dir ./checkout/6.8 --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true --stacktrace resolveAllDependencies
+
+## Gradle is able to resolve dependencies resolved with earlier gradle versions
+## therefore we run master _AFTER_ we run 6.8 which uses an earlier gradle version
+export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
+./gradlew --parallel clean -s resolveAllDependencies


### PR DESCRIPTION
This allows us to cache dependencies from the elasticsearch 6.8 branch which should help reducing the overall CI failures on that branch caused by dependency resolution errors.  