### PR TITLE
[DOCS] Correct the url in restore-snapshot-api doc

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -59,7 +59,7 @@ POST /_snapshot/my_repository/my_snapshot/_restore
 [[restore-snapshot-api-request]]
 ==== {api-request-title}
 
-`POST /_snapshot/<repository>/<snapshot>`
+`POST /_snapshot/<repository>/<snapshot>/_restore`
 
 [[restore-snapshot-api-desc]]
 ==== {api-description-title}


### PR DESCRIPTION
The Restore Snapshot API's url is not correct in the doc: https://www.elastic.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html