### PR TITLE
[DOCS] Add rollup V2 security privileges

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -48,8 +48,8 @@ POST /my-index-000001/_rollup
 [[rollup-api-prereqs]]
 ==== {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the `manage` cluster
-privilege to use this API. See <<security-privileges>>.
+If the {es} {security-features} are enabled, you must have the `manage` or
+`manage_rollup` cluster privilege to use this API. See <<security-privileges>>.
 
 [[rollup-api-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -94,9 +94,20 @@ authenticated user. The operations include
 `manage_pipeline`::
 All operations on ingest pipelines.
 
+ifdef::permanently-unreleased-branch[]
+
+`manage_rollup`::
+All rollup operations. Includes legacy rollup operations, such as creating,
+starting, stopping and deleting legacy rollup jobs.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 `manage_rollup`::
 All rollup operations, including creating, starting, stopping and deleting
 rollup jobs.
+
+endif::[]
 
 `manage_saml`::
 Enables the use of internal {es} APIs to initiate and manage SAML authentication
@@ -139,9 +150,20 @@ All read-only operations related to {transforms}.
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,
 model snapshots, or results.
 
+ifdef::permanently-unreleased-branch[]
+
+`monitor_rollup`::
+All read-only operations for legacy rollups, such as viewing the list of
+historical and currently running rollup jobs and their capabilities.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 `monitor_rollup`::
 All read-only rollup operations, such as viewing the list of historical and
 currently running rollup jobs and their capabilities.
+
+endif::[]
 
 `monitor_watcher`::
 All read-only watcher operations, such as getting a watch and watcher stats.

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -98,7 +98,7 @@ ifdef::permanently-unreleased-branch[]
 
 `manage_rollup`::
 All rollup operations. Includes legacy rollup operations, such as creating,
-starting, stopping and deleting legacy rollup jobs.
+starting, stopping and deleting rollup jobs.
 
 endif::[]
 ifndef::permanently-unreleased-branch[]


### PR DESCRIPTION
Changes:

* Adds `manage_rollup` to the rollup API's security privileges
* Updates definitions for the `manage_rollup` and `monitor_rollup` privileges

Relates to #65469.

### Previews
Security privileges: https://elasticsearch_65512.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-privileges.html

Rollup API: https://elasticsearch_65512.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-api.html