### PR TITLE
[DOCS] Update rollup glossary item

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -451,9 +451,8 @@ ifdef::permanently-unreleased-branch[]
 
 [[glossary-rollup]] rollup ::
 // tag::rollup-def[]
-Aggregates an index's time-series data and stores the results in another index,
-called a rollup index. For example, you can roll up hourly data into daily or
-weekly summaries.
+Aggregates an index's time-series data and stores the results in another index.
+For example, you can roll up hourly data into daily or weekly summaries.
 // end::rollup-def[]
 
 endif::[]

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -447,6 +447,18 @@ See the {ref}/indices-rollover-index.html[rollover index API].
 // end::rollover-def[]
 --
 
+ifdef::permanently-unreleased-branch[]
+
+[[glossary-rollup]] rollup ::
+// tag::rollup-def[]
+Aggregates an index's time-series data and stores the results in another index,
+called a rollup index. For example, you can roll up hourly data into daily or
+weekly summaries.
+// end::rollup-def[]
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [[glossary-rollup]] rollup ::
 // tag::rollup-def[]
 Summarize high-granularity data into a more compressed format to
@@ -465,6 +477,8 @@ A background task that runs continuously to summarize documents in an index and
 index the summaries into a separate rollup index.
 The job configuration controls what information is rolled up and how often.
 // end::rollup-job-def[]
+
+endif::[]
 
 [[glossary-routing]] routing ::
 +

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -451,7 +451,7 @@ ifdef::permanently-unreleased-branch[]
 
 [[glossary-rollup]] rollup ::
 // tag::rollup-def[]
-Aggregates an index's time-series data and stores the results in another index.
+Aggregates an index's time series data and stores the results in another index.
 For example, you can roll up hourly data into daily or weekly summaries.
 // end::rollup-def[]
 


### PR DESCRIPTION
Changes:
- Updates the `rollup` glossary item from the rollup refactor.
- Removes glossary items related to legacy rollups.

### Preview
https://elasticsearch_65519.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/glossary.html#glossary-rollup