### PR TITLE
[7.x] [DOCS] Add rollup V2 security privileges (#65512)

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -48,8 +48,8 @@ POST /my-index-000001/_rollup
 [[rollup-api-prereqs]]
 ==== {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the `manage` cluster
-privilege to use this API. See <<security-privileges>>.
+If the {es} {security-features} are enabled, you must have the `manage` or
+`manage_rollup` cluster privilege to use this API. See <<security-privileges>>.
 
 [[rollup-api-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -87,9 +87,20 @@ authenticated user. The operations include
 `manage_pipeline`::
 All operations on ingest pipelines.
 
+ifdef::permanently-unreleased-branch[]
+
+`manage_rollup`::
+All rollup operations. Includes legacy rollup operations, such as creating,
+starting, stopping and deleting rollup jobs.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 `manage_rollup`::
 All rollup operations, including creating, starting, stopping and deleting
 rollup jobs.
+
+endif::[]
 
 `manage_saml`::
 Enables the use of internal {es} APIs to initiate and manage SAML authentication
@@ -132,9 +143,20 @@ All read-only operations related to {transforms}.
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,
 model snapshots, or results.
 
+ifdef::permanently-unreleased-branch[]
+
+`monitor_rollup`::
+All read-only operations for legacy rollups, such as viewing the list of
+historical and currently running rollup jobs and their capabilities.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 `monitor_rollup`::
 All read-only rollup operations, such as viewing the list of historical and
 currently running rollup jobs and their capabilities.
+
+endif::[]
 
 `monitor_watcher`::
 All read-only watcher operations, such as getting a watch and watcher stats.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add rollup V2 security privileges (#65512)