### PR TITLE
Searchable snapshot terminology

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -254,7 +254,7 @@ node.roles: [ data_warm ]
 [[data-cold-node]]
 ==== [x-pack]#Cold data node#
 
-Cold data nodes store read-only indices that are accessed less frequently. This tier uses less performant hardware and may leverage snapshot-backed indices to minimize the resources required.
+Cold data nodes store read-only indices that are accessed less frequently. This tier uses less performant hardware and may leverage searchable snapshot indices to minimize the resources required.
 
 To create a dedicated cold node, set:
 [source,yaml]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1262,9 +1262,9 @@ See <<wildcard-field-type>>.
 [role="exclude",id="searchable-snapshots-api-clear-cache"]
 === Clear cache API
 
-We have removed documentation for this API. This a low-level API used to get
-information about snapshot-backed indices. We plan to remove or drastically
-change this API as part of a future release.
+We have removed documentation for this API. This a low-level API used to clear
+the searchable snapshot cache. We plan to remove or drastically change this API
+as part of a future release.
 
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
 
@@ -1272,7 +1272,7 @@ For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
 === Searchable snapshot statistics API
 
 We have removed documentation for this API. This a low-level API used to get
-information about snapshot-backed indices. We plan to remove or drastically
+information about searchable snapshot indices. We plan to remove or drastically
 change this API as part of a future release.
 
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
@@ -1281,7 +1281,7 @@ For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
 === Searchable snapshot repository statistics API
 
 We have removed documentation for this API. This a low-level API used to get
-information about snapshot-backed indices. We plan to remove or drastically
+information about searchable snapshot indices. We plan to remove or drastically
 change this API as part of a future release.
 
 For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -8,7 +8,7 @@
 
 beta::[]
 
-Mount a snapshot as a snapshot backed index.
+Mount a snapshot as a searchable snapshot index.
 
 [[searchable-snapshots-api-mount-request]]
 ==== {api-request-title}


### PR DESCRIPTION
We chose to use searchable snapshot index over snapshot-backed index, so
changed terminology towards this in a couple places.
