### PR TITLE
[DOCS] Label legacy rollup APIs

### DIFF
--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -1,3 +1,21 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-delete-job]]
+=== Delete legacy {rollup-jobs} API
+[subs="attributes"]
+++++
+<titleabbrev>Delete legacy {rollup-jobs}</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Deletes a legacy {rollup-job}.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-delete-job]]
@@ -10,6 +28,8 @@
 Deletes an existing {rollup-job}. 
 
 experimental[]
+
+endif::[]
 
 [[rollup-delete-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -1,3 +1,20 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-get-job]]
+=== Get legacy {rollup-jobs} API
+++++
+<titleabbrev>Get legacy job</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Gets the configuration, stats, and status of legacy {rollup-jobs}.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-get-job]]
@@ -9,6 +26,8 @@
 Retrieves the configuration, stats, and status of {rollup-jobs}.
 
 experimental[]
+
+endif::[]
 
 [[rollup-get-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -1,3 +1,25 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-put-job]]
+=== Create legacy {rollup-jobs} API
+[subs="attributes"]
+++++
+<titleabbrev>Create legacy {rollup-jobs}</titleabbrev>
+++++
+
+// tag::legacy-rollup-admon[]
+WARNING: This documentation is about legacy rollups. Legacy rollups are
+deprecated and will be replaced by new rollup functionality introduced in {es}
+7.x.
+// end::legacy-rollup-admon[]
+
+Creates a legacy {rollup-job}.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-put-job]]
@@ -10,6 +32,8 @@
 Creates a {rollup-job}.
 
 experimental[]
+
+endif::[]
 
 [[rollup-put-job-api-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -1,3 +1,20 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-get-rollup-caps]]
+=== Get legacy {rollup-job} capabilities API
+++++
+<titleabbrev>Get legacy rollup caps</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Returns the capabilities of legacy {rollup-jobs} for an index pattern.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-get-rollup-caps]]
@@ -10,6 +27,8 @@ Returns the capabilities of any {rollup-jobs} that have been configured for a
 specific index or index pattern.
 
 experimental[]
+
+endif::[]
 
 [[rollup-get-rollup-caps-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -1,3 +1,20 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-get-rollup-index-caps]]
+=== Get legacy rollup index capabilities API
+++++
+<titleabbrev>Get legacy rollup index caps</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Returns the capabilities of rollup jobs for a legacy rollup index.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-get-rollup-index-caps]]
@@ -10,6 +27,8 @@ Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
 index where rollup data is stored).
 
 experimental[]
+
+endif::[]
 
 [[rollup-get-rollup-index-caps-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -1,3 +1,20 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-search]]
+=== Legacy rollup search
+++++
+<titleabbrev>Legacy rollup search</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Searches legacy rollup data using <<query-dsl,query DSL>>.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-search]]
@@ -9,6 +26,8 @@
 Enables searching rolled-up data using the standard query DSL.
 
 experimental[]
+
+endif::[]
 
 [[rollup-search-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -1,3 +1,21 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-start-job]]
+=== Start legacy {rollup-jobs} API
+[subs="attributes"]
+++++
+<titleabbrev>Start legacy {rollup-jobs}</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Starts a stopped legacy {rollup-job}.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-start-job]]
@@ -10,6 +28,8 @@
 Starts an existing, stopped {rollup-job}.
 
 experimental[]
+
+endif::[]
 
 [[rollup-start-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -1,3 +1,21 @@
+ifdef::permanently-unreleased-branch[]
+
+[role="xpack"]
+[testenv="basic"]
+[[rollup-stop-job]]
+=== Stop legacy {rollup-jobs} API
+[subs="attributes"]
+++++
+<titleabbrev>Stop legacy {rollup-jobs}</titleabbrev>
+++++
+
+include::put-job.asciidoc[tag=legacy-rollup-admon]
+
+Stops an ongoing legacy {rollup-job}.
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [role="xpack"]
 [testenv="basic"]
 [[rollup-stop-job]]
@@ -10,6 +28,8 @@
 Stops an existing, started {rollup-job}.
 
 experimental[]
+
+endif::[]
 
 [[rollup-stop-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/rollup-apis.asciidoc
+++ b/docs/reference/rollup/rollup-apis.asciidoc
@@ -24,22 +24,22 @@ release.
 [[rollup-jobs-endpoint]]
 ==== Jobs
 
-* <<rollup-put-job,Create>> or <<rollup-delete-job,delete {rollup-jobs}>>
-* <<rollup-start-job,Start>> or <<rollup-stop-job,stop {rollup-jobs}>>
-* <<rollup-get-job,Get {rollup-jobs}>>
+* <<rollup-put-job,Create>> or <<rollup-delete-job,delete legacy {rollup-jobs}>>
+* <<rollup-start-job,Start>> or <<rollup-stop-job,stop legacy {rollup-jobs}>>
+* <<rollup-get-job,Get legacy {rollup-jobs}>>
 
 [discrete]
 [[rollup-data-endpoint]]
 ==== Data
 
-* <<rollup-get-rollup-caps,Get rollup capabilities>>
-* <<rollup-get-rollup-index-caps,Get rollup index capabilities>>
+* <<rollup-get-rollup-caps,Get legacy rollup capabilities>>
+* <<rollup-get-rollup-index-caps,Get legacy rollup index capabilities>>
 
 [discrete]
 [[rollup-search-endpoint]]
 ==== Search
 
-* <<rollup-search,Rollup search>>
+* <<rollup-search,Legacy rollup search>>
 
 include::apis/rollup-api.asciidoc[]
 include::apis/put-job.asciidoc[]


### PR DESCRIPTION
Changes:

* Updates several rollup API titles to include "legacy"
* Adds a deprecation warning for legacy APIs

### Previews

- Rollup APIs: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-apis.html#legacy-rollup-apis
- Create legacy rollup jobs API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-put-job.html
- Delete legacy rollup jobs API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html
- Start legacy rollup jobs API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-start-job.html
- Stop legacy rollup jobs API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html
- Get legacy rollup jobs API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-get-job.html
- Get legacy rollup caps API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html
- Get legacy rollup index caps API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html
- Legacy rollup search API: https://elasticsearch_65518.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-search.html