### PR TITLE
Fix Inconsistent API Behavior when Cluster never had a Snapshot Repository Configured (#65535)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -37,6 +37,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
@@ -93,6 +94,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -1024,6 +1026,12 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.PARTIAL));
         assertThat(snapshotInfo.shardFailures().size(), greaterThan(0));
         logger.info("--> done");
+    }
+
+    public void testGetReposWithWildcard() {
+        internalCluster().startMasterOnlyNode();
+        List<RepositoryMetadata> repositoryMetadata = client().admin().cluster().prepareGetRepositories("*").get().repositories();
+        assertThat(repositoryMetadata, empty());
     }
 
     private long calculateTotalFilesSize(List<Path> files) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -37,7 +36,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,41 +62,33 @@ public class TransportGetRepositoriesAction extends
     @Override
     protected void masterOperation(final GetRepositoriesRequest request, ClusterState state,
                                    final ActionListener<GetRepositoriesResponse> listener) {
-        Metadata metadata = state.metadata();
-        RepositoriesMetadata repositories = metadata.custom(RepositoriesMetadata.TYPE);
-        if (request.repositories().length == 0 || (request.repositories().length == 1 && "_all".equals(request.repositories()[0]))) {
-            if (repositories != null) {
+        RepositoriesMetadata repositories = state.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+        if (request.repositories().length == 0 || (request.repositories().length == 1
+                && ("_all".equals(request.repositories()[0]) || "*".equals(request.repositories()[0])))) {
                 listener.onResponse(new GetRepositoriesResponse(repositories));
-            } else {
-                listener.onResponse(new GetRepositoriesResponse(new RepositoriesMetadata(Collections.emptyList())));
-            }
         } else {
-            if (repositories != null) {
-                Set<String> repositoriesToGet = new LinkedHashSet<>(); // to keep insertion order
-                for (String repositoryOrPattern : request.repositories()) {
-                    if (Regex.isSimpleMatchPattern(repositoryOrPattern) == false) {
-                        repositoriesToGet.add(repositoryOrPattern);
-                    } else {
-                        for (RepositoryMetadata repository : repositories.repositories()) {
-                            if (Regex.simpleMatch(repositoryOrPattern, repository.name())) {
-                                repositoriesToGet.add(repository.name());
-                            }
+            Set<String> repositoriesToGet = new LinkedHashSet<>(); // to keep insertion order
+            for (String repositoryOrPattern : request.repositories()) {
+                if (Regex.isSimpleMatchPattern(repositoryOrPattern) == false) {
+                    repositoriesToGet.add(repositoryOrPattern);
+                } else {
+                    for (RepositoryMetadata repository : repositories.repositories()) {
+                        if (Regex.simpleMatch(repositoryOrPattern, repository.name())) {
+                            repositoriesToGet.add(repository.name());
                         }
                     }
                 }
-                List<RepositoryMetadata> repositoryListBuilder = new ArrayList<>();
-                for (String repository : repositoriesToGet) {
-                    RepositoryMetadata repositoryMetadata = repositories.repository(repository);
-                    if (repositoryMetadata == null) {
-                        listener.onFailure(new RepositoryMissingException(repository));
-                        return;
-                    }
-                    repositoryListBuilder.add(repositoryMetadata);
-                }
-                listener.onResponse(new GetRepositoriesResponse(new RepositoriesMetadata(repositoryListBuilder)));
-            } else {
-                listener.onFailure(new RepositoryMissingException(request.repositories()[0]));
             }
+            List<RepositoryMetadata> repositoryListBuilder = new ArrayList<>();
+            for (String repository : repositoriesToGet) {
+                RepositoryMetadata repositoryMetadata = repositories.repository(repository);
+                if (repositoryMetadata == null) {
+                    listener.onFailure(new RepositoryMissingException(repository));
+                    return;
+                }
+                repositoryListBuilder.add(repositoryMetadata);
+            }
+            listener.onResponse(new GetRepositoriesResponse(new RepositoriesMetadata(repositoryListBuilder)));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -778,6 +778,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return (T) customs.get(type);
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends Custom> T custom(String type, T defaultValue) {
+        return (T) customs.getOrDefault(type, defaultValue);
+    }
 
     /**
      * Gets the total number of shards from all indices, including replicas and

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -47,6 +47,8 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
 
     public static final String TYPE = "repositories";
 
+    public static final RepositoriesMetadata EMPTY = new RepositoriesMetadata(Collections.emptyList());
+
     /**
      * Serialization parameter used to hide the {@link RepositoryMetadata#generation()} and {@link RepositoryMetadata#pendingGeneration()}
      * in {@link org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse}.

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -733,8 +733,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @param state   current cluster state
      */
     private static void validate(String repositoryName, String snapshotName, ClusterState state) {
-        RepositoriesMetadata repositoriesMetadata = state.getMetadata().custom(RepositoriesMetadata.TYPE);
-        if (repositoriesMetadata == null || repositoriesMetadata.repository(repositoryName) == null) {
+        RepositoriesMetadata repositoriesMetadata = state.getMetadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+        if (repositoriesMetadata.repository(repositoryName) == null) {
             throw new RepositoryMissingException(repositoryName);
         }
         validate(repositoryName, snapshotName);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
@@ -231,9 +231,9 @@ public class SnapshotLifecycleService implements Closeable, ClusterStateListener
      * @throws IllegalArgumentException if the repository does not exist
      */
     public static void validateRepositoryExists(final String repository, final ClusterState state) {
-        Optional.ofNullable((RepositoriesMetadata) state.metadata().custom(RepositoriesMetadata.TYPE))
-            .map(repoMeta -> repoMeta.repository(repository))
-            .orElseThrow(() -> new IllegalArgumentException("no such repository [" + repository + "]"));
+        if (state.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY).repository(repository) == null) {
+            throw new IllegalArgumentException("no such repository [" + repository + "]");
+        }
     }
 
     /**


### PR DESCRIPTION
The behavior of APIs was different depending on whether or not a cluster ever had any
repository configured due to the way we handled the `Custom` `null` values.
Added a default value overload for `#custom` the same way we have it for
custom non-metadata CS values and simplified code accordingly.

Closes #65511

backport of #65535 