### PR TITLE
EQL: Add ? support (match single char) to wildcard functionality in  `:` operator

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -312,3 +312,17 @@ query = '''
 file where file_name : ("winini?.exe", "lsass.e?e") and opcode == 2
 '''
 expected_event_ids  = [65, 86]
+
+[[queries]]
+name = "wildcardFunctionWildcardPattern"
+query = '''
+file where wildcard(file_name, "winini*.exe", "lsass.*") and opcode == 2
+'''
+expected_event_ids  = [65, 86]
+
+[[queries]]
+name = "wildcardFunctionQuestionMarkPattern"
+query = '''
+file where file_name : ("winini?.exe", "lsass.e?e") and opcode == 2
+'''
+expected_event_ids  = [65, 86]

--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -323,6 +323,6 @@ expected_event_ids  = [65, 86]
 [[queries]]
 name = "wildcardFunctionQuestionMarkPattern"
 query = '''
-file where file_name : ("winini?.exe", "lsass.e?e") and opcode == 2
+file where wildcard(file_name, "winini?.exe", "lsass.e?e") and opcode == 2
 '''
 expected_event_ids  = [65, 86]

--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -288,6 +288,11 @@ query = 'process where string(serial_event_id) : ("1*")'
 expected_event_ids  = [1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
 
 [[queries]]
+name = "seqSingleArgPatternQuestionMark"
+query = 'process where string(serial_event_id) : ("1?")'
+expected_event_ids  = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+[[queries]]
 name = "seqMultipleArgs"
 query = '''
 file where file_name : ("wininit.exe", "lsass.exe") and opcode == 2
@@ -298,5 +303,12 @@ expected_event_ids  = [65, 86]
 name = "seqMultipleArgsWildcardPattern"
 query = '''
 file where file_name : ("winini*.exe", "lsass.*") and opcode == 2
+'''
+expected_event_ids  = [65, 86]
+
+[[queries]]
+name = "seqMultipleArgsWildcardPatternQuestionMark"
+query = '''
+file where file_name : ("winini?.exe", "lsass.e?e") and opcode == 2
 '''
 expected_event_ids  = [65, 86]

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -114,7 +114,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         @Override
         protected LogicalPlan rule(Filter filter) {
             return filter.transformExpressionsUp(e -> {
-                // expr : "wildcard*phrase" || expr !: "wildcard*phrase"
+                // expr : "wildcard*phrase?" || expr !: "wildcard*phrase?"
                 if (e instanceof InsensitiveBinaryComparison) {
                     InsensitiveBinaryComparison cmp = (InsensitiveBinaryComparison) e;
 
@@ -144,7 +144,10 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         private static boolean isWildcard(Expression expr) {
             if (expr instanceof Literal) {
                 Object value = expr.fold();
-                return value instanceof String && ((String) value).contains("*");
+                if (value instanceof String) {
+                    String string = (String) value;
+                    return string.contains("*") || string.contains("?");
+                }
             }
             return false;
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/StringUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/StringUtils.java
@@ -18,11 +18,13 @@ public final class StringUtils {
     public static LikePattern toLikePattern(String s) {
         // pick a character that is guaranteed not to be in the string, because it isn't allowed to escape itself
         char escape = 1;
+        String escapeString = Character.toString(escape);
 
         // replace wildcards with % and escape special characters
-        String likeString = s.replace("%", escape + "%")
-            .replace("_", escape + "_")
-            .replace("*", "%");
+        String likeString = s.replace("%", escapeString + "%")
+            .replace("_", escapeString + "_")
+            .replace("*", "%")
+            .replace("?", "_");
 
         return new LikePattern(likeString, escape);
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/StringUtilsTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/StringUtilsTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.eql;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.LikePattern;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.eql.util.StringUtils.toLikePattern;
+
+public class StringUtilsTests extends ESTestCase {
+
+    public void testLikePatternNoPattern() throws Exception {
+        String string = "abc123";
+        assertEquals(string, toLikePattern(string).asString());
+    }
+
+    public void testLikePatternLikeChars() throws Exception {
+        String string = "a%bc%%12_3__";
+        String escape = Character.toString(1);
+        LikePattern pattern = toLikePattern(string);
+        assertEquals(string, pattern.asString());
+        assertEquals("a" + escape + "%bc" + escape + "%" + escape + "%" +
+            "12" + escape + "_" + "3" + escape + "_" + escape + "_", pattern.pattern());
+        assertEquals(string, pattern.asLuceneWildcard());
+    }
+
+    public void testLikePatternEqlChars() throws Exception {
+        String string = "abc*123?";
+        LikePattern pattern = toLikePattern(string);
+        assertEquals("abc%123_", pattern.asString());
+        assertEquals("abc%123_", pattern.pattern());
+        assertEquals(string, pattern.asLuceneWildcard());
+    }
+
+    public void testLikePatternMixEqlAndLikeChars() throws Exception {
+        String string = "abc*%123?_";
+        String escape = Character.toString(1);
+        LikePattern pattern = toLikePattern(string);
+        assertEquals("abc%%123__", pattern.asString());
+        assertEquals("abc%" + escape + "%123_" + escape + "_", pattern.pattern());
+        assertEquals(string, pattern.asLuceneWildcard());
+    }
+
+    public void testIsExactMatch() throws Exception {
+        List<String> list = asList("abc%123", "abc_123", "abc%%123__");
+        for (String string : list) {
+            LikePattern pattern = toLikePattern(string);
+            assertTrue(pattern.isExactMatch());
+        }
+    }
+
+    public void testIsNonExactMatch() throws Exception {
+        List<String> list = asList("abc*123", "abc?123", "abc**123??");
+        for (String string : list) {
+            LikePattern pattern = toLikePattern(string);
+            assertFalse(pattern.isExactMatch());
+        }
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/optimizer/OptimizerTests.java
@@ -50,7 +50,6 @@ import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.TypesTests;
 
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -94,7 +93,7 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testIsNull() {
-        List<String> tests = Arrays.asList(
+        List<String> tests = asList(
             "foo where command_line == null",
             "foo where null == command_line"
         );
@@ -113,7 +112,7 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testIsNotNull() {
-        List<String> tests = Arrays.asList(
+        List<String> tests = asList(
             "foo where command_line != null",
             "foo where null != command_line"
         );
@@ -132,50 +131,44 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testEqualsWildcardOnRight() {
-        List<String> tests = Arrays.asList(
-            "foo where command_line : \"* bar *\""
-        );
+        String q = "foo where command_line : \"* bar *\"";
 
-        for (String q : tests) {
-            LogicalPlan plan = defaultPipes(accept(q));
-            assertTrue(plan instanceof Filter);
+        LogicalPlan plan = defaultPipes(accept(q));
+        assertTrue(plan instanceof Filter);
 
-            Filter filter = (Filter) plan;
-            And condition = (And) filter.condition();
-            assertTrue(condition.right() instanceof Like);
+        Filter filter = (Filter) plan;
+        And condition = (And) filter.condition();
+        assertTrue(condition.right() instanceof Like);
 
-            Like like = (Like) condition.right();
-            assertEquals(((FieldAttribute) like.field()).name(), "command_line");
-            assertEquals(like.pattern().asJavaRegex(), "^.* bar .*$");
-            assertEquals(like.pattern().asLuceneWildcard(), "* bar *");
-            assertEquals(like.pattern().asIndexNameWildcard(), "* bar *");
-        }
+        Like like = (Like) condition.right();
+        assertEquals(((FieldAttribute) like.field()).name(), "command_line");
+        assertEquals(like.pattern().asJavaRegex(), "^.* bar .*$");
+        assertEquals(like.pattern().asLuceneWildcard(), "* bar *");
+        assertEquals(like.pattern().asIndexNameWildcard(), "* bar *");
     }
 
     public void testEqualsWildcardQuestionmarkOnRight() {
-        List<String> tests = Arrays.asList(
-            "foo where command_line : \"? bar ?\""
-        );
+        String q = "foo where command_line : \"? bar ?\"";
 
-        for (String q : tests) {
-            LogicalPlan plan = defaultPipes(accept(q));
-            assertTrue(plan instanceof Filter);
+        LogicalPlan plan = defaultPipes(accept(q));
+        assertTrue(plan instanceof Filter);
 
-            Filter filter = (Filter) plan;
-            And condition = (And) filter.condition();
-            assertTrue(condition.right() instanceof Like);
+        Filter filter = (Filter) plan;
+        And condition = (And) filter.condition();
+        assertTrue(condition.right() instanceof Like);
 
-            Like like = (Like) condition.right();
-            assertEquals("command_line", ((FieldAttribute) like.field()).name());
-            assertEquals( "^. bar .$", like.pattern().asJavaRegex());
-            assertEquals("? bar ?", like.pattern().asLuceneWildcard());
-            assertEquals( "* bar *", like.pattern().asIndexNameWildcard());
-        }
+        Like like = (Like) condition.right();
+        assertEquals("command_line", ((FieldAttribute) like.field()).name());
+        assertEquals( "^. bar .$", like.pattern().asJavaRegex());
+        assertEquals("? bar ?", like.pattern().asLuceneWildcard());
+        assertEquals( "* bar *", like.pattern().asIndexNameWildcard());
     }
 
     public void testEqualsWildcardWithLiteralsOnLeft() {
-        List<String> tests = Arrays.asList(
-            "foo where \"abc\": \"*b*\""
+        List<String> tests = asList(
+            "foo where \"abc\": \"*b*\"",
+            "foo where \"abc\": \"ab*\"",
+            "foo where \"abc\": \"*bc\""
         );
 
         for (String q : tests) {
@@ -190,7 +183,7 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testEqualsWildcardIgnoredOnLeftLiteral() {
-        List<String> tests = Arrays.asList(
+        List<String> tests = asList(
             "foo where \"*b*\" : \"abc\"",
             "foo where \"*b\" : \"abc\"",
             "foo where \"b*\" : \"abc\"",
@@ -208,7 +201,7 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testEqualsWildcardWithLiteralsOnLeftAndPatternOnRightNotMatching() {
-        List<String> tests = Arrays.asList(
+        List<String> tests = asList(
             "foo where \"abc\": \"*b\"",
             "foo where \"abc\": \"b*\"",
             "foo where \"abc\": \"b?\"",

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -92,7 +92,7 @@ public final class StringUtils {
 
     // % -> .*
     // _ -> .
-    // escape character - can be 0 (in which case every regex gets escaped) or
+    // escape character - can be 0 (in which case no regex gets escaped) or
     // should be followed by % or _ (otherwise an exception is thrown)
     public static String likeToJavaPattern(String pattern, char escape) {
         StringBuilder regex = new StringBuilder(pattern.length() + 4);
@@ -155,7 +155,7 @@ public final class StringUtils {
      * <pre>
      * % -&gt; *
      * _ -&gt; ?
-     * escape character - can be 0 (in which case every regex gets escaped) or should be followed by
+     * escape character - can be 0 (in which case no regex gets escaped) or should be followed by
      * % or _ (otherwise an exception is thrown)
      * </pre>
      */


### PR DESCRIPTION
Introduce support for ? character to wildcard pattern to : operator and
by transition, to wildcard function.

Fix #65536