### PR TITLE
Allow to add existing cache files in searchable snapshots cache service

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentSet;
 import static org.elasticsearch.index.store.cache.TestUtils.mergeContiguousRanges;
+import static org.elasticsearch.index.store.cache.TestUtils.randomRanges;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -562,19 +563,5 @@ public class SparseFileTrackerTests extends ESTestCase {
             gap.onCompletion();
             return true;
         }
-    }
-
-    /**
-     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
-     */
-    private static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
-        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
-        for (long i = 0L; i < length;) {
-            long start = randomLongBetween(i, Math.max(0L, length - 1L));
-            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
-            randomRanges.add(Tuple.tuple(start, end));
-            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
-        }
-        return randomRanges;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -99,6 +99,20 @@ public final class TestUtils {
         return numberOfRanges;
     }
 
+    /**
+     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
+     */
+    public static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
+        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+        for (long i = 0L; i < length;) {
+            long start = randomLongBetween(i, Math.max(0L, length - 1L));
+            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
+            randomRanges.add(Tuple.tuple(start, end));
+            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
+        }
+        return randomRanges;
+    }
+
     public static SortedSet<Tuple<Long, Long>> mergeContiguousRanges(final SortedSet<Tuple<Long, Long>> ranges) {
         // Eclipse needs the TreeSet type to be explicit (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=568600)
         return ranges.stream().collect(() -> new TreeSet<Tuple<Long, Long>>(Comparator.comparingLong(Tuple::v1)), (gaps, gap) -> {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTe
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -30,9 +31,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 
+import static java.util.Collections.emptySortedSet;
 import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
+import static org.elasticsearch.index.store.cache.TestUtils.randomRanges;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
 
@@ -158,6 +164,45 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                     assertThat(cacheService.isCacheFileToSync(cacheFile), is(false));
                     assertThat(fileSystemProvider.getNumberOfFSyncs(cacheFile.getFile()), equalTo(cacheFileAndExpectedNumberOfFSyncs.v2()));
                 });
+            }
+        }
+    }
+
+    public void testPut() throws Exception {
+        final Path cacheDir = createTempDir();
+        try (CacheService cacheService = defaultCacheService()) {
+            final long fileLength = randomLongBetween(0L, 1000L);
+            final CacheKey cacheKey = new CacheKey(
+                new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+                new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+                new ShardId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()), randomInt(5)),
+                randomAlphaOfLength(105).toLowerCase(Locale.ROOT)
+            );
+            final String cacheFileUuid = UUIDs.randomBase64UUID(random());
+            final SortedSet<Tuple<Long, Long>> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();
+
+            if (randomBoolean()) {
+                final Path cacheFilePath = cacheDir.resolve(cacheFileUuid);
+                Files.createFile(cacheFilePath);
+
+                cacheService.put(cacheKey, fileLength, cacheDir, cacheFileUuid, cacheFileRanges);
+
+                cacheService.start();
+                final CacheFile cacheFile = cacheService.get(cacheKey, fileLength, cacheDir);
+                assertThat(cacheFile, notNullValue());
+                assertThat(cacheFile.getFile(), equalTo(cacheFilePath));
+                assertThat(cacheFile.getCacheKey(), equalTo(cacheKey));
+                assertThat(cacheFile.getLength(), equalTo(fileLength));
+
+                for (Tuple<Long, Long> cacheFileRange : cacheFileRanges) {
+                    assertThat(cacheFile.getAbsentRangeWithin(cacheFileRange.v1(), cacheFileRange.v2()), nullValue());
+                }
+            } else {
+                final FileNotFoundException exception = expectThrows(
+                    FileNotFoundException.class,
+                    () -> cacheService.put(cacheKey, fileLength, cacheDir, cacheFileUuid, cacheFileRanges)
+                );
+                assertThat(exception.getMessage(), containsString(cacheFileUuid));
             }
         }
     }


### PR DESCRIPTION
This pull request adds a new `put()` method to the `CacheService` that allows to add existing cache files to the searchable snapshot cache before the service is effectively started. This method will be used in the future to fill the cache at node start-up time with information retrieved from a Lucene index.