### PR TITLE
Fix Inconsistent API Behavior when Cluster never had a Snapshot Repository Configured

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
@@ -90,6 +91,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -986,6 +988,12 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.PARTIAL));
         assertThat(snapshotInfo.shardFailures().size(), greaterThan(0));
         logger.info("--> done");
+    }
+
+    public void testGetReposWithWildcard() {
+        internalCluster().startMasterOnlyNode();
+        List<RepositoryMetadata> repositoryMetadata = client().admin().cluster().prepareGetRepositories("*").get().repositories();
+        assertThat(repositoryMetadata, empty());
     }
 
     private long calculateTotalFilesSize(List<Path> files) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -38,7 +37,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -75,40 +73,31 @@ public class TransportGetRepositoriesAction extends TransportMasterNodeReadActio
      * @return list of repository metadata
      */
     public static List<RepositoryMetadata> getRepositories(ClusterState state, String[] repoNames) {
-        Metadata metadata = state.metadata();
-        RepositoriesMetadata repositories = metadata.custom(RepositoriesMetadata.TYPE);
-        if (repoNames.length == 0 || (repoNames.length == 1 && "_all".equals(repoNames[0]))) {
-            if (repositories != null) {
-                return repositories.repositories();
-            } else {
-                return Collections.emptyList();
-            }
+        RepositoriesMetadata repositories = state.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+        if (repoNames.length == 0 || (repoNames.length == 1 && ("_all".equals(repoNames[0]) || "*".equals(repoNames[0])))) {
+            return repositories.repositories();
         } else {
-            if (repositories != null) {
-                Set<String> repositoriesToGet = new LinkedHashSet<>(); // to keep insertion order
-                for (String repositoryOrPattern : repoNames) {
-                    if (Regex.isSimpleMatchPattern(repositoryOrPattern) == false) {
-                        repositoriesToGet.add(repositoryOrPattern);
-                    } else {
-                        for (RepositoryMetadata repository : repositories.repositories()) {
-                            if (Regex.simpleMatch(repositoryOrPattern, repository.name())) {
-                                repositoriesToGet.add(repository.name());
-                            }
+            Set<String> repositoriesToGet = new LinkedHashSet<>(); // to keep insertion order
+            for (String repositoryOrPattern : repoNames) {
+                if (Regex.isSimpleMatchPattern(repositoryOrPattern) == false) {
+                    repositoriesToGet.add(repositoryOrPattern);
+                } else {
+                    for (RepositoryMetadata repository : repositories.repositories()) {
+                        if (Regex.simpleMatch(repositoryOrPattern, repository.name())) {
+                            repositoriesToGet.add(repository.name());
                         }
                     }
                 }
-                List<RepositoryMetadata> repositoryListBuilder = new ArrayList<>();
-                for (String repository : repositoriesToGet) {
-                    RepositoryMetadata repositoryMetadata = repositories.repository(repository);
-                    if (repositoryMetadata == null) {
-                        throw new RepositoryMissingException(repository);
-                    }
-                    repositoryListBuilder.add(repositoryMetadata);
-                }
-                return repositoryListBuilder;
-            } else {
-                throw new RepositoryMissingException(repoNames[0]);
             }
+            List<RepositoryMetadata> repositoryListBuilder = new ArrayList<>();
+            for (String repository : repositoriesToGet) {
+                RepositoryMetadata repositoryMetadata = repositories.repository(repository);
+                if (repositoryMetadata == null) {
+                    throw new RepositoryMissingException(repository);
+                }
+                repositoryListBuilder.add(repositoryMetadata);
+            }
+            return repositoryListBuilder;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -720,6 +720,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return (T) customs.get(type);
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends Custom> T custom(String type, T defaultValue) {
+        return (T) customs.getOrDefault(type, defaultValue);
+    }
 
     /**
      * Gets the total number of shards from all indices, including replicas and

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -47,6 +47,8 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
 
     public static final String TYPE = "repositories";
 
+    public static final RepositoriesMetadata EMPTY = new RepositoriesMetadata(Collections.emptyList());
+
     /**
      * Serialization parameter used to hide the {@link RepositoryMetadata#generation()} and {@link RepositoryMetadata#pendingGeneration()}
      * in {@link org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse}.

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -611,8 +611,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @param state   current cluster state
      */
     private static void validate(String repositoryName, String snapshotName, ClusterState state) {
-        RepositoriesMetadata repositoriesMetadata = state.getMetadata().custom(RepositoriesMetadata.TYPE);
-        if (repositoriesMetadata == null || repositoriesMetadata.repository(repositoryName) == null) {
+        RepositoriesMetadata repositoriesMetadata = state.getMetadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+        if (repositoriesMetadata.repository(repositoryName) == null) {
             throw new RepositoryMissingException(repositoryName);
         }
         validate(repositoryName, snapshotName);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
@@ -231,9 +231,9 @@ public class SnapshotLifecycleService implements Closeable, ClusterStateListener
      * @throws IllegalArgumentException if the repository does not exist
      */
     public static void validateRepositoryExists(final String repository, final ClusterState state) {
-        Optional.ofNullable((RepositoriesMetadata) state.metadata().custom(RepositoriesMetadata.TYPE))
-            .map(repoMeta -> repoMeta.repository(repository))
-            .orElseThrow(() -> new IllegalArgumentException("no such repository [" + repository + "]"));
+        if (state.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY).repository(repository) == null) {
+            throw new IllegalArgumentException("no such repository [" + repository + "]");
+        }
     }
 
     /**


### PR DESCRIPTION
The behavior of APIs was different depending on whether or not a cluster ever had any
repository configured due to the way we handled the `Custom` `null` values.
Added a default value overload for `#custom` the same way we have it for
custom non-metadata CS values and simplified code accordingly.

Closes #65511
